### PR TITLE
Add finalisers to Chez and Racket back ends

### DIFF
--- a/docs/source/ffi/ffi.rst
+++ b/docs/source/ffi/ffi.rst
@@ -436,4 +436,4 @@ the pointer is no longer accessible, or at the end of execution.
 
 Note that finalisers might not be supported by all back ends, since they depend
 on the facilities offered by a specific back end's run time system. They are
-certainly supported in the Chez Scheme back end.
+certainly supported in the Chez Scheme and Racket back ends.

--- a/docs/source/ffi/ffi.rst
+++ b/docs/source/ffi/ffi.rst
@@ -409,3 +409,31 @@ can convert between a ``void*`` and a ``char*`` in C:
 
     %foreign (pfn "getString")
     getString : Ptr String -> String
+
+
+Finalisers
+----------
+
+In some libraries, a foreign function creates a pointer and the caller is
+responsible for freeing it. In this case, you can make an explicit foreign
+call to ``free``. However, this is not always convenient, or even possible.
+Instead, you can ask the Idris run-time to be responsible for freeing the
+pointer when it is no longer accessible, using ``onCollect`` (or its
+typeless variant ``onCollectAny``) defined in the Prelude:
+
+.. code-block:: idris
+
+    onCollect : Ptr t -> (Ptr t -> IO ()) -> IO (GCPtr t)
+    onCollectAny : AnyPtr -> (AnyPtr -> IO ()) -> IO GCAnyPtr
+
+A ``GCPtr t`` behaves exactly like ``Ptr t`` when passed to a foreign
+function (and, similarly, ``GCAnyPtr`` behaves like ``AnyPtr``). A foreign
+function cannot return a ``GCPtr`` however, because then we can no longer
+assume the pointer is completely managed by the Idris run-time.
+
+The finaliser is called either when the garbage collector determines that
+the pointer is no longer accessible, or at the end of execution.
+
+Note that finalisers might not be supported by all back ends, since they depend
+on the facilities offered by a specific back end's run time system. They are
+certainly supported in the Chez Scheme back end.

--- a/libs/prelude/PrimIO.idr
+++ b/libs/prelude/PrimIO.idr
@@ -56,6 +56,14 @@ data Ptr : Type -> Type where [external]
 public export
 data AnyPtr : Type where [external]
 
+-- As Ptr, but associated with a finaliser that is run on garbage collection
+public export
+data GCPtr : Type -> Type where [external]
+
+-- As AnyPtr, but associated with a finaliser that is run on garbage collection
+public export
+data GCAnyPtr : Type where [external]
+
 public export
 data ThreadID : Type where [external]
 
@@ -95,6 +103,19 @@ prim__forgetPtr = believe_me
 export %inline
 prim__nullPtr : Ptr t -> Int -- can't pass 'type' to a foreign function
 prim__nullPtr p = prim__nullAnyPtr (prim__forgetPtr p)
+
+%extern
+prim__onCollectAny : AnyPtr -> (AnyPtr -> PrimIO ()) -> PrimIO GCAnyPtr
+%extern
+prim__onCollect : Ptr t -> (Ptr t -> PrimIO ()) -> PrimIO (GCPtr t)
+
+export
+onCollectAny : AnyPtr -> (AnyPtr -> IO ()) -> IO GCAnyPtr
+onCollectAny ptr c = primIO (prim__onCollectAny ptr (\x => toPrim (c x)))
+
+export
+onCollect : Ptr t -> (Ptr t -> IO ()) -> IO (GCPtr t)
+onCollect ptr c = primIO (prim__onCollect ptr (\x => toPrim (c x)))
 
 %foreign "C:idris2_getString, libidris2_support"
 export

--- a/src/Compiler/CompileExpr.idr
+++ b/src/Compiler/CompileExpr.idr
@@ -461,6 +461,7 @@ data NArgs : Type where
      Struct : String -> List (String, Closure []) -> NArgs
      NUnit : NArgs
      NPtr : NArgs
+     NGCPtr : NArgs
      NIORes : Closure [] -> NArgs
 
 getPArgs : Defs -> Closure [] -> Core (String, Closure [])
@@ -491,6 +492,8 @@ getNArgs : Defs -> Name -> List (Closure []) -> Core NArgs
 getNArgs defs (NS _ (UN "IORes")) [arg] = pure $ NIORes arg
 getNArgs defs (NS _ (UN "Ptr")) [arg] = pure NPtr
 getNArgs defs (NS _ (UN "AnyPtr")) [] = pure NPtr
