### PR TITLE
Reflection fixes

### DIFF
--- a/src/Core/Reflect.idr
+++ b/src/Core/Reflect.idr
@@ -444,7 +444,7 @@ Reify t => Reify (PiInfo t) where
              (NS _ (UN "ImplicitArg"), _) => pure Implicit
              (NS _ (UN "ExplicitArg"), _) => pure Explicit
              (NS _ (UN "AutoImplicit"), _) => pure AutoImplicit
-             (NS _ (UN "DefImplicit"), [t])
+             (NS _ (UN "DefImplicit"), [_, t])
                  => do t' <- reify defs !(evalClosure defs t)
                        pure (DefImplicit t')
              _ => cantReify val "PiInfo"
@@ -452,12 +452,15 @@ Reify t => Reify (PiInfo t) where
 
 export
 Reflect t => Reflect (PiInfo t) where
-  reflect fc defs env Implicit = getCon fc defs (reflectiontt "ImplicitArg")
-  reflect fc defs env Explicit = getCon fc defs (reflectiontt "ExplicitArg")
-  reflect fc defs env AutoImplicit = getCon fc defs (reflectiontt "AutoImplicit")
+  reflect fc defs env Implicit
+      = appCon fc defs (reflectiontt "ImplicitArg") [Erased fc False]
+  reflect fc defs env Explicit
+      = appCon fc defs (reflectiontt "ExplicitArg") [Erased fc False]
+  reflect fc defs env AutoImplicit
+      = appCon fc defs (reflectiontt "AutoImplicit") [Erased fc False]
   reflect fc defs env (DefImplicit t)
       = do t' <- reflect fc defs env t
-           appCon fc defs (reflectiontt "DefImplicit") [t']
+           appCon fc defs (reflectiontt "DefImplicit") [Erased fc False, t']
 
 export
 Reify LazyReason where

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -84,8 +84,8 @@ elabScript fc nest env (NDCon nfc nm t ar args) exp
              scriptRet (Just !(unelabNoSugar env ty))
     elabCon defs "GenSym" [str]
         = do str' <- evalClosure defs str
-             n <- uniqueName defs [] !(reify defs str')
-             scriptRet (UN n)
+             n <- genVarName !(reify defs str')
+             scriptRet n
     elabCon defs "InCurrentNS" [n]
         = do n' <- evalClosure defs n
              nsn <- inCurrentNS !(reify defs n')

--- a/tests/idris2/reflection003/expected
+++ b/tests/idris2/reflection003/expected
@@ -12,4 +12,4 @@ Error during reflection: Still not trying
 refprims.idr:43:10--45:1:While processing right hand side of dummy3 at refprims.idr:43:1--45:1:
 Error during reflection: Undefined name
 refprims.idr:46:10--48:1:While processing right hand side of dummy4 at refprims.idr:46:1--48:1:
-Error during reflection: failed after generating Main.plus_1
+Error during reflection: failed after generating Main.{plus:5817}


### PR DESCRIPTION
PiInfo was reflected wrongly. Also there is a more useful behaviour for genSym - instead of just checking the name doesn't exist globally, use the name supply which unification uses, which will give a completely new name.