### PR TITLE
Fix ambigious expression in contrib

### DIFF
--- a/libs/contrib/System/Path.idr
+++ b/libs/contrib/System/Path.idr
@@ -358,7 +358,7 @@ verbatimUnc = do verbatim
                  server <- match PTText
                  bodySeparator
                  share <- match PTText
-                 Text.Parser.Core pure $ UNC server share
+                 Text.Parser.Core.pure $ UNC server share
 
 -- Example: C:
 private

--- a/libs/contrib/System/Path.idr
+++ b/libs/contrib/System/Path.idr
@@ -349,7 +349,7 @@ unc = do count (exactly 2) $ match $ PTPunct '\\'
          server <- match PTText
          bodySeparator
          share <- match PTText
-         pure $ UNC server share
+         Text.Parser.Core.pure $ UNC server share
 
 -- Example: \\?\server\share
 private
@@ -358,7 +358,7 @@ verbatimUnc = do verbatim
                  server <- match PTText
                  bodySeparator
                  share <- match PTText
-                 pure $ UNC server share
+                 Text.Parser.Core pure $ UNC server share
 
 -- Example: C:
 private


### PR DESCRIPTION
Replace ``pure`` with ``Text.Parser.Core.pure`` to fix ambiguity in contrib.