### PR TITLE
Make System.Path work with String

### DIFF
--- a/libs/contrib/System/Path.idr
+++ b/libs/contrib/System/Path.idr
@@ -25,43 +25,44 @@ export
 pathSeparator : Char
 pathSeparator = if isWindows then ';' else ':'
 
-||| Windows' path prefixes.
-|||
-||| @ UNC Windows' Uniform Naming Convention, e.g., a network sharing
-|||   directory: `\\host\c$\Windows\System32`
-||| @ Disk the drive, e.g., "C:". The disk character is in upper case
+||| Windows' path prefixes of path component.
 public export
-data Volumn = UNC String String
-            | Disk Char
+data Volumn
+  = 
+  ||| Windows' Uniform Naming Convention, e.g., a network sharing
+  ||| directory: `\\host\c$\Windows\System32`
+  UNC String String |
+  ||| The drive, e.g., "C:". The disk character is in upper case
+  Disk Char
 
-||| A single body of path.
-|||
-||| @ CurDir "."
-||| @ ParentDir ".."
-||| @ Normal common directory or file
+||| A single body of path component.
 public export
-data Body = CurDir
-          | ParentDir
-          | Normal String
+data Body
+  = 
+  ||| Represents "."
+  CurDir |
+  ||| Represents ".."
+  ParentDir |
+  ||| Common directory or file
+  Normal String
 
-||| A cross-platform file system path.
+||| A parsed cross-platform file system path.
 |||
-||| The function `parse` is the most common way to construct a Path
-||| from String, and the function `show` converts in reverse.
+||| The function `parse` constructs a Path component from String,
+||| and the function `show` converts in reverse.
 |||
 ||| Trailing separator is only used for display and is ignored while
 ||| comparing paths.
-|||
-||| @ volumn Windows' path prefix (only on Windows)
-||| @ hasRoot whether the path contains a root
-||| @ body path bodies
-||| @ hasTrailSep whether the path terminates with a separator
 public export
 record Path where
     constructor MkPath
+    ||| Windows' path prefix (only on Windows)
     volumn : Maybe Volumn
+    ||| Whether the path contains a root
     hasRoot : Bool
+    ||| Path bodies
     body : List Body
+    ||| Whether the path terminates with a separator
     hasTrailSep : Bool
 
 export
@@ -215,17 +216,18 @@ parsePath = do vol <- optional parseVolumn
                trailSep <- optional bodySeparator
                pure $ MkPath vol (isJust root) body (isJust trailSep)
 
-||| Attempt to parse a String into Path.
+||| Parse a String into Path component.
 |||
-||| Returns a error message if the parser fails.
+||| Returns the path parsed as much as possible from left to right, the 
+||| invalid parts on the right end is ignored.
 |||
-||| The parser is relaxed to accept invalid inputs. Relaxing rules:
+||| Some kind of invalid path is accepted. Relaxing rules:
 |||
