### PR TITLE
Split Source and Package Parser (Part 2)

### DIFF
--- a/docs/source/reference/records.rst
+++ b/docs/source/reference/records.rst
@@ -14,7 +14,7 @@ Lexical structure
   constructor ``RF "foo"``)
 
 * ``Foo.bar.baz`` starting with uppercase ``F`` is one lexeme, a namespaced
-  identifier: ``NSIdent ["baz", "bar", "Foo"]``
+  identifier: ``DotSepIdent ["baz", "bar", "Foo"]``
 
 * ``foo.bar.baz`` starting with lowercase ``f`` is three lexemes: ``foo``,
   ``.bar``, ``.baz``

--- a/idris2.ipkg
+++ b/idris2.ipkg
@@ -83,9 +83,12 @@ modules =
     Idris.Version,
 
     Parser.Lexer.Common,
+    Parser.Lexer.Package,
     Parser.Lexer.Source,
     Parser.Rule.Common,
+    Parser.Rule.Package,
     Parser.Rule.Source,
+    Parser.Package,
     Parser.Source,
     Parser.Support,
     Parser.Unlit,

--- a/idris2api.ipkg
+++ b/idris2api.ipkg
@@ -83,9 +83,12 @@ modules =
     Idris.Version,
 
     Parser.Lexer.Common,
+    Parser.Lexer.Package,
     Parser.Lexer.Source,
     Parser.Rule.Common,
+    Parser.Rule.Package,
     Parser.Rule.Source,
+    Parser.Package,
     Parser.Source,
     Parser.Support,
     Parser.Unlit,

--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -119,7 +119,8 @@ data Error : Type where
      GenericMsg : FC -> String -> Error
      TTCError : TTCErrorMsg -> Error
      FileErr : String -> FileError -> Error
-     ParseFail : FC -> ParseError -> Error
+     ParseFail : Show token =>
+               FC -> ParseError token -> Error
      ModuleNotFound : FC -> List String -> Error
      CyclicImports : List (List String) -> Error
      ForceNeeded : Error

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -15,6 +15,12 @@ import Data.Strings
 import Data.StringTrie
 import Data.These
 
+import Parser.Package
+import System
+import Text.Parser
+import Utils.Binary
+import Utils.String
+
 import Idris.CommandLine
 import Idris.ModTree
 import Idris.ProcessIdr
@@ -23,13 +29,6 @@ import Idris.REPLOpts
 import Idris.SetOptions
 import Idris.Syntax
 import Idris.Version
-import Parser.Lexer.Source
-import Parser.Source
-import Utils.Binary
-
-import System
-import Text.Parser
-
 import IdrisPaths
 
 %default covering
@@ -114,7 +113,7 @@ data DescField : Type where
   PPreclean    : FC -> String -> DescField
   PPostclean   : FC -> String -> DescField
 
-field : String -> SourceRule DescField
+field : String -> Rule DescField
 field fname
       = strField PVersion "version"
     <|> strField PAuthors "authors"
@@ -134,43 +133,41 @@ field fname
     <|> strField PPostinstall "postinstall"
     <|> strField PPreclean "preclean"
     <|> strField PPostclean "postclean"
-    <|> do exactIdent "depends"; symbol "="
-           ds <- sepBy1 (symbol ",") unqualifiedName
+    <|> do exactProperty "depends"
+           equals
+           ds <- sep packageName
            pure (PDepends ds)
-    <|> do exactIdent "modules"; symbol "="
-           ms <- sepBy1 (symbol ",")
-                      (do start <- location
-                          ns <- nsIdent
-                          end <- location
-                          Parser.Core.pure (MkFC fname start end, ns))
-           Parser.Core.pure (PModules ms)
-    <|> do exactIdent "main"; symbol "="
+    <|> do exactProperty "modules"
+           equals
+           ms <- sep (do start <- location
+                         m <- moduleIdent
+                         end <- location
+                         pure (MkFC fname start end, m))
+           pure (PModules ms)
+    <|> do exactProperty "main"
+           equals
            start <- location
-           m <- nsIdent
+           m <- namespacedIdent
            end <- location
-           Parser.Core.pure (PMainMod (MkFC fname start end) m)
-    <|> do exactIdent "executable"; symbol "="
-           e <- unqualifiedName
-           Parser.Core.pure (PExec e)
+           pure (PMainMod (MkFC fname start end) m)
+    <|> do exactProperty "executable"
+           equals
+           e <- (stringLit <|> packageName)
+           pure (PExec e)
   where
-    getStr : (FC -> String -> DescField) -> FC ->
-             String -> Constant -> SourceEmptyRule DescField
-    getStr p fc fld (Str s) = pure (p fc s)
-    getStr p fc fld _ = fail $ fld ++ " field must be a string"
-
-    strField : (FC -> String -> DescField) -> String -> SourceRule DescField
-    strField p f
+    strField : (FC -> String -> DescField) -> String -> Rule DescField
+    strField fieldConstructor fieldName
         = do start <- location
-             exactIdent f
-             symbol "="
-             c <- constant
+             exactProperty fieldName
+             equals
+             str <- stringLit
              end <- location
-             getStr p (MkFC fname start end) f c
+             pure $ fieldConstructor (MkFC fname start end) str
 
-parsePkgDesc : String -> SourceRule (String, List DescField)
+parsePkgDesc : String -> Rule (String, List DescField)
 parsePkgDesc fname
-    = do exactIdent "package"
-         name <- unqualifiedName
+    = do exactProperty "package"
+         name <- packageName
          fields <- many (field fname)
          pure (name, fields)
 
@@ -424,6 +421,12 @@ clean pkg
         = do let ttFile = builddir ++ dirSep ++ showSep dirSep ns ++ dirSep ++ mod
              delete $ ttFile ++ ".ttc"
              delete $ ttFile ++ ".ttm"
