### PR TITLE
Define blodwen-os in Gambit support.scm

### DIFF
--- a/support/gambit/support.scm
+++ b/support/gambit/support.scm
@@ -1,3 +1,12 @@
+;; Inspired by:
+;; https://github.com/gambit/gambit/blob/master/gsc/_t-x86.scm#L1106 #L1160
+(define (blodwen-os)
+  (cond
+    [(memq (cadr (system-type)) '(apple)) "darwin"]
+    [(memq (caddr (system-type)) '(linux-gnu)) "unix"]
+    [(memq (caddr (system-type)) '(mingw32 mingw64)) "windows"]
+    [else "unknown"]))
+
 ;; TODO Convert to macro
 (define (blodwen-read-args desc)
   (if (fx= (vector-ref desc 0) 0)


### PR DESCRIPTION
### Why
I have noticed this function being defined in Chez [support.ss](https://github.com/idris-lang/Idris2/blob/master/support/chez/support.ss) and Racket [support.rkt](https://github.com/idris-lang/Idris2/blob/master/support/racket/support.rkt#L1) support files but not in Gambit.
Also as it is called in
```
File: src/Compiler/Scheme/Common.idr
405:18:      = pure $ "(blodwen-os)"
```
Thought it may be useful to add it.

### Tested
on OSX, Windows (mingw32) and Ubuntu (WSL)

### Next steps
I have also created this spreadsheet to see difference between different scheme files
https://docs.google.com/spreadsheets/d/1lLd-6OuOLVntq7AR6Ecr0CXDUBzFQj3iZxjlYw3Up4k/edit#gid=0
and may try to fill some gaps as exercise :)
Thank you!