### PR TITLE
Split bootstrap into separate build and test stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,16 +27,22 @@ IDRIS2_SUPPORT := libidris2_support${SHLIB_SUFFIX}
 IDRIS2_IPKG := idris2.ipkg
 
 ifeq ($(OS), windows)
+	# This produces D:/../.. style paths
 	IDRIS2_PREFIX := $(shell cygpath -m ${PREFIX})
 	IDRIS2_CURDIR := $(shell cygpath -m ${CURDIR})
-	export IDRIS2_BOOT_PATH = "${IDRIS2_CURDIR}/libs/prelude/build/ttc;${IDRIS2_CURDIR}/libs/base/build/ttc;${IDRIS2_CURDIR}/libs/network/build/ttc"
+	SEP := ;
 else
 	IDRIS2_PREFIX := ${PREFIX}
 	IDRIS2_CURDIR := ${CURDIR}
-	export IDRIS2_BOOT_PATH = ${IDRIS2_CURDIR}/libs/prelude/build/ttc:${IDRIS2_CURDIR}/libs/base/build/ttc:${IDRIS2_CURDIR}/libs/network/build/ttc
+	SEP := :
 endif
 
+# Library and data paths for bootstrap-test
+IDRIS2_BOOT_TEST_LIBS := ${IDRIS2_CURDIR}/bootstrap/${NAME}-${IDRIS2_VERSION}/lib
+IDRIS2_BOOT_TEST_DATA := ${IDRIS2_CURDIR}/bootstrap/${NAME}-${IDRIS2_VERSION}/support
 
+# These are the library path in the build dir to be used during build
+export IDRIS2_BOOT_PATH := "${IDRIS2_CURDIR}/libs/prelude/build/ttc${SEP}${IDRIS2_CURDIR}/libs/base/build/ttc${SEP}${IDRIS2_CURDIR}/libs/network/build/ttc"
 
 export SCHEME
 