+
+getParseErrorLoc : String -> ParseError Token -> FC
+getParseErrorLoc fname (ParseFail _ (Just pos) _) = MkFC fname pos pos
+getParseErrorLoc fname (LexFail (l, c, _)) = MkFC fname (l, c) (l, c)
+getParseErrorLoc fname (LitFail _) = MkFC fname (0, 0) (0, 0) -- TODO: Remove this unused case
+getParseErrorLoc fname _ = replFC
 
 -- Just load the 'Main' module, if it exists, which will involve building
 -- it if necessary

--- a/src/Idris/ProcessIdr.idr
+++ b/src/Idris/ProcessIdr.idr
@@ -177,7 +177,7 @@ modTime fname
          pure (cast t)
 
 export
-getParseErrorLoc : String -> ParseError -> FC
+getParseErrorLoc : String -> ParseError Token -> FC
 getParseErrorLoc fname (ParseFail _ (Just pos) _) = MkFC fname pos pos
 getParseErrorLoc fname (LexFail (l, c, _)) = MkFC fname (l, c) (l, c)
 getParseErrorLoc fname (LitFail (MkLitErr l c _)) = MkFC fname (l, 0) (l, 0)
@@ -195,7 +195,7 @@ readHeader path
   where
     -- Stop at the first :, that's definitely not part of the header, to
     -- save lexing the whole file unnecessarily
-    isColon : TokenData SourceToken -> Bool
+    isColon : TokenData Token -> Bool
     isColon t
         = case tok t of
                Symbol ":" => True

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -749,7 +749,7 @@ parseCmd : SourceEmptyRule (Maybe REPLCmd)
 parseCmd = do c <- command; eoi; pure $ Just c
 
 export
-parseRepl : String -> Either ParseError (Maybe REPLCmd)
+parseRepl : String -> Either (ParseError Token) (Maybe REPLCmd)
 parseRepl inp
     = case fnameCmd [(":load ", Load), (":l ", Load), (":cd ", CD)] inp of
            Nothing => runParser Nothing inp (parseEmptyCmd <|> parseCmd)

--- a/src/Parser/Lexer/Common.idr
+++ b/src/Parser/Lexer/Common.idr
@@ -18,15 +18,13 @@ comment
 -- There are multiple variants.
 
 public export
-data Flavour = Capitalised | AllowDashes | Normal
+data Flavour = AllowDashes | Capitalised | Normal
 
-export
 isIdentStart : Flavour -> Char -> Bool
 isIdentStart _           '_' = True
 isIdentStart Capitalised  x  = isUpper x || x > chr 160
 isIdentStart _            x  = isAlpha x || x > chr 160
 
-export
 isIdentTrailing : Flavour -> Char -> Bool
 isIdentTrailing AllowDashes '-'  = True
 isIdentTrailing _           '\'' = True
@@ -45,3 +43,26 @@ ident : Flavour -> Lexer
 ident flavour =
   (pred $ isIdentStart flavour) <+>
     (many . pred $ isIdentTrailing flavour)
+
+export
+isIdentNormal : String -> Bool
+isIdentNormal = isIdent Normal
+
+export
+identNormal : Lexer
+identNormal = ident Normal
+
+export
+identAllowDashes : Lexer
+identAllowDashes = ident AllowDashes
+
+namespaceIdent : Lexer
+namespaceIdent = ident Capitalised <+> many (is '.' <+> ident Capitalised <+> expect (is '.'))
+
+export
+namespacedIdent : Lexer
+namespacedIdent = namespaceIdent <+> opt (is '.' <+> identNormal)
+
+export
+spacesOrNewlines : Lexer
+spacesOrNewlines = some (space <|> newline)

--- a/src/Parser/Lexer/Package.idr
+++ b/src/Parser/Lexer/Package.idr
@@ -1,0 +1,65 @@
+module Parser.Lexer.Package
+
+import public Parser.Lexer.Common
+import public Text.Lexer
+import public Text.Parser
+
+import Data.List
+import Data.Strings
+import Data.String.Extra
+import Utils.String
+
+%default total
+
+public export
+data Token
+  = Comment String
+  | EndOfInput
+  | Equals
+  | DotSepIdent (List String)
+  | Separator
+  | Space
+  | StringLit String
+
+public export
+Show Token where
+  show (Comment str) = "Comment: " ++ str
+  show EndOfInput = "EndOfInput"
+  show Equals = "Equals"
+  show (DotSepIdent dsid) = "DotSepIdentifier: " ++ dotSep dsid
+  show Separator = "Separator"
+  show Space = "Space"
+  show (StringLit s) = "StringLit: " ++ s
+
+equals : Lexer
+equals = is '='
+
+separator : Lexer
+separator = is ','
+
+rawTokens : TokenMap Token
+rawTokens =
+  [ (equals, const Equals)
+  , (comment, Comment . drop 2)
+  , (namespacedIdent, DotSepIdent . splitNamespace)
+  , (identAllowDashes, DotSepIdent . pure)
+  , (separator, const Separator)
+  , (spacesOrNewlines, const Space)
+  , (stringLit, \s => StringLit (stripQuotes s))
+  ]
+  where
+    splitNamespace : String -> List String
+    splitNamespace = Data.Strings.split (== '.')
+
+export
+lex : String -> Either (Int, Int, String) (List (TokenData Token))
+lex str =
+  case lexTo (const False) rawTokens str of
+       (tokenData, (l, c, "")) =>
+         Right $ (filter (useful . tok) tokenData) ++  [MkToken l c EndOfInput]
+       (_, fail) => Left fail
+  where
+    useful : Token -> Bool
+    useful (Comment c) = False
+    useful Space       = False
+    useful _ = True

