### PR TITLE
Fixing path: `idris2-boot.ss` instead of `idris2-boot.so`

### DIFF
--- a/bootstrap/idris2-boot
+++ b/bootstrap/idris2-boot
@@ -2,4 +2,4 @@
 
 DIR="`realpath $0`"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:`dirname "$DIR"`/"idris2_app""
-${SCHEME} --script "`dirname $DIR`"/"idris2_app/idris2-boot.so" "$@"
+${SCHEME} --script "`dirname $DIR`"/"idris2_app/idris2-boot.ss" "$@"


### PR DESCRIPTION
It seems that this is a typo in the `idris-boot` shell script.