### PR TITLE
Make pathToNS handle absolute path

### DIFF
--- a/libs/contrib/System/Path.idr
+++ b/libs/contrib/System/Path.idr
@@ -1,16 +1,21 @@
 module System.Path
 
-import Control.Delayed
 import Data.List
 import Data.Maybe
 import Data.Nat
 import Data.Strings
 import Data.String.Extra
+
 import System.Info
+
 import Text.Token
 import Text.Lexer
 import Text.Parser
 import Text.Quantity
+
+infixr 5 </>
+infixr 7 <.>
+
 
 ||| The character that separates directories in the path.
 export
@@ -22,47 +27,48 @@ export
 pathSeparator : Char
 pathSeparator = if isWindows then ';' else ':'
 
-||| Windows' path prefixes.
-|||
-||| @ UNC Windows' Uniform Naming Convention, e.g., a network sharing
-|||   directory: `\\host\c$\Windows\System32`
-||| @ Disk the drive, e.g., "C:". The disk character is in upper case
+||| Windows' path prefixes of path component.
 public export
-data Volumn = UNC String String
-            | Disk Char
+data Volume
+  = 
+  ||| Windows' Uniform Naming Convention, e.g., a network sharing
+  ||| directory: `\\host\c$\Windows\System32`
+  UNC String String |
+  ||| The drive, e.g., "C:". The disk character is in upper case
+  Disk Char
 
-||| A single body of path.
-|||
-||| @ CurDir "."
-||| @ ParentDir ".."
-||| @ Normal common directory or file
+||| A single body of path component.
 public export
-data Body = CurDir
-          | ParentDir
-          | Normal String
+data Body
+  = 
+  ||| Represents "."
+  CurDir |
+  ||| Represents ".."
+  ParentDir |
+  ||| Common directory or file
+  Normal String
 
-||| A cross-platform file system path.
+||| A parsed cross-platform file system path.
 |||
-||| The function `parse` is the most common way to construct a Path
-||| from String, and the function `show` converts in reverse.
+||| The function `parse` constructs a Path component from String,
+||| and the function `show` converts in reverse.
 |||
 ||| Trailing separator is only used for display and is ignored while
 ||| comparing paths.
-|||
-||| @ volumn Windows' path prefix (only on Windows)
-||| @ hasRoot whether the path contains a root
-||| @ body path bodies
-||| @ hasTrailSep whether the path terminates with a separator
 public export
 record Path where
     constructor MkPath
-    volumn : Maybe Volumn
+    ||| Windows' path prefix (only on Windows)
+    volume : Maybe Volume
+    ||| Whether the path contains a root
     hasRoot : Bool
+    ||| Path bodies
     body : List Body
+    ||| Whether the path terminates with a separator
     hasTrailSep : Bool
 
 export
-Eq Volumn where
+Eq Volume where
   (==) (UNC l1 l2) (UNC r1 r2) = l1 == r1 && r1 == r2
   (==) (Disk l) (Disk r) = l == r
   (==) _ _ = False
@@ -85,175 +91,6 @@ public export
 emptyPath : Path
 emptyPath = MkPath Nothing False [] False
 
