### PR TITLE
Make fastAppend a foreign call

### DIFF
--- a/libs/base/Data/Strings.idr
+++ b/libs/base/Data/Strings.idr
@@ -20,7 +20,7 @@ foldl1 f (x::xs) = foldl f x xs
 -- enough room in advance so there's only one allocation, rather than lots!
 %foreign
     "scheme:string-concat"
-    "node:lambda:__prim_idris2js_stringConcat"
+    "javascript:lambda:__prim_idris2js_stringConcat"
 export
 fastConcat : List String -> String
 

--- a/libs/base/Data/Strings.idr
+++ b/libs/base/Data/Strings.idr
@@ -20,7 +20,7 @@ foldl1 f (x::xs) = foldl f x xs
 -- enough room in advance so there's only one allocation, rather than lots!
 %foreign
     "scheme:string-concat"
-    "javascript:lambda:__prim_idris2js_stringConcat"
+    "javascript:lambda:(xs)=>''.concat(...__prim_idris2js_array(xs))"
 export
 fastConcat : List String -> String
 

--- a/libs/base/Data/Strings.idr
+++ b/libs/base/Data/Strings.idr
@@ -20,6 +20,7 @@ foldl1 f (x::xs) = foldl f x xs
 -- enough room in advance so there's only one allocation, rather than lots!
 %foreign
     "scheme:string-concat"
+    "node:lambda:__prim_idris2js_stringConcat"
 export
 fastConcat : List String -> String
 

--- a/libs/base/Data/Strings.idr
+++ b/libs/base/Data/Strings.idr
@@ -21,7 +21,13 @@ foldl1 f (x::xs) = foldl f x xs
 %foreign
     "scheme:string-concat"
 export
+fastConcat : List String -> String
+
+-- This is a deprecated alias for fastConcat for backwards compatibility
+-- (unfortunately, we don't have %deprecated yet).
+export
 fastAppend : List String -> String
+fastAppend = fastConcat
 
 ||| Splits a character list into a list of whitespace separated character lists.
 |||

--- a/libs/base/Data/Strings.idr
+++ b/libs/base/Data/Strings.idr
@@ -16,15 +16,12 @@ partial
 foldl1 : (a -> a -> a) -> List a -> a
 foldl1 f (x::xs) = foldl f x xs
 
--- This works quickly because when string-append builds the result, it allocates
+-- This works quickly because when string-concat builds the result, it allocates
 -- enough room in advance so there's only one allocation, rather than lots!
+%foreign
+    "scheme:string-concat"
 export
 fastAppend : List String -> String
-fastAppend xs = unsafePerformIO (schemeCall String "string-append" (toFArgs xs))
-  where
-    toFArgs : List String -> FArgList
-    toFArgs [] = []
-    toFArgs (x :: xs) = x :: toFArgs xs
 
 ||| Splits a character list into a list of whitespace separated character lists.
 |||

--- a/src/Compiler/ES/ES.idr
+++ b/src/Compiler/ES/ES.idr
@@ -421,7 +421,6 @@ static_preamble =
   , "function __prim_idris2js_FArgList(x){if(x.h === 0){return []}else{return x.a2.concat(__prim_idris2js_FArgList(x.a3))}}"
   , "function __prim_js2idris_array(x){if(x.length ===0){return {h:0}}else{return {h:1,a1:x[0],a2: __prim_js2idris_array(x.slice(1))}}}"
   , "function __prim_idris2js_array(x){const result = Array();while (x.h != 0) {result.push(x.a1); x = x.a2;}return result;}"
-  , "function __prim_idris2js_stringConcat(x){return ''.concat(...__prim_idris2js_array(x))}"
   ]
 
 export

--- a/src/Compiler/ES/ES.idr
+++ b/src/Compiler/ES/ES.idr
@@ -337,9 +337,7 @@ jsPrim (NS _ (UN "prim__os")) [] =
     sysos <- addConstToPreamble "sysos" (oscalc ++ "(" ++ os ++ ".platform())")
     pure sysos
 jsPrim  (NS _ (UN "prim__schemeCall"))[_, fn, args, _] =
-  case fn of
-    "'string-append'" => pure $ "''.concat(...__prim_idris2js_FArgList("++ args ++"))"
-    o => throw (InternalError $ "schemeCall not implemented " ++ show o)
+    throw (InternalError $ "schemeCall not implemented " ++ show (fn, args))
 jsPrim x args = throw $ InternalError $ "prim not implemented: " ++ (show x)
 
 tag2es : Either Int String -> String
@@ -423,6 +421,7 @@ static_preamble =
   , "function __prim_idris2js_FArgList(x){if(x.h === 0){return []}else{return x.a2.concat(__prim_idris2js_FArgList(x.a3))}}"
   , "function __prim_js2idris_array(x){if(x.length ===0){return {h:0}}else{return {h:1,a1:x[0],a2: __prim_js2idris_array(x.slice(1))}}}"
   , "function __prim_idris2js_array(x){const result = Array();while (x.h != 0) {result.push(x.a1); x = x.a2;}return result;}"
+  , "function __prim_idris2js_stringConcat(x){return ''.concat(...__prim_idris2js_array(x))}"
   ]
 
 export

--- a/support/chez/support.ss
+++ b/support/chez/support.ss
@@ -61,6 +61,12 @@
 (define cast-string-double
   (lambda (x)
     (cast-num (string->number (destroy-prefix x)))))
+
+(define (from-idris-list xs)
+  (if (= (vector-ref xs 0) 0)
+    '()
+    (cons (vector-ref xs 1) (from-idris-list (vector-ref xs 2)))))
+(define (string-concat xs) (apply string-append (from-idris-list xs)))
 (define string-cons (lambda (x y) (string-append (string x) y)))
 (define get-tag (lambda (x) (vector-ref x 0)))
 (define string-reverse (lambda (x)

--- a/support/gambit/support.scm
+++ b/support/gambit/support.scm
@@ -68,6 +68,13 @@
 (define-macro (cast-string-int x)
   `(floor (cast-string-double ,x)))
 
+(define (from-idris-list xs)
+  (if (= (vector-ref xs 0) 0)
+    '()
+    (cons (vector-ref xs 1) (from-idris-list (vector-ref xs 2)))))
+(define-macro (string-concat xs)
+  `(apply string-append (from-idris-list ,xs)))
+
 (define-macro (string-cons x y)
   `(string-append (string ,x) ,y))
 

--- a/support/racket/support.rkt
+++ b/support/racket/support.rkt
@@ -55,6 +55,11 @@
 (define cast-string-double
   (lambda (x)
     (cast-num (string->number (destroy-prefix x)))))
+(define (from-idris-list xs)
+  (if (= (vector-ref xs 0) 0)
+    '()
+    (cons (vector-ref xs 1) (from-idris-list (vector-ref xs 2)))))
+(define (string-concat xs) (apply string-append (from-idris-list xs)))
 (define string-cons (lambda (x y) (string-append (string x) y)))
 (define get-tag (lambda (x) (vector-ref x 0)))
 (define string-reverse (lambda (x)


### PR DESCRIPTION
`Data.Strings.fastAppend` was a `schemeCall`; this patch makes it a foreign call, so it can be implemented on non-Scheme backends.