### PR TITLE
Improved parsing for literate modes.

### DIFF
--- a/src/Text/Literate.idr
+++ b/src/Text/Literate.idr
@@ -35,8 +35,7 @@ untilEOL : Recognise False
 untilEOL = manyUntil newline any
 
 line : String -> Lexer
-line s = exact s <+> newline
-     <|> exact s <+> space <+> untilEOL
+line s = exact s <+> (newline <|> space <+> untilEOL)
 
 block : String -> String -> Lexer
 block s e = surround (exact s <+> untilEOL) (exact e <+> untilEOL) any

--- a/src/Text/Literate.idr
+++ b/src/Text/Literate.idr
@@ -32,13 +32,18 @@ import Data.Strings
 %default total
 
 untilEOL : Recognise False
-untilEOL = manyUntil (is '\n') any
+untilEOL = manyUntil newline any
 
 line : String -> Lexer
-line s = exact s <+> space <+> untilEOL
+line s = exact s <+> newline
+     <|> exact s <+> space <+> untilEOL
 
 block : String -> String -> Lexer
 block s e = surround (exact s <+> untilEOL) (exact e <+> untilEOL) any
+
+notCodeLine : Lexer
+notCodeLine = newline
+           <|> any <+> untilEOL
 
 data Token = CodeBlock String String String
            | Any String
@@ -55,7 +60,7 @@ rawTokens : (delims  : List (String, String))
 rawTokens delims ls =
           map (\(l,r) => (block l r, CodeBlock (trim l) (trim r))) delims
        ++ map (\m => (line m, CodeLine (trim m))) ls
-       ++ [(any, Any)]
+       ++ [(notCodeLine, Any)]
 
 ||| Merge the tokens into a single source file.
 reduce : List (TokenData Token) -> String -> String
@@ -68,10 +73,11 @@ reduce (MkToken _ _ (Any x) :: rest) acc = reduce rest (acc ++ blank_content)
       then concat $ replicate (length (lines x)) "\n"
       else ""
 reduce (MkToken _ _ (CodeLine m src) :: rest) acc =
-    reduce rest (acc ++ (substr
-                           (length m + 1) -- remove space to right of marker.
-                           (length src)
-                           src))
+    if m == trim src
+    then reduce rest (acc ++ "\n")
+    else reduce rest (acc ++ (substr (length m + 1) -- remove space to right of marker.
+                                     (length src)
+                                     src))
 
 reduce (MkToken _ _ (CodeBlock l r src) :: rest) acc with (lines src) -- Strip the deliminators surrounding the block.
   reduce (MkToken _ _ (CodeBlock l r src) :: rest) acc | [] = reduce rest acc -- 1

--- a/src/Text/Literate.idr
+++ b/src/Text/Literate.idr
@@ -62,28 +62,28 @@ rawTokens delims ls =
        ++ [(notCodeLine, Any)]
 
 ||| Merge the tokens into a single source file.
-reduce : List (TokenData Token) -> String -> String
-reduce [] acc = acc
-reduce (MkToken _ _ (Any x) :: rest) acc = reduce rest (acc ++ blank_content)
+reduce : List (TokenData Token) -> List String -> String
+reduce [] acc = fastAppend (reverse acc)
+reduce (MkToken _ _ (Any x) :: rest) acc = reduce rest (blank_content::acc)
   where
     -- Preserve the original document's line count.
     blank_content : String
-    blank_content = if elem '\n' (unpack x)
-      then concat $ replicate (length (lines x)) "\n"
-      else ""
+    blank_content = fastAppend (replicate (length (lines x)) "\n")
+
 reduce (MkToken _ _ (CodeLine m src) :: rest) acc =
     if m == trim src
-    then reduce rest (acc ++ "\n")
-    else reduce rest (acc ++ (substr (length m + 1) -- remove space to right of marker.
-                                     (length src)
-                                     src))
+    then reduce rest ("\n"::acc)
+    else reduce rest ((substr (length m + 1) -- remove space to right of marker.
+                              (length src)
+                              src
+                      )::acc)
 
 reduce (MkToken _ _ (CodeBlock l r src) :: rest) acc with (lines src) -- Strip the deliminators surrounding the block.
   reduce (MkToken _ _ (CodeBlock l r src) :: rest) acc | [] = reduce rest acc -- 1
   reduce (MkToken _ _ (CodeBlock l r src) :: rest) acc | (s :: ys) with (snocList ys)
     reduce (MkToken _ _ (CodeBlock l r src) :: rest) acc | (s :: []) | Empty = reduce rest acc -- 2
     reduce (MkToken _ _ (CodeBlock l r src) :: rest) acc | (s :: (srcs ++ [f])) | (Snoc f srcs rec) =
-        reduce rest (acc ++ "\n" ++ unlines srcs)
+        reduce rest ("\n" :: unlines srcs :: acc)
 
 -- [ NOTE ] 1 & 2 shouldn't happen as code blocks are well formed i.e. have two deliminators.
 
@@ -164,7 +164,7 @@ extractCode : (specification : LiterateStyle)
            -> Either LiterateError String
 extractCode (MkLitStyle delims markers exts) str =
       case lex (rawTokens delims markers) str of
-        (toks, (_,_,"")) => Right $ reduce toks ""
+        (toks, (_,_,"")) => Right (reduce toks Nil)
         (_, (l,c,i))     => Left (MkLitErr l c i)
 
 ||| Synonym for `extractCode`.

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -58,6 +58,7 @@ idrisTests
        "literate001", "literate002", "literate003", "literate004",
        "literate005", "literate006", "literate007", "literate008",
        "literate009", "literate010", "literate011", "literate012",
+       "literate013",
        -- Interfaces
        "interface001", "interface002", "interface003", "interface004",
        "interface005", "interface006", "interface007", "interface008",

--- a/tests/idris2/literate013/Lit.lidr
+++ b/tests/idris2/literate013/Lit.lidr
@@ -1,0 +1,16 @@
+> module Lit
+>
+> %default total
+
+a > b
+
+a < b
+
+> data V a = Empty | Extend a (V a)
+
+> isCons : V a -> Bool
+> isCons Empty = False
+> isCons (Extend _ _) = True
+
+< namespace Hidden
+<   data U a = Empty | Extend a (U a)

--- a/tests/idris2/literate013/expected
+++ b/tests/idris2/literate013/expected
@@ -1,0 +1,1 @@
+1/1: Building Lit (Lit.lidr)

--- a/tests/idris2/literate013/run
+++ b/tests/idris2/literate013/run
@@ -1,0 +1,3 @@
+$1 --no-banner --check Lit.lidr
+
+rm -rf build


### PR DESCRIPTION
The tokenizer for literate modes was incorrectly detecting code lines within the text. 
Code line deliminators should only be at the start of a line.

This PR fixes that by ensuring tokenizers consume whole lines at a time. We also allow for empty code lines..

This commit partially addresses  #211.

No performance improvements are made, and the hidden bird style remains.