### PR TITLE
Run the self-hosting step in CI

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -8,7 +8,8 @@ on:
   pull_request:
     branches:
       - master
-
+env:
+  SCHEME: chez
 jobs:
   build:
     runs-on: macos-latest
@@ -19,6 +20,10 @@ jobs:
         run: |
           brew install chezscheme
           brew install coreutils
+          echo "::add-path::$HOME/.idris2/bin"
       - name: Build and test Idris 2 from bootstrap
-        run: make bootstrap SCHEME=chez
+        run: make bootstrap && make install
+        shell: bash
+      - name: Build and test self-hosted
+        run: make clean && make all && make test INTERACTIVE=''
         shell: bash

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -9,6 +9,8 @@ on:
     branches:
       - master
 
+env:
+  SCHEME: scheme
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,7 +20,11 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get install -y chezscheme
+          echo "::add-path::$HOME/.idris2/bin"
       - name: Build from bootstrap
-        run: make bootstrap SCHEME=scheme
+        run: make bootstrap && make install
+        shell: bash
+      - name: Build and test self-hosted
+        run: make clean && make all && make test INTERACTIVE=''
         shell: bash
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -9,7 +9,10 @@ on:
     branches:
       - master
 env:
+  MSYSTEM: MINGW64
   MSYS2_PATH_TYPE: inherit
+  SCHEME: scheme
+  CC: gcc
 
 jobs:
   build:
@@ -17,24 +20,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install MSYS2
-        uses: eine/setup-msys2@v0
-        with:
-          update: true
-          install: make mingw-w64-x86_64-clang tar
       - name: Get Chez Scheme
         run: | 
           git clone --depth 1 https://github.com/cisco/ChezScheme
+          c:\msys64\usr\bin\bash -l -c "pacman -S --noconfirm tar make"
+          echo "::set-env name=PWD::$(c:\msys64\usr\bin\cygpath -u $(pwd))"
       - name: Configure and Build Chez Scheme
-        run: msys2do cd ChezScheme; ./configure --threads; make; cd ..
-        shell: cmd
+        run: |
+          c:\msys64\usr\bin\bash -l -c "cd $env:PWD && cd ChezScheme && ./configure --threads && make"
       - name: Set Path
         run: |
           $chez="$(pwd)\ChezScheme\ta6nt\bin\ta6nt"
+          $idris="$(pwd)\.idris2"
           echo "::add-path::$chez"
-          echo "::set-env name=SCHEME::scheme"
+          echo "::add-path::$idris\bin"
+          echo "::set-env name=IDRIS_PREFIX::$idris"
+          echo "::set-env name=PREFIX::$(c:\msys64\usr\bin\cygpath -u $idris)"
       - name: Test Scheme
-        run: scheme.exe --version
-      - name: Bootstrap
-        run: msys2do make bootstrap
-        shell: cmd
+        run: |
+          scheme --version
+      - name: Bootstrap and install
+        run: c:\msys64\usr\bin\bash -l -c "cd $env:PWD && make bootstrap && make install"

--- a/config.mk
+++ b/config.mk
@@ -2,8 +2,7 @@
 
 PREFIX ?= $(HOME)/.idris2
 
-# clang compiles the output much faster than gcc!
-CC := clang
+CC ?= clang
 
 ##################################################################
 


### PR DESCRIPTION
The github actions latest windows image contains msys2 so use that.
Also use gcc that comes with thatm to save downloading clang.

Skip Racket as it's slow enough already.