-||| - Both slash('/') and backslash('\\') are parsed as directory separator,
-|||   regardless of the platform;
-||| - Invalid characters in path body in allowed, e.g., glob like "/root/*";
-||| - Ignoring the verbatim prefix(`\\?\`) that disables the forward
-|||   slash (Windows only).
+||| - Both slash('/') and backslash('\\') are parsed as valid directory
+|||   separator, regardless of the platform;
+||| - Any characters in path body in allowed, e.g., glob like "/root/*";
+||| - Verbatim prefix(`\\?\`) that disables the forward
+|||   slash (Windows only) is ignored.
 |||
 ||| ```idris example
 ||| parse "C:\\Windows/System32"
@@ -279,7 +281,7 @@ isRelative = not . isAbsolute
 ||| - If the right path has a volumn but no root, it replaces left.
 |||
 ||| ```idris example
-||| pure $ !(parse "/usr") </> !(parse "local/etc")
+||| "/usr" </> "local/etc"
 ||| ```
 export
 (</>) : (left : String) -> (right : String) -> String

--- a/libs/contrib/System/Path.idr
+++ b/libs/contrib/System/Path.idr
@@ -10,7 +10,8 @@ import Text.Lexer
 import Text.Parser
 import Text.Quantity
 
-private
+infixl 7 </>
+
 isWindows : Bool
 isWindows = os `elem` ["windows", "mingw32", "cygwin32"]
 
@@ -87,175 +88,6 @@ public export
 emptyPath : Path
 emptyPath = MkPath Nothing False [] False
 
-||| Returns true if the path is absolute.
-|||
-||| - On Unix, a path is absolute if it starts with the root,
-|||   so isAbsolute and hasRoot are equivalent.
-|||
-||| - On Windows, a path is absolute if it has a volumn and starts
-|||   with the root. e.g., `c:\\windows` is absolute, while `c:temp`
-|||   and `\temp` are not. In addition, a path with UNC volumn is absolute.
-export
-isAbsolute : Path -> Bool
-isAbsolute p = if isWindows
-                 then case p.volumn of
-                           Just (UNC _ _) => True
-                           Just (Disk _) => p.hasRoot
-                           Nothing => False
-                 else p.hasRoot
-
-||| Returns true if the path is relative, i.e., not absolute.
-export
-isRelative : Path -> Bool
-isRelative = not . isAbsolute
-
-||| Appends the right path to the left one.
-|||
-||| If the path on the right is absolute, it replaces the left path.
-|||
-||| On Windows:
-|||
-||| - If the right path has a root but no volumn (e.g., `\windows`), it
-|||   replaces everything except for the volumn (if any) of left.
-||| - If the right path has a volumn but no root, it replaces left.
-|||
-||| ```idris example
-||| pure $ !(parse "/usr") `append` !(parse "local/etc")
-||| ```
-export
-append : (left : Path) -> (right : Path) -> Path
-append l r = if isAbsolute r || isJust r.volumn
-                then r
-                else if hasRoot r
-                  then record { volumn = l.volumn } r
-                  else record { body = l.body ++ r.body,
-                                hasTrailSep = r.hasTrailSep } l
-
-||| Returns the path without its final component, if there is one.
-|||
-||| Returns Nothing if the path terminates in a root or volumn.
-export
-parent : Path -> Maybe Path
-parent p = case p.body of
-                [] => Nothing
-                (x::xs) => Just $ record { body = init (x::xs),
-                                           hasTrailSep = False } p
-
-||| Returns a list of all parents of the path, longest first,
-||| self excluded.
-|||
-||| For example, the parent of the path, and the parent of the
-||| parent of the path, and so on. The list terminates in a
-||| root or volumn (if any).
-export
-parents : Path -> List Path
-parents p = drop 1 $ iterate parent p
-
-||| Determines whether base is either one of the parents of full or
-||| is identical to full.
-|||
-||| Trailing separator is ignored.
-export
-startWith : (base : Path) -> (full : Path) -> Bool
-startWith base full = base `elem` (iterate parent full)
-
-||| Returns a path that, when appended onto base, yields full.
-|||
-||| If base is not a prefix of full (i.e., startWith returns false),
-||| returns Nothing.
-stripPrefix : (base : Path) -> (full : Path) -> Maybe Path
-stripPrefix base full
-    = do let MkPath vol1 root1 body1 _ = base
-         let MkPath vol2 root2 body2 trialSep = full
-         if vol1 == vol2 && root1 == root2 then Just () else Nothing
-         body <- stripBody body1 body2
-         pure $ MkPath Nothing False body trialSep
-  where
-    stripBody : (base : List Body) -> (full : List Body) -> Maybe (List Body)
-    stripBody [] ys = Just ys
-    stripBody xs [] = Nothing
-    stripBody (x::xs) (y::ys) = if x == y then stripBody xs ys else Nothing
-
-||| Returns the final body of the path, if there is one.
-|||
-||| If the path is a normal file, this is the file name. If it's the
-||| path of a directory, this is the directory name.
-|||
-||| Returns Nothing if the final body is ".." or "."
-export
-fileName : Path -> Maybe String
-fileName p = case last' p.body of
-                  Just (Normal s) => Just s
-                  _ => Nothing
-
-private
-splitFileName : String -> (String, String)
-splitFileName name
-    = case break (== '.') $ reverse $ unpack name of
-           (_, []) => (name, "")
-           (_, ['.']) => (name, "")
-           (revExt, (dot :: revStem))
-              => ((pack $ reverse revStem), (pack $ reverse revExt))
-
-
-||| Extracts the stem (non-extension) portion of the file name of path.
-|||
-||| The stem is:
-|||
-||| - Nothing, if there is no file name;
-||| - The entire file name if there is no embedded ".";
-||| - The entire file name if the file name begins with "." and has
-|||   no other "."s within;
-||| - Otherwise, the portion of the file name before the final "."
-export
-fileStem : Path -> Maybe String
-fileStem p = pure $ fst $ splitFileName !(fileName p)
-
-||| Extracts the extension of the file name of path.
-|||
-||| The extension is:
-|||
-||| - Nothing, if there is no file name;
-||| - Nothing, if there is no embedded ".";
-||| - Nothing, if the file name begins with "." and has no other "."s within;
-||| - Otherwise, the portion of the file name after the final "."
-export
-extension : Path -> Maybe String
-extension p = pure $ snd $ splitFileName !(fileName p)
-
-||| Updates the file name of the path.
-|||
-||| If no file name, this is equivalent to appending the name;
-||| Otherwise it is equivalent to appending the name to the parent.
-export
-setFileName : (name : String) -> Path -> Path
-setFileName name p = record { body $= updateLastBody name } p
-  where
-    updateLastBody : String -> List Body -> List Body
-    updateLastBody s [] = [Normal s]
-    updateLastBody s [Normal _] = [Normal s]
-    updateLastBody s [x] = x :: [Normal s]
-    updateLastBody s (x::xs) = x :: (updateLastBody s xs)
-
-||| Updates the extension of the path.
-|||
-||| Returns Nothing if no file name.
-|||
-||| If extension is Nothing, the extension is added; otherwise it is replaced.
-export
-setExtension : (ext : String) -> Path -> Maybe Path
-setExtension ext p = do name <- fileName p
-                        let (stem, _) = splitFileName name
-                        pure $ setFileName (stem ++ "." ++ ext) p
-
-public export
-Semigroup Path where
-  (<+>) = append
-
-public export
-Monoid Path where
-  neutral = emptyPath
-
 --------------------------------------------------------------------------------
 -- Show
 --------------------------------------------------------------------------------
@@ -279,26 +111,22 @@ Show Path where
                rootStr = if p.hasRoot then sep else ""
                bodyStr = join sep $ map show p.body
                trailStr = if p.hasTrailSep then sep else "" in
-           volStr ++ rootStr ++ bodyStr ++ trailStr
+             volStr ++ rootStr ++ bodyStr ++ trailStr
 
 --------------------------------------------------------------------------------
 -- Parser
 --------------------------------------------------------------------------------
 
-private
 data PathTokenKind = PTText | PTPunct Char
 
-private
 Eq PathTokenKind where
   (==) PTText PTText = True
   (==) (PTPunct c1) (PTPunct c2) = c1 == c2
   (==) _ _ = False
 
-private
 PathToken : Type
 PathToken = Token PathTokenKind
 
-private
 TokenKind PathTokenKind where
   TokType PTText = String
   TokType (PTPunct _) = ()
@@ -306,7 +134,6 @@ TokenKind PathTokenKind where
   tokValue PTText x = x
   tokValue (PTPunct _) _ = ()
 
-private
 pathTokenMap : TokenMap PathToken
 pathTokenMap = toTokenMap $
   [ (is '/', PTPunct '/')
@@ -316,18 +143,12 @@ pathTokenMap = toTokenMap $
   , (some $ non $ oneOf "/\\:?", PTText)
   ]
 
-private
-lexPath : String -> Either String (List PathToken)
-lexPath str
-    = case lex pathTokenMap str of
-           (tokens, _, _, "") => Right (map TokenData.tok tokens)
-           (tokens, l, c, rest) => Left ("Unrecognized tokens "
-                                     ++ show rest
-                                     ++ " at col "
-                                     ++ show c)
+export
+lexPath : String -> List PathToken
+lexPath str = let (tokens, _, _, _) = lex pathTokenMap str in 
+                map TokenData.tok tokens
 
 -- match both '/' and '\\' regardless of the platform.
-private
 bodySeparator : Grammar PathToken True ()
 bodySeparator = (match $ PTPunct '\\') <|> (match $ PTPunct '/')
 
@@ -335,7 +156,6 @@ bodySeparator = (match $ PTPunct '\\') <|> (match $ PTPunct '/')
 -- Windows can automatically translate '/' to '\\'. The verbatim prefix,
 -- i.e., `\\?\`, disables the translation.
 -- Here, we simply parse and then ignore it.
-private
 verbatim : Grammar PathToken True ()
 verbatim = do count (exactly 2) $ match $ PTPunct '\\'
               match $ PTPunct '?'
@@ -343,7 +163,6 @@ verbatim = do count (exactly 2) $ match $ PTPunct '\\'
               pure ()
 
 -- Example: \\server\share
-private
 unc : Grammar PathToken True Volumn
 unc = do count (exactly 2) $ match $ PTPunct '\\'
          server <- match PTText
@@ -352,7 +171,6 @@ unc = do count (exactly 2) $ match $ PTPunct '\\'
          pure $ UNC server share
 
 -- Example: \\?\server\share
-private
 verbatimUnc : Grammar PathToken True Volumn
 verbatimUnc = do verbatim
                  server <- match PTText
@@ -361,7 +179,6 @@ verbatimUnc = do verbatim
                  pure $ UNC server share
 
 -- Example: C:
-private
 disk : Grammar PathToken True Volumn
 disk = do text <- match PTText
           disk <- case unpack text of
@@ -371,20 +188,17 @@ disk = do text <- match PTText
           pure $ Disk (toUpper disk)
 
 -- Example: \\?\C:
-private
 verbatimDisk : Grammar PathToken True Volumn
 verbatimDisk = do verbatim
                   d <- disk
                   pure d
 
-private
 parseVolumn : Grammar PathToken True Volumn
 parseVolumn = verbatimUnc
           <|> verbatimDisk
           <|> unc
           <|> disk
 
-private
 parseBody : Grammar PathToken True Body
 parseBody = do text <- match PTText
                the (Grammar _ False _) $
@@ -394,7 +208,6 @@ parseBody = do text <- match PTText
                         "." => pure CurDir
                         s => pure (Normal s)
 
-private
 parsePath : Grammar PathToken False Path
 parsePath = do vol <- optional parseVolumn
                root <- optional bodySeparator
@@ -421,18 +234,187 @@ parsePath = do vol <- optional parseVolumn
 ||| parse "/usr/local/etc/*"
 ||| ```
 export
-parse : String -> Either String Path
-parse str = case parse parsePath !(lexPath str) of
-                 Right (p, []) => Right p
-                 Right (p, ts) => Left ("Unrecognised tokens remaining : "
-                                     ++ show (map text ts))
-                 Left (Error msg ts) => Left (msg ++ " : " ++ show (map text ts))
+parse : String -> Path
+parse str = case parse parsePath (lexPath str) of
+                 Right (p, _) => p
+                 _ => emptyPath
 
-||| Attempt to parse the parts of a path and appends together.
+--------------------------------------------------------------------------------
+-- Manipulations
+--------------------------------------------------------------------------------
+
+isAbsolute' : Path -> Bool
+isAbsolute' p = if isWindows
+                  then case p.volumn of
+                            Just (UNC _ _) => True
+                            Just (Disk _) => p.hasRoot
+                            Nothing => False
+                  else p.hasRoot
+
+||| Returns true if the path is absolute.
+|||
+||| - On Unix, a path is absolute if it starts with the root,
+|||   so isAbsolute and hasRoot are equivalent.
+|||
+||| - On Windows, a path is absolute if it has a volumn and starts
+|||   with the root. e.g., `c:\\windows` is absolute, while `c:temp`
+|||   and `\temp` are not. In addition, a path with UNC volumn is absolute.
+export
+isAbsolute : String -> Bool
+isAbsolute p = isAbsolute' (parse p)
+
+||| Returns true if the path is relative, i.e., not absolute.
+export
+isRelative : String -> Bool
+isRelative = not . isAbsolute
+
+||| Appends the right path to the left one.
+|||
+||| If the path on the right is absolute, it replaces the left path.
+|||
+||| On Windows:
+|||
+||| - If the right path has a root but no volumn (e.g., `\windows`), it
+|||   replaces everything except for the volumn (if any) of left.
+||| - If the right path has a volumn but no root, it replaces left.
 |||
 ||| ```idris example
-||| parseParts ["/usr", "local/etc"]
+||| pure $ !(parse "/usr") </> !(parse "local/etc")
 ||| ```
 export
-parseParts : (parts : List String) -> Either String Path
-parseParts parts = map concat (traverse parse parts)
+(</>) : (left : String) -> (right : String) -> String
+(</>) l r = let l = parse l
+                r = parse r in
+              show $ if isAbsolute' r || isJust r.volumn
+                        then r
+                        else if hasRoot r
+                                then record { volumn = l.volumn } r
+                                else record { body = l.body ++ r.body,
+                                              hasTrailSep = r.hasTrailSep } l
+
+parent' : Path -> Maybe Path
+parent' p = case p.body of
+                [] => Nothing
+                (x::xs) => Just $ record { body = init (x::xs),
+                                           hasTrailSep = False } p
+
+||| Returns the path without its final component, if there is one.
+|||
+||| Returns Nothing if the path terminates in a root or volumn.
+export
+parent : String -> Maybe String
+parent p = map show $ parent' (parse p)
+
+||| Returns a list of all parents of the path, longest first,
+||| self excluded.
+|||
+||| For example, the parent of the path, and the parent of the
+||| parent of the path, and so on. The list terminates in a
+||| root or volumn (if any).
+export
+parents : String -> List String
+parents p = map show $ drop 1 $ iterate parent' (parse p)
+
+||| Determines whether base is either one of the parents of full or
+||| is identical to full.
+|||
+||| Trailing separator is ignored.
+export
+startWith : (base : String) -> (full : String) -> Bool
+startWith base full = (parse base) `elem` (iterate parent' (parse full))
+
+||| Returns a path that, when appended onto base, yields full.
+|||
+||| If base is not a prefix of full (i.e., startWith returns false),
+||| returns Nothing.
+stripPrefix : (base : String) -> (full : String) -> Maybe String
+stripPrefix base full
+    = do let MkPath vol1 root1 body1 _ = parse base
+         let MkPath vol2 root2 body2 trialSep = parse full
+         if vol1 == vol2 && root1 == root2 then Just () else Nothing
+         body <- stripBody body1 body2
+         pure $ show $ MkPath Nothing False body trialSep
+  where
+    stripBody : (base : List Body) -> (full : List Body) -> Maybe (List Body)
+    stripBody [] ys = Just ys
+    stripBody xs [] = Nothing
+    stripBody (x::xs) (y::ys) = if x == y then stripBody xs ys else Nothing
+
+fileName' : Path -> Maybe String
+fileName' p = case last' p.body of
+                   Just (Normal s) => Just s
+                   _ => Nothing
+
+||| Returns the final body of the path, if there is one.
+|||
+||| If the path is a normal file, this is the file name. If it's the
+||| path of a directory, this is the directory name.
+|||
+||| Returns Nothing if the final body is ".." or "."
+export
+fileName : String -> Maybe String
+fileName p = fileName' (parse p)
+
+splitFileName : String -> (String, String)
+splitFileName name
+    = case break (== '.') $ reverse $ unpack name of
+           (_, []) => (name, "")
+           (_, ['.']) => (name, "")
+           (revExt, (dot :: revStem))
+              => ((pack $ reverse revStem), (pack $ reverse revExt))
+
+
+||| Extracts the stem (non-extension) portion of the file name of path.
+|||
+||| The stem is:
+|||
+||| - Nothing, if there is no file name;
+||| - The entire file name if there is no embedded ".";
+||| - The entire file name if the file name begins with "." and has
+|||   no other "."s within;
+||| - Otherwise, the portion of the file name before the final "."
+export
+fileStem : String -> Maybe String
+fileStem p = pure $ fst $ splitFileName !(fileName p)
+
+||| Extracts the extension of the file name of path.
+|||
+||| The extension is:
+|||
+||| - Nothing, if there is no file name;
+||| - Nothing, if there is no embedded ".";
+||| - Nothing, if the file name begins with "." and has no other "."s within;
+||| - Otherwise, the portion of the file name after the final "."
+export
+extension : String -> Maybe String
+extension p = pure $ snd $ splitFileName !(fileName p)
+
+setFileName' : (name : String) -> Path -> Path
+setFileName' name p = record { body $= updateLastBody name } p
+  where
+    updateLastBody : String -> List Body -> List Body
+    updateLastBody s [] = [Normal s]
+    updateLastBody s [Normal _] = [Normal s]
+    updateLastBody s [x] = x :: [Normal s]
+    updateLastBody s (x::xs) = x :: (updateLastBody s xs)
+
+||| Updates the file name of the path.
+|||
+||| If no file name, this is equivalent to appending the name;
+||| Otherwise it is equivalent to appending the name to the parent.
+export
+setFileName : (name : String) -> String -> String
+setFileName name p = show $ setFileName' name (parse p)
+
+||| Updates the extension of the path.
+|||
+||| Returns Nothing if no file name.
+|||
+||| If extension is Nothing, the extension is added; otherwise it is replaced.
+export
+setExtension : (ext : String) -> String -> String
+setExtension ext p = let p' = parse p in
+                       case fileName' p' of
+                            Just name => let (stem, _) = splitFileName name in
+                                           show $ setFileName' (stem ++ "." ++ ext) p'
+                            Nothing => p


### PR DESCRIPTION
Lift String to be the primitive of System.Path, that is, use pure String to represent paths, and the original Path ADT has become the internal util used to manipulate path.

I made this change because I've attempted to replace System.Path in the compiler itself, and I've found that the ADT path is kind of useless in practice, because it forces every function uses Path argument to be wrapped by a do-block and to parse every argument in advance, including the hard-code one, and to `show path` in every call to file functions.

The previous module interface is adopted from Rust [std](https://doc.rust-lang.org/std/path/struct.Path.html) and [FilePath](https://github.com/haskell/filepath) of Haskell, both of whom manipulate Path in String, so I switched to stick closer to them.

One thing weird is that this PR works fine in my testing project, nevertheless, it will cause **`Exception: invalid memory reference. Some debugging context lost`** when I run the compiler that is modified to use System.Path, I suspect it may indicate some bugs in libidris2_support.