### PR TITLE
More explicitness in evaluator return type

### DIFF
--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -92,6 +92,7 @@ idrisTests
        "reg001", "reg002", "reg003", "reg004", "reg005", "reg006", "reg007",
        "reg008", "reg009", "reg010", "reg011", "reg012", "reg013", "reg014",
        "reg015", "reg016", "reg017", "reg018", "reg019", "reg020", "reg021",
+       "reg022", "reg023",
        -- Totality checking
        "total001", "total002", "total003", "total004", "total005",
        "total006", "total007", "total008",

--- a/tests/idris2/reg023/boom.idr
+++ b/tests/idris2/reg023/boom.idr
@@ -1,0 +1,27 @@
+import Data.Vect
+
+%default total
+
+infix 3 .<=.
+(.<=.) : Int -> Int -> Bool
+(.<=.) p q = case (p, q) of
+  (0, _) => True
+  _ => False
+
+countGreater : (thr : Int) -> (ctx : Vect n Int) -> Nat
+countGreater thr [] = Z
+countGreater thr (x :: xs) with (x .<=. thr)
+  countGreater thr (x :: xs) | True = countGreater thr xs
+  countGreater thr (x :: xs) | False = S $ countGreater thr xs
+
+-- map a variable from the old context to the erased context
+-- where we erase all bindings less than or equal to the threshold
+eraseVar : (thr : Int) -> (ctx : Vect n Int) -> Fin n -> Maybe (Fin (countGreater thr ctx))
+eraseVar thr (x :: xs) j with (x .<=. thr)
+  eraseVar thr (x :: xs) FZ | True = Nothing
+  eraseVar thr (x :: xs) FZ | False = Just FZ
+  eraseVar thr (x :: xs) (FS i) | True = FS <$> eraseVar thr xs i
+  eraseVar thr (x :: xs) (FS i) | False = FS <$> eraseVar thr xs i
+
+boom : Maybe (Fin 1)
+boom = eraseVar 0 [0, 1] (FS FZ)

--- a/tests/idris2/reg023/expected
+++ b/tests/idris2/reg023/expected
@@ -1,0 +1,6 @@
+1/1: Building boom (boom.idr)
+boom.idr:23:42--24:3:While processing right hand side of with block in eraseVar at boom.idr:23:3--24:3:
+Can't solve constraint between:
+	S (countGreater thr xs)
+and
+	countGreater thr xs

--- a/tests/idris2/reg023/run
+++ b/tests/idris2/reg023/run
@@ -1,0 +1,3 @@
+$1 --check boom.idr
+
+rm -rf build


### PR DESCRIPTION
Another one from the "stop trying to be clever" files :). Instead of a
continuation for fallthrough in the evaluator, be explicit about whether
there's a result, no match, or evaluation is stuck.
Fixes #70