### PR TITLE
Add edits to Chapter 1 section

### DIFF
--- a/docs/source/typedd/typedd.rst
+++ b/docs/source/typedd/typedd.rst
@@ -39,6 +39,14 @@ In ``AveMain.idr`` and ``Reverse.idr`` add:
 .. code-block:: idris
 
     import System.REPL -- for 'repl'
+ 
+To resolve disambiguation, use ``Prelude.Strings.(++)`` while concatenating strings in ``showAverage``. 
+(Atleast since Idris 1.3.3)
+
+.. code-block:: idris
+   
+   (Prelude.String.(++) "The average word length is " (show (average str))
+    
 
 Chapter 3
 ---------


### PR DESCRIPTION
Using Idrs 1.3.3, there is a disambigation error between Prelude.Strings.(++) and Prelude.List.(++).

```
Hello.idr:6:15-62:
  |
6 | showAve str = "The average length is " ++ (show (average str))
  |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
When checking right hand side of showAve with expected type
        String

Can't disambiguate since no name has a suitable type:
        Prelude.List.++, Prelude.Strings.++
```
Using explicit (++) resolves this issue.