### PR TITLE
Gambit ffi callbacks

### DIFF
--- a/src/Compiler/Scheme/Gambit.idr
+++ b/src/Compiler/Scheme/Gambit.idr
@@ -123,6 +123,27 @@ data Loaded : Type where
 -- Label for noting which struct types are declared
 data Structs : Type where
 
+cType : FC -> CFType -> Core String
+cType fc CFUnit = pure "void"
+cType fc CFInt = pure "int"
+cType fc CFString = pure "char *"
+cType fc CFDouble = pure "double"
+cType fc CFChar = pure "char"
+cType fc CFPtr = pure "void *"
+cType fc (CFIORes t) = cType fc t
+cType fc (CFStruct n t) = pure $ "struct " ++ n
+cType fc (CFFun s t) = funTySpec [s] t
+  where
+    funTySpec : List CFType -> CFType -> Core String
+    funTySpec args (CFFun CFWorld t) = funTySpec args t
+    funTySpec args (CFFun s t) = funTySpec (s :: args) t
+    funTySpec args retty
+        = do rtyspec <- cType fc retty
+             argspecs <- traverse (cType fc) (reverse args)
+             pure $ rtyspec ++ " (*)(" ++ showSep ", " argspecs ++ ")"
+cType fc t = throw (GenericMsg fc ("Can't pass argument of type " ++ show t ++
+                       " to foreign function"))
+
 cftySpec : FC -> CFType -> Core String
 cftySpec fc CFUnit = pure "void"
 cftySpec fc CFInt = pure "int"
@@ -144,11 +165,26 @@ cftySpec fc (CFFun s t) = funTySpec [s] t
 cftySpec fc t = throw (GenericMsg fc ("Can't pass argument of type " ++ show t ++
                          " to foreign function"))
 
+
+record CCallbackInfo where
+  constructor MkCCallbackInfo
+  schemeArgName : String
+  schemeWrapName : String
+  callbackBody : String
+  argTypes : List String
+  retType : String
+
+record CWrapperDefs where
+  constructor MkCWrapperDefs
+  setBox : String
+  boxDef : String
+  cWrapDef : String
+
 cCall : {auto c : Ref Ctxt Defs} ->
         {auto l : Ref Loaded (List String)} ->
-        FC -> (cfn : String) -> (clib : String) ->
-        List (Name, CFType) -> CFType -> Core String
-cCall fc cfn clib args ret
+        FC -> (cfn : String) -> (fnWrapName : String -> String) -> (clib : String) ->
+        List (Name, CFType) -> CFType -> Core (String, String)
+cCall fc cfn fnWrapName clib args ret
     = do -- loaded <- get Loaded
          -- lib <- if clib `elem` loaded
          --           then pure ""
@@ -158,13 +194,26 @@ cCall fc cfn clib args ret
          --                   pure ""
          argTypes <- traverse (\a => cftySpec fc (snd a)) args
          retType <- cftySpec fc ret
-         let call = "((c-lambda (" ++ showSep " " argTypes ++ ") "
+
+         argsInfo <- traverse buildArg args
+         argCTypes <- traverse (\a => cType fc (snd a)) args
+         retCType <- cType fc ret
+
+         let cWrapperDefs = map buildCWrapperDefs $ mapMaybe snd argsInfo
+         let cFunWrapDeclaration = buildCFunWrapDeclaration cfn retCType argCTypes
+         let wrapDeclarations = cFunWrapDeclaration
+                                ++ concatMap (.boxDef) cWrapperDefs
+                                ++ concatMap (.cWrapDef) cWrapperDefs
+
+         let setBoxes = concatMap (.setBox) cWrapperDefs
+         let call = " ((c-lambda (" ++ showSep " " argTypes ++ ") "
                       ++ retType ++ " " ++ show cfn ++ ") "
-                      ++ showSep " " !(traverse buildArg args) ++ ")"
+                      ++ showSep " " (map fst argsInfo) ++ ")"
+         let body = setBoxes ++ "\n" ++ call
 
          pure $ case ret of -- XXX
-                     CFIORes _ => handleRet retType call
-                     _ => call
+                     CFIORes _ => (handleRet retType body, wrapDeclarations) 
+                     _ => (body, wrapDeclarations)
   where
     mkNs : Int -> List CFType -> List (Maybe String)
     mkNs i [] = []
@@ -176,6 +225,34 @@ cCall fc cfn clib args ret
     applyLams n (Nothing :: as) = applyLams ("(" ++ n ++ " #f)") as
     applyLams n (Just a :: as) = applyLams ("(" ++ n ++ " " ++ a ++ ")") as
 
+    replaceChar : Char -> Char -> String -> String
+    replaceChar old new = pack . replaceOn old new . unpack
+
+    buildCWrapperDefs : CCallbackInfo -> CWrapperDefs
+    buildCWrapperDefs (MkCCallbackInfo arg schemeWrap callbackStr argTypes retType) = 
+      let box = schemeWrap ++ "-box"
+          setBox = "\n (set-box! " ++ box ++ " " ++ callbackStr ++ ")"
+          cWrapName = replaceChar '-' '_' schemeWrap
+          boxDef = "\n(define " ++ box ++ " (box #f))\n"
+
+          args = showSep " " $ map (\i => "farg-" ++ show i) [0 .. (natToInteger $ length argTypes) - 1]
+
+          cWrapDef =
+            "\n(c-define " ++
+            "(" ++ schemeWrap ++ " " ++ args ++ ")" ++
+            " (" ++ showSep " " argTypes ++ ")" ++
+            " " ++ retType ++
+            " \"" ++ cWrapName ++ "\"" ++ " \"\"" ++
+            "\n ((unbox " ++ box ++ ") " ++ args ++ ")" ++
+            "\n)\n"
+      in MkCWrapperDefs setBox boxDef cWrapDef
+
+    buildCFunWrapDeclaration : String -> String -> List String -> String
+    buildCFunWrapDeclaration name ret args =
+      "\n(c-declare #<<c-declare-end\n" ++
+      ret ++ " " ++ name ++ "(" ++ showSep ", " args ++ ");" ++
+      "\nc-declare-end\n)\n"
+
     mkFun : List CFType -> CFType -> String -> String
     mkFun args ret n
         = let argns = mkNs 0 args in
