### PR TITLE
Fix MkRecord signature

### DIFF
--- a/libs/base/Language/Reflection/TTImp.idr
+++ b/libs/base/Language/Reflection/TTImp.idr
@@ -132,7 +132,7 @@ mutual
   data Record : Type where
        MkRecord : FC -> (n : Name) ->
                   (params : List (Name, TTImp)) ->
-                  (conName : Maybe Name) ->
+                  (conName : Name) ->
                   (fields : List IField) ->
                   Record
 

--- a/tests/idris2/reflection004/refdecl.idr
+++ b/tests/idris2/reflection004/refdecl.idr
@@ -1,6 +1,22 @@
+import Data.Nat
+import Data.Vect
 import Language.Reflection
 
 %language ElabReflection
+
+axes : (n : Nat) -> {auto gt : GT n 0} -> {auto lte : LTE n 4} -> Vect n String
+axes 1 = ["x"]
+axes 2 = "y" :: axes 1
+axes 3 = "z" :: axes 2
+axes 4  = "w" :: axes 3
+axes (S (S (S (S (S _))))) {lte = (LTESucc (LTESucc (LTESucc (LTESucc (LTESucc _)))))} impossible
+
+mkPoint : (n : Nat) -> {auto gt : GT n 0} -> {auto lte : LTE n 4} -> Decl
+mkPoint n
+    = let type = "Point" ++ show n ++ "D" in
+      IRecord emptyFC Public
+      (MkRecord emptyFC (NS ["Main"] (UN type)) [] (NS ["Main"] (UN ("Mk" ++ type)))
+        (toList $ map (\axis => MkIField emptyFC MW ExplicitArg (RF axis) `(Double)) (axes n)))
 
 logDecls : TTImp -> Elab (Int -> Int)
 logDecls v
@@ -9,6 +25,8 @@ logDecls v
                                `(Int -> Int -> Int) )]
 
          declare `[ foo x y = x + y ]
+
+         declare [ mkPoint 3 ]
 
          declare `[ multBy : Int -> Int
                     multBy x = x * ~(v) ]
@@ -19,3 +37,6 @@ logDecls v
 
 mkMult : Int -> Int
 mkMult = %runElab logDecls `(4)
+
+point : Point3D
+point = MkPoint3D 1.0 2.0 3.0


### PR DESCRIPTION
I'm probably doing something wrong in the test (I must admit I don't have much experience and it's been a long time since I've played with Idris), feel free to request changes (if I define `axes` as a subroutine of `mkPoint` by using `where`, the totality checker will complain but maybe it's unrelated?).

If I `declare [ mkPoint 4 ]`, I'll get `Main.(.z) is already defined` which seems about right but I couldn't figure out if there is a way to properly namespace fields (adding `NS [type, "Main"]` doesn't help, any idea?).