### PR TITLE
Extend Control.App.FileIO

### DIFF
--- a/libs/base/Control/App/FileIO.idr
+++ b/libs/base/Control/App/FileIO.idr
@@ -25,6 +25,7 @@ interface Has [Exception IOError] e => FileIO e where
   fGetChar : File -> App e Char
   fPutStr : File -> String -> App e ()
   fPutStrLn : File -> String -> App e ()
+  fflush : File -> App e ()
   fEOF : File -> App e Bool
 
 -- TODO : Add Binary File IO with buffers
@@ -68,6 +69,8 @@ Has [PrimIO, Exception IOError] e => FileIO e where
   fPutStr f str = fileOp (fPutStr f str)
 
   fPutStrLn f str = fileOp (File.fPutStrLn f str)
+
+  fflush f = primIO $ fflush f
 
   fEOF f = primIO $ fEOF f
 

--- a/support/c/idris_file.c
+++ b/support/c/idris_file.c
@@ -107,7 +107,7 @@ char* idris2_readLine(FILE* f) {
     return buffer; // freed by RTS if not NULL
 }
 
-char* idris_readChars(int num, FILE* f) {
+char* idris2_readChars(int num, FILE* f) {
     char *buffer = malloc((num+1)*sizeof(char));
     size_t len;
     len = fread(buffer, sizeof(char), (size_t)num, f);

--- a/support/c/idris_file.h
+++ b/support/c/idris_file.h
@@ -18,7 +18,7 @@ int idris2_fpoll(FILE* f);
 
 // Treat as a Ptr String (might be NULL)
 char* idris2_readLine(FILE* f);
-char* idris_readChars(int num, FILE* f);
+char* idris2_readChars(int num, FILE* f);
 
 int idris2_writeLine(FILE* f, char* str);
 

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -113,7 +113,7 @@ chezTests
    = ["chez001", "chez002", "chez003", "chez004", "chez005", "chez006",
       "chez007", "chez008", "chez009", "chez010", "chez011", "chez012",
       "chez013", "chez014", "chez015", "chez016", "chez017", "chez018",
-      "chez019", "chez020", "chez021", "chez022",
+      "chez019", "chez020", "chez021", "chez022", "chez023",
       "reg001"]
 
 ideModeTests : List String

--- a/tests/chez/chez023/File.idr
+++ b/tests/chez/chez023/File.idr
@@ -1,0 +1,39 @@
+import System.File
+
+import Control.App
+import Control.App.FileIO
+import Control.App.Console
+
+testFileReadOps : File -> Has [Console, FileIO] e => App e ()
+testFileReadOps file = do
+    testStr <- fGetChars file 6
+    putStrLn testStr
+    chr <- fGetChar file
+    putStrLn (show chr)
+    rest <- fGetStr file
+    putStrLn rest
+
+testFileWriteOps : File -> Has [Console, FileIO] e => App e ()
+testFileWriteOps file = do
+    fPutStr file "Hello "
+    fPutStrLn file "Idris!"
+    fPutStrLn file "Another line"
+
+runTests : Has [Console, FileIO] e => App e ()
+runTests = do
+    withFile "test.txt" WriteTruncate
+        (\err => putStrLn $ "Failed to open file in write mode: " ++ show err)
+        (\file => testFileWriteOps file)
+    withFile "test.txt" Read
+        (\err => putStrLn $ "Failed to open file in read mode: " ++ show err)
+        (\file => testFileReadOps file)
+
+prog : App Init ()
+prog =
+    handle runTests
+        (\() => putStrLn "No exceptions occurred")
+        (\err: IOError =>
+            putStrLn $ "Caught file error : " ++ show err)
+
+main : IO ()
+main = run prog

--- a/tests/chez/chez023/expected
+++ b/tests/chez/chez023/expected
@@ -1,0 +1,7 @@
+Hello 
+'I'
+dris!
+
+No exceptions occurred
+1/1: Building File (File.idr)
+Main> Main> Bye for now!

--- a/tests/chez/chez023/input
+++ b/tests/chez/chez023/input
@@ -1,0 +1,2 @@
+:exec main
+:q

--- a/tests/chez/chez023/run
+++ b/tests/chez/chez023/run
@@ -1,0 +1,3 @@
+$1 --no-banner File.idr < input
+
+rm -rf build test.txt


### PR DESCRIPTION
* Add ` fGetChars`, `fGetChar`, `fPutStrLn` to `FileIO`
* Make `withFile` close the file after performing the operations
* Fix `fGetChars` by renaming `idris_readChars` to `idris2_readChars`
* Add a simple test case for `Control.App.FileIO`

Can we rename `fGetStr` to `fGetLine` for consistency or is there a reason for the different name? Thanks :)