### PR TITLE
Fix import loading

### DIFF
--- a/libs/base/Data/Fin.idr
+++ b/libs/base/Data/Fin.idr
@@ -1,6 +1,6 @@
 module Data.Fin
 
-import Data.Maybe
+import public Data.Maybe
 import Data.Nat
 import Decidable.Equality
 

--- a/libs/base/Data/List/Views.idr
+++ b/libs/base/Data/List/Views.idr
@@ -2,6 +2,7 @@ module Data.List.Views
 
 import Control.WellFounded
 import Data.List
+import Data.Nat
 import Data.Nat.Views
 
 lengthSuc : (xs : List a) -> (y : a) -> (ys : List a) ->

--- a/libs/base/Data/Nat/Views.idr
+++ b/libs/base/Data/Nat/Views.idr
@@ -1,6 +1,7 @@
 module Data.Nat.Views
 
 import Control.WellFounded
+import Data.Nat
 
 ||| View for dividing a Nat in half
 public export

--- a/libs/base/System.idr
+++ b/libs/base/System.idr
@@ -1,6 +1,6 @@
 module System
 
-import Data.So
+import public Data.So
 import Data.List
 import Data.Strings
 

--- a/libs/contrib/Data/String/Extra.idr
+++ b/libs/contrib/Data/String/Extra.idr
@@ -1,5 +1,7 @@
 module Data.String.Extra
 
+import Data.List
+import Data.Nat
 import Data.Strings
 
 %default total

--- a/libs/contrib/Language/JSON/String/Lexer.idr
+++ b/libs/contrib/Language/JSON/String/Lexer.idr
@@ -1,5 +1,6 @@
 module Language.JSON.String.Lexer
 
+import Data.Nat
 import Language.JSON.String.Tokens
 import Text.Lexer
 

--- a/libs/contrib/System/Path.idr
+++ b/libs/contrib/System/Path.idr
@@ -1,7 +1,9 @@
 module System.Path
 
+import Control.Delayed
 import Data.List
 import Data.Maybe
+import Data.Nat
 import Data.Strings
 import Data.String.Extra
 import System.Info

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -17,7 +17,10 @@ import Data.Maybe
 import Data.NameMap
 import Data.Strings
 import Data.Vect
+
 import System
+import System.Directory
+import System.File
 import System.Info
 
 %default covering

--- a/src/Compiler/Scheme/Gambit.idr
+++ b/src/Compiler/Scheme/Gambit.idr
@@ -17,7 +17,10 @@ import Data.Maybe
 import Data.NameMap
 import Data.Strings
 import Data.Vect
+
 import System
+import System.Directory
+import System.File
 import System.Info
 
 %default covering

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -18,7 +18,10 @@ import Data.NameMap
 import Data.Nat
 import Data.Strings
 import Data.Vect
+
 import System
+import System.Directory
+import System.File
 import System.Info
 
 %default covering

--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -8,6 +8,7 @@ import Parser.Source
 
 import public Data.IORef
 import System
+import System.File
 
 %default covering
 

--- a/src/Core/LinearCheck.idr
+++ b/src/Core/LinearCheck.idr
@@ -330,6 +330,13 @@ mutual
                       pure (App fc f' aerased,
                             glueBack defs env sc',
                             fused ++ aused)
+                NApp _ (NRef _ n) _ =>
+                      do Just _ <- lookupCtxtExact n (gamma defs)
+                              | _ => throw (UndefinedName fc n)
+                         tfty <- getTerm gfty
+                         throw (GenericMsg fc ("Linearity checking failed on " ++ show f' ++
+                              " (" ++ show tfty ++ " not a function type)"))
+
                 _ => do tfty <- getTerm gfty
                         throw (GenericMsg fc ("Linearity checking failed on " ++ show f' ++
                               " (" ++ show tfty ++ " not a function type)"))
@@ -567,14 +574,14 @@ mutual
   lcheckDef fc rig True env n
       = do defs <- get Ctxt
            Just def <- lookupCtxtExact n (gamma defs)
-                | Nothing => throw (InternalError ("Linearity checking failed on " ++ show n))
+                | Nothing => throw (UndefinedName fc n)
            pure (type def)
   lcheckDef fc rig False env n
       = do defs <- get Ctxt
            let Just idx = getNameID n (gamma defs)
-                | Nothing => throw (InternalError ("Linearity checking failed on " ++ show n))
+                | Nothing => throw (UndefinedName fc n)
            Just def <- lookupCtxtExact (Resolved idx) (gamma defs)
-                | Nothing => throw (InternalError ("Linearity checking failed on " ++ show n))
+                | Nothing => throw (UndefinedName fc n)
            rigSafe (multiplicity def) rig
            if linearChecked def
               then pure (type def)

--- a/src/Core/Metadata.idr
+++ b/src/Core/Metadata.idr
@@ -13,6 +13,8 @@ import Data.List
 
 import Utils.Binary
 
+import System.File
+
 -- Additional data we keep about the context to support interactive editing
 
 public export

--- a/src/Core/TTC.idr
+++ b/src/Core/TTC.idr
@@ -788,7 +788,7 @@ export
 TTC Def where
   toBuf b None = tag 0
   toBuf b (PMDef pi args ct rt pats)