@@ -125,9 +131,12 @@ install-libs: libs
 	${MAKE} -C libs/contrib install IDRIS2=../../${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 
 
-.PHONY: bootstrap bootstrap-racket bootstrap-clean
+.PHONY: bootstrap bootstrap-build bootstrap-racket bootstrap-racket-build bootstrap-test bootstrap-clean
 
-bootstrap: support
+# Bootstrapping using SCHEME
+bootstrap: bootstrap-build bootstrap-test
+
+bootstrap-build: support
 	cp support/c/${IDRIS2_SUPPORT} bootstrap/idris2_app
 	sed s/libidris2_support.so/${IDRIS2_SUPPORT}/g bootstrap/idris2_app/idris2.ss > bootstrap/idris2_app/idris2-boot.ss
 ifeq ($(OS), darwin)
@@ -135,9 +144,14 @@ ifeq ($(OS), darwin)
 else
 	sed -i 's|__PREFIX__|${IDRIS2_CURDIR}/bootstrap|g' bootstrap/idris2_app/idris2-boot.ss
 endif
+	SCHEME=${SCHEME} \
+	IDRIS2_VERSION=${IDRIS2_VERSION} \
 	sh ./bootstrap.sh
 
-bootstrap-racket: support
+# Bootstrapping using racket
+bootstrap-racket: bootstrap-racket-build bootstrap-test
+
+bootstrap-racket-build: support
 	cp support/c/${IDRIS2_SUPPORT} bootstrap/idris2_app
 	cp bootstrap/idris2_app/idris2.rkt bootstrap/idris2_app/idris2-boot.rkt
 ifeq ($(OS), darwin)
@@ -145,7 +159,11 @@ ifeq ($(OS), darwin)
 else
 	sed -i 's|__PREFIX__|${IDRIS2_CURDIR}/bootstrap|g' bootstrap/idris2_app/idris2-boot.rkt
 endif
+	IDRIS2_VERSION=${IDRIS2_VERSION} \
 	sh ./bootstrap-rkt.sh
+
+bootstrap-test:
+	$(MAKE) test INTERACTIVE='' IDRIS2_PATH=${IDRIS2_BOOT_PATH} IDRIS2_DATA=${IDRIS2_BOOT_TEST_DATA} IDRIS2_LIBS=${IDRIS2_BOOT_TEST_LIBS}
 
 bootstrap-clean:
 	$(RM) -r bootstrap/bin bootstrap/lib bootstrap/idris2-${IDRIS2_VERSION}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,13 +1,18 @@
 #!/bin/sh
 
-if [ -z "$SCHEME" ]
+set -e  # Exit on any error
+
+echo "bootstrapping SCHEME=$SCHEME IDRIS2_VERSION=$IDRIS2_VERSION"
+if [ -z "$SCHEME" ] || [ -z "$IDRIS2_VERSION" ]
 then
-    echo "SCHEME not set. Invoke with SCHEME=[name of chez executable]"
+    echo "Required ENV not set."
     exit 1
 fi
 
 # Compile the bootstrap scheme
+# TODO: Move boot-build to Makefile in bootstrap/Makefile
 cd bootstrap
+echo "Building idris2-boot from idris2-boot.ss"
 ${SCHEME} --script compile.ss
 
 # Put the result in the usual place where the target goes
@@ -18,32 +23,27 @@ install idris2_app/* ../build/exec/idris2_app
 
 cd ..
 
-# Install with the bootstrap directory as the PREFIX
-DIR="`realpath $0`"
-PREFIX="`dirname $DIR`"/bootstrap
+# TODO: Unify with bootstrap-rkt
+PREFIX=${PWD}/bootstrap
 
 if [ ${OS} = "windows" ]; then
+    # IDRIS_PREFIX is only used to build IDRIS2_BOOT_PATH
     IDRIS_PREFIX=$(cygpath -m $PREFIX)
     SEP=";"
-    NEW_PREFIX=$(cygpath -m $(dirname "$DIR"))
 else
     IDRIS_PREFIX=${PREFIX}
     SEP=":"
-    NEW_PREFIX="`dirname $DIR`"
 fi
 
-IDRIS2_BOOT_PATH="${IDRIS_PREFIX}/idris2-0.2.0/prelude${SEP}${IDRIS_PREFIX}/idris2-0.2.0/base${SEP}${IDRIS_PREFIX}/idris2-0.2.0/contrib${SEP}${IDRIS_PREFIX}/idris2-0.2.0/network"
-IDRIS2_TEST_LIBS="${IDRIS_PREFIX}/idris2-0.2.0/lib"
-IDRIS2_TEST_DATA="${IDRIS_PREFIX}/idris2-0.2.0/support"
-IDRIS2_NEW_PATH="${NEW_PREFIX}/libs/prelude/build/ttc${SEP}${NEW_PREFIX}/libs/base/build/ttc${SEP}${NEW_PREFIX}/libs/network/build/ttc"
+BOOT_PATH_BASE=${IDRIS_PREFIX}/idris2-${IDRIS2_VERSION}
+IDRIS2_BOOT_PATH="${BOOT_PATH_BASE}/prelude${SEP}${BOOT_PATH_BASE}/base${SEP}${BOOT_PATH_BASE}/contrib${SEP}${BOOT_PATH_BASE}/network"
 
 # Now rebuild everything properly
+# PREFIX must be the "clean" build root, without cygpath -m
+# Otherwise, we get 'git: Bad address'
 echo ${PREFIX}
-
 make libs SCHEME=${SCHEME} PREFIX=${PREFIX}
 make install SCHEME=${SCHEME} PREFIX=${PREFIX}
 make clean IDRIS2_BOOT=${PREFIX}/bin/idris2
 make all IDRIS2_BOOT=${PREFIX}/bin/idris2 SCHEME=${SCHEME} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 
-echo "Testing using libraries in ${IDRIS2_NEW_PATH}"
-make test INTERACTIVE='' IDRIS2_PATH=${IDRIS2_NEW_PATH} SCHEME=${SCHEME} IDRIS2_LIBS=${IDRIS2_TEST_LIBS} IDRIS2_DATA=${IDRIS2_TEST_DATA}


### PR DESCRIPTION
* Refactor bootstrap and bootstrap-rkt scripts
* Move the execution of the test phase after bootstrapping from bootstrap
  scripts into the Makefile. This allows separate execution of build
  and test seperately.
* Fixes #125