### PR TITLE
Erase function argument of cong

### DIFF
--- a/libs/prelude/Prelude.idr
+++ b/libs/prelude/Prelude.idr
@@ -117,7 +117,7 @@ public export
 
 ||| Equality is a congruence.
 public export
-cong : (f : t -> u) -> (1 p : a = b) -> f a = f b
+cong : (0 f : t -> u) -> (1 p : a = b) -> f a = f b
 cong f Refl = Refl
 
 ||| A canonical proof that some type is empty.


### PR DESCRIPTION
This allows proofs to use erased arguments: 

```
data Split : List a -> List a -> List a -> Type where
  Nil   : Split [] [] []
  ConsR : Split xs ls rs -> Split (x::xs)     ls (x::rs)
  ConsL : Split xs ls rs -> Split (x::xs) (x::ls)    rs

splitRInv : Split xs [] rs -> xs = rs
splitRInv  Nil          = Refl
splitRInv (ConsR {x} s) = cong (Prelude.(::) x) $ splitRInv s
```

Without `0` on `f` this produces `x is not accessible in this context` on the last line.