### PR TITLE
Shorten names on CI icons

### DIFF
--- a/.github/workflows/ci-ubuntu-racket.yml
+++ b/.github/workflows/ci-ubuntu-racket.yml
@@ -1,4 +1,4 @@
-name: Ubuntu CI bootstrap scheme
+name: Ubuntu Racket
 on:
   push:
     branches:
@@ -17,8 +17,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install build dependencies
         run: |
-          sudo apt-get install -y chezscheme
+          sudo apt-get install -y racket
       - name: Build from bootstrap
-        run: make bootstrap SCHEME=scheme
+        run: make bootstrap-racket
         shell: bash
 

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -1,4 +1,4 @@
-name: Ubuntu CI boostrap racket
+name: Ubuntu
 on:
   push:
     branches:
@@ -17,8 +17,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install build dependencies
         run: |
-          sudo apt-get install -y racket
+          sudo apt-get install -y chezscheme
       - name: Build from bootstrap
-        run: make bootstrap-racket
+        run: make bootstrap SCHEME=scheme
         shell: bash
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,4 +1,4 @@
-name: Windows CI
+name: Windows
 on:
   push:
     branches:

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@ Idris 2
 =======
 
 [![Documentation Status](https://readthedocs.org/projects/idris2/badge/?version=latest)](https://idris2.readthedocs.io/en/latest/?badge=latest)
-![Windows CI](https://github.com/idris-lang/Idris2/workflows/Windows%20CI/badge.svg)
-![Ubuntu CI bootstrap scheme](https://github.com/idris-lang/Idris2/workflows/Ubuntu%20CI%20bootstrap%20scheme/badge.svg)
-![Ubuntu CI boostrap racket](https://github.com/idris-lang/Idris2/workflows/Ubuntu%20CI%20boostrap%20racket/badge.svg)
+[![](https://github.com/idris-lang/Idris2/workflows/Windows/badge.svg)](https://github.com/idris-lang/Idris2/actions?query=workflow%3A"Windows")
+[![](https://github.com/idris-lang/Idris2/workflows/Ubuntu/badge.svg)](https://github.com/idris-lang/Idris2/actions?query=workflow%3A"Ubuntu")
+[![](https://github.com/idris-lang/Idris2/workflows/Ubuntu%20Racket/badge.svg)](https://github.com/idris-lang/Idris2/actions?query=workflow%3A"Ubuntu+Racket")
 
 [Idris 2](https://idris-lang.org/) is a purely functional programming language
 with first class types.


### PR DESCRIPTION
Link them to the respective workflow page.
Rename to be more consistent.

Turns out that the name in the link on the README doesn't matter, so leave it blank.