### PR TITLE
Fix test reporting when in interactive mode.

### DIFF
--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -198,8 +198,8 @@ runTest opts testPath
               ]
             Just exp => do
               putStrLn "Golden value differs from actual value."
-              code <- system "git diff expected output"
-              when (code /= 0) $ printExpectedVsOutput exp out
+              code <- system "git diff --exit-code expected output"
+              when (code < 0) $ printExpectedVsOutput exp out
               putStrLn "Accept actual value as new golden value? [yn]"
           b <- getAnswer
           when b $ do Right _ <- writeFile "expected" out


### PR DESCRIPTION
The current approach has the wrong boolean test.
When the command executed cleanly it will return 0.
A non-zero answer implies that `git diff` errored.