### PR TITLE
A couple more elab reflection primitives

### DIFF
--- a/libs/base/Language/Reflection.idr
+++ b/libs/base/Language/Reflection.idr
@@ -3,6 +3,8 @@ module Language.Reflection
 import public Language.Reflection.TT
 import public Language.Reflection.TTImp
 
+-- Elaboration scripts. Where types/terms are returned, binders will have
+-- unique, if not necessarily human readabe, names
 export
 data Elab : Type -> Type where
      Pure : a -> Elab a
@@ -17,19 +19,20 @@ data Elab : Type -> Type where
      -- Get the current goal type, if known 
      -- (it might need to be inferred from the solution)
      Goal : Elab (Maybe TTImp)
+     -- Get the names of local variables in scope
+     LocalVars : Elab (List Name)
      -- Generate a new unique name, based on the given string
      GenSym : String -> Elab Name
      -- Put a name in the current namespace
      InCurrentNS : Name -> Elab Name
-
      -- Get the types of every name which matches.
      -- There may be ambiguities - returns a list of fully explicit names
      -- and their types. If there's no results, the name is undefined.
      GetType : Name -> Elab (List (Name, TTImp))
-
+     -- Get the type of a local variable
+     GetLocalType : Name -> Elab TTImp
      -- Get the constructors of a data type. The name must be fully resolved.
      GetCons : Name -> Elab (List Name)
-
      -- Check a group of top level declarations
      Declare : List Decl -> Elab ()
 
@@ -80,6 +83,10 @@ goal : Elab (Maybe TTImp)
 goal = Goal
 
 export
+localVars : Elab (List Name)
+localVars = LocalVars
+
+export
 genSym : String -> Elab Name
 genSym = GenSym
 
@@ -90,6 +97,10 @@ inCurrentNS = InCurrentNS
 export
 getType : Name -> Elab (List (Name, TTImp))
 getType = GetType
+
+export
+getLocalType : Name -> Elab TTImp
+getLocalType = GetLocalType
 
 export
 getCons : Name -> Elab (List Name)

--- a/src/Core/TT.idr
+++ b/src/Core/TT.idr
@@ -865,26 +865,28 @@ renameVarList prf (MkVar p) = renameLocalRef prf p
 
 export
 renameVars : CompatibleVars xs ys -> Term xs -> Term ys
-renameVars CompatPre tm = tm
-renameVars prf (Local fc r idx vprf)
-    = let MkVar vprf' = renameLocalRef prf vprf in
-          Local fc r _ vprf'
-renameVars prf (Ref fc x name) = Ref fc x name
-renameVars prf (Meta fc n i args)
-    = Meta fc n i (map (renameVars prf) args)
-renameVars prf (Bind fc x b scope)
-    = Bind fc x (map (renameVars prf) b) (renameVars (CompatExt prf) scope)
-renameVars prf (App fc fn arg)
-    = App fc (renameVars prf fn) (renameVars prf arg)
-renameVars prf (As fc s as tm)
-    = As fc s (renameVars prf as) (renameVars prf tm)
-renameVars prf (TDelayed fc r ty) = TDelayed fc r (renameVars prf ty)
-renameVars prf (TDelay fc r ty tm)
-    = TDelay fc r (renameVars prf ty) (renameVars prf tm)
-renameVars prf (TForce fc r x) = TForce fc r (renameVars prf x)
-renameVars prf (PrimVal fc c) = PrimVal fc c
-renameVars prf (Erased fc i) = Erased fc i
-renameVars prf (TType fc) = TType fc
+renameVars compat tm = believe_me tm -- no names in term, so it's identity
+-- This is how we would define it:
+-- renameVars CompatPre tm = tm
+-- renameVars prf (Local fc r idx vprf)
+--     = let MkVar vprf' = renameLocalRef prf vprf in
+--           Local fc r _ vprf'
+-- renameVars prf (Ref fc x name) = Ref fc x name
+-- renameVars prf (Meta fc n i args)
+--     = Meta fc n i (map (renameVars prf) args)
+-- renameVars prf (Bind fc x b scope)
+--     = Bind fc x (map (renameVars prf) b) (renameVars (CompatExt prf) scope)
+-- renameVars prf (App fc fn arg)
+--     = App fc (renameVars prf fn) (renameVars prf arg)
+-- renameVars prf (As fc s as tm)
+--     = As fc s (renameVars prf as) (renameVars prf tm)
+-- renameVars prf (TDelayed fc r ty) = TDelayed fc r (renameVars prf ty)
+-- renameVars prf (TDelay fc r ty tm)
+--     = TDelay fc r (renameVars prf ty) (renameVars prf tm)
+-- renameVars prf (TForce fc r x) = TForce fc r (renameVars prf x)
+-- renameVars prf (PrimVal fc c) = PrimVal fc c
+-- renameVars prf (Erased fc i) = Erased fc i
+-- renameVars prf (TType fc) = TType fc
 
 export
 renameTop : (m : Name) -> Term (n :: vars) -> Term (m :: vars)

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -81,7 +81,9 @@ elabScript fc nest env (NDCon nfc nm t ar args) exp
                  | Nothing => nfOpts withAll defs env
                                      !(reflect fc defs env (the (Maybe RawImp) Nothing))
              ty <- getTerm gty
-             scriptRet (Just !(unelabNoSugar env ty))
+             scriptRet (Just !(unelabUniqueBinders env ty))
+    elabCon defs "LocalVars" []
+        = scriptRet vars
     elabCon defs "GenSym" [str]
         = do str' <- evalClosure defs str
              n <- uniqueName defs [] !(reify defs str')
@@ -97,7 +99,16 @@ elabScript fc nest env (NDCon nfc nm t ar args) exp
       where
         unelabType : (Name, Int, ClosedTerm) -> Core (Name, RawImp)
         unelabType (n, _, ty)
-            = pure (n, !(unelabNoSugar [] ty))
+            = pure (n, !(unelabUniqueBinders [] ty))
+    elabCon defs "GetLocalType" [n]
+        = do n' <- evalClosure defs n
+             n <- reify defs n'
+             case defined n env of
+                  Just (MkIsDefined rigb lv) =>
+                       do let binder = getBinder lv env
+                          let bty = binderType binder
+                          scriptRet !(unelabUniqueBinders env bty)
+                  _ => throw (GenericMsg fc (show n ++ " is not a local variable"))
     elabCon defs "GetCons" [n]
         = do n' <- evalClosure defs n
              cn <- reify defs n'


### PR DESCRIPTION
Get the names of local variables. and add the ability to look up their
types.
When we get a reflected TTImp, either checking the Goal or looking up a
type, it's not impossible that there'll be some repeated binder names,
so also make sure binders are unique relative to the current context.
Ideally we'd also rename things in the environment to guarantee that all
names are unique, but we don't yet.

(This would be much easier if reflected terms were typed such that they
were well scoped, but that would also make reflection harder to use.)