### PR TITLE
Add GitHub CI action that bootstraps on Ubuntu

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -1,0 +1,24 @@
+name: Ubuntu CI
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install build dependencies
+        run: |
+          sudo apt-get install -y chezscheme
+      - name: Build from bootstrap
+        run: make bootstrap SCHEME=scheme
+        shell: bash
+

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ Idris 2
 
 [![Build Status](https://travis-ci.org/idris-lang/Idris2.svg?branch=master)](https://travis-ci.org/idris-lang/Idris2)
 [![Documentation Status](https://readthedocs.org/projects/idris2/badge/?version=latest)](https://idris2.readthedocs.io/en/latest/?badge=latest)
-![](https://github.com/idris-lang/Idris2/workflows/Windows%20CI/badge.svg)
+![Windows CI](https://github.com/idris-lang/Idris2/workflows/Windows%20CI/badge.svg)
+![Ubuntu CI](https://github.com/idris-lang/Idris2/workflows/Ubuntu%20CI/badge.svg)
 
 [Idris 2](https://idris-lang.org/) is a purely functional programming language
 with first class types.


### PR DESCRIPTION
The latest commits broke bootstrapping on Linux, even though we have CI using Travis already that should detect this problem.

This CR adds a bootstrap build for Ubuntu using GitHub actions, similarly to the ones we have for windows. This hopes to achieve more stable and faster feedback on builds and their problems.

The proposed action shows the current build failure, as shown here: https://github.com/wchresta/Idris2/runs/702631251
The current Travis build for the same commit is currently stuck: https://travis-ci.org/github/idris-lang/Idris2/builds/690433878

This will not fix the build failure for Linux but rather make the failure obvious through (hopefully) better CI. We can leave both builds in, Travis and GitHub, and observe which works better for us. Eventually, we'll want to get rid of one of them.