-||| Returns true if the path is absolute.
-|||
-||| - On Unix, a path is absolute if it starts with the root,
-|||   so isAbsolute and hasRoot are equivalent.
-|||
-||| - On Windows, a path is absolute if it has a volumn and starts
-|||   with the root. e.g., `c:\\windows` is absolute, while `c:temp`
-|||   and `\temp` are not. In addition, a path with UNC volumn is absolute.
-export
-isAbsolute : Path -> Bool
-isAbsolute p = if isWindows
-                 then case p.volumn of
-                           Just (UNC _ _) => True
-                           Just (Disk _) => p.hasRoot
-                           Nothing => False
-                 else p.hasRoot
-
-||| Returns true if the path is relative, i.e., not absolute.
-export
-isRelative : Path -> Bool
-isRelative = not . isAbsolute
-
-||| Appends the right path to the left one.
-|||
-||| If the path on the right is absolute, it replaces the left path.
-|||
-||| On Windows:
-|||
-||| - If the right path has a root but no volumn (e.g., `\windows`), it
-|||   replaces everything except for the volumn (if any) of left.
-||| - If the right path has a volumn but no root, it replaces left.
-|||
-||| ```idris example
-||| pure $ !(parse "/usr") `append` !(parse "local/etc")
-||| ```
-export
-append : (left : Path) -> (right : Path) -> Path
-append l r = if isAbsolute r || isJust r.volumn
-                then r
-                else if hasRoot r
-                  then record { volumn = l.volumn } r
-                  else record { body = l.body ++ r.body,
-                                hasTrailSep = r.hasTrailSep } l
-
-||| Returns the path without its final component, if there is one.
-|||
-||| Returns Nothing if the path terminates in a root or volumn.
-export
-parent : Path -> Maybe Path
-parent p = case p.body of
-                [] => Nothing
-                (x::xs) => Just $ record { body = init (x::xs),
-                                           hasTrailSep = False } p
-
-||| Returns a list of all parents of the path, longest first,
-||| self excluded.
-|||
-||| For example, the parent of the path, and the parent of the
-||| parent of the path, and so on. The list terminates in a
-||| root or volumn (if any).
-export
-parents : Path -> List Path
-parents p = drop 1 $ iterate parent p
-
-||| Determines whether base is either one of the parents of full or
-||| is identical to full.
-|||
-||| Trailing separator is ignored.
-export
-startWith : (base : Path) -> (full : Path) -> Bool
-startWith base full = base `elem` (iterate parent full)
-
-||| Returns a path that, when appended onto base, yields full.
-|||
-||| If base is not a prefix of full (i.e., startWith returns false),
-||| returns Nothing.
-stripPrefix : (base : Path) -> (full : Path) -> Maybe Path
-stripPrefix base full
-    = do let MkPath vol1 root1 body1 _ = base
-         let MkPath vol2 root2 body2 trialSep = full
-         if vol1 == vol2 && root1 == root2 then Just () else Nothing
-         body <- stripBody body1 body2
-         pure $ MkPath Nothing False body trialSep
-  where
-    stripBody : (base : List Body) -> (full : List Body) -> Maybe (List Body)
-    stripBody [] ys = Just ys
-    stripBody xs [] = Nothing
-    stripBody (x::xs) (y::ys) = if x == y then stripBody xs ys else Nothing
-
-||| Returns the final body of the path, if there is one.
-|||
-||| If the path is a normal file, this is the file name. If it's the
-||| path of a directory, this is the directory name.
-|||
-||| Returns Nothing if the final body is ".." or "."
-export
-fileName : Path -> Maybe String
-fileName p = case last' p.body of
-                  Just (Normal s) => Just s
-                  _ => Nothing
-
-private
-splitFileName : String -> (String, String)
-splitFileName name
-    = case break (== '.') $ reverse $ unpack name of
-           (_, []) => (name, "")
-           (_, ['.']) => (name, "")
-           (revExt, (dot :: revStem))
-              => ((pack $ reverse revStem), (pack $ reverse revExt))
-
-
-||| Extracts the stem (non-extension) portion of the file name of path.
-|||
-||| The stem is:
-|||
-||| - Nothing, if there is no file name;
-||| - The entire file name if there is no embedded ".";
-||| - The entire file name if the file name begins with "." and has
-|||   no other "."s within;
-||| - Otherwise, the portion of the file name before the final "."
-export
-fileStem : Path -> Maybe String
-fileStem p = pure $ fst $ splitFileName !(fileName p)
-
-||| Extracts the extension of the file name of path.
-|||
-||| The extension is:
-|||
-||| - Nothing, if there is no file name;
-||| - Nothing, if there is no embedded ".";
-||| - Nothing, if the file name begins with "." and has no other "."s within;
-||| - Otherwise, the portion of the file name after the final "."
-export
-extension : Path -> Maybe String
-extension p = pure $ snd $ splitFileName !(fileName p)
-
-||| Updates the file name of the path.
-|||
-||| If no file name, this is equivalent to appending the name;
-||| Otherwise it is equivalent to appending the name to the parent.
-export
-setFileName : (name : String) -> Path -> Path
-setFileName name p = record { body $= updateLastBody name } p
-  where
-    updateLastBody : String -> List Body -> List Body
-    updateLastBody s [] = [Normal s]
-    updateLastBody s [Normal _] = [Normal s]
-    updateLastBody s [x] = x :: [Normal s]
-    updateLastBody s (x::xs) = x :: (updateLastBody s xs)
-
-||| Updates the extension of the path.
-|||
-||| Returns Nothing if no file name.
-|||
-||| If extension is Nothing, the extension is added; otherwise it is replaced.
-export
-setExtension : (ext : String) -> Path -> Maybe Path
-setExtension ext p = do name <- fileName p
-                        let (stem, _) = splitFileName name
-                        pure $ setFileName (stem ++ "." ++ ext) p
-
-public export
-Semigroup Path where
-  (<+>) = append
-
-public export
-Monoid Path where
-  neutral = emptyPath
-
 --------------------------------------------------------------------------------
 -- Show
 --------------------------------------------------------------------------------
