### PR TITLE
[ fix ] make some exports public

### DIFF
--- a/libs/base/Data/List.idr
+++ b/libs/base/Data/List.idr
@@ -332,7 +332,7 @@ init [x] = []
 init (x::y::ys) = x :: init (y::ys)
 
 ||| Attempt to get the head of a list. If the list is empty, return `Nothing`.
-export
+public export
 head' : List a -> Maybe a
 head' []      = Nothing
 head' (x::xs) = Just x
@@ -402,7 +402,7 @@ intercalate sep xss = concat $ intersperse sep xss
 
 ||| Apply a partial function to the elements of a list, keeping the ones at which
 ||| it is defined.
-export
+public export
 mapMaybe : (a -> Maybe b) -> List a -> List b
 mapMaybe f []      = []
 mapMaybe f (x::xs) =


### PR DESCRIPTION
I have managed to track down the reason why not enough computation was
happening on the idris2 branch of tparsec to get the STLC example running.
We use these two functions at the type level but they are not publically exported.

It turns out that by simply asking for the type of `test` in the repl, I would
not get the top-level type I had declared but rather the one Idris inferred: a 
big expression clearly stuck on `mapMaybe`, and then on `head'`.

Having to make some functions `public` in the main repo on a per-project
basis does not seem like a tractable solution.