### PR TITLE
Add additional information on requirements in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,18 +1,20 @@
 Installing
 ==========
 
-The easiest way to install is via the existing generated Scheme code. The
-requirements are:
+The easiest way to install is via the existing generated Scheme code.
+The requirements are:
 
-* A Scheme compiler; either Chez Scheme (default), or Racket
-* `bash`, with `realpath`. On Linux, you probably already have this. On
-  a Mac, you can install this with `brew install coreutils`.
+* A Scheme compiler; either Chez Scheme (default), or Racket.
+* `bash`, with `realpath`. On Linux, you probably already have this.
+  On a Mac, you can install this with `brew install coreutils`.
 
 On Windows, it has been reported that installing via `MSYS2` works
 (https://www.msys2.org/). On Raspberry Pi, you can bootstrap via Racket.
 
 By default, code generation is via Chez Scheme. You can use Racket instead,
 by setting the environment variable `IDRIS2_CG=racket` before running `make`.
+If you install Chez Scheme from source files, building it locally,
+make sure you run `./configure --threads` to build multithreading support in.
 
 1: Set the PREFIX
 -----------------
@@ -56,7 +58,7 @@ If all is well, to install, type:
 ----------------------------------------------------
 
 If you have [Idris-2-in-Idris-1](https://github.com/edwinb/Idris2-boot)
-installed: 
+installed:
 
 * `make all IDRIS2_BOOT=idris2boot`
 * `make install IDRIS2_BOOT=idris2boot`


### PR DESCRIPTION
and improve formatting in terminal.

Why:
This may help people prevent or resolve following issues
when running `make bootstrap SCHEME=chez`

- missing clang
```
make: clang: Command not found
make[1]: Entering directory 'support/c'
make[1]: clang: Command not found
```
- missing Chez thread support
```
Compiling idris2_app/idris2-boot.ss with output to idris2_app/idris2-boot.so
Exception: attempt to reference unbound identifier
make-thread-parameter at line 171, char 30 of idris2_app/idris2-boot.ss
```

`$ less INSTALL.md` before:
![install-less-before](https://user-images.githubusercontent.com/578608/82736416-95be9c00-9d21-11ea-8be5-fe34b983afd8.jpg)

`$ less INSTALL.md` after:
![install-less-after](https://user-images.githubusercontent.com/578608/82736429-a4a54e80-9d21-11ea-9895-5c560a0b52cc.jpg)

