### PR TITLE
Remove dependency on pthreads on Windows

### DIFF
--- a/support/c/idris_support.c
+++ b/support/c/idris_support.c
@@ -8,6 +8,7 @@
 
 #ifdef _WIN32
 extern char **_environ;
+#include "windows/win_utils.h"
 #define environ _environ
 #else
 extern char** environ;
@@ -42,19 +43,27 @@ void idris2_putStr(char* f) {
 }
 
 void idris2_sleep(int sec) {
+#ifdef _WIN32
+    win32_sleep(sec*1000);
+#else
     struct timespec t;
     t.tv_sec = sec;
     t.tv_nsec = 0;
 
     nanosleep(&t, NULL);
+#endif
 }
 
 void idris2_usleep(int usec) {
+#ifdef _WIN32
+    win32_sleep(usec/1000);
+#else
     struct timespec t;
     t.tv_sec = usec / 1000000;
     t.tv_nsec = (usec % 1000000) * 1000;
 
     nanosleep(&t, NULL);
+#endif
 }
 
 int idris2_time() {

--- a/support/c/windows/win_utils.c
+++ b/support/c/windows/win_utils.c
@@ -64,3 +64,7 @@ void win32_gettime(int64_t* sec, int64_t* nsec)
     *sec = t.QuadPart / 10000000;
     *sec -= 11644473600; // LDAP epoch to Unix epoch 
 }
+
+void win32_sleep(int ms) {
+    Sleep(ms);
+}

--- a/support/c/windows/win_utils.h
+++ b/support/c/windows/win_utils.h
@@ -7,3 +7,4 @@ int win_fpoll(FILE *h);
 FILE *win32_u8fopen(const char *path, const char *mode);
 FILE *win32_u8popen(const char *path, const char *mode);
 void win32_gettime(int64_t* sec, int64_t* nsec);
+void win32_sleep(int ms);


### PR DESCRIPTION
This eliminates a dependency on libwinpthread-l that has been documented to cause confusion when it's absent. An alternative would be to always copy it around when we build. But as we only use nanosleep from there it is much better to eliminate that function on windows.

It's possible to do a bit better with a lot more work, but people will just have to make do with millisecond resolution.

