### PR TITLE
Replace FFI implementation of 'hex' function with a plain Idris version

### DIFF
--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -56,14 +56,8 @@ showRacketChar : Char -> String -> String
 showRacketChar '\\' = ("\\\\" ++)
 showRacketChar c
    = if c < chr 32 || c > chr 126
-        then (("\\u" ++ pad (asHex (cast c))) ++)
+        then (("\\u" ++ leftPad '0' 4 (asHex (cast c))) ++)
         else strCons c
-  where
-    pad : String -> String
-    pad str
-        = case isLTE (length str) 4 of
-               Yes _ => pack (List.replicate (minus 4 (length str)) '0') ++ str
-               No _ => str
 
 showRacketString : List Char -> String -> String
 showRacketString [] = id

--- a/src/Utils/Hex.idr
+++ b/src/Utils/Hex.idr
@@ -1,5 +1,6 @@
 module Utils.Hex
 
+import Data.List
 import Data.Primitives.Views
 
 %default total
@@ -26,13 +27,23 @@ hexDigit _ = 'X' -- TMP HACK: Ideally we'd have a bounds proof, generated below
 ||| Convert a positive integer into a list of (lower case) hexadecimal characters
 export
 asHex : Int -> String
-asHex n = pack $ asHex' n []
+asHex n =
+  if n > 0
+    then pack $ asHex' n []
+    else "0"
   where
     asHex' : Int -> List Char -> List Char
     asHex' 0 hex = hex
     asHex' n hex with (n `divides` 16)
       asHex' (16 * div + rem) hex | DivBy div rem _ =
-        assert_total $ asHex' div (hexDigit rem :: hex)
+        asHex' (assert_smaller n div) (hexDigit rem :: hex)
+
+export
+leftPad : Char -> Nat -> String -> String
+leftPad paddingChar padToLength str =
+  if length str < padToLength
+    then pack (List.replicate (minus padToLength (length str)) paddingChar) ++ str
+    else str
 
 export
 fromHexDigit : Char -> Maybe Int


### PR DESCRIPTION
The motivation for this change is to remove the usage of FFI in the `Idris.IDEMode.Commands.hex` function so that code generators have one less thing to worry about.

This change is covered by the `ideModeNNN` tests.

Notes about the changes in this pull request:
- Changed `Utils.Hex.asHex` to be a total function. Before one could supply a negative integer and it would loop forever. There was also an edge case where calling `asHex 0` would result in an empty string (instead of `"0"`).
- Moved `Compiler.Scheme.Racket.showRacketChar.pad` to `Utils.Hex` because it is used in two places.
- Renamed `sendLine` to `sendStr` because it doesn't send a newline.
