### PR TITLE
Try to load libidris2_support on older Windows

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,7 +9,10 @@ requirements are:
   a Mac, you can install this with `brew install coreutils`.
 
 On Windows, it has been reported that installing via `MSYS2` works
-(https://www.msys2.org/). On Raspberry Pi, you can bootstrap via Racket.
+(https://www.msys2.org/). On Windows older than Windows 8, you may need to
+set an environment variable `OLD_WIN=1` or modify it in `config.mk`.
+
+On Raspberry Pi, you can bootstrap via Racket.
 
 By default, code generation is via Chez Scheme. You can use Racket instead,
 by setting the environment variable `IDRIS2_CG=racket` before running `make`.

--- a/config.mk
+++ b/config.mk
@@ -4,6 +4,9 @@ PREFIX ?= $(HOME)/.idris2
 
 CC ?= clang
 
+# For Windows targets. Set to 1 to support Windows 7.
+OLD_WIN ?= 0
+
 ##################################################################
 
 RANLIB ?= ranlib

--- a/support/c/Makefile
+++ b/support/c/Makefile
@@ -11,6 +11,9 @@ SRCS = $(wildcard *.c)
 ifeq ($(OS), windows)
 	SRCS += windows/win_utils.c windows/win_hack.c
 	LDFLAGS += -lws2_32
+ifeq ($(OLD_WIN), 1)
+	CFLAGS += -D_OLD_WIN
+endif
 endif
 OBJS = $(SRCS:.c=.o)
 DEPS = $(OBJS:.o=.d)

--- a/support/c/windows/win_utils.c
+++ b/support/c/windows/win_utils.c
@@ -55,7 +55,12 @@ FILE *win32_u8popen(const char *path, const char *mode)
 void win32_gettime(int64_t* sec, int64_t* nsec)
 {
     FILETIME ft;
+#ifdef _OLD_WIN
+    GetSystemTimeAsFileTime(&ft);
+#else
+    // For Windows NT 6.2 or higher
     GetSystemTimePreciseAsFileTime(&ft);
+#endif
     ULARGE_INTEGER t;
     t.HighPart = ft.dwHighDateTime;
     t.LowPart = ft.dwLowDateTime;


### PR DESCRIPTION
`GetSystemTimePreciseAsFileTime ` was introduced in Windows 8. On earlier Windows systems, it might compile (with a newer SDK), but the result dll cannot be loaded. For these systems, use `GetSystemTimeAsFileTime ` instead.