### PR TITLE
Initial steps to elaborator reflection

### DIFF
--- a/idris2.ipkg
+++ b/idris2.ipkg
@@ -121,6 +121,7 @@ modules =
     TTImp.Elab.Quote,
     TTImp.Elab.Record,
     TTImp.Elab.Rewrite,
+    TTImp.Elab.RunElab,
     TTImp.Elab.Term,
     TTImp.Elab.Utils,
     TTImp.Impossible,

--- a/libs/base/Language/Reflection.idr
+++ b/libs/base/Language/Reflection.idr
@@ -13,18 +13,18 @@ data Elab : Type -> Type where
      Check : TTImp -> Elab TT
 
 mutual
-  export
+  public export
   Functor Elab where
     map f e = do e' <- e
                  pure (f e')
 
-  export
+  public export
   Applicative Elab where
     pure = Pure
     f <*> a = do f' <- f
                  a' <- a
                  pure (f' a')
 
-  export
+  public export
   Monad Elab where
     (>>=) = Bind

--- a/libs/base/Language/Reflection.idr
+++ b/libs/base/Language/Reflection.idr
@@ -3,28 +3,57 @@ module Language.Reflection
 import public Language.Reflection.TT
 import public Language.Reflection.TTImp
 
-public export
+export
 data Elab : Type -> Type where
      Pure : a -> Elab a
      Bind : Elab a -> (a -> Elab b) -> Elab b
-     Log : Nat -> String -> Elab ()
+     LogMsg : Nat -> String -> Elab ()
+     LogTerm : Nat -> String -> TTImp -> Elab ()
 
      -- Check a TTImp term against the current goal type
      Check : TTImp -> Elab TT
+     -- Get the current goal type, if known 
+     -- (it might need to be inferred from the solution)
+     Goal : Elab (Maybe TTImp)
 
 mutual
-  public export
+  export
   Functor Elab where
     map f e = do e' <- e
                  pure (f e')
 
-  public export
+  export
   Applicative Elab where
     pure = Pure
     f <*> a = do f' <- f
                  a' <- a
                  pure (f' a')
 
-  public export
+  export
   Monad Elab where
     (>>=) = Bind
+
+export
+logMsg : Nat -> String -> Elab ()
+logMsg = LogMsg
+
+export
+logTerm : Nat -> String -> TTImp -> Elab ()
+logTerm = LogTerm
+
+export
+logGoal : Nat -> String -> Elab ()
+logGoal n msg
+    = do g <- Goal
+         case g of
+              Nothing => pure ()
+              Just t => logTerm n msg t
+
+-- Check a TTImp term against the current goal type
+export
+check : TTImp -> Elab TT
+check = Check
+
+export
+goal : Elab (Maybe TTImp)
+goal = Goal

--- a/libs/base/Language/Reflection.idr
+++ b/libs/base/Language/Reflection.idr
@@ -7,8 +7,10 @@ public export
 data Elab : Type -> Type where
      Pure : a -> Elab a
      Bind : Elab a -> (a -> Elab b) -> Elab b
+     Log : Nat -> String -> Elab ()
 
-     Check : TTImp -> Elab a
+     -- Check a TTImp term against the current goal type
+     Check : TTImp -> Elab TT
 
 mutual
   export

--- a/libs/base/Language/Reflection/TT.idr
+++ b/libs/base/Language/Reflection/TT.idr
@@ -55,6 +55,10 @@ data IsVar : Name -> Nat -> List Name -> Type where
 public export
 data LazyReason = LInf | LLazy | LUnknown
 
+export
+data TT : Type where [external]
+
+{-
 -- Type checked terms in the core TT
 public export
 data TT : List Name -> Type where
@@ -73,6 +77,7 @@ data TT : List Name -> Type where
      PrimVal : FC -> Constant -> TT vars
      Erased : FC -> TT vars
      TType : FC -> TT vars
+     -}
 
 public export
 data TotalReq = Total | CoveringOnly | PartialOK

--- a/libs/base/Language/Reflection/TTImp.idr
+++ b/libs/base/Language/Reflection/TTImp.idr
@@ -1,6 +1,6 @@
 module Language.Reflection.TTImp
 
-import Language.Reflection.TT
+import public Language.Reflection.TT
 
 -- Unchecked terms and declarations in the intermediate language
 mutual

--- a/src/Core/Options.idr
+++ b/src/Core/Options.idr
@@ -82,11 +82,15 @@ record PrimNames where
   fromCharName : Maybe Name
 
 public export
-data LangExt = Borrowing -- not yet implemented
+data LangExt
+     = ElabReflection
+     | Borrowing -- not yet implemented
 
 export
 Eq LangExt where
+  ElabReflection == ElabReflection = True
   Borrowing == Borrowing = True
+  _ == _ = False
 
 -- Other options relevant to the current session (so not to be saved in a TTC)
 public export

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -402,6 +402,11 @@ mutual
            end <- location
            pure (PIdiom (MkFC fname start end) e)
     <|> do start <- location
+           pragma "runElab"
+           e <- expr pdef fname indents
+           end <- location
+           pure (PRunElab (MkFC fname start end) e)
+    <|> do start <- location
            pragma "logging"
            lvl <- intLit
            e <- expr pdef fname indents
@@ -1035,7 +1040,9 @@ onoff
 
 extension : Rule LangExt
 extension
-    = do exactIdent "Borrowing"
+    = do exactIdent "ElabReflection"
+         pure ElabReflection
+  <|> do exactIdent "Borrowing"
          pure Borrowing
 
 totalityOpt : Rule TotalReq

--- a/src/Parser/Lexer/Source.idr
+++ b/src/Parser/Lexer/Source.idr
@@ -174,7 +174,7 @@ reservedSymbols : List String
 reservedSymbols
     = symbols ++
       ["%", "\\", ":", "=", "|", "|||", "<-", "->", "=>", "?", "!",
-       "&", "**", ".."]
+       "&", "**", "..", "~"]
 
 fromHexLit : String -> Integer
 fromHexLit str

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -1,0 +1,69 @@
+module TTImp.Elab.RunElab
+
+import Core.Context
+import Core.Core
+import Core.Env
+import Core.GetType
+import Core.Metadata
+import Core.Normalise
+import Core.Options
+import Core.Reflect
+import Core.Unify
+import Core.TT
+import Core.Value
+
+import TTImp.Elab.Check
+import TTImp.Elab.Delayed
+import TTImp.Reflect
+import TTImp.TTImp
+
+elabScript : {vars : _} ->
+             {auto c : Ref Ctxt Defs} ->
+             {auto m : Ref MD Metadata} ->
+             {auto u : Ref UST UState} ->
+             {auto e : Ref EST (EState vars)} ->
+             FC -> RigCount -> ElabInfo -> NestedNames vars ->
+             Env Term vars -> NF vars -> Maybe (Glued vars) ->
+             Core (Term vars, Glued vars)
+elabScript fc rig elabinfo nest env
+           tm@(NDCon _ nm _ _ args) exp
+    = do defs <- get Ctxt
+         fnm <- toFullNames nm
+         case fnm of
+              NS ["Reflection", "Language"] (UN n)
+                 => elabCon defs n args
+              _ => failWith defs
+  where
+    failWith : Defs -> Core a
+    failWith defs
+      = do defs <- get Ctxt
+           empty <- clearDefs defs
+           throw (BadRunElab fc env !(quote empty env tm))
+
+    elabCon : Defs -> String -> List (Closure vars) -> Core (Term vars, Glued vars)
+    elabCon defs "Check" [ttimp]
+        = do tt <- evalClosure defs ttimp
+             raw <- reify defs tt
+             check rig elabinfo nest env raw exp
+    elabCon defs n args = failWith defs
+elabScript fc rig elabinfo nest env script exp
+    = do defs <- get Ctxt
+         empty <- clearDefs defs
+         throw (BadRunElab fc env !(quote empty env script))
+
+export
+checkRunElab : {vars : _} ->
+               {auto c : Ref Ctxt Defs} ->
+               {auto m : Ref MD Metadata} ->
+               {auto u : Ref UST UState} ->
+               {auto e : Ref EST (EState vars)} ->
+               RigCount -> ElabInfo ->
+               NestedNames vars -> Env Term vars -> 
+               FC -> RawImp -> Maybe (Glued vars) ->
+               Core (Term vars, Glued vars)
+checkRunElab rig elabinfo nest env fc script exp
+    = do defs <- get Ctxt
+         when (not (isExtension ElabReflection defs)) $
+             throw (GenericMsg fc "%language ElabReflection not enabled")
+         (stm, sty) <- check rig elabinfo nest env script Nothing
+         elabScript fc rig elabinfo nest env !(nf defs env stm) exp

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -26,7 +26,7 @@ elabScript : {vars : _} ->
              FC -> ElabInfo -> NestedNames vars ->
              Env Term vars -> NF vars -> Maybe (Glued vars) ->
              Core (NF vars)
-elabScript fc elabinfo nest env tm@(NDCon _ nm _ _ args) exp
+elabScript fc elabinfo nest env (NDCon nfc nm t ar args) exp
     = do defs <- get Ctxt
          fnm <- toFullNames nm
          case fnm of
@@ -38,7 +38,7 @@ elabScript fc elabinfo nest env tm@(NDCon _ nm _ _ args) exp
     failWith defs
       = do defs <- get Ctxt
            empty <- clearDefs defs
-           throw (BadRunElab fc env !(quote empty env tm))
+           throw (BadRunElab fc env !(quote empty env (NDCon nfc nm t ar args)))
 
     scriptRet : Reflect a => a -> Core (NF vars)
     scriptRet tm

--- a/src/TTImp/Elab/Term.idr
+++ b/src/TTImp/Elab/Term.idr
@@ -28,6 +28,7 @@ import TTImp.Elab.Prim
 import TTImp.Elab.Quote
 import TTImp.Elab.Record
 import TTImp.Elab.Rewrite
+import TTImp.Elab.RunElab
 import TTImp.Reflect
 import TTImp.TTImp
 
@@ -182,7 +183,7 @@ checkTerm rig elabinfo nest env (IQuoteDecl fc tm) exp
 checkTerm rig elabinfo nest env (IUnquote fc tm) exp
     = throw (GenericMsg fc "Can't escape outside a quoted term")
 checkTerm rig elabinfo nest env (IRunElab fc tm) exp
-    = throw (GenericMsg fc "RunElab not implemented yet")
+    = checkRunElab rig elabinfo nest env fc tm exp
 checkTerm {vars} rig elabinfo nest env (IPrimVal fc c) exp
     = do let (cval, cty) = checkPrim {vars} fc c
          checkExp rig elabinfo env fc cval (gnf env cty) exp

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -86,7 +86,7 @@ idrisTests
        -- Records, access and dependent update
        "record001", "record002", "record003", "record004",
        -- Quotation and reflection
-       "reflection001",
+       "reflection001", "reflection002",
        -- Miscellaneous regressions
        "reg001", "reg002", "reg003", "reg004", "reg005", "reg006", "reg007",
        "reg008", "reg009", "reg010", "reg011", "reg012", "reg013", "reg014",

--- a/tests/idris2/reflection002/expected
+++ b/tests/idris2/reflection002/expected
@@ -1,0 +1,5 @@
+1/1: Building power (power.idr)
+Main> Main.cube : Nat -> Nat
+cube = \x => mult x (mult x (mult x (const (fromInteger 1) x)))
+Main> 27
+Main> Bye for now!

--- a/tests/idris2/reflection002/input
+++ b/tests/idris2/reflection002/input
@@ -1,0 +1,3 @@
+:printdef cube
+cube 3
+:q

--- a/tests/idris2/reflection002/power.idr
+++ b/tests/idris2/reflection002/power.idr
@@ -7,12 +7,4 @@ powerFn Z = `(const 1)
 powerFn (S k) = `(\x => mult x (~(powerFn k) x))
 
 cube : Nat -> Nat
-cube = %runElab Check (powerFn 3)
-
-{-
-Main> cube 3
-27
-Main> :printdef cube
-Main.cube : Nat -> Nat
-cube = \x => mult x (mult x (mult x (const (fromInteger 1) x)))
--}
+cube = %runElab check (powerFn 3)

--- a/tests/idris2/reflection002/power.idr
+++ b/tests/idris2/reflection002/power.idr
@@ -1,0 +1,18 @@
+import Language.Reflection
+
+%language ElabReflection
+
+powerFn : Nat -> TTImp
+powerFn Z = `(const 1)
+powerFn (S k) = `(\x => mult x (~(powerFn k) x))
+
+cube : Nat -> Nat
+cube = %runElab Check (powerFn 3)
+
+{-
+Main> cube 3
+27
+Main> :printdef cube
+Main.cube : Nat -> Nat
+cube = \x => mult x (mult x (mult x (const (fromInteger 1) x)))
+-}

--- a/tests/idris2/reflection002/run
+++ b/tests/idris2/reflection002/run
@@ -1,0 +1,3 @@
+$1 --no-banner power.idr < input
+
+rm -rf build


### PR DESCRIPTION
The entire documentation is in the `Language.Reflection` part of `base`, and tests `idris2/reflection00x`.

So far, you can run elaborator scripts inside term elaboration. The scripts can inspect the goal, construct terms for checking, and do various bits of basic logging according to the overall elaborator log level. Terms can be quoted, and you can unquote terms inside quoted terms.

This already gives you what is essentially "template Idris", and you can probably do some quite interesting proof automation already, with some effort, by inspecting the goal and trying to construct a term accordingly.

One warning though: everything might change! So it's hidden behind an extension flag.