### PR TITLE
In reflection, check now takes a concrete type

### DIFF
--- a/libs/base/Language/Reflection.idr
+++ b/libs/base/Language/Reflection.idr
@@ -14,8 +14,8 @@ data Elab : Type -> Type where
      LogMsg : Nat -> String -> Elab ()
      LogTerm : Nat -> String -> TTImp -> Elab ()
 
-     -- Check a TTImp term against the current goal type
-     Check : TTImp -> Elab TT
+     -- Elaborate a TTImp term to a concrete value
+     Check : {expected : Type} -> TTImp -> Elab expected
      -- Get the current goal type, if known 
      -- (it might need to be inferred from the solution)
      Goal : Elab (Maybe TTImp)
@@ -73,9 +73,8 @@ logGoal n msg
               Nothing => pure ()
               Just t => logTerm n msg t
 
--- Check a TTImp term against the current goal type
 export
-check : TTImp -> Elab TT
+check : {expected : Type} -> TTImp -> Elab expected
 check = Check
 
 export

--- a/libs/base/Language/Reflection.idr
+++ b/libs/base/Language/Reflection.idr
@@ -16,6 +16,8 @@ data Elab : Type -> Type where
 
      -- Elaborate a TTImp term to a concrete value
      Check : {expected : Type} -> TTImp -> Elab expected
+     -- Quote a concrete expression back to a TTImp
+     Quote : val -> Elab TTImp
      -- Get the current goal type, if known 
      -- (it might need to be inferred from the solution)
      Goal : Elab (Maybe TTImp)
@@ -76,6 +78,10 @@ logGoal n msg
 export
 check : {expected : Type} -> TTImp -> Elab expected
 check = Check