@@ -265,7 +102,7 @@ Show Body where
   show (Normal s) = s
 
 export
-Show Volumn where
+Show Volume where
   show (UNC server share) = "\\\\" ++ server ++ "\\" ++ share
   show (Disk disk) = singleton disk ++ ":"
 
@@ -273,30 +110,26 @@ Show Volumn where
 export
 Show Path where
   show p = let sep = singleton dirSeparator
-               volStr = fromMaybe "" (map show p.volumn)
+               volStr = fromMaybe "" (map show p.volume)
                rootStr = if p.hasRoot then sep else ""
                bodyStr = join sep $ map show p.body
                trailStr = if p.hasTrailSep then sep else "" in
-           volStr ++ rootStr ++ bodyStr ++ trailStr
+             volStr ++ rootStr ++ bodyStr ++ trailStr
 
 --------------------------------------------------------------------------------
 -- Parser
 --------------------------------------------------------------------------------
 
-private
 data PathTokenKind = PTText | PTPunct Char
 
-private
 Eq PathTokenKind where
   (==) PTText PTText = True
   (==) (PTPunct c1) (PTPunct c2) = c1 == c2
   (==) _ _ = False
 
-private
 PathToken : Type
 PathToken = Token PathTokenKind
 
-private
 TokenKind PathTokenKind where
   TokType PTText = String
   TokType (PTPunct _) = ()
@@ -304,7 +137,6 @@ TokenKind PathTokenKind where
   tokValue PTText x = x
   tokValue (PTPunct _) _ = ()
 
-private
 pathTokenMap : TokenMap PathToken
 pathTokenMap = toTokenMap $
   [ (is '/', PTPunct '/')
@@ -314,18 +146,12 @@ pathTokenMap = toTokenMap $
   , (some $ non $ oneOf "/\\:?", PTText)
   ]
 
-private
-lexPath : String -> Either String (List PathToken)
-lexPath str
-    = case lex pathTokenMap str of
-           (tokens, _, _, "") => Right (map TokenData.tok tokens)
-           (tokens, l, c, rest) => Left ("Unrecognized tokens "
-                                     ++ show rest
-                                     ++ " at col "
-                                     ++ show c)
+export
+lexPath : String -> List PathToken
+lexPath str = let (tokens, _, _, _) = lex pathTokenMap str in 
+                map TokenData.tok tokens
 
 -- match both '/' and '\\' regardless of the platform.
-private
 bodySeparator : Grammar PathToken True ()
 bodySeparator = (match $ PTPunct '\\') <|> (match $ PTPunct '/')
 
