### PR TITLE
Possible copy-paste mistake in typesfuns.rst

### DIFF
--- a/docs/source/tutorial/typesfuns.rst
+++ b/docs/source/tutorial/typesfuns.rst
@@ -20,7 +20,7 @@ into the Idris interactive environment by typing ``idris2 Prims.idr``:
     module Prims
 
     x : Int
-    x = 42
+    x = 94
 
     foo : String
     foo = "Sausage machine"


### PR DESCRIPTION
In the intial code listing we currently have "x = 42" but in following listings "x == 9 * 9 + 13" and "x == 8 * 8 + 30" return true.