--- a/src/Parser/Package.idr
+++ b/src/Parser/Package.idr
@@ -1,0 +1,24 @@
+module Parser.Package
+
+import public Parser.Lexer.Package
+import public Parser.Rule.Package
+import public Text.Lexer
+import public Text.Parser
+import public Parser.Support
+
+import System.File
+import Utils.Either
+
+export
+runParser : String -> Rule ty -> Either (ParseError Token) ty
+runParser str p
+    = do toks   <- mapError LexFail $ lex str
+         parsed <- mapError toGenericParsingError $ parse p toks
+         Right (fst parsed)
+
+export
+parseFile : (fn : String) -> Rule ty -> IO (Either (ParseError Token) ty)
+parseFile fn p
+    = do Right str <- readFile fn
+             | Left err => pure (Left (FileFail err))
+         pure (runParser str p)

--- a/src/Parser/Rule/Package.idr
+++ b/src/Parser/Rule/Package.idr
@@ -1,0 +1,79 @@
+module Parser.Rule.Package
+
+import public Parser.Lexer.Package
+import public Parser.Rule.Common
+
+import Data.List
+
+%default total
+
+public export
+Rule : Type -> Type
+Rule = Rule Token
+
+public export
+PackageEmptyRule : Type -> Type
+PackageEmptyRule = EmptyRule Token
+
+export
+equals : Rule ()
+equals = terminal "Expected equals"
+                      (\x => case tok x of
+                                  Equals => Just ()
+                                  _ => Nothing)
+
+export
+eoi : Rule ()
+eoi = terminal "Expected end of input"
+               (\x => case tok x of
+                           EndOfInput => Just ()
+                           _ => Nothing)
+
+export
+exactProperty : String -> Rule String
+exactProperty p = terminal ("Expected property " ++ p)
+                           (\x => case tok x of
+                                       DotSepIdent [p'] =>
+                                         if p == p' then Just p
+                                         else Nothing
+                                       _ => Nothing)
+
+export
+stringLit : Rule String
+stringLit = terminal "Expected string"
+                     (\x => case tok x of
+                                 StringLit str => Just str
+                                 _ => Nothing)
+
+export
+namespacedIdent : Rule (List String)
+namespacedIdent = terminal "Expected namespaced identifier"
+                           (\x => case tok x of
+                                       DotSepIdent nsid => Just $ reverse nsid
+                                       _ => Nothing)
+
+export
+moduleIdent : Rule (List String)
+moduleIdent = terminal "Expected module identifier"
+                       (\x => case tok x of
+                                   DotSepIdent m => Just $ reverse m
+                                   _ => Nothing)
+
+export
+packageName : Rule String
+packageName = terminal "Expected package name"
+                       (\x => case tok x of
+                                   DotSepIdent [str] =>
+                                     if isIdent AllowDashes str then Just str
+                                     else Nothing
+                                   _ => Nothing)
+
+sep' : Rule ()
+sep' = terminal "Expected separator"
+                (\x => case tok x of
+                            Separator => Just ()
+                            _ => Nothing)
+
+export
+sep : Rule t -> Rule (List t)
+sep rule = sepBy1 sep' rule

--- a/src/Parser/Rule/Source.idr
+++ b/src/Parser/Rule/Source.idr
@@ -9,12 +9,12 @@ import Core.TT
 %default total
 
 public export
-SourceRule : Type -> Type
-SourceRule = Rule SourceToken
+Rule : Type -> Type
+Rule = Rule Token
 
 public export
 SourceEmptyRule : Type -> Type
-SourceEmptyRule = EmptyRule SourceToken
+SourceEmptyRule = EmptyRule Token
 
 export
 eoi : SourceEmptyRule ()
@@ -22,48 +22,48 @@ eoi
     = do nextIs "Expected end of input" (isEOI . tok)
          pure ()
   where
-    isEOI : SourceToken -> Bool
+    isEOI : Token -> Bool
     isEOI EndInput = True
     isEOI _ = False
 
 export
-constant : SourceRule Constant
+constant : Rule Constant
 constant
     = terminal "Expected constant"
                (\x => case tok x of
-                           Literal i => Just (BI i)
-                           StrLit s => case escape s of
-                                            Nothing => Nothing
-                                            Just s' => Just (Str s')
                            CharLit c => case getCharLit c of
                                              Nothing => Nothing
                                              Just c' => Just (Ch c')
-                           DoubleLit d => Just (Db d)
-                           NSIdent ["Int"] => Just IntType
-                           NSIdent ["Integer"] => Just IntegerType
-                           NSIdent ["String"] => Just StringType
-                           NSIdent ["Char"] => Just CharType
-                           NSIdent ["Double"] => Just DoubleType
+                           DoubleLit d  => Just (Db d)
+                           IntegerLit i => Just (BI i)
+                           StringLit s => case escape s of
+                                               Nothing => Nothing
+                                               Just s' => Just (Str s')
+                           Ident "Char"    => Just CharType
+                           Ident "Double"  => Just DoubleType
+                           Ident "Int"     => Just IntType
+                           Ident "Integer" => Just IntegerType
+                           Ident "String"  => Just StringType
                            _ => Nothing)
 
 export
-intLit : SourceRule Integer
+intLit : Rule Integer
 intLit
     = terminal "Expected integer literal"
                (\x => case tok x of
-                           Literal i => Just i
+                           IntegerLit i => Just i
                            _ => Nothing)
 
 export
-strLit : SourceRule String
+strLit : Rule String
 strLit
     = terminal "Expected string literal"
                (\x => case tok x of
-                           StrLit s => Just s
+                           StringLit s => Just s
                            _ => Nothing)
 
 export
-recField : SourceRule Name
+recField : Rule Name
 recField
     = terminal "Expected record field"
                (\x => case tok x of
@@ -71,7 +71,7 @@ recField
                            _ => Nothing)
 
 export