-      = do tag 1; toBuf b pi; toBuf b args; toBuf b ct; toBuf b rt; toBuf b pats
+      = do tag 1; toBuf b pi; toBuf b args; toBuf b ct; toBuf b pats
   toBuf b (ExternDef a)
       = do tag 2; toBuf b a
   toBuf b (ForeignDef a cs)
@@ -815,9 +815,8 @@ TTC Def where
              1 => do pi <- fromBuf b
                      args <- fromBuf b
                      ct <- fromBuf b
-                     rt <- fromBuf b
                      pats <- fromBuf b
-                     pure (PMDef pi args ct rt pats)
+                     pure (PMDef pi args ct (Unmatched "") pats)
              2 => do a <- fromBuf b
                      pure (ExternDef a)
              3 => do a <- fromBuf b

--- a/src/Core/Unify.idr
+++ b/src/Core/Unify.idr
@@ -230,6 +230,11 @@ postpone blockedMetas loc mode logstr env x y
                  yq <- quote defs env y
                  pure (logstr ++ ": " ++ show !(toFullNames xq) ++
                                     " =?= " ++ show !(toFullNames yq))
+
+         -- If we're blocked because a name is undefined, give up
+         checkDefined defs x
+         checkDefined defs y
+
          xtm <- quote empty env x
          ytm <- quote empty env y
          -- Need to find all the metas in the constraint since solving any one
@@ -249,6 +254,13 @@ postpone blockedMetas loc mode logstr env x y
          logTerm 10 "Y" ytm
          pure (constrain c)
   where
+    checkDefined : Defs -> NF vars -> Core ()
+    checkDefined defs (NApp _ (NRef _ n) _)
+        = do Just _ <- lookupCtxtExact n (gamma defs)
+                  | _ => throw (UndefinedName loc n)
+             pure ()
+    checkDefined _ _ = pure ()
+
     undefinedN : Name -> Core Bool
     undefinedN n
         = do defs <- get Ctxt
@@ -567,11 +579,11 @@ solveIfUndefined env metavar soln
     = pure False
 
 isDefInvertible : {auto c : Ref Ctxt Defs} ->
-                  Int -> Core Bool
-isDefInvertible i
+                  FC -> Int -> Core Bool
+isDefInvertible fc i
     = do defs <- get Ctxt
          Just gdef <- lookupCtxtExact (Resolved i) (gamma defs)
-              | Nothing => pure False
+              | Nothing => throw (UndefinedName fc (Resolved i))
          pure (invertible gdef)
 
 mutual
@@ -906,7 +918,7 @@ mutual
                                        (NApp yfc (NLocal yr y yp) yargs)
   -- If they're both holes, solve the one with the bigger context
   unifyBothApps mode loc env xfc (NMeta xn xi xargs) xargs' yfc (NMeta yn yi yargs) yargs'
-      = do invx <- isDefInvertible xi
+      = do invx <- isDefInvertible loc xi
            if xi == yi && (invx || umode mode == InSearch)
                                -- Invertible, (from auto implicit search)
                                -- so we can also unify the arguments.

--- a/src/Data/ANameMap.idr
+++ b/src/Data/ANameMap.idr
@@ -2,6 +2,8 @@
 module Data.ANameMap
 
 import Core.Name
+
+import Data.List
 import Data.NameMap
 import Data.StringMap
 

--- a/src/Idris/Error.idr
+++ b/src/Idris/Error.idr
@@ -12,6 +12,7 @@ import Idris.Syntax
 import Parser.Source
 
 import Data.List
+import System.File
 
 %default covering
 

--- a/src/Idris/IDEMode/REPL.idr
+++ b/src/Idris/IDEMode/REPL.idr
@@ -15,6 +15,8 @@ import Core.Options
 import Core.TT
 import Core.Unify
 
+import Data.So
+
 import Idris.Desugar
 import Idris.Error
 import Idris.ModTree
@@ -24,8 +26,9 @@ import Idris.REPL
 import Idris.Syntax
 import Idris.Version
 
-import Idris.IDEMode.Parser
 import Idris.IDEMode.Commands
+import Idris.IDEMode.Holes
+import Idris.IDEMode.Parser
 import Idris.IDEMode.SyntaxHighlight
 
 import TTImp.Interactive.CaseSplit
@@ -37,6 +40,7 @@ import Utils.Hex
 
 import Data.List
 import System
+import System.File
 
 import Network.Socket
 import Network.Socket.Data

--- a/src/Idris/Main.idr
+++ b/src/Idris/Main.idr
@@ -22,9 +22,12 @@ import Idris.Syntax
 import Idris.Version
 
 import Data.List
+import Data.So
 import Data.Strings
 import Data.Vect
 import System
+import System.Directory
+import System.File
 
 import Yaffle.Main
 
@@ -171,7 +174,7 @@ stMain opts
                  the (Core ()) $ case fname of
                       Nothing => logTime "Loading prelude" $
                                    when (not $ noprelude session) $
