### PR TITLE
libs/network: Port FFI calls from deprecated interface to `%foreign` pragma

### DIFF
--- a/libs/network/Network/FFI.idr
+++ b/libs/network/Network/FFI.idr
@@ -1,0 +1,149 @@
+||| FFI binding to the low-Level C Sockets bindings for Idris. 
+||| 
+||| Modified (C) The Idris Community, 2020
+module Network.FFI
+
+import Network.Socket.Data
+
+-- From sys/socket.h
+
+%foreign "C:close,idris_net"
+export
+socket_close : (sockdes : SocketDescriptor) -> PrimIO Int
+
+%foreign "C:listen,idris_net"
+export
+socket_listen : (sockfd : SocketDescriptor) -> (backlog : Int) -> PrimIO Int
+
+
+-- From idris_net.h
+
+%foreign "C:idrnet_socket,idris_net"
+export
+idrnet_socket : (domain, type, protocol : Int) -> PrimIO Int
+
+%foreign "C:idrnet_bind,idris_net"
+export
+idrnet_bind : (sockfd : SocketDescriptor) -> (family, socket_type : Int) -> (host : String) 
+            -> (port : Port) -> PrimIO Int
+            
+%foreign "C:idrnet_connect,idris_net"
+export
+idrnet_connect : (sockfd : SocketDescriptor) -> (family, socket_type : Int) -> (host : String) 
+               -> (port : Port) -> PrimIO Int
+
+%foreign "C:idrnet_sockaddr_family,idris_net"
+export
+idrnet_sockaddr_family : (sockaddr : AnyPtr) -> PrimIO Int
+
+%foreign "C:idrnet_sockaddr_ipv4,idris_net"
+export
+idrnet_sockaddr_ipv4 : (sockaddr : AnyPtr) -> PrimIO String
+
+%foreign "C:idrnet_sockaddr_ipv4_port,idris_net"
+export
+idrnet_sockaddr_ipv4_port : (sockaddr : AnyPtr) -> PrimIO Int
+
+%foreign "C:idrnet_sockaddr_port,idris_net"
+export
+idrnet_sockaddr_port : (sockfd : SocketDescriptor) -> PrimIO Int
+
+
+%foreign "C:idrnet_create_sockaddr,idris_net"
+export
+idrnet_create_sockaddr : PrimIO AnyPtr
+
+%foreign "C:idrnet_accept,idris_net"
+export
+idrnet_accept : (sockfd : SocketDescriptor) -> (sockaddr : AnyPtr) -> PrimIO Int
+
+%foreign "C:idrnet_send,idris_net"
+export
+idrnet_send : (sockfd : SocketDescriptor) -> (dataString : String) -> PrimIO Int
+
+%foreign "C:idrnet_send_buf,idris_net"
+export
+idrnet_send_buf : (sockfd : SocketDescriptor) -> (dataBuffer : AnyPtr) -> (len : Int) -> PrimIO Int
+
+
+%foreign "C:idrnet_recv,idris_net"
+export
+idrnet_recv : (sockfd : SocketDescriptor) -> (len : Int) -> PrimIO AnyPtr
+
+%foreign "C:idrnet_recv_buf,idris_net"
+export
+idrnet_recv_buf : (sockfd : SocketDescriptor) -> (buf : AnyPtr) -> (len : Int) 
+               -> PrimIO Int
+
+%foreign "C:idrnet_sendto,idris_net"
+export
+idrnet_sendto : (sockfd : SocketDescriptor) -> (dataString,host : String)
+             -> (port : Port) -> (family : Int) -> PrimIO Int
+
+%foreign "C:idrnet_sendto_buf,idris_net"
+export
+idrnet_sendto_buf : (sockfd : SocketDescriptor) -> (dataBuf : AnyPtr) -> (buf_len : Int) 
+                 -> (host : String) -> (port : Port) -> (family : Int) -> PrimIO Int
+                 
+%foreign "C:idrnet_recvfrom,idris_net"
+export
+idrnet_recvfrom : (sockfd : SocketDescriptor) -> (len : Int) -> PrimIO AnyPtr                 
+
+%foreign "C:idrnet_recvfrom_buf,idris_net"
+export
+idrnet_recvfrom_buf : (sockfd : SocketDescriptor) -> (buf : AnyPtr) -> (len : Int) 
+                   -> PrimIO AnyPtr                 
+
+%foreign "C:idrnet_get_recv_res,idris_net"
+export
+idrnet_get_recv_res : (res_struct : AnyPtr) -> PrimIO Int
+
+%foreign "C:idrnet_get_recv_payload,idris_net"
+export
+idrnet_get_recv_payload : (res_struct : AnyPtr) -> PrimIO String
+
+%foreign "C:idrnet_free_recv_struct,idris_net"
+export
+idrnet_free_recv_struct : (res_struct : AnyPtr) -> PrimIO ()
+
+%foreign "C:idrnet_get_recvfrom_res,idris_net"
+export
+idrnet_get_recvfrom_res : (res_struct : AnyPtr) -> PrimIO Int
+
+%foreign "C:idrnet_get_recvfrom_payload,idris_net"
+export
+idrnet_get_recvfrom_payload : (res_struct : AnyPtr) -> PrimIO String
+
+%foreign "C:idrnet_get_recvfrom_sockaddr,idris_net"
+export
+idrnet_get_recvfrom_sockaddr : (res_struct : AnyPtr) -> PrimIO AnyPtr
+
+%foreign "C:idrnet_free_recvfrom_struct,idris_net"
+export
+idrnet_free_recvfrom_struct : (res_struct : AnyPtr) -> PrimIO ()
+
+
+%foreign "C:idrnet_geteagain,idris_net"
+export
+idrnet_geteagain : PrimIO Int
+
+%foreign "C:idrnet_errno,idris_net"
+export
+idrnet_errno : PrimIO Int
+
+%foreign "C:idrnet_malloc,idris_net"
+export
+idrnet_malloc : (size : Int) -> PrimIO AnyPtr
+
+%foreign "C:idrnet_free,idris_net"
+export
+idrnet_free : (ptr : AnyPtr) -> PrimIO ()
+
+%foreign "C:idrnet_peek,idris_net"
+export
+idrnet_peek : (ptr : AnyPtr) -> (offset : {-Unsigned-} Int) -> PrimIO {-Unsigned-} Int
+
+%foreign "C:idrnet_poke,idris_net"
+export
+idrnet_poke : (ptr : AnyPtr) -> (offset : {-Unsigned-} Int) -> (val : Int {- should be Char? -}) 
+           -> PrimIO ()