-symbol : String -> SourceRule ()
+symbol : String -> Rule ()
 symbol req
     = terminal ("Expected '" ++ req ++ "'")
                (\x => case tok x of
@@ -80,7 +80,7 @@ symbol req
                            _ => Nothing)
 
 export
-keyword : String -> SourceRule ()
+keyword : String -> Rule ()
 keyword req
     = terminal ("Expected '" ++ req ++ "'")
                (\x => case tok x of
@@ -89,16 +89,16 @@ keyword req
                            _ => Nothing)
 
 export
-exactIdent : String -> SourceRule ()
+exactIdent : String -> Rule ()
 exactIdent req
     = terminal ("Expected " ++ req)
                (\x => case tok x of
-                           NSIdent [s] => if s == req then Just ()
-                                                      else Nothing
+                           Ident s => if s == req then Just ()
+                                      else Nothing
                            _ => Nothing)
 
 export
-pragma : String -> SourceRule ()
+pragma : String -> Rule ()
 pragma n =
   terminal ("Expected pragma " ++ n)
     (\x => case tok x of
@@ -109,7 +109,7 @@ pragma n =
       _ => Nothing)
 
 export
-operator : SourceRule Name
+operator : Rule Name
 operator
     = terminal "Expected operator"
                (\x => case tok x of
@@ -119,27 +119,28 @@ operator
                                    else Just (UN s)
                            _ => Nothing)
 
-identPart : SourceRule String
+identPart : Rule String
 identPart
     = terminal "Expected name"
                (\x => case tok x of
-                           NSIdent [str] => Just str
+                           Ident str => Just str
                            _ => Nothing)
 
 export
-nsIdent : SourceRule (List String)
-nsIdent
+namespacedIdent : Rule (List String)
+namespacedIdent
     = terminal "Expected namespaced name"
         (\x => case tok x of
-            NSIdent ns => Just ns
+            DotSepIdent ns => Just ns
+            Ident i => Just $ [i]
             _ => Nothing)
 
 export
-unqualifiedName : SourceRule String
+unqualifiedName : Rule String
 unqualifiedName = identPart
 
 export
-holeName : SourceRule String
+holeName : Rule String
 holeName
     = terminal "Expected hole name"
                (\x => case tok x of
@@ -152,17 +153,17 @@ reservedNames
        "Lazy", "Inf", "Force", "Delay"]
 
 export
-name : SourceRule Name
+name : Rule Name
 name = opNonNS <|> do
-  ns <- nsIdent
+  ns <- namespacedIdent
   opNS ns <|> nameNS ns
  where
   reserved : String -> Bool
   reserved n = n `elem` reservedNames
 
-  nameNS : List String -> Grammar (TokenData SourceToken) False Name
+  nameNS : List String -> SourceEmptyRule Name
   nameNS [] = pure $ UN "IMPOSSIBLE"
-  nameNS [x] = 
+  nameNS [x] =
     if reserved x
       then fail $ "can't use reserved name " ++ x
       else pure $ UN x
@@ -171,10 +172,10 @@ name = opNonNS <|> do
       then fail $ "can't use reserved name " ++ x
       else pure $ NS xs (UN x)
 
-  opNonNS : SourceRule Name
+  opNonNS : Rule Name
   opNonNS = symbol "(" *> (operator <|> recField) <* symbol ")"
 
-  opNS : List String -> SourceRule Name
+  opNS : List String -> Rule Name
   opNS ns = do
     symbol ".("
     n <- (operator <|> recField)
@@ -238,7 +239,7 @@ checkValid (AfterPos x) c = if c >= x
 checkValid EndOfBlock c = fail "End of block"
 
 ||| Any token which indicates the end of a statement/block
-isTerminator : SourceToken -> Bool
+isTerminator : Token -> Bool
 isTerminator (Symbol ",") = True
 isTerminator (Symbol "]") = True
 isTerminator (Symbol ";") = True
@@ -318,8 +319,8 @@ terminator valid laststart
    afterDedent EndOfBlock col = pure EndOfBlock
 
 -- Parse an entry in a block
-blockEntry : ValidIndent -> (IndentInfo -> SourceRule ty) ->
-             SourceRule (ty, ValidIndent)
+blockEntry : ValidIndent -> (IndentInfo -> Rule ty) ->
+             Rule (ty, ValidIndent)
 blockEntry valid rule
     = do col <- column
          checkValid valid col
@@ -327,7 +328,7 @@ blockEntry valid rule
          valid' <- terminator valid col
          pure (p, valid')
 
-blockEntries : ValidIndent -> (IndentInfo -> SourceRule ty) ->
+blockEntries : ValidIndent -> (IndentInfo -> Rule ty) ->
                SourceEmptyRule (List ty)
 blockEntries valid rule
      = do eoi; pure []
@@ -337,7 +338,7 @@ blockEntries valid rule
    <|> pure []
 
 export
-block : (IndentInfo -> SourceRule ty) -> SourceEmptyRule (List ty)
+block : (IndentInfo -> Rule ty) -> SourceEmptyRule (List ty)
 block item
     = do symbol "{"
          commit
@@ -353,7 +354,7 @@ block item
 ||| by curly braces). `rule` is a function of the actual indentation
 ||| level.
 export
-blockAfter : Int -> (IndentInfo -> SourceRule ty) -> SourceEmptyRule (List ty)
+blockAfter : Int -> (IndentInfo -> Rule ty) -> SourceEmptyRule (List ty)
 blockAfter mincol item
     = do symbol "{"
          commit
@@ -366,7 +367,7 @@ blockAfter mincol item
             else blockEntries (AtPos col) item
 
 export
