### PR TITLE
(->) operator

### DIFF
--- a/libs/prelude/Builtin.idr
+++ b/libs/prelude/Builtin.idr
@@ -2,6 +2,12 @@ module Builtin
 
 -- The most primitive data types; things which are used by desugaring
 
+infix 1 =
+infixr 0 ->
+public export
+(->) : (a : Type) -> (b : Type) -> Type
+a -> b = (_ : a) -> b
+
 -- Totality assertions
 
 ||| Assert to the totality checker that the given expression will always

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1424,7 +1424,7 @@ fixDecl fname indents
          fixity <- fix
          commit
          prec <- intLit
-         ops <- sepBy1 (symbol ",") iOperator
+         ops <- sepBy1 (symbol ",") (iOperator <|> (symbol "=" *> pure (UN "=")))
          end <- location
          pure (map (PFixity (MkFC fname start end) fixity (fromInteger prec)) ops)
 

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -815,9 +815,9 @@ mutual
       = do start <- location
            arg <- opExpr q fname indents
            (do continue indents
-               rest <- some (do exp <- bindSymbol
+               rest <- some (do symbol "=>"
                                 op <- opExpr pdef fname indents
-                                pure (exp, op))
+                                pure (AutoImplicit, op))
                end <- location
                pure (mkPi start end arg rest))
              <|> pure arg

--- a/src/Parser/Lexer/Source.idr
+++ b/src/Parser/Lexer/Source.idr
@@ -172,7 +172,7 @@ export
 reservedSymbols : List String
 reservedSymbols
     = symbols ++
-      ["%", "\\", ":", "=", "|", "|||", "<-", "->", "=>", "?", "!",
+      ["%", "\\", ":", "=", "|", "|||", "<-", "=>", "?", "!",
        "&", "**", ".."]
 
 fromHexLit : String -> Integer


### PR DESCRIPTION
This is a follow-up to https://github.com/idris-lang/Idris2/issues/187.

The syntax was surprisingly easy (the Prelude builds fine) but there seem to be issues with unification for some reason:
```idris
../../build/exec/idris2 --build base.ipkg
25/38: Building Control.WellFounded (Control/WellFounded.idr)
Control/WellFounded.idr:27:29--27:34:While processing right hand side of accInd at Control/WellFounded.idr:26:1--29:1:
When unifying (x : a) -> ((y : a) -> rel y x -> P y) -> P x
          and (x : a) -> ((y : a) -> ?rel y x -> ?P y) -> ?P x
Can't make solution for Control.WellFounded.{rel:5451}
```
Any ideas?