### PR TITLE
Fix IDE Mode not unescaping escape sequences in SExpr string literals

### DIFF
--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1206,7 +1206,7 @@ transformDecl : FileName -> IndentInfo -> Rule PDecl
 transformDecl fname indents
     = do start <- location
          pragma "transform"
-         n <- strLit
+         n <- rawStrLit
          lhs <- expr plhs fname indents
          symbol "="
          rhs <- expr pnowith fname indents

--- a/src/Parser/Rule/Source.idr
+++ b/src/Parser/Rule/Source.idr
@@ -69,13 +69,23 @@ intLit
                            IntegerLit i => Just i
                            _ => Nothing)
 
+||| Raw string literal without escape sequence support
 export
-strLit : Rule String
-strLit
-    = terminal "Expected string literal"
+rawStrLit : Rule String
+rawStrLit
+    = terminal "Expected string literal without escape sequences"
                (\x => case tok x of
                            StringLit s => Just s
                            _ => Nothing)
+
+||| String literal with escape sequence support
+export
+strLit : Rule String
+strLit
+   = terminal "Expected string literal"
+              (\x => case tok x of
+                          StringLit s => escape s
+                          _ => Nothing)
 
 export
 dotIdent : Rule Name

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -139,7 +139,7 @@ nodeTests
 
 ideModeTests : List String
 ideModeTests
-  =  [ "ideMode001", "ideMode002", "ideMode003" ]
+  =  [ "ideMode001", "ideMode002", "ideMode003", "ideMode004" ]
 
 ------------------------------------------------------------------------
 -- Options

--- a/tests/ideMode/ideMode004/expected
+++ b/tests/ideMode/ideMode004/expected
@@ -1,0 +1,3 @@
+000018(:protocol-version 2 0)
+000025(:return (:ok "\"Hey there\"" ()) 1)
+Alas the file is done, aborting

--- a/tests/ideMode/ideMode004/input
+++ b/tests/ideMode/ideMode004/input
@@ -1,0 +1,1 @@
+000029((:interpret "\"Hey \" ++ \"there\"") 1)

--- a/tests/ideMode/ideMode004/run
+++ b/tests/ideMode/ideMode004/run
@@ -1,0 +1,3 @@
+$1 --ide-mode < input
+
+rm -rf build


### PR DESCRIPTION
Previous behavior:
```
000018(:protocol-version 2 0)
000029((:interpret "\"Hey \" ++ \"there\"") 1)
0000f2(:return (:error "Parse error: Parse error: Expected end of input (next tokens: [symbol (, symbol (, symbol :, identifier interpret, string \"\\\\\\\"Hey \\\\\\\" ++ \\\\\\\"there\\\\\\\"\", symbol ), literal 1, symbol ), end of input])") 0)
```

Fixed behavior:
```
000018(:protocol-version 2 0)
000029((:interpret "\"Hey \" ++ \"there\"") 1)
000025(:return (:ok "\"Hey there\"" ()) 1)
```

The problem is that the IDE mode uses `strLit` which does not unescape escape sequences. The only other place which uses `strLit` seems to be `transformDecl`. I added `rawStrLit` to preserve the previous behavior for `transformDecl`.

Remaining questions:
1. Naming of `rawStrLit` and `strLit`
2. Should `transformDecl` also handle escape sequences (therefore making `rawStrLit` redundant)?
3. Should the IDE mode only accept a subset of the escape sequences handled in `Parser.Support.escape`? The [docs](http://docs.idris-lang.org/en/latest/reference/ide-protocol.html) only mention escaped quotes. `escape` handles all supported escape sequences in Idris.
4. Should `escape` be renamed to `unescape`?