-blockWithOptHeaderAfter : Int -> (IndentInfo -> SourceRule hd) -> (IndentInfo -> SourceRule ty) -> SourceEmptyRule (Maybe hd, List ty)
+blockWithOptHeaderAfter : Int -> (IndentInfo -> Rule hd) -> (IndentInfo -> Rule ty) -> SourceEmptyRule (Maybe hd, List ty)
 blockWithOptHeaderAfter {ty} mincol header item
     = do symbol "{"
          commit
@@ -379,7 +380,7 @@ blockWithOptHeaderAfter {ty} mincol header item
                     ps <- blockEntries (AtPos col) item
                     pure (map fst hidt, ps)
   where
-  restOfBlock : Maybe (hd, ValidIndent) -> SourceRule (Maybe hd, List ty)
+  restOfBlock : Maybe (hd, ValidIndent) -> Rule (Maybe hd, List ty)
   restOfBlock (Just (h, idt)) = do ps <- blockEntries idt item
                                    symbol "}"
                                    pure (Just h, ps)
@@ -388,7 +389,7 @@ blockWithOptHeaderAfter {ty} mincol header item
                            pure (Nothing, ps)
 
 export
-nonEmptyBlock : (IndentInfo -> SourceRule ty) -> SourceRule (List ty)
+nonEmptyBlock : (IndentInfo -> Rule ty) -> Rule (List ty)
 nonEmptyBlock item
     = do symbol "{"
          commit

--- a/src/Parser/Source.idr
+++ b/src/Parser/Source.idr
@@ -3,8 +3,6 @@ module Parser.Source
 import public Parser.Lexer.Source
 import public Parser.Rule.Source
 import public Parser.Unlit
-import public Text.Lexer
-import public Text.Parser
 
 import System.File
 import Utils.Either
@@ -13,21 +11,21 @@ import Utils.Either
 
 export
 runParserTo : {e : _} ->
-              Maybe LiterateStyle -> (TokenData SourceToken -> Bool) ->
-              String -> Grammar (TokenData SourceToken) e ty -> Either ParseError ty
+              Maybe LiterateStyle -> (TokenData Token -> Bool) ->
+              String -> Grammar (TokenData Token) e ty -> Either (ParseError Token) ty
 runParserTo lit pred str p
     = do str    <- mapError LitFail $ unlit lit str
          toks   <- mapError LexFail $ lexTo pred str
-         parsed <- mapError mapParseError $ parse p toks
+         parsed <- mapError toGenericParsingError $ parse p toks
          Right (fst parsed)
 
 export
 runParser : {e : _} ->
-            Maybe LiterateStyle -> String -> Grammar (TokenData SourceToken) e ty -> Either ParseError ty
+            Maybe LiterateStyle -> String -> Grammar (TokenData Token) e ty -> Either (ParseError Token) ty
 runParser lit = runParserTo lit (const False)
 
-export covering -- readFile might not terminate
-parseFile : (fn : String) -> SourceRule ty -> IO (Either ParseError ty)
+export covering
+parseFile : (fn : String) -> Rule ty -> IO (Either (ParseError Token) ty)
 parseFile fn p
     = do Right str <- readFile fn
              | Left err => pure (Left (FileFail err))

--- a/src/Parser/Support.idr
+++ b/src/Parser/Support.idr
@@ -1,6 +1,5 @@
 module Parser.Support
 
-import public Parser.Lexer.Source
 import public Text.Lexer
 import public Text.Parser
 
@@ -13,13 +12,14 @@ import System.File
 %default total
 
 public export
-data ParseError = ParseFail String (Maybe (Int, Int)) (List SourceToken)
-                | LexFail (Int, Int, String)
-                | FileFail FileError
-                | LitFail LiterateError
+data ParseError tok
+  = ParseFail String (Maybe (Int, Int)) (List tok)
+  | LexFail   (Int, Int, String)
+  | FileFail  FileError
+  | LitFail   LiterateError
 
 export
-Show ParseError where
+Show tok => Show (ParseError tok) where
   show (ParseFail err loc toks)
       = "Parse error: " ++ err ++ " (next tokens: "
             ++ show (take 10 toks) ++ ")"
@@ -31,9 +31,9 @@ Show ParseError where
       = "Lit error(s) at " ++ show (c, l) ++ " input: " ++ str
 
 export
-mapParseError : ParseError (TokenData SourceToken) -> ParseError
-mapParseError (Error err [])      = ParseFail err Nothing []
-mapParseError (Error err (t::ts)) = ParseFail err (Just (line t, col t)) (map tok (t::ts))
+toGenericParsingError : ParsingError (TokenData token) -> ParseError token
+toGenericParsingError (Error err [])      = ParseFail err Nothing []
+toGenericParsingError (Error err (t::ts)) = ParseFail err (Just (line t, col t)) (map tok (t::ts))
 
 export
 hex : Char -> Maybe Int

--- a/src/TTImp/Parser.idr
+++ b/src/TTImp/Parser.idr
@@ -12,7 +12,7 @@ import        Data.List
 import        Data.List.Views
 import        Data.Strings
 
-topDecl : FileName -> IndentInfo -> SourceRule ImpDecl
+topDecl : FileName -> IndentInfo -> Rule ImpDecl
 -- All the clauses get parsed as one-clause definitions. Collect any
 -- neighbouring clauses with the same function name into one definition.
 export
@@ -26,7 +26,7 @@ collectDefs : List ImpDecl -> List ImpDecl
 %hide Lexer.Core.(<|>)
 %hide Prelude.(<|>)
 
-atom : FileName -> SourceRule RawImp
+atom : FileName -> Rule RawImp
 atom fname
     = do start <- location
          x <- constant
@@ -62,7 +62,7 @@ atom fname
          end <- location
          pure (IHole (MkFC fname start end) x)
 
