### PR TITLE
Added auto_implicit_depth pragma

### DIFF
--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -2017,6 +2017,13 @@ setAmbigLimit max
          put Ctxt (record { options->elabDirectives->ambigLimit = max } defs)
 
 export
+setAutoImplicitLimit : {auto c : Ref Ctxt Defs} ->
+                       Nat -> Core ()
+setAutoImplicitLimit max
+    = do defs <- get Ctxt
+         put Ctxt (record { options->elabDirectives->autoImplicitLimit = max } defs)
+
+export
 isLazyActive : {auto c : Ref Ctxt Defs} ->
                Core Bool
 isLazyActive
@@ -2048,6 +2055,13 @@ getAmbigLimit : {auto c : Ref Ctxt Defs} ->
 getAmbigLimit
     = do defs <- get Ctxt
          pure (ambigLimit (elabDirectives (options defs)))
+
+export
+getAutoImplicitLimit : {auto c : Ref Ctxt Defs} ->
+                       Core Nat
+getAutoImplicitLimit
+    = do defs <- get Ctxt
+         pure (autoImplicitLimit (elabDirectives (options defs)))
 
 export
 setPair : {auto c : Ref Ctxt Defs} ->

--- a/src/Core/Options.idr
+++ b/src/Core/Options.idr
@@ -101,6 +101,7 @@ record ElabDirectives where
   totality : TotalReq
   ambigLimit : Nat
   undottedRecordProjections : Bool
+  autoImplicitLimit : Nat
 
 public export
 record Session where
@@ -150,7 +151,7 @@ defaultSession = MkSessionOpts False False False Chez 0 False False
 
 export
 defaultElab : ElabDirectives
-defaultElab = MkElabDirectives True True CoveringOnly 3 True
+defaultElab = MkElabDirectives True True CoveringOnly 3 True 50
 
 export
 defaults : Options

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -810,6 +810,7 @@ mutual
              UndottedRecordProjections b => do
                pure [IPragma (\nest, env => setUndottedRecordProjections b)]
              AmbigDepth n => pure [IPragma (\nest, env => setAmbigLimit n)]
+             AutoImplicitDepth n => pure [IPragma (\nest, env => setAutoImplicitLimit n)]
              PairNames ty f s => pure [IPragma (\nest, env => setPair fc ty f s)]
              RewriteName eq rw => pure [IPragma (\nest, env => setRewrite fc eq rw)]
              PrimInteger n => pure [IPragma (\nest, env => setFromInteger n)]

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1096,6 +1096,10 @@ directive fname indents
          lvl <- intLit
          atEnd indents
          pure (AmbigDepth (fromInteger lvl))
+  <|> do pragma "auto_implicit_depth"
+         dpt <- intLit
+         atEnd indents
+         pure (AutoImplicitDepth (fromInteger dpt))
   <|> do pragma "pair"
          ty <- name
          f <- name

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -168,6 +168,7 @@ mutual
        Extension : LangExt -> Directive
        DefaultTotality : TotalReq -> Directive
        UndottedRecordProjections : Bool -> Directive
+       AutoImplicitDepth : Nat -> Directive
 
   public export
   data PField : Type where

--- a/src/TTImp/Elab/App.idr
+++ b/src/TTImp/Elab/App.idr
@@ -195,7 +195,8 @@ mutual
                    -- so we might as well calculate the whole thing now
                    metaty <- quote defs env aty
                    est <- get EST
-                   metaval <- searchVar fc argRig 50 (Resolved (defining est))
+                   lim <- getAutoImplicitLimit
+                   metaval <- searchVar fc argRig lim (Resolved (defining est))
                                         env nm metaty
                    let fntm = App fc tm metaval
                    fnty <- sc defs (toClosure defaultOpts env metaval)


### PR DESCRIPTION
By default, the search depth for auto implicit arguments is limited to 50. In some cases, it may be reasonable to manually extend this limit for a specific file or portion of a file.
This patch adds a `%auto_implicit_depth n` pragma that overrides the default limit.

For example, this trivial code fails, because the autosearch cannot construct a LTE value deeper than 50:
```
consumeBoundedNat : (x : Nat) -> LTE x 255 => ()
consumeBoundedNat x = ()

testSearch : ()
testSearch = consumeBoundedNat 100
-- Fails with:
-- Can't find an implementation for LTE 100 255
```
Adding `%auto_implicit_depth 256` on top of testSearch declaration leads to a correct typecheck with reasonable compile times, in this particular case. To revert to the default depth it suffices to write `%auto_implicit_depth 50`. 

Should I leave the option as it is, or should I allow `%auto_implicit_depth default` to revert to the default configuration?