### PR TITLE
Add CI for bootstrapping via racket

### DIFF
--- a/.github/workflows/ci-ubuntu-bootstrap-racket.yml
+++ b/.github/workflows/ci-ubuntu-bootstrap-racket.yml
@@ -1,0 +1,24 @@
+name: Ubuntu CI boostrap racket
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install build dependencies
+        run: |
+          sudo apt-get install -y racket
+      - name: Build from bootstrap
+        run: make bootstrap-racket
+        shell: bash
+

--- a/.github/workflows/ci-ubuntu-bootstrap-scheme.yml
+++ b/.github/workflows/ci-ubuntu-bootstrap-scheme.yml
@@ -1,4 +1,4 @@
-name: Ubuntu CI
+name: Ubuntu CI bootstrap scheme
 on:
   push:
     branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-dist: bionic
-language: minimal
-install: sudo apt-get install chezscheme9.5
-script:
-    - make bootstrap SCHEME=chezscheme9.5

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 Idris 2
 =======
 
-[![Build Status](https://travis-ci.org/idris-lang/Idris2.svg?branch=master)](https://travis-ci.org/idris-lang/Idris2)
 [![Documentation Status](https://readthedocs.org/projects/idris2/badge/?version=latest)](https://idris2.readthedocs.io/en/latest/?badge=latest)
 ![Windows CI](https://github.com/idris-lang/Idris2/workflows/Windows%20CI/badge.svg)
-![Ubuntu CI](https://github.com/idris-lang/Idris2/workflows/Ubuntu%20CI/badge.svg)
+![Ubuntu CI bootstrap scheme](https://github.com/idris-lang/Idris2/workflows/Ubuntu%20CI%20bootstrap%20scheme/badge.svg)
+![Ubuntu CI boostrap racket](https://github.com/idris-lang/Idris2/workflows/Ubuntu%20CI%20boostrap%20racket/badge.svg)
 
 [Idris 2](https://idris-lang.org/) is a purely functional programming language
 with first class types.


### PR DESCRIPTION
* Remove Travis as described in #127

This adds a CI build for bootstrapping `racket` on Ubuntu and drops builds for Travis.