-visOption : SourceRule Visibility
+visOption : Rule Visibility
 visOption
     = do keyword "public"
          keyword "export"
@@ -77,7 +77,7 @@ visibility
     = visOption
   <|> pure Private
 
-totalityOpt : SourceRule TotalReq
+totalityOpt : Rule TotalReq
 totalityOpt
     = do keyword "partial"
          pure PartialOK
@@ -86,11 +86,11 @@ totalityOpt
   <|> do keyword "covering"
          pure CoveringOnly
 
-fnOpt : SourceRule FnOpt
+fnOpt : Rule FnOpt
 fnOpt = do x <- totalityOpt
            pure $ Totality x
 
-fnDirectOpt : SourceRule FnOpt
+fnDirectOpt : Rule FnOpt
 fnDirectOpt
     = do pragma "hint"
          pure (Hint True)
@@ -105,7 +105,7 @@ fnDirectOpt
   <|> do pragma "extern"
          pure ExternFn
 
-visOpt : SourceRule (Either Visibility FnOpt)
+visOpt : Rule (Either Visibility FnOpt)
 visOpt
     = do vis <- visOption
          pure (Left vis)
@@ -127,7 +127,7 @@ getRight : Either a b -> Maybe b
 getRight (Left _) = Nothing
 getRight (Right v) = Just v
 
-bindSymbol : SourceRule (PiInfo RawImp)
+bindSymbol : Rule (PiInfo RawImp)
 bindSymbol
     = do symbol "->"
          pure Explicit
@@ -135,7 +135,7 @@ bindSymbol
          pure AutoImplicit
 
 mutual
-  appExpr : FileName -> IndentInfo -> SourceRule RawImp
+  appExpr : FileName -> IndentInfo -> Rule RawImp
   appExpr fname indents
       = case_ fname indents
     <|> lazy fname indents
@@ -155,7 +155,7 @@ mutual
           = applyExpImp start end (IImplicitApp (MkFC fname start end) f n imp) args
 
   argExpr : FileName -> IndentInfo ->
-            SourceRule (Either RawImp (Maybe Name, RawImp))
+            Rule (Either RawImp (Maybe Name, RawImp))
   argExpr fname indents
       = do continue indents
            arg <- simpleExpr fname indents
@@ -164,7 +164,7 @@ mutual
            arg <- implicitArg fname indents
            pure (Right arg)
 
-  implicitArg : FileName -> IndentInfo -> SourceRule (Maybe Name, RawImp)
+  implicitArg : FileName -> IndentInfo -> Rule (Maybe Name, RawImp)
   implicitArg fname indents
       = do start <- location
            symbol "{"
@@ -183,7 +183,7 @@ mutual
            symbol "}"
            pure (Nothing, tm)
 
-  as : FileName -> IndentInfo -> SourceRule RawImp
+  as : FileName -> IndentInfo -> Rule RawImp
   as fname indents
       = do start <- location
            x <- unqualifiedName
@@ -192,7 +192,7 @@ mutual
            end <- location
            pure (IAs (MkFC fname start end) UseRight (UN x) pat)
 
-  simpleExpr : FileName -> IndentInfo -> SourceRule RawImp
+  simpleExpr : FileName -> IndentInfo -> Rule RawImp
   simpleExpr fname indents
       = as fname indents
     <|> atom fname
@@ -223,7 +223,7 @@ mutual
            = IPi fc rig p n ty (pibindAll fc p rest scope)
 
   bindList : FileName -> FilePos -> IndentInfo ->
-             SourceRule (List (RigCount, Name, RawImp))
+             Rule (List (RigCount, Name, RawImp))
   bindList fname start indents
       = sepBy1 (symbol ",")
                (do rigc <- multiplicity
@@ -238,7 +238,7 @@ mutual
 
 
   pibindListName : FileName -> FilePos -> IndentInfo ->
-                   SourceRule (List (RigCount, Name, RawImp))
+                   Rule (List (RigCount, Name, RawImp))
   pibindListName fname start indents
        = do rigc <- multiplicity
             ns <- sepBy1 (symbol ",") unqualifiedName
@@ -256,13 +256,13 @@ mutual
                     pure (rig, n, ty))
 
   pibindList : FileName -> FilePos -> IndentInfo ->
-               SourceRule (List (RigCount, Maybe Name, RawImp))
+               Rule (List (RigCount, Maybe Name, RawImp))
   pibindList fname start indents
     = do params <- pibindListName fname start indents
          pure $ map (\(rig, n, ty) => (rig, Just n, ty)) params
 
 
-  autoImplicitPi : FileName -> IndentInfo -> SourceRule RawImp
+  autoImplicitPi : FileName -> IndentInfo -> Rule RawImp
   autoImplicitPi fname indents
       = do start <- location
            symbol "{"
@@ -275,7 +275,7 @@ mutual
            end <- location
            pure (pibindAll (MkFC fname start end) AutoImplicit binders scope)
 
-  forall_ : FileName -> IndentInfo -> SourceRule RawImp
+  forall_ : FileName -> IndentInfo -> Rule RawImp
   forall_ fname indents
       = do start <- location
            keyword "forall"
@@ -290,7 +290,7 @@ mutual
            end <- location
            pure (pibindAll (MkFC fname start end) Implicit binders scope)
 
-  implicitPi : FileName -> IndentInfo -> SourceRule RawImp
+  implicitPi : FileName -> IndentInfo -> Rule RawImp
   implicitPi fname indents
       = do start <- location
            symbol "{"
@@ -301,7 +301,7 @@ mutual
            end <- location
            pure (pibindAll (MkFC fname start end) Implicit binders scope)
 
-  explicitPi : FileName -> IndentInfo -> SourceRule RawImp
+  explicitPi : FileName -> IndentInfo -> Rule RawImp
   explicitPi fname indents
       = do start <- location
            symbol "("