-                                     readPrelude
+                                     readPrelude True
                       Just f => logTime "Loading main file" $
                                    (loadMainFile f >>= displayErrors)
 

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -11,6 +11,7 @@ import Core.Unify
 
 import Data.List
 import Data.Maybe
+import Data.So
 import Data.StringMap
 import Data.Strings
 import Data.StringTrie
@@ -18,6 +19,9 @@ import Data.These
 
 import Parser.Package
 import System
+import System.Directory
+import System.File
+
 import Text.Parser
 import Utils.Binary
 import Utils.String

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -50,6 +50,7 @@ import Data.Stream
 import Data.Strings
 
 import System
+import System.File
 
 %default covering
 

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -13,6 +13,7 @@ import Idris.Version
 
 import IdrisPaths
 
+import Data.So
 import System
 
 -- TODO: Version numbers on dependencies

--- a/src/TTImp/ProcessType.idr
+++ b/src/TTImp/ProcessType.idr
@@ -298,6 +298,7 @@ processType {vars} eopts nest env fc rig vis opts (MkImpTy tfc n_in ty_raw)
          addTyDecl fc (Resolved idx) env ty -- for definition generation
          addNameType fc (Resolved idx) env ty -- for looking up types
 
+
          traverse_ addToSave (keys (getMetas ty))
          addToSave n
          log 10 $ "Saving from " ++ show n ++ ": " ++ show (keys (getMetas ty))

--- a/src/Yaffle/Main.idr
+++ b/src/Yaffle/Main.idr
@@ -21,6 +21,7 @@ import TTImp.TTImp
 import Yaffle.REPL
 
 import Data.List
+import Data.So
 import Data.Strings
 import System
 
@@ -51,7 +52,7 @@ yaffleMain fname args
          addPrimitives
          case span (/= '.') fname of
               (_, ".ttc") => do coreLift $ putStrLn "Processing as TTC"
-                                readFromTTC {extra = ()} emptyFC True fname [] []
+                                readFromTTC {extra = ()} True emptyFC True fname [] []
                                 coreLift $ putStrLn "Read TTC"
               _ => do coreLift $ putStrLn "Processing as TTImp"
                       ok <- processTTImpFile fname

--- a/tests/idris2/coverage005/Cover.idr
+++ b/tests/idris2/coverage005/Cover.idr
@@ -1,4 +1,5 @@
 import Data.Fin
+import Data.Maybe
 
 data NNat = NZ | NS NNat
 

--- a/tests/idris2/import002/expected
+++ b/tests/idris2/import002/expected
@@ -2,6 +2,6 @@
 2/3: Building Mult (Mult.idr)
 3/3: Building Test (Test.idr)
 Test.idr:5:9--5:13:While processing type of thing at Test.idr:5:1--6:1:
-Name Nat.Nat is inaccessible since Nat is not explicitly imported
+Undefined name Nat
 Test.idr:6:1--8:1:No type declaration for Test.thing
 Test> Bye for now!

--- a/tests/idris2/reg003/expected
+++ b/tests/idris2/reg003/expected
@@ -1,11 +1,11 @@
 1/1: Building Holes (Holes.idr)
 Holes.idr:4:64--4:85:While processing type of Vect_ext at Holes.idr:4:1--7:1:
-Name Builtin.~=~ is inaccessible since Builtin is not explicitly imported
+Undefined name ~=~
 Holes.idr:7:26--8:1:While processing type of Weird at Holes.idr:7:1--8:1:
-Name Builtin.~=~ is inaccessible since Builtin is not explicitly imported
+Undefined name ~=~
 Holes.idr:8:1--10:1:No type declaration for Main.Weird
 Holes.idr:10:5--10:10:While processing type of f at Holes.idr:10:1--11:1:
-Name Prelude.Bool is inaccessible since Prelude is not explicitly imported
+Undefined name Bool
 Holes.idr:11:1--12:1:No type declaration for Main.f
 Main> (interactive):1:4--1:8:Undefined name help
 Main> (interactive):1:4--1:9:Undefined name hole0

--- a/tests/typedd-book/chapter14/Hangman.idr
+++ b/tests/typedd-book/chapter14/Hangman.idr
@@ -2,6 +2,8 @@ import Data.Vect
 import Data.List
 import Data.Strings
 
+import Decidable.Equality
+
 %default total
 
 data GameState : Type where


### PR DESCRIPTION
This was taking too long, and adding too many things, because it was
going too deep in the name of having everything accessible at the REPL
and for the compiler. So, it's done a bit differently now, only chasing
everything on a "full" load (i.e., final load at the REPL)

This has some effects:
+ As systems get bigger, load time gets better (on my machine, checking
  Idris.Main now takes 52s from scratch, down from 76s)
+ You might find import errors that you didn't previously get, because
  things were being imported that shouldn't have been. The new way is
  correct!

An unfortunate effect is that sometimes you end up getting "undefined
name" errors even if you didn't explicitly use the name, because
sometimes a module uses a name from another module in a type, which then
gets exported, and eventually needs to be reduced. This mostly happens
because there is a compile time check that should be done which I
haven't implemented yet. That is, public export definitions should only
be allowed to use names that are also public export. I'll get to this
soon.