### PR TITLE
In IDE mode, look for a ipkg file before loading

### DIFF
--- a/src/Idris/IDEMode/REPL.idr
+++ b/src/Idris/IDEMode/REPL.idr
@@ -20,6 +20,7 @@ import Data.So
 import Idris.Desugar
 import Idris.Error
 import Idris.ModTree
+import Idris.Package
 import Idris.Parser
 import Idris.Resugar
 import Idris.REPL
@@ -148,8 +149,11 @@ process : {auto c : Ref Ctxt Defs} ->
           IDECommand -> Core IDEResult
 process (Interpret cmd)
     = replWrap $ interpret cmd
-process (LoadFile fname _)
-    = replWrap $ Idris.REPL.process (Load fname) >>= outputSyntaxHighlighting fname
+process (LoadFile fname_in _)
+    = do let fname = case !(findIpkg (Just fname_in)) of
+                          Nothing => fname_in
+                          Just f' => f'
+         replWrap $ Idris.REPL.process (Load fname) >>= outputSyntaxHighlighting fname
 process (TypeOf n Nothing)
     = replWrap $ Idris.REPL.process (Check (PRef replFC (UN n)))
 process (TypeOf n (Just (l, c)))

--- a/tests/ideMode/ideMode001/dummy.ipkg
+++ b/tests/ideMode/ideMode001/dummy.ipkg
@@ -1,0 +1,1 @@
+package idemode001

--- a/tests/ideMode/ideMode003/dummy.ipkg
+++ b/tests/ideMode/ideMode003/dummy.ipkg
@@ -1,0 +1,1 @@
+package idemode003


### PR DESCRIPTION
This takes the responsibility of finding the ipkg away from IDE mode, which seems sensible given that we can do it ourselves. If there isn't one, it'll load from the local directory as always.

(I won't merge this immediately - please shout if it's likely to break anything. I think it's a better way to go, though, in the end.)