@@ -333,7 +159,6 @@ bodySeparator = (match $ PTPunct '\\') <|> (match $ PTPunct '/')
 -- Windows can automatically translate '/' to '\\'. The verbatim prefix,
 -- i.e., `\\?\`, disables the translation.
 -- Here, we simply parse and then ignore it.
-private
 verbatim : Grammar PathToken True ()
 verbatim = do count (exactly 2) $ match $ PTPunct '\\'
               match $ PTPunct '?'
@@ -341,8 +166,7 @@ verbatim = do count (exactly 2) $ match $ PTPunct '\\'
               pure ()
 
 -- Example: \\server\share
-private
-unc : Grammar PathToken True Volumn
+unc : Grammar PathToken True Volume
 unc = do count (exactly 2) $ match $ PTPunct '\\'
          server <- match PTText
          bodySeparator
@@ -350,8 +174,7 @@ unc = do count (exactly 2) $ match $ PTPunct '\\'
          Core.pure $ UNC server share
 
 -- Example: \\?\server\share
-private
-verbatimUnc : Grammar PathToken True Volumn
+verbatimUnc : Grammar PathToken True Volume
 verbatimUnc = do verbatim
                  server <- match PTText
                  bodySeparator
@@ -359,8 +182,7 @@ verbatimUnc = do verbatim
                  Core.pure $ UNC server share
 
 -- Example: C:
-private
-disk : Grammar PathToken True Volumn
+disk : Grammar PathToken True Volume
 disk = do text <- match PTText
           disk <- case unpack text of
                        (disk :: xs) => pure disk
@@ -369,48 +191,55 @@ disk = do text <- match PTText
           pure $ Disk (toUpper disk)
 
 -- Example: \\?\C:
-private
-verbatimDisk : Grammar PathToken True Volumn
+verbatimDisk : Grammar PathToken True Volume
 verbatimDisk = do verbatim
                   d <- disk
                   pure d
 
-private
-parseVolumn : Grammar PathToken True Volumn
-parseVolumn = verbatimUnc
+parseVolume : Grammar PathToken True Volume
+parseVolume = verbatimUnc
           <|> verbatimDisk
           <|> unc
           <|> disk
 
-private
 parseBody : Grammar PathToken True Body
 parseBody = do text <- match PTText
                the (Grammar _ False _) $
                    case text of
-                        " " => fail "Empty body"
                         ".." => pure ParentDir
                         "." => pure CurDir
                         s => pure (Normal s)
 
-private
 parsePath : Grammar PathToken False Path
-parsePath = do vol <- optional parseVolumn
+parsePath = do vol <- optional parseVolume
                root <- optional (some bodySeparator)
                body <- sepBy (some bodySeparator) parseBody
                trailSep <- optional (some bodySeparator)
+               let body = filter (\case Normal s => ltrim s /= ""
+                                        _ => True) body
+               let body = case body of
+                               [] => []
+                               (x::xs) => x :: delete CurDir xs
                pure $ MkPath vol (isJust root) body (isJust trailSep)
 
-||| Attempt to parse a String into Path.
+||| Parse a String into Path component.
 |||
-||| Returns a error message if the parser fails.
+||| Returns the path parsed as much as possible from left to right, the 
+||| invalid parts on the right end is ignored.
 |||
-||| The parser is relaxed to accept invalid inputs. Relaxing rules:
+||| Some kind of invalid path is accepted. Relaxing rules:
 |||
-||| - Both slash('/') and backslash('\\') are parsed as directory separator,
-|||   regardless of the platform;
-||| - Invalid characters in path body in allowed, e.g., glob like "/root/*";
-||| - Ignoring the verbatim prefix(`\\?\`) that disables the forward
-|||   slash (Windows only).
+||| - Both slash('/') and backslash('\\') are parsed as valid directory
+|||   separator, regardless of the platform;
+||| - Any characters in path body in allowed, e.g., glob like "/root/*";
+||| - Verbatim prefix(`\\?\`) that disables the forward
+|||   slash (Windows only) is ignored.
+||| - Repeated separators are ignored, so "a/b" and "a//b" both have "a" 
+|||   and "b" as bodies.
+||| - Occurrences of "." are normalized away, except if they are at the
+|||   beginning of the path. For example, "a/./b", "a/b/", "a/b/". and 
+|||   "a/b" all have "a" and "b" as bodies, but "./a/b" starts with an 
+|||   additional `CurDir` body.
 |||
 ||| ```idris example
 ||| parse "C:\\Windows/System32"
@@ -419,18 +248,220 @@ parsePath = do vol <- optional parseVolumn
 ||| parse "/usr/local/etc/*"
 ||| ```
 export
-parse : String -> Either String Path
-parse str = case parse parsePath !(lexPath str) of
-                 Right (p, []) => Right p
-                 Right (p, ts) => Left ("Unrecognised tokens remaining : "
-                                     ++ show (map text ts))
-                 Left (Error msg ts) => Left (msg ++ " : " ++ show (map text ts))
+parse : String -> Path
+parse str = case parse parsePath (lexPath str) of
+                 Right (p, _) => p
+                 _ => emptyPath
 
-||| Attempt to parse the parts of a path and appends together.
+--------------------------------------------------------------------------------
+-- Utils
+--------------------------------------------------------------------------------
+
+isAbsolute' : Path -> Bool
+isAbsolute' p = if isWindows
+                  then case p.volume of
+                            Just (UNC _ _) => True
+                            Just (Disk _) => p.hasRoot
+                            Nothing => False
+                  else p.hasRoot
+
+append' : (left : Path) -> (right : Path) -> Path
+append' l r = if isAbsolute' r || isJust r.volume
+                 then r
+                 else if hasRoot r
+                         then record { volume = l.volume } r
+                         else record { body = l.body ++ r.body,
+                                       hasTrailSep = r.hasTrailSep } l
+
+splitParent' : Path -> Maybe (Path, Path)
+splitParent' p 
+  = case p.body of
+         [] => Nothing
+         (x::xs) => let parentPath = record { body = init (x::xs),
+                                          hasTrailSep = False } p
+                        lastPath = MkPath Nothing False [last (x::xs)] p.hasTrailSep in
+                      Just (parentPath, lastPath)
+
+parent' : Path -> Maybe Path
+parent' p = map fst (splitParent' p) 
+
+fileName' : Path -> Maybe String
+fileName' p = findNormal (reverse p.body)
+  where
+    findNormal : List Body -> Maybe String
+    findNormal ((Normal s)::xs) = Just s
+    findNormal (CurDir::xs) = findNormal xs
+    findNormal _ = Nothing
+    
+setFileName' : (name : String) -> Path -> Path
+setFileName' name p = if isJust (fileName' p)
+                         then append' (fromMaybe emptyPath $ parent' p) (parse name)
+                         else append' p (parse name)
+    
+splitFileName : String -> (String, String)
+splitFileName name
+    = case break (== '.') $ reverse $ unpack name of
+           (_, []) => (name, "")
+           (_, ['.']) => (name, "")
+           (revExt, (dot :: revStem))
+              => ((pack $ reverse revStem), (pack $ reverse revExt))
+
+--------------------------------------------------------------------------------
+-- Manipulations
+--------------------------------------------------------------------------------
+
+||| Returns true if the path is absolute.
+|||
+||| - On Unix, a path is absolute if it starts with the root,
+|||   so isAbsolute and hasRoot are equivalent.
+|||
+||| - On Windows, a path is absolute if it has a volume and starts
+|||   with the root. e.g., `c:\\windows` is absolute, while `c:temp`
+|||   and `\temp` are not. In addition, a path with UNC volume is absolute.
+export
+isAbsolute : String -> Bool
+isAbsolute p = isAbsolute' (parse p)
+
+||| Returns true if the path is relative, i.e., not absolute.
+export
+isRelative : String -> Bool
+isRelative = not . isAbsolute
+
+||| Appends the right path to the left one.
+|||
+||| If the path on the right is absolute, it replaces the left path.
+|||
+||| On Windows:
+|||
+||| - If the right path has a root but no volume (e.g., `\windows`), it
+|||   replaces everything except for the volume (if any) of left.
+||| - If the right path has a volume but no root, it replaces left.
 |||
 ||| ```idris example
-||| parseParts ["/usr", "local/etc"]
+||| "/usr" </> "local/etc"
 ||| ```
 export
-parseParts : (parts : List String) -> Either String Path
-parseParts parts = map concat (traverse parse parts)
+(</>) : (left : String) -> (right : String) -> String
+(</>) l r = show $ append' (parse l) (parse r)
+
+||| Join path elements together.
+|||
+||| ```idris example
+||| joinPath ["/usr", "local/etc"] == "/usr/local/etc"
+||| ```
+export
+joinPath : List String -> String
+joinPath xs = foldl (</>) "" xs
+
+||| Returns the parent and child.
+|||
+||| ```idris example
+||| splitParent "/usr/local/etc" == Just ("/usr/local", "etc")
+||| ```
+export
+splitParent : String -> Maybe (String, String)
+splitParent p = do (a, b) <- splitParent' (parse p)
+                   pure $ (show a, show b)
+
+||| Returns the path without its final component, if there is one.
+|||
+||| Returns Nothing if the path terminates in a root or volume.
+export
+parent : String -> Maybe String
+parent p = map show $ parent' (parse p)
+
+||| Returns a list of all the parents of the path, longest first,
+||| self included.
+|||
+||| ```idris example
+||| parents "/etc/kernel" == ["/etc/kernel", "/etc", "/"]
+||| ```
+export
+parents : String -> List String
+parents p = map show $ iterate parent' (parse p)
+
+||| Determines whether base is either one of the parents of full.
+|||
+||| Trailing separator is ignored.
+export
+startWith : (base : String) -> (full : String) -> Bool
+startWith base full = (parse base) `elem` (iterate parent' (parse full))
+
+||| Returns a path that, when appended onto base, yields full.
+|||
+||| If base is not a prefix of full (i.e., startWith returns false),
+||| returns Nothing.
+export
+stripPrefix : (base : String) -> (full : String) -> Maybe String
+stripPrefix base full
+    = do let MkPath vol1 root1 body1 _ = parse base
+         let MkPath vol2 root2 body2 trialSep = parse full
+         if vol1 == vol2 && root1 == root2 then Just () else Nothing
+         body <- stripBody body1 body2
+         pure $ show $ MkPath Nothing False body trialSep
+  where
+    stripBody : (base : List Body) -> (full : List Body) -> Maybe (List Body)
+    stripBody [] ys = Just ys
+    stripBody xs [] = Nothing
+    stripBody (x::xs) (y::ys) = if x == y then stripBody xs ys else Nothing
+
+||| Returns the final body of the path, if there is one.
+|||
+||| If the path is a normal file, this is the file name. If it's the
+||| path of a directory, this is the directory name.
+|||
+||| Returns Nothing if the final body is "..".
+export
+fileName : String -> Maybe String
+fileName p = fileName' (parse p)
+
+||| Extracts the stem (non-extension) portion of the file name of path.
+|||
+||| The stem is:
+|||
+||| - Nothing, if there is no file name;
+||| - The entire file name if there is no embedded ".";
+||| - The entire file name if the file name begins with "." and has
+|||   no other "."s within;
+||| - Otherwise, the portion of the file name before the final "."
+export
+fileStem : String -> Maybe String
+fileStem p = pure $ fst $ splitFileName !(fileName p)
+
+||| Extracts the extension of the file name of path.
+|||
+||| The extension is:
+|||
+||| - Nothing, if there is no file name;
+||| - Nothing, if there is no embedded ".";
+||| - Nothing, if the file name begins with "." and has no other "."s within;
+||| - Otherwise, the portion of the file name after the final "."
+export
+extension : String -> Maybe String
+extension p = pure $ snd $ splitFileName !(fileName p)
+
+||| Updates the file name of the path.
+|||
+||| If no file name, this is equivalent to appending the name;
+||| Otherwise it is equivalent to appending the name to the parent.
+export
+setFileName : (name : String) -> String -> String
+setFileName name p = show $ setFileName' name (parse p)
+
+||| Append a extension to the path.
+|||
+||| Returns the path as it is if no file name.
+|||
+||| If `extension` of the path is Nothing, the extension is added; otherwise
+||| it is replaced.
+||| 
+||| If the ext is empty, the extension is dropped.
+export
+(<.>) : String -> (ext : String) -> String
+(<.>) p ext = let p' = parse p 
+                  ext = pack $ dropWhile (== '.') (unpack ext)
+                  ext = if ltrim ext == "" then "" else "." ++ ext in
+                case fileName' p' of
+                     Just name => let (stem, _) = splitFileName name in
+                                    show $ setFileName' (stem ++ ext) p'
+                     Nothing => p

--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -126,6 +126,7 @@ data Error : Type where
      CyclicImports : List (List String) -> Error
      ForceNeeded : Error
      InternalError : String -> Error
+     UserError : String -> Error
 
      InType : FC -> Name -> Error -> Error
      InCon : FC -> Name -> Error -> Error
@@ -290,6 +291,7 @@ Show Error where
       showMod ns = showSep "." (reverse ns)
   show ForceNeeded = "Internal error when resolving implicit laziness"
   show (InternalError str) = "INTERNAL ERROR: " ++ str
+  show (UserError str) = "Error: " ++ str
 
   show (InType fc n err)
        = show fc ++ ":When elaborating type of " ++ show n ++ ":\n" ++
@@ -363,6 +365,7 @@ getErrorLoc (ModuleNotFound loc _) = Just loc
 getErrorLoc (CyclicImports _) = Nothing
 getErrorLoc ForceNeeded = Nothing
 getErrorLoc (InternalError _) = Nothing
+getErrorLoc (UserError _) = Nothing
 getErrorLoc (InType _ _ err) = getErrorLoc err
 getErrorLoc (InCon _ _ err) = getErrorLoc err
 getErrorLoc (InLHS _ _ err) = getErrorLoc err

--- a/src/Idris/Error.idr
+++ b/src/Idris/Error.idr
@@ -245,6 +245,7 @@ perror (CyclicImports ns)
     showMod ns = showSep "." (reverse ns)
 perror ForceNeeded = pure "Internal error when resolving implicit laziness"
 perror (InternalError str) = pure $ "INTERNAL ERROR: " ++ str
+perror (UserError str) = pure $ "Error: " ++ str
 
 perror (InType fc n err)
     = pure $ "While processing type of " ++ !(prettyName n) ++

--- a/src/Idris/Main.idr
+++ b/src/Idris/Main.idr
@@ -122,6 +122,13 @@ checkVerbose [] = False
 checkVerbose (Verbose :: _) = True
 checkVerbose (_ :: xs) = checkVerbose xs
 
+checkRelative : Maybe String -> Core (Maybe String)
+checkRelative Nothing = pure Nothing
+checkRelative (Just str)
+    = if isAbsolute str
+         then throw (InternalError "Absolute paths only allowed with --find-ipkg")
+         else pure (Just str)
+
 stMain : List CLOpt -> Core ()
 stMain opts
     = do False <- tryYaffle opts
@@ -163,7 +170,8 @@ stMain opts
                    iputStrLn banner
                  fname <- if findipkg session
                              then findIpkg fname
-                             else pure fname
+                             else checkRelative fname
+                 setMainFile fname
                  the (Core ()) $ case fname of
                       Nothing => logTime "Loading prelude" $
                                    when (not $ noprelude session) $

--- a/src/Idris/Main.idr
+++ b/src/Idris/Main.idr
@@ -122,13 +122,6 @@ checkVerbose [] = False
 checkVerbose (Verbose :: _) = True
 checkVerbose (_ :: xs) = checkVerbose xs
 
-checkRelative : Maybe String -> Core (Maybe String)
-checkRelative Nothing = pure Nothing
-checkRelative (Just str)
-    = if isAbsolute str
-         then throw (InternalError "Absolute paths only allowed with --find-ipkg")
-         else pure (Just str)
-
 stMain : List CLOpt -> Core ()
 stMain opts
     = do False <- tryYaffle opts
@@ -170,7 +163,7 @@ stMain opts
                    iputStrLn banner
                  fname <- if findipkg session
                              then findIpkg fname
-                             else checkRelative fname
+                             else pure fname
                  setMainFile fname
                  the (Core ()) $ case fname of
                       Nothing => logTime "Loading prelude" $

--- a/src/Idris/ModTree.idr
+++ b/src/Idris/ModTree.idr
@@ -126,7 +126,7 @@ getBuildMods : {auto c : Ref Ctxt Defs} ->
 getBuildMods loc done fname
     = do a <- newRef AllMods []
          d <- getDirs
-         let fname_ns = pathToNS (working_dir d) (source_dir d) fname
+         fname_ns <- pathToNS (working_dir d) (source_dir d) fname
          if fname_ns `elem` map buildNS done
             then pure []
             else
@@ -158,7 +158,7 @@ buildMod loc num len mod
    = do clearCtxt; addPrimitives
         lazyActive True; setUnboundImplicits True
         let src = buildFile mod
-        mttc <- getTTCFileName src ".ttc"
+        mttc <- getTTCFileName src "ttc"
         -- We'd expect any errors in nsToPath to have been caught by now
         -- since the imports have been built! But we still have to check.
         depFilesE <- traverse (nsToPath loc) (imports mod)
@@ -230,12 +230,12 @@ buildDeps fname
               [] => do -- On success, reload the main ttc in a clean context
                        clearCtxt; addPrimitives
                        put MD initMetadata
-                       mainttc <- getTTCFileName fname ".ttc"
+                       mainttc <- getTTCFileName fname "ttc"
                        log 10 $ "Reloading " ++ show mainttc ++ " from " ++ fname
                        readAsMain mainttc
 
                        -- Load the associated metadata for interactive editing
-                       mainttm <- getTTCFileName fname ".ttm"
+                       mainttm <- getTTCFileName fname "ttm"
                        log 10 $ "Reloading " ++ show mainttm
                        readFromTTM mainttm
                        pure []

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -550,9 +550,7 @@ findIpkg : {auto c : Ref Ctxt Defs} ->
            Maybe String -> Core (Maybe String)
 findIpkg fname
    = do Just (dir, ipkgn, up) <- coreLift findIpkgFile
-             | Nothing => case fname of
-                               Nothing => pure Nothing
-                               Just srcpath => pure (fileName srcpath)
+             | Nothing => pure fname
         coreLift $ changeDir dir
         Right (pname, fs) <- coreLift $ parseFile ipkgn
                                  (do desc <- parsePkgDesc ipkgn
@@ -566,10 +564,8 @@ findIpkg fname
         loadDependencies (depends pkg)
         case fname of
              Nothing => pure Nothing
-             Just srcpath =>
-                do let Just src = fileName srcpath
-                       | _ => pure (Just srcpath)
-                   let src' = up </> src
+             Just srcpath  =>
+                do let src' = up </> srcpath 
                    setSource src'
                    opts <- get ROpts
                    put ROpts (record { mainfile = Just src' } opts)

--- a/src/Idris/REPLOpts.idr
+++ b/src/Idris/REPLOpts.idr
@@ -48,6 +48,13 @@ getOutput = do opts <- get ROpts
                pure (idemode opts)
 
 export
+setMainFile : {auto o : Ref ROpts REPLOpts} ->
+              Maybe String -> Core ()
+setMainFile src
+    = do opts <- get ROpts
+         put ROpts (record { mainfile = src } opts)
+
+export
 setSource : {auto o : Ref ROpts REPLOpts} ->
             String -> Core ()
 setSource src

--- a/src/Utils/Path.idr
+++ b/src/Utils/Path.idr
@@ -217,6 +217,9 @@ parsePath = do vol <- optional parseVolume
                trailSep <- optional (some bodySeparator)
                let body = filter (\case Normal s => ltrim s /= ""
                                         _ => True) body
+               let body = case body of
+                               [] => []
+                               (x::xs) => x :: delete CurDir xs
                pure $ MkPath vol (isJust root) body (isJust trailSep)
 
 ||| Parse a String into Path component.
@@ -246,14 +249,9 @@ parsePath = do vol <- optional parseVolume
 ||| ```
 export
 parse : String -> Path
-parse str = let p = case parse parsePath (lexPath str) of
-                         Right (p, _) => p
-                         _ => emptyPath
-                body' = case p.body of
-                             [] => []
-                             (x::xs) => x :: delete CurDir xs
-              in
-                record { body = body' } p
+parse str = case parse parsePath (lexPath str) of
+                 Right (p, _) => p
+                 _ => emptyPath
 
 --------------------------------------------------------------------------------
 -- Utils

--- a/src/Yaffle/Main.idr
+++ b/src/Yaffle/Main.idr
@@ -13,6 +13,7 @@ import Core.Normalise
 import Core.Options
 import Core.TT
 import Core.UnifyState
+import Utils.Path
 
 import TTImp.Parser
 import TTImp.ProcessDecls
@@ -52,15 +53,16 @@ yaffleMain fname args
          t <- processArgs args
          setLogTimings t
          addPrimitives
-         case span (/= '.') fname of
-              (_, ".ttc") => do coreLift $ putStrLn "Processing as TTC"
-                                readFromTTC {extra = ()} True emptyFC True fname [] []
-                                coreLift $ putStrLn "Read TTC"
+         case extension fname of
+              Just "ttc" => do coreLift $ putStrLn "Processing as TTC"
+                               readFromTTC {extra = ()} True emptyFC True fname [] []
+                               coreLift $ putStrLn "Read TTC"
               _ => do coreLift $ putStrLn "Processing as TTImp"
                       ok <- processTTImpFile fname
                       when ok $
-                         do makeBuildDirectory (pathToNS (working_dir d) (source_dir d) fname)
-                            writeToTTC () !(getTTCFileName fname ".ttc")
+                         do ns <- pathToNS (working_dir d) (source_dir d) fname
+                            makeBuildDirectory ns
+                            writeToTTC () !(getTTCFileName fname "ttc")
                             coreLift $ putStrLn "Written TTC"
          ust <- get UST
 


### PR DESCRIPTION
Based on https://github.com/idris-lang/Idris2/pull/200

This allows absolute input file in any situation.

And since System.Path is out of sync with Utils.Path, I copied the src/Utils/Path.idr to contrib.