+
+export
+quote : val -> Elab TTImp
+quote = Quote
 
 export
 goal : Elab (Maybe TTImp)

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -85,6 +85,11 @@ elabScript fc nest env (NDCon nfc nm t ar args) exp
                            (Just (glueBack defs env exp'))
              empty <- clearDefs defs
              nf empty env checktm
+    elabCon defs "Quote" [exp, tm]
+        = do tm' <- evalClosure defs tm
+             defs <- get Ctxt
+             empty <- clearDefs defs
+             scriptRet !(unelabUniqueBinders env !(quote empty env tm'))
     elabCon defs "Goal" []
         = do let Just gty = exp
                  | Nothing => nfOpts withAll defs env

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -75,7 +75,16 @@ elabScript fc nest env (NDCon nfc nm t ar args) exp
                      pure $ !(reify defs str') ++ ": " ++
                              show (the RawImp !(reify defs tm'))
              scriptRet ()
-    elabCon defs "Check" [ttimp] = evalClosure defs ttimp -- to be reified
+    elabCon defs "Check" [exp, ttimp]
+        = do exp' <- evalClosure defs exp
+             ttimp' <- evalClosure defs ttimp
+             tidx <- resolveName (UN "[elaborator script]")
+             e <- newRef EST (initEState tidx env)
+             (checktm, _) <- runDelays 0 $
+                     check top (initElabInfo InExpr) nest env !(reify defs ttimp')
+                           (Just (glueBack defs env exp'))
+             empty <- clearDefs defs
+             nf empty env checktm
     elabCon defs "Goal" []
         = do let Just gty = exp
                  | Nothing => nfOpts withAll defs env
@@ -138,17 +147,23 @@ checkRunElab : {vars : _} ->
                FC -> RawImp -> Maybe (Glued vars) ->
                Core (Term vars, Glued vars)
 checkRunElab rig elabinfo nest env fc script exp
-    = do defs <- get Ctxt
+    = do expected <- mkExpected exp
+         defs <- get Ctxt
          when (not (isExtension ElabReflection defs)) $
              throw (GenericMsg fc "%language ElabReflection not enabled")
          let n = NS ["Reflection", "Language"] (UN "Elab")
          let ttn = reflectiontt "TT"
-         tt <- getCon fc defs ttn
-         elabtt <- appCon fc defs n [tt]
+         elabtt <- appCon fc defs n [expected]
          (stm, sty) <- runDelays 0 $
                            check rig elabinfo nest env script (Just (gnf env elabtt))
          defs <- get Ctxt -- checking might have resolved some holes
          ntm <- elabScript fc nest env
-                           !(nfOpts withAll defs env stm) exp
+                           !(nfOpts withAll defs env stm) (Just (gnf env expected))
          defs <- get Ctxt -- might have updated as part of the script
-         check rig elabinfo nest env !(reify defs ntm) exp
+         pure (!(quote defs env ntm), gnf env expected)
+  where
+    mkExpected : Maybe (Glued vars) -> Core (Term vars)
+    mkExpected (Just ty) = pure !(getTerm ty)
+    mkExpected Nothing
+        = do nm <- genName "scriptTy"
+             metaVar fc erased env nm (TType fc)

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -87,7 +87,7 @@ idrisTests
        "record001", "record002", "record003", "record004",
        -- Quotation and reflection
        "reflection001", "reflection002", "reflection003", "reflection004",
-       "reflection005", "reflection006",
+       "reflection005", "reflection006", "reflection007",
        -- Miscellaneous regressions
        "reg001", "reg002", "reg003", "reg004", "reg005", "reg006", "reg007",
        "reg008", "reg009", "reg010", "reg011", "reg012", "reg013", "reg014",

--- a/tests/idris2/reflection002/expected
+++ b/tests/idris2/reflection002/expected
@@ -2,4 +2,7 @@
 Main> Main.cube : Nat -> Nat
 cube = \x => mult x (mult x (mult x 1))
 Main> 27
+Main> Main.cube' : Nat -> Nat
+cube' = \x => mult (mult (plus x 0) x) x
+Main> 27
 Main> Bye for now!

--- a/tests/idris2/reflection002/expected
+++ b/tests/idris2/reflection002/expected
@@ -1,5 +1,5 @@
 1/1: Building power (power.idr)
 Main> Main.cube : Nat -> Nat
-cube = \x => mult x (mult x (mult x (const (fromInteger 1) x)))
+cube = \x => mult x (mult x (mult x 1))
 Main> 27
 Main> Bye for now!

--- a/tests/idris2/reflection002/expected
+++ b/tests/idris2/reflection002/expected
@@ -1,8 +1,8 @@
 1/1: Building power (power.idr)
 Main> Main.cube : Nat -> Nat
-cube = \x => mult x (mult x (mult x 1))
+cube = \x => mult x (mult x (mult x (const (fromInteger 1) x)))
 Main> 27
 Main> Main.cube' : Nat -> Nat
-cube' = \x => mult (mult (plus x 0) x) x
+cube' = \x => mult (mult (mult (const (fromInteger 1) x) x) x) x
 Main> 27
 Main> Bye for now!

--- a/tests/idris2/reflection002/input
+++ b/tests/idris2/reflection002/input
@@ -1,3 +1,5 @@
 :printdef cube
 cube 3
+:printdef cube'
+cube' 3
 :q

--- a/tests/idris2/reflection002/power.idr
+++ b/tests/idris2/reflection002/power.idr
@@ -6,9 +6,21 @@ powerFn : Nat -> TTImp
 powerFn Z = `(const 1)
 powerFn (S k) = `(\x => mult x (~(powerFn k) x))
 
+powerFn' : Nat -> Elab (Nat -> Nat)
+powerFn' Z = pure (const 1)
+powerFn' (S k) = do powerk <- powerFn' k
+                    pure (\x => mult (powerk x) x)
+
 %macro
 power : Nat -> Elab (Nat -> Nat)
 power n = check (powerFn n)
 
+%macro
+power' : Nat -> Elab (Nat -> Nat)
+power' n = powerFn' n
+
 cube : Nat -> Nat
 cube = power 3
+
+cube' : Nat -> Nat
+cube' = power' 3

--- a/tests/idris2/reflection002/power.idr
+++ b/tests/idris2/reflection002/power.idr
@@ -7,7 +7,7 @@ powerFn Z = `(const 1)
 powerFn (S k) = `(\x => mult x (~(powerFn k) x))
 
 %macro
-power : Nat -> Elab TT
+power : Nat -> Elab (Nat -> Nat)
 power n = check (powerFn n)
 
 cube : Nat -> Nat

--- a/tests/idris2/reflection003/expected
+++ b/tests/idris2/reflection003/expected
@@ -12,4 +12,4 @@ Error during reflection: Still not trying
 refprims.idr:43:10--45:1:While processing right hand side of dummy3 at refprims.idr:43:1--45:1:
 Error during reflection: Undefined name
 refprims.idr:46:10--48:1:While processing right hand side of dummy4 at refprims.idr:46:1--48:1:
-Error during reflection: failed after generating Main.{plus:5817}
+Error during reflection: failed after generating Main.{plus:5841}

--- a/tests/idris2/reflection003/refprims.idr
+++ b/tests/idris2/reflection003/refprims.idr
@@ -2,7 +2,7 @@ import Language.Reflection
 
 %language ElabReflection
 
-logPrims : Elab TT
+logPrims : Elab a
 logPrims
     = do ns <- getType `{{ (++) }} 
          traverse (\ (n, ty) =>
@@ -10,7 +10,7 @@ logPrims
                            logTerm 0 "Type" ty) ns
          fail "Not really trying"
 
-logDataCons : Elab TT
+logDataCons : Elab a
 logDataCons
     = do [(n, _)] <- getType `{{ Nat }}
              | _ => fail "Ambiguous name"
@@ -18,7 +18,7 @@ logDataCons
          logMsg 0 ("Constructors: " ++ show !(getCons n))
          fail "Still not trying"
 
-logBad : Elab TT
+logBad : Elab a
 logBad
     = do [(n, _)] <- getType `{{ DoesntExist }}
              | [] => fail "Undefined name"
@@ -27,7 +27,7 @@ logBad
          logMsg 0 ("Constructors: " ++ show !(getCons n))
          fail "Still not trying"
 
-tryGenSym : Elab TT
+tryGenSym : Elab a
 tryGenSym
    = do n <- genSym "plus"
         ns <- inCurrentNS n

--- a/tests/idris2/reflection004/refdecl.idr
+++ b/tests/idris2/reflection004/refdecl.idr
@@ -2,7 +2,7 @@ import Language.Reflection
 
 %language ElabReflection
 
-logDecls : TTImp -> Elab TT
+logDecls : TTImp -> Elab (Int -> Int)
 logDecls v
     = do declare [IClaim EmptyFC MW Public []
                  (MkTy EmptyFC `{{ Main.foo }}

--- a/tests/idris2/reflection005/expected
+++ b/tests/idris2/reflection005/expected
@@ -1,9 +1,9 @@
 1/1: Building refdecl (refdecl.idr)
 refdecl.idr:13:16--14:1:While processing right hand side of bad at refdecl.idr:13:1--14:1:
-When unifying Elab () and Elab TT
+When unifying Elab () and Elab a
 Mismatch between:
 	()
 and
-	TT
+	a
 Main> 9400
 Main> Bye for now!

--- a/tests/idris2/reflection006/refleq.idr
+++ b/tests/idris2/reflection006/refleq.idr
@@ -2,7 +2,7 @@ import Language.Reflection
 
 %language ElabReflection
 
-solveReflected : TTImp -> Elab TT
+solveReflected : TTImp -> Elab any
 solveReflected `(Builtin.Equal {a=_} {b=_} ~(left) ~(right))
     = do logTerm 0 "Left" left
          logTerm 0 "Right" right
@@ -12,7 +12,7 @@ solveReflected g
          fail "I don't know how to prove this"
 
 %macro
-prove : Elab TT
+prove : Elab any
 prove
     = do env <- localVars
          Just g <- goal

--- a/tests/idris2/reflection007/NatExpr.idr
+++ b/tests/idris2/reflection007/NatExpr.idr
@@ -1,0 +1,40 @@
+import Language.Reflection
+
+%language ElabReflection
+
+data NatExpr : Nat -> Type where
+     Plus : NatExpr x -> NatExpr y -> NatExpr (plus x y)
+     Mult : NatExpr x -> NatExpr y -> NatExpr (mult x y)
+     Dbl : NatExpr x -> NatExpr (mult 2 x)
+     Val : (val : Nat) -> NatExpr val
+
+getNatExpr : TTImp -> Elab (n ** NatExpr n)
+getNatExpr `(Prelude.plus ~(x) ~(y))
+   = do (_ ** xval) <- getNatExpr x
+        (_ ** yval) <- getNatExpr y
+        pure (_ ** Plus xval yval)
+getNatExpr `(Prelude.mult (Prelude.S (Prelude.S Prelude.Z)) ~(y))
+   = do (y ** yval) <- getNatExpr y
+        pure (_ ** Dbl yval)
+getNatExpr `(Prelude.mult ~(x) ~(y))
+   = do (_ ** xval) <- getNatExpr x
+        (_ ** yval) <- getNatExpr y
+        pure (_ ** Mult xval yval)
+getNatExpr x = pure (_ ** Val !(check x))
+
+%macro
+mkNatExpr : (n : Nat) -> Elab (NatExpr n)
+mkNatExpr n
+    = do Just `(Main.NatExpr ~(expr)) <- goal
+              | _ => fail "Goal is not a NatExpr"
+         (n' ** expr') <- getNatExpr expr
+         check !(quote expr')
+
+test1 : (x : Nat) -> (y : Nat) -> NatExpr (plus x (plus y x))
+test1 x y = mkNatExpr _ -- yes, auto implicits can do this too :)
+
+test2 : (x : Nat) -> (y : Nat) -> NatExpr (plus x (mult y x))
+test2 x y = mkNatExpr _
+
+test3 : (x : Nat) -> (y : Nat) -> NatExpr (plus x (mult 2 x))
+test3 x y = mkNatExpr _ -- auto implicit search gets something different

--- a/tests/idris2/reflection007/expected
+++ b/tests/idris2/reflection007/expected
@@ -1,0 +1,8 @@
+1/1: Building NatExpr (NatExpr.idr)
+Main> Main.test1 : (x : Nat) -> (y : Nat) -> NatExpr (plus x (plus y x))
+test1 x y = Plus (Val x) (Plus (Val y) (Val x))
+Main> Main.test2 : (x : Nat) -> (y : Nat) -> NatExpr (plus x (mult y x))
+test2 x y = Plus (Val x) (Mult (Val y) (Val x))
+Main> Main.test3 : (x : Nat) -> Nat -> NatExpr (plus x (mult 2 x))
+test3 x y = Plus (Val x) (Dbl (Val x))
+Main> Bye for now!

--- a/tests/idris2/reflection007/input
+++ b/tests/idris2/reflection007/input
@@ -1,0 +1,4 @@
+:printdef test1
+:printdef test2
+:printdef test3
+:q

--- a/tests/idris2/reflection007/run
+++ b/tests/idris2/reflection007/run
@@ -1,0 +1,3 @@
+$1 --no-banner NatExpr.idr < input
+
+rm -rf build


### PR DESCRIPTION
So the type of Elab now gives the expected type that's being elaborated
to, meaning that we can run 'check' in the middle of scripts and use the
result.