@@ -186,17 +263,21 @@ cCall fc cfn clib args ret
     notWorld CFWorld = False
     notWorld _ = True
 
-    callback : String -> List CFType -> CFType -> Core String
+    callback : String -> List CFType -> CFType -> Core (String, List String, String)
     callback n args (CFFun s t) = callback n (s :: args) t
     callback n args_rev retty
         = do let args = reverse args_rev
              argTypes <- traverse (cftySpec fc) (filter notWorld args)
              retType <- cftySpec fc retty
-             pure $ mkFun args retty n -- FIXME Needs a top-level c-define
+             pure (mkFun args retty n, argTypes, retType)
 
-    buildArg : (Name, CFType) -> Core String
-    buildArg (n, CFFun s t) = callback (schName n) [s] t
-    buildArg (n, _) = pure $ schName n
+    buildArg : (Name, CFType) -> Core (String, Maybe CCallbackInfo)
+    buildArg (n, CFFun s t) = do
+      let arg = schName n
+      let schemeWrap = fnWrapName arg
+      (callbackBody, argTypes, retType) <- callback arg [s] t
+      pure (schemeWrap, Just $ MkCCallbackInfo arg schemeWrap callbackBody argTypes retType)
+    buildArg (n, _) = pure (schName n, Nothing)
 
 schemeCall : FC -> (sfn : String) ->
              List Name -> CFType -> Core String
@@ -211,16 +292,20 @@ schemeCall fc sfn argns ret
 -- of the function call.
 useCC : {auto c : Ref Ctxt Defs} ->
         {auto l : Ref Loaded (List String)} ->
-        FC -> List String -> List (Name, CFType) -> CFType -> Core (Maybe String, String)
+        FC -> List String -> List (Name, CFType) -> CFType -> Core (Maybe String, (String, String))
 useCC fc [] args ret
     = throw (GenericMsg fc "No recognised foreign calling convention")
 useCC fc (cc :: ccs) args ret
     = case parseCC cc of
            Nothing => useCC fc ccs args ret
-           Just ("scheme", [sfn]) => pure (Nothing, !(schemeCall fc sfn (map fst args) ret))
-           Just ("C", [cfn, clib]) => pure (Just clib, !(cCall fc cfn clib args ret))
-           Just ("C", [cfn, clib, chdr]) => pure (Just clib, !(cCall fc cfn clib args ret))
+           Just ("scheme", [sfn]) => pure (Nothing, (!(schemeCall fc sfn (map fst args) ret), ""))
+           Just ("C", [cfn, clib]) => pure (Just clib, !(cCall fc cfn (fnWrapName cfn) clib args ret))
+           Just ("C", [cfn, clib, chdr]) => pure (Just clib, !(cCall fc cfn (fnWrapName cfn) clib args ret))
            _ => useCC fc ccs args ret
+  where
+    fnWrapName : String -> String -> String
+    fnWrapName cfn schemeArgName = schemeArgName ++ "-" ++ cfn ++ "-cFunWrap"
+
 
 -- For every foreign arg type, return a name, and whether to pass it to the
 -- foreign call (we don't pass '%World')
@@ -256,10 +341,11 @@ schFgnDef fc n (MkNmForeign cs args ret)
          let useargns = map fst (filter snd argns)
          argStrs <- traverse mkStruct args
          retStr <- mkStruct ret
-         (lib, body) <- useCC fc cs (zip useargns args) ret
+         (lib, (body, wrapDeclarations)) <- useCC fc cs (zip useargns args) ret
          defs <- get Ctxt
          pure (lib,
                 concat argStrs ++ retStr ++
+                wrapDeclarations ++
                 "(define " ++ schName !(full (gamma defs) n) ++
                 " (lambda (" ++ showSep " " (map schName allargns) ++ ") " ++
                 body ++ "))\n")

--- a/support/c/idris_file.c
+++ b/support/c/idris_file.c
@@ -5,6 +5,7 @@
 #include <errno.h>
 #include <sys/stat.h>
 #include <time.h>
+#include <sys/time.h>
 #include <dirent.h>
 #include <unistd.h>
 


### PR DESCRIPTION
I tried to play with Idris on ios and the easiest way for it is Gambit backend and it worked great :)
But I found that Gambit backend didn't support callbacks in ffi so I added it.

Not sure if I should add tests for gambit backend. Locally I tested it on the example from the docs:
```
%foreign (libsmall "applyFn")
prim_applyFn : String -> Int -> (String -> Int -> String) -> PrimIO String

applyFn : String -> Int -> (String -> Int -> String) -> IO String
applyFn c i f = primIO $ prim_applyFn c i f
```

I also added #include <sys/time.h> to satisfy xcode.
It seems relevant to all BSD systems.
In xcode the option -Wno-error-implicit-function-declaration is enabled. So the following error occured:
"Idris2/support/c/idris_file.c:76:13: Missing '#include <sys/time.h>'; declaration of 'select' must be imported from module 'Darwin.POSIX.sys.time' before it is required"
I hope it won't break anything on linux.