### PR TITLE
Allow cli given option overriding for ipkg cmds

### DIFF
--- a/src/Idris/CommandLine.idr
+++ b/src/Idris/CommandLine.idr
@@ -130,12 +130,16 @@ options = [MkOpt ["--check", "-c"] [] [CheckOnly]
               (Just "Show installation prefix"),
            MkOpt ["--paths"] [] [BlodwenPaths]
               (Just "Show paths"),
+
            MkOpt ["--build"] ["package file"] (\f => [Package Build f])
               (Just "Build modules/executable for the given package"),
            MkOpt ["--install"] ["package file"] (\f => [Package Install f])
               (Just "Install the given package"),
            MkOpt ["--clean"] ["package file"] (\f => [Package Clean f])
               (Just "Clean intermediate files/executables for the given package"),
+
+           MkOpt ["--repl"] ["package file"] (\f => [Package REPL f])
+              (Just "Build the given package and launch a REPL instance."),
 
            MkOpt ["--libdir"] [] [Directory LibDir]
               (Just "Show library directory"),

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -79,7 +79,7 @@ idrisTests
        "perror001", "perror002", "perror003", "perror004", "perror005",
        "perror006",
        -- Packages and ipkg files
-       "pkg001", "pkg002",
+       "pkg001", "pkg002", "pkg003",
        -- Larger programs arising from real usage. Typically things with
        -- interesting interactions between features
        "real001", "real002",
@@ -205,7 +205,7 @@ runTest opts testPath
           b <- getAnswer
           when b $ do Right _ <- writeFile "expected" out
                           | Left err => print err
-                      pure () 
+                      pure ()
         runTest' : IO Bool
         runTest'
             = do putStr $ testPath ++ ": "
@@ -220,9 +220,9 @@ runTest opts testPath
                            else print FileNotFound
                          pure False
                      | Left err => do print err
-                                      pure False 
+                                      pure False
                  let result = normalize out == normalize exp
-                 if normalize out == normalize exp 
+                 if normalize out == normalize exp
                     then putStrLn "success"
                     else do
                       putStrLn "FAILURE"

--- a/tests/idris2/pkg003/Main.idr
+++ b/tests/idris2/pkg003/Main.idr
@@ -1,0 +1,4 @@
+module Main
+
+main : IO ()
+main = putStrLn "CouCou!"

--- a/tests/idris2/pkg003/expected
+++ b/tests/idris2/pkg003/expected
@@ -12,5 +12,4 @@ Overridable options are:
 
 
 Packages must have an '.ipkg' extension: "malformed-package-name".
-The presented iPKG file does not exist: "non-existent-package.ipkg".
-The presented iPKG file does not exist: "non-existent-package".
+Uncaught error: File error (non-existent-package.ipkg): File Not Found.

--- a/tests/idris2/pkg003/expected
+++ b/tests/idris2/pkg003/expected
@@ -1,0 +1,16 @@
+1/1: Building Main (Main.idr)
+Not all command line options can be used to override package options.
+
+Overridable options are:
+        --quiet
+        --verbose
+        --timing
+        --dumpcases <file>
+        --dumplifted <file>
+        --dumpvmcode <file>
+        --debug-elab-check
+
+
+Packages must have an '.ipkg' extension: "malformed-package-name".
+The presented iPKG file does not exist: "non-existent-package.ipkg".
+The presented iPKG file does not exist: "non-existent-package".

--- a/tests/idris2/pkg003/expected
+++ b/tests/idris2/pkg003/expected
@@ -2,14 +2,14 @@
 Not all command line options can be used to override package options.
 
 Overridable options are:
-        --quiet
-        --verbose
-        --timing
-        --dumpcases <file>
-        --dumplifted <file>
-        --dumpvmcode <file>
-        --debug-elab-check
-
+    --quiet
+    --verbose
+    --timing
+    --dumpcases <file>
+    --dumplifted <file>
+    --dumpvmcode <file>
+    --debug-elab-check
+    --codegen <cg>
 
 Packages must have an '.ipkg' extension: "malformed-package-name".
-Uncaught error: File error (non-existent-package.ipkg): File Not Found.
+Uncaught error: File error (non-existent-package.ipkg): File Not Found

--- a/tests/idris2/pkg003/run
+++ b/tests/idris2/pkg003/run
@@ -1,0 +1,11 @@
+$1 --build testpkg.ipkg
+rm -f  build/
+$1 --build testpkg.ipkg --quiet
+$1 --build testpkg.ipkg --verbose
+$1 --build testpkg.ipkg --timing
+$1 --build testpkg.ipkg --codegen gambit
+$1 --build testpkg.ipkg --ide-mode
+$1 --build malformed-package-name
+$1 --build non-existent-package.ipkg
+$1 --build non-existent-package-with-malformed-name
+rm -f  build/

--- a/tests/idris2/pkg003/run
+++ b/tests/idris2/pkg003/run
@@ -1,11 +1,9 @@
 $1 --build testpkg.ipkg
-rm -f  build/
+rm -rf  build/
 $1 --build testpkg.ipkg --quiet
 $1 --build testpkg.ipkg --verbose
-$1 --build testpkg.ipkg --timing
 $1 --build testpkg.ipkg --codegen gambit
 $1 --build testpkg.ipkg --ide-mode
 $1 --build malformed-package-name
 $1 --build non-existent-package.ipkg
-$1 --build non-existent-package-with-malformed-name
-rm -f  build/
+rm -rf  build/

--- a/tests/idris2/pkg003/testpkg.ipkg
+++ b/tests/idris2/pkg003/testpkg.ipkg
@@ -1,0 +1,11 @@
+package testpkg
+
+authors = "Joe Bloggs"
+maintainers = "Joe Bloggs"
+license = "BSD3 but see LICENSE for more information"
+brief = "This is a dummy package."
+readme = "README.md"
+
+main = Main
+
+modules = Main


### PR DESCRIPTION
As it was in Idris1 being able to override *some*, or introduce new, options to an Idris IPKG is beneficial. For example, generate code for multiple codegens from a single source.

This PR is the beginning of adding this ability to Idris2. I have fixed some other minor issues with how Idris handle's IPKG files as well.

I will get round to this as and when I can. This PR is there to let people know something is being done.