--- a/libs/network/Network/Socket/Data.idr
+++ b/libs/network/Network/Socket/Data.idr
@@ -48,22 +48,36 @@ export
 BACKLOG : Int
 BACKLOG = 20
 
+-- Repeat to avoid a dependency cycle
+%foreign "C:idrnet_geteagain,idris_net"
+idrnet_geteagain : PrimIO Int
+
 export
 EAGAIN : Int
 EAGAIN =
   -- I'm sorry
   -- maybe
-  unsafePerformIO $ cCall Int "idrnet_geteagain" []
+  unsafePerformIO $ primIO $ idrnet_geteagain
 
 -- ---------------------------------------------------------------- [ Error Code ]
 
+-- repeat without export to avoid dependency cycles
+%foreign "C:idrnet_errno,idris_net"
+idrnet_errno : PrimIO Int
+
+%foreign "C:isNull,idris_net"
+idrnet_isNull : (ptr : AnyPtr) -> PrimIO Int
+
+
 export
 getErrno : IO SocketError
-getErrno = cCall Int "idrnet_errno" []
+getErrno = primIO $ idrnet_errno
 
 export
 nullPtr : AnyPtr -> IO Bool
-nullPtr p = cCall Bool "isNull" [p]
+nullPtr p = do 0 <- primIO  $ idrnet_isNull p
+               | _ => pure True
+               pure False
 
 -- -------------------------------------------------------------- [ Interfaces ]
 

--- a/libs/network/network.ipkg
+++ b/libs/network/network.ipkg
@@ -2,4 +2,5 @@ package network
 
 modules = Network.Socket,
           Network.Socket.Data,
-          Network.Socket.Raw
+          Network.Socket.Raw,
+          Network.FFI


### PR DESCRIPTION
Mostly tedious rebinding.

There's a slight wiggle in `Network.Socket.Data`, where this module also calls (at one point sneakily) foreign functions. I repeated the binding of the three functions it calls locally (without exporting them).