@@ -312,7 +312,7 @@ mutual
            end <- location
            pure (pibindAll (MkFC fname start end) exp binders scope)
 
-  lam : FileName -> IndentInfo -> SourceRule RawImp
+  lam : FileName -> IndentInfo -> Rule RawImp
   lam fname indents
       = do start <- location
            symbol "\\"
@@ -328,7 +328,7 @@ mutual
        bindAll fc ((rig, n, ty) :: rest) scope
            = ILam fc rig Explicit (Just n) ty (bindAll fc rest scope)
 
-  let_ : FileName -> IndentInfo -> SourceRule RawImp
+  let_ : FileName -> IndentInfo -> Rule RawImp
   let_ fname indents
       = do start <- location
            keyword "let"
@@ -353,7 +353,7 @@ mutual
            end <- location
            pure (ILocal (MkFC fname start end) (collectDefs ds) scope)
 
-  case_ : FileName -> IndentInfo -> SourceRule RawImp
+  case_ : FileName -> IndentInfo -> Rule RawImp
   case_ fname indents
       = do start <- location
            keyword "case"
@@ -364,14 +364,14 @@ mutual
            pure (let fc = MkFC fname start end in
                      ICase fc scr (Implicit fc False) alts)
 
-  caseAlt : FileName -> IndentInfo -> SourceRule ImpClause
+  caseAlt : FileName -> IndentInfo -> Rule ImpClause
   caseAlt fname indents
       = do start <- location
            lhs <- appExpr fname indents
            caseRHS fname indents start lhs
 
   caseRHS : FileName -> IndentInfo -> (Int, Int) -> RawImp ->
-            SourceRule ImpClause
+            Rule ImpClause
   caseRHS fname indents start lhs
       = do symbol "=>"
            continue indents
@@ -384,7 +384,7 @@ mutual
            end <- location
            pure (ImpossibleClause (MkFC fname start end) lhs)
 
-  record_ : FileName -> IndentInfo -> SourceRule RawImp
+  record_ : FileName -> IndentInfo -> Rule RawImp
   record_ fname indents
       = do start <- location
            keyword "record"
@@ -396,7 +396,7 @@ mutual
            end <- location
            pure (IUpdate (MkFC fname start end) fs sc)
 
-  field : FileName -> IndentInfo -> SourceRule IFieldUpdate
+  field : FileName -> IndentInfo -> Rule IFieldUpdate
   field fname indents
       = do path <- sepBy1 (symbol "->") unqualifiedName
            upd <- (do symbol "="; pure ISetField)
@@ -405,7 +405,7 @@ mutual
            val <- appExpr fname indents
            pure (upd path val)
 
-  rewrite_ : FileName -> IndentInfo -> SourceRule RawImp
+  rewrite_ : FileName -> IndentInfo -> Rule RawImp
   rewrite_ fname indents
       = do start <- location
            keyword "rewrite"
@@ -415,7 +415,7 @@ mutual
            end <- location
            pure (IRewrite (MkFC fname start end) rule tm)
 
-  lazy : FileName -> IndentInfo -> SourceRule RawImp
+  lazy : FileName -> IndentInfo -> Rule RawImp
   lazy fname indents
       = do start <- location
            exactIdent "Lazy"
@@ -439,7 +439,7 @@ mutual
            pure (IForce (MkFC fname start end) tm)
 
 
-  binder : FileName -> IndentInfo -> SourceRule RawImp
+  binder : FileName -> IndentInfo -> Rule RawImp
   binder fname indents
       = autoImplicitPi fname indents
     <|> forall_ fname indents
@@ -448,7 +448,7 @@ mutual
     <|> lam fname indents
     <|> let_ fname indents
 
-  typeExpr : FileName -> IndentInfo -> SourceRule RawImp
+  typeExpr : FileName -> IndentInfo -> Rule RawImp
   typeExpr fname indents
       = do start <- location
            arg <- appExpr fname indents
@@ -467,10 +467,10 @@ mutual
                   (mkPi start end a as)
 
   export
-  expr : FileName -> IndentInfo -> SourceRule RawImp
+  expr : FileName -> IndentInfo -> Rule RawImp
   expr = typeExpr
 
-tyDecl : FileName -> IndentInfo -> SourceRule ImpTy
+tyDecl : FileName -> IndentInfo -> Rule ImpTy
 tyDecl fname indents
     = do start <- location
          n <- name
@@ -483,7 +483,7 @@ tyDecl fname indents
 mutual
   parseRHS : (withArgs : Nat) ->
              FileName -> IndentInfo -> (Int, Int) -> RawImp ->
-             SourceRule (Name, ImpClause)
+             Rule (Name, ImpClause)
   parseRHS withArgs fname indents start lhs
       = do symbol "="
            commit
@@ -518,7 +518,7 @@ mutual
   ifThenElse True t e = t
   ifThenElse False t e = e
 
-  clause : Nat -> FileName -> IndentInfo -> SourceRule (Name, ImpClause)
+  clause : Nat -> FileName -> IndentInfo -> Rule (Name, ImpClause)
   clause withArgs fname indents
       = do start <- location
            lhs <- expr fname indents
@@ -531,7 +531,7 @@ mutual
       applyArgs f [] = f
       applyArgs f ((fc, a) :: args) = applyArgs (IApp fc f a) args
 
-      parseWithArg : SourceRule (FC, RawImp)
+      parseWithArg : Rule (FC, RawImp)
       parseWithArg
           = do symbol "|"
                start <- location
@@ -539,14 +539,14 @@ mutual
                end <- location
                pure (MkFC fname start end, tm)
 
-definition : FileName -> IndentInfo -> SourceRule ImpDecl
+definition : FileName -> IndentInfo -> Rule ImpDecl
 definition fname indents
     = do start <- location
          nd <- clause 0 fname indents
          end <- location
          pure (IDef (MkFC fname start end) (fst nd) [snd nd])
 
-dataOpt : SourceRule DataOpt
+dataOpt : Rule DataOpt
 dataOpt
     = do exactIdent "noHints"
          pure NoHints
@@ -556,7 +556,7 @@ dataOpt
          ns <- some name
          pure (SearchBy ns)
 
-dataDecl : FileName -> IndentInfo -> SourceRule ImpData
+dataDecl : FileName -> IndentInfo -> Rule ImpData
 dataDecl fname indents
     = do start <- location
          keyword "data"
@@ -572,7 +572,7 @@ dataDecl fname indents
          end <- location
          pure (MkImpData (MkFC fname start end) n ty opts cs)
 
-recordParam : FileName -> IndentInfo -> SourceRule (List (Name, RigCount, PiInfo RawImp, RawImp))
+recordParam : FileName -> IndentInfo -> Rule (List (Name, RigCount, PiInfo RawImp, RawImp))
 recordParam fname indents
     = do symbol "("
          start <- location
@@ -597,7 +597,7 @@ recordParam fname indents
          end <- location
          pure [(n, top, Explicit, Implicit (MkFC fname start end) False)]
 
-fieldDecl : FileName -> IndentInfo -> SourceRule (List IField)
+fieldDecl : FileName -> IndentInfo -> Rule (List IField)
 fieldDecl fname indents
       = do symbol "{"
            commit
@@ -609,7 +609,7 @@ fieldDecl fname indents
            atEnd indents
            pure fs
   where
-    fieldBody : PiInfo RawImp -> SourceRule (List IField)
+    fieldBody : PiInfo RawImp -> Rule (List IField)
     fieldBody p
         = do start <- location
              ns <- sepBy1 (symbol ",") unqualifiedName
@@ -619,7 +619,7 @@ fieldDecl fname indents
              pure (map (\n => MkIField (MkFC fname start end)
                                        linear p (UN n) ty) ns)
 
-recordDecl : FileName -> IndentInfo -> SourceRule ImpDecl
+recordDecl : FileName -> IndentInfo -> Rule ImpDecl
 recordDecl fname indents
     = do start <- location
          vis <- visibility
@@ -638,14 +638,14 @@ recordDecl fname indents
                    IRecord fc Nothing vis
                            (MkImpRecord fc n params dc (concat flds)))
 
-namespaceDecl : SourceRule (List String)
+namespaceDecl : Rule (List String)
 namespaceDecl
     = do keyword "namespace"
          commit
-         ns <- nsIdent
+         ns <- namespacedIdent
          pure ns
 
-directive : FileName -> IndentInfo -> SourceRule ImpDecl
+directive : FileName -> IndentInfo -> Rule ImpDecl
 directive fname indents
     = do pragma "logging"
          commit
@@ -672,7 +672,7 @@ directive fname indents
                    IPragma (\c, nest, env => setRewrite {c} fc eq rw))
     -}
 -- Declared at the top
--- topDecl : FileName -> IndentInfo -> SourceRule ImpDecl
+-- topDecl : FileName -> IndentInfo -> Rule ImpDecl
 topDecl fname indents
     = do start <- location
          vis <- visibility
@@ -720,14 +720,14 @@ collectDefs (d :: ds)
 
 -- full programs
 export
-prog : FileName -> SourceRule (List ImpDecl)
+prog : FileName -> Rule (List ImpDecl)
 prog fname
     = do ds <- nonEmptyBlock (topDecl fname)
          pure (collectDefs ds)
 
 -- TTImp REPL commands
 export
-command : SourceRule ImpREPL
+command : Rule ImpREPL
 command
     = do symbol ":"; exactIdent "t"
          tm <- expr "(repl)" init

--- a/src/Text/Parser/Core.idr
+++ b/src/Text/Parser/Core.idr
@@ -272,14 +272,14 @@ mutual
   -- doParse _ _ _ = Failure True True "Help the coverage checker!" []
 
 public export
-data ParseError tok = Error String (List tok)
+data ParsingError tok = Error String (List tok)
 
 ||| Parse a list of tokens according to the given grammar. If successful,
 ||| returns a pair of the parse result and the unparsed tokens (the remaining
 ||| input).
 export
 parse : {c : Bool} -> (act : Grammar tok c ty) -> (xs : List tok) ->
-        Either (ParseError tok) (ty, List tok)
+        Either (ParsingError tok) (ty, List tok)
 parse act xs
     = case doParse False act xs of
            Failure _ _ msg ts => Left (Error msg ts)

--- a/src/Utils/String.idr
+++ b/src/Utils/String.idr
@@ -3,6 +3,12 @@ module Utils.String
 %default total
 
 export
+dotSep : List String -> String
+dotSep [] = ""
+dotSep [x] = x
+dotSep (x :: xs) = x ++ concat ["." ++ y | y <- xs]
+
+export
 stripQuotes : (str : String) -> String
 stripQuotes str = prim__strSubstr 1 (lengthInt - 2) str
   where


### PR DESCRIPTION
This has two commits, the first one refactors SourceToken a bit and the second one implements an (unpolished) Package Lexer/Parser and refactors Idris/Package.idr to use this new Lexer/Parser.

Feedback is appreciated. First part is #89.

One pro is that package names can now have dashes in their name UwU

## Cleanup of SourceToken

There are many organizational and consistency changes, one of the more important ones being `Literal` being rename `StringLit` to correspond with `CharLit`, `IntegerLit`, `DoubleLit` and extracting more common code to Parser/Lexer/Common.

## Change to `ParseError tok` and `ParseError`

`ParseError tok` was renamed `ParsingError tok` and `ParseError` was refactored to `ParseError tok` to accept a token type.