### PR TITLE
Remove redundant thin functions and replace with insertNames

### DIFF
--- a/src/Compiler/CompileExpr.idr
+++ b/src/Compiler/CompileExpr.idr
@@ -370,9 +370,9 @@ mutual
 --                              let env : SubstCEnv args (MN "eff" 0 :: vars)
 --                                      = mkSubst 0 (CLocal fc First) pos args in
 --                              do sc' <- toCExpTree n sc
---                                 let scope = thin {outer=args}
---                                                  {inner=vars}
---                                                  (MN "eff" 0) sc'
+--                                 let scope = insertNames {outer=args}
+--                                                         {inner=vars}
+--                                                         [MN "eff" 0] sc'
 --                                 pure $ Just (CLet fc (MN "eff" 0) False scr
 --                                                   (substs env scope))
                 _ => pure Nothing -- there's a normal match to do

--- a/src/Core/CaseTree.idr
+++ b/src/Core/CaseTree.idr
@@ -143,16 +143,6 @@ mutual
       = DefaultCase (insertCaseNames ns ct)
 
 export
-thinTree : {outer, inner : _} ->
-           (n : Name) -> CaseTree (outer ++ inner) -> CaseTree (outer ++ n :: inner)
-thinTree n (Case idx prf scTy alts)
-    = let MkNVar prf' = insertNVar {n} _ prf in
-          Case _ prf' (thin n scTy) (map (insertCaseAltNames [n]) alts)
-thinTree n (STerm i tm) = STerm i (thin n tm)
-thinTree n (Unmatched msg) = Unmatched msg
-thinTree n Impossible = Impossible
-
-export
 Weaken CaseTree where
   weakenNs ns t = insertCaseNames {outer = []} ns t
 

--- a/src/Core/TT.idr
+++ b/src/Core/TT.idr
@@ -712,42 +712,6 @@ insertNVarNames {ns} {outer = (y :: xs)} (S i) (Later x)
           MkNVar (Later prf)
 
 export
-thin : {outer, inner : _} ->
-       (n : Name) -> Term (outer ++ inner) -> Term (outer ++ n :: inner)
-thin n (Local fc r idx prf)
-    = let MkNVar var' = insertNVar {n} idx prf in
-          Local fc r _ var'
-thin n (Ref fc nt name) = Ref fc nt name
-thin n (Meta fc name idx args) = Meta fc name idx (map (thin n) args)
-thin {outer} {inner} n (Bind fc x b scope)
-    = let sc' = thin {outer = x :: outer} {inner} n scope in
-          Bind fc x (thinBinder n b) sc'
-  where
-    thinPi : (n : Name) -> PiInfo (Term (outer ++ inner)) ->
-             PiInfo (Term (outer ++ n :: inner))
-    thinPi n Explicit = Explicit
-    thinPi n Implicit = Implicit
-    thinPi n AutoImplicit = AutoImplicit
-    thinPi n (DefImplicit t) = DefImplicit (thin n t)
-
-    thinBinder : (n : Name) -> Binder (Term (outer ++ inner)) ->
-                 Binder (Term (outer ++ n :: inner))
-    thinBinder n (Lam c p ty) = Lam c (thinPi n p) (thin n ty)
-    thinBinder n (Let c val ty) = Let c (thin n val) (thin n ty)
-    thinBinder n (Pi c p ty) = Pi c (thinPi n p) (thin n ty)
-    thinBinder n (PVar c p ty) = PVar c (thinPi n p) (thin n ty)
-    thinBinder n (PLet c val ty) = PLet c (thin n val) (thin n ty)
-    thinBinder n (PVTy c ty) = PVTy c (thin n ty)
-thin n (App fc fn arg) = App fc (thin n fn) (thin n arg)
-thin n (As fc s nm tm) = As fc s (thin n nm) (thin n tm)
-thin n (TDelayed fc r ty) = TDelayed fc r (thin n ty)
-thin n (TDelay fc r ty tm) = TDelay fc r (thin n ty) (thin n tm)
-thin n (TForce fc r tm) = TForce fc r (thin n tm)
-thin n (PrimVal fc c) = PrimVal fc c
-thin n (Erased fc i) = Erased fc i
-thin n (TType fc) = TType fc
-
-export
 insertNames : {outer, inner : _} ->
               (ns : List Name) -> Term (outer ++ inner) ->
               Term (outer ++ (ns ++ inner))
@@ -774,7 +738,6 @@ insertNames ns (TType fc) = TType fc
 
 export
 Weaken Term where
-  weaken tm = thin {outer = []} _ tm
   weakenNs ns tm = insertNames {outer = []} ns tm
 
 export


### PR DESCRIPTION
There are three functions; `Core.TT.thin`, `Core.CaseTree.thinTree`, and `Core.CompileExpr.thin`; which duplicate much of the code of `Core.TT.insertNames`, `Core.CaseTree.insertCaseNames`, and `Core.CompileExpr.insertNames`.

This PR removes them, and replaces their (very infrequent) use by equivalent uses of `insertNames`.

I'm not sure how much you try to keep a stable module API, but this would be a breaking change.  If that's something that's important, I can add short wrapper functions in place of the originals:

```idris
%inline
export
thin : {outer, inner : _} ->
       (n : Name) -> Term (outer ++ inner) -> Term (outer ++ n :: inner)
thin n t = insertNames [n] t
```