### PR TITLE
findIpkg needs to set working directory

### DIFF
--- a/src/Core/Directory.idr
+++ b/src/Core/Directory.idr
@@ -93,7 +93,7 @@ pathToNS wdir sdir fname
           base = if isAbsolute fname then wdir </> sdir else sdir
         in
           case stripPrefix base fname of
-               Nothing => throw (UserError ("Source file " ++ show fname 
+               Nothing => throw (UserError ("Source file " ++ show fname
                                             ++ " is not in the source directory " 
                                             ++ show (wdir </> sdir)))
                Just p => pure $ map show $ reverse $ (parse (p <.> "")).body

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -552,6 +552,7 @@ findIpkg fname
    = do Just (dir, ipkgn, up) <- coreLift findIpkgFile
              | Nothing => pure fname
         coreLift $ changeDir dir
+        setWorkingDir dir
         Right (pname, fs) <- coreLift $ parseFile ipkgn
                                  (do desc <- parsePkgDesc ipkgn
                                      eoi


### PR DESCRIPTION
This makes vim mode work again.
I don't know a good way to test this, since it involves dealing with
absolute paths. If anyone has the bash skills to get this working in a
pkg test, please do...