+getNArgs defs (NS _ (UN "GCPtr")) [arg] = pure NGCPtr
+getNArgs defs (NS _ (UN "GCAnyPtr")) [] = pure NGCPtr
 getNArgs defs (NS _ (UN "Unit")) [] = pure NUnit
 getNArgs defs (NS _ (UN "Struct")) [n, args]
     = do NPrimVal _ (Str n') <- evalClosure defs n
@@ -536,6 +539,7 @@ nfToCFType _ s (NTCon fc n_in _ _ args)
                    pure (CFStruct n fs')
               NUnit => pure CFUnit
               NPtr => pure CFPtr
+              NGCPtr => pure CFGCPtr
               NIORes uarg =>
                 do narg <- evalClosure defs uarg
                    carg <- nfToCFType fc s narg

--- a/src/Compiler/Scheme/Common.idr
+++ b/src/Compiler/Scheme/Common.idr
@@ -183,6 +183,8 @@ data ExtPrim = CCall | SchemeCall
              | GetField | SetField
              | VoidElim
              | SysOS | SysCodegen
+             | OnCollect
+             | OnCollectAny
              | Unknown Name
 
 export
@@ -200,6 +202,8 @@ Show ExtPrim where
   show VoidElim = "VoidElim"
   show SysOS = "SysOS"
   show SysCodegen = "SysCodegen"
+  show OnCollect = "OnCollect"
+  show OnCollectAny = "OnCollectAny"
   show (Unknown n) = "Unknown " ++ show n
 
 ||| Match on a user given name to get the scheme primitive
@@ -217,7 +221,9 @@ toPrim pn@(NS _ n)
             (n == UN "prim__setField", SetField),
             (n == UN "void", VoidElim),
             (n == UN "prim__os", SysOS),
-            (n == UN "prim__codegen", SysCodegen)
+            (n == UN "prim__codegen", SysCodegen),
+            (n == UN "prim__onCollect", OnCollect),
+            (n == UN "prim__onCollectAny", OnCollectAny)
             ]
            (Unknown pn)
 toPrim pn = Unknown pn

--- a/src/Core/CompileExpr.idr
+++ b/src/Core/CompileExpr.idr
@@ -116,6 +116,7 @@ data CFType : Type where
      CFDouble : CFType
      CFChar : CFType
      CFPtr : CFType
+     CFGCPtr : CFType
      CFWorld : CFType
      CFFun : CFType -> CFType -> CFType
      CFIORes : CFType -> CFType
@@ -296,6 +297,7 @@ Show CFType where
   show CFDouble = "Double"
   show CFChar = "Char"
   show CFPtr = "Ptr"
+  show CFGCPtr = "GCPtr"
   show CFWorld = "%World"
   show (CFFun s t) = show s ++ " -> " ++ show t
   show (CFIORes t) = "IORes " ++ show t

--- a/src/Core/TTC.idr
+++ b/src/Core/TTC.idr
@@ -688,6 +688,7 @@ TTC CFType where
   toBuf b (CFIORes t) = do tag 9; toBuf b t
   toBuf b (CFStruct n a) = do tag 10; toBuf b n; toBuf b a
   toBuf b (CFUser n a) = do tag 11; toBuf b n; toBuf b a
+  toBuf b CFGCPtr = tag 12
 
   fromBuf b
       = case !getTag of
@@ -703,6 +704,7 @@ TTC CFType where
              9 => do t <- fromBuf b; pure (CFIORes t)
              10 => do n <- fromBuf b; a <- fromBuf b; pure (CFStruct n a)
              11 => do n <- fromBuf b; a <- fromBuf b; pure (CFUser n a)
+             12 => pure CFGCPtr
              _ => corrupt "CFType"
 
 export

--- a/support/chez/support.ss
+++ b/support/chez/support.ss
@@ -267,3 +267,18 @@
         (if (> k 0)
               (random k)
               (assertion-violationf 'blodwen-random "invalid range argument ~a" k)))]))
+
+;; For finalisers
+
+(define blodwen-finaliser (make-guardian))
+(define (blodwen-register-object obj proc)
+  (let [(x (cons obj proc))]
+       (blodwen-finaliser x)
+       x))
+(define blodwen-run-finalisers
+  (lambda ()
+    (let run ()
+      (let ([x (blodwen-finaliser)])
+        (when x
+          (((cdr x) (car x)) 'erased)
+          (run))))))

--- a/support/racket/support.rkt
+++ b/support/racket/support.rkt
@@ -263,3 +263,9 @@
     [(k) (if (> k 0)
            (random k)
            (raise 'blodwen-random-invalid-range-argument))]))
+
+;; For finalisers
+
+(define (blodwen-register-object obj proc)
+   (register-finalizer obj (lambda (ptr) ((proc ptr) 'erased)))
+   obj)

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -112,7 +112,7 @@ chezTests
    = ["chez001", "chez002", "chez003", "chez004", "chez005", "chez006",
       "chez007", "chez008", "chez009", "chez010", "chez011", "chez012",
       "chez013", "chez014", "chez015", "chez016", "chez017", "chez018",
-      "chez019", "chez020", "chez021",
+      "chez019", "chez020", "chez021", "chez022",
       "reg001"]
 
 ideModeTests : List String

--- a/tests/chez/chez022/Makefile
+++ b/tests/chez/chez022/Makefile
@@ -1,0 +1,28 @@
+include ../../../config.mk
+
+TARGET = libmkalloc
+
+SRCS = $(wildcard *.c)
+OBJS = $(SRCS:.c=.o)
+DEPS = $(OBJS:.o=.d)
+
+
+all: $(TARGET)$(SHLIB_SUFFIX)
+
+$(TARGET)$(SHLIB_SUFFIX): $(OBJS)
+	$(CC) -shared $(LDFLAGS) -o $@ $^
+
+
+-include $(DEPS)
+
+%.d: %.c
+	@$(CPP) $(CFLAGS) $< -MM -MT $(@:.d=.o) >$@
+
+
+.PHONY: clean
+
+clean :
+	$(RM) $(OBJS) $(TARGET)$(SHLIB_SUFFIX)
+
+cleandep: clean
+	$(RM) $(DEPS)

--- a/tests/chez/chez022/expected
+++ b/tests/chez/chez022/expected
@@ -1,0 +1,9 @@
+Hello
+Hello
+Done
+Free X
+Freeing 0 Hello
+Free Y
+Freeing 1 Hello
+1/1: Building usealloc (usealloc.idr)
+Main> Main> Bye for now!

--- a/tests/chez/chez022/input
+++ b/tests/chez/chez022/input
@@ -1,0 +1,2 @@
+:exec main
+:q

--- a/tests/chez/chez022/mkalloc.c
+++ b/tests/chez/chez022/mkalloc.c
@@ -1,4 +1,5 @@
-#include <malloc.h>
+#include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 
 typedef struct {

--- a/tests/chez/chez022/mkalloc.c
+++ b/tests/chez/chez022/mkalloc.c
@@ -1,0 +1,26 @@
+#include <malloc.h>
+#include <string.h>
+
+typedef struct {
+    int val;
+    char* str;
+} Stuff;
+
+Stuff* mkThing() {
+    static int num = 0;
+    Stuff* x = malloc(sizeof(Stuff));
+    x->val = num++;
+    x->str = malloc(20);
+    strcpy(x->str,"Hello");
+    return x;
+}
+
+char* getStr(Stuff* x) {
+    return x->str;
+}
+
+void freeThing(Stuff* x) {
+    printf("Freeing %d %s\n", x->val, x->str);
+    free(x->str);
+    free(x);
+}

--- a/tests/chez/chez022/run
+++ b/tests/chez/chez022/run
@@ -1,0 +1,4 @@
+make all > /dev/null
+$1 --no-banner usealloc.idr < input
+rm -rf build
+make clean > /dev/null

--- a/tests/chez/chez022/usealloc.idr
+++ b/tests/chez/chez022/usealloc.idr
@@ -1,0 +1,34 @@
+
+%foreign "C:mkThing, libmkalloc"
+prim__mkThing : PrimIO AnyPtr
+%foreign "C:getStr, libmkalloc"
+prim__getStr : GCAnyPtr -> PrimIO String
+%foreign "C:freeThing, libmkalloc"
+prim__freeThing : AnyPtr -> PrimIO ()
+
+mkThing : IO AnyPtr
+mkThing = primIO prim__mkThing
+
+getThingStr : GCAnyPtr -> IO String
+getThingStr t = primIO (prim__getStr t)
+
+freeThing : AnyPtr -> IO ()
+freeThing t = primIO (prim__freeThing t)
+
+doThings : IO ()
+doThings 
+     = do xp <- mkThing
+          yp <- mkThing
+
+          x <- onCollectAny xp (\p => do putStrLn "Free X"
+                                         freeThing p)
+          y <- onCollectAny yp (\p => do putStrLn "Free Y"
+                                         freeThing p)
+
+          putStrLn !(getThingStr x)
+          putStrLn !(getThingStr y)
+
+main : IO ()
+main = do doThings
+          putStrLn "Done"
+

--- a/tests/chez/chez022/usealloc.idr
+++ b/tests/chez/chez022/usealloc.idr
@@ -1,4 +1,3 @@
-
 %foreign "C:mkThing, libmkalloc"
 prim__mkThing : PrimIO AnyPtr
 %foreign "C:getStr, libmkalloc"
@@ -31,4 +30,3 @@ doThings
 main : IO ()
 main = do doThings
           putStrLn "Done"
-

--- a/tests/idris2/coverage008/expected
+++ b/tests/idris2/coverage008/expected
@@ -1,6 +1,6 @@
 1/1: Building wcov (wcov.idr)
 Main> Main.tfoo is total
 Main> Main.wfoo is total
-Main> Main.wbar is not covering due to call to function Main.with block in 1368
+Main> Main.wbar is not covering due to call to function Main.with block in 1376
 Main> Main.wbar1 is total
 Main> Bye for now!

--- a/tests/idris2/coverage010/expected
+++ b/tests/idris2/coverage010/expected
@@ -1,3 +1,3 @@
 1/1: Building casetot (casetot.idr)
 casetot.idr:12:1--13:1:main is not covering:
-	Calls non covering function Main.case block in 2079(287)
+	Calls non covering function Main.case block in 2087(287)


### PR DESCRIPTION
This involves new primitives GCPtr and GCAnyPtr which are pointer types that have finalisers attached. The finalisers are run when the associated pointer goes out of scope, or at the end (so there's now an explicit call to the GC at the end).

In the test, I am assuming that the GC will only be called once, right at the end. Otherwise, the output isn't guaranteed to be deterministic! Let's see how this assumption holds...

I expect it'll be easy enough to add to the Gambit back end, but I'll wait for a patch for that.