### PR TITLE
Exclude `DN` from `Hashable Name`

### DIFF
--- a/src/Core/Hash.idr
+++ b/src/Core/Hash.idr
@@ -64,6 +64,8 @@ Hashable String where
 export
 Hashable Name where
   hashWithSalt h (MN s _) = hashWithSalt h s
+  hashWithSalt h (DN _ n) = hashWithSalt h n
+  hashWithSalt h (NS ns n) = hashWithSalt (hashWithSalt h ns) n
   hashWithSalt h (Resolved i) = hashWithSalt h i
   hashWithSalt h n = hashWithSalt h (show n)
 


### PR DESCRIPTION
File locations end up in module interface hashes, triggering unnecessary rebuilds. This patch ignores `DN` layers in hashes to prevent this behaviour.

Everything else, such as the `Show` instance for names, should be unaffected.

Fixes #95.