### PR TITLE
Add missing import

### DIFF
--- a/src/Utils/Path.idr
+++ b/src/Utils/Path.idr
@@ -2,6 +2,7 @@ module Utils.Path
 
 import Data.List
 import Data.Maybe
+import Data.Nat
 import Data.Strings
 import Data.String.Extra
 


### PR DESCRIPTION
This wouldn't have got caught since the merge that caused the problem
was checked before I pushed the patch that made import work right! So
hopefully this'll sort it.