### PR TITLE
Calculate compile time references even in case

### DIFF
--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -768,9 +768,9 @@ processDef opts nest env fc n_in cs_in
          put Ctxt (record { toCompileCase $= (n ::) } defs)
 
          atotal <- toResolvedNames (NS ["Builtin"] (UN "assert_total"))
+         calcRefs False atotal (Resolved nidx)
          when (not (InCase `elem` opts)) $
-             do calcRefs False atotal (Resolved nidx)
-                sc <- calculateSizeChange fc n
+             do sc <- calculateSizeChange fc n
                 setSizeChange fc n sc
                 checkIfGuarded fc n
 

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -43,7 +43,7 @@ idrisTests
        -- Coverage checking
        "coverage001", "coverage002", "coverage003", "coverage004",
        "coverage005", "coverage006", "coverage007", "coverage008",
-       "coverage009",
+       "coverage009", "coverage010",
        -- Error messages
        "error001", "error002", "error003", "error004", "error005",
        "error006", "error007", "error008", "error009", "error010",

--- a/tests/idris2/coverage010/casetot.idr
+++ b/tests/idris2/coverage010/casetot.idr
@@ -1,0 +1,21 @@
+module Main
+
+import Data.Strings
+import Data.Vect
+import System
+
+%default total
+
+ints : Vect 4 Int
+ints = [1, 2, 3, 4]
+
+main : IO ()
+main = do
+  [_, arg] <- getArgs
+      | _ => do putStrLn "One argument expected."
+                exitFailure
+  let n = stringToNatOrZ arg
+  case natToFin n (length ints + 1) of
+       Nothing => do putStrLn "Invalid number."
+                     exitFailure
+       Just (FS i) => putStrLn $ "Value: " ++ show (index i ints)

--- a/tests/idris2/coverage010/expected
+++ b/tests/idris2/coverage010/expected
@@ -1,0 +1,3 @@
+1/1: Building casetot (casetot.idr)
+casetot.idr:12:1--13:1:main is not covering:
+	Calls non covering function Main.case block in 1921(290)

--- a/tests/idris2/coverage010/run
+++ b/tests/idris2/coverage010/run
@@ -1,0 +1,3 @@
+$1 --check casetot.idr
+
+rm -rf build


### PR DESCRIPTION
If we don't do this, we don't look inside case blocks to check they
cover, and so we might miss coverage errors in nested case blocks.
Fixes #202