### PR TITLE
Added fix to recvAll that doesn't use signal (Left 0)

### DIFF
--- a/libs/network/Network/Socket.idr
+++ b/libs/network/Network/Socket.idr
@@ -173,10 +173,10 @@ recvAll sock = recvRec sock [] 64
     recvRec : Socket -> List String -> ByteLength -> IO (Either SocketError String)
     recvRec sock acc n = do res <- recv sock n
                             case res of
-                              Left 0 => pure (Right $ concat $ reverse acc)
                               Left c => pure (Left c)
-                              Right (str, _) => let n' = min (n * 2) 65536 in
-                                                recvRec sock (str :: acc) n'
+                              Right (str, res) => let n' = min (n * 2) 65536 in
+                                                  if res < n then pure (Right $ concat $ reverse $ str :: acc)
+                                                  else recvRec sock (str :: acc) n'
 
 ||| Send a message.
 |||


### PR DESCRIPTION
We have tried to use the recvAll functionality in the Network.Socket library from the contrib package.
It seems that when it runs recursively into the recv on an empty buffer, it is blocking and not receiving the clean exit (Left 0) signal, thus running infinitely and never returning.
We propose a solution to this issue that instead of waiting for a Left 0 signal, the function runs recursively until then buffer size is smaller than the reading size that it is trying to achieve.