### PR TITLE
Fix setenv and unsetenv

### DIFF
--- a/libs/base/System.idr
+++ b/libs/base/System.idr
@@ -36,9 +36,9 @@ getArgs = primIO prim__getArgs
 prim_getEnv : String -> PrimIO (Ptr String)
 %foreign support "idris2_getEnvPair"
 prim_getEnvPair : Int -> PrimIO (Ptr String)
-%foreign libc "setenv"
+%foreign support "idris2_setenv"
 prim_setEnv : String -> String -> Int -> PrimIO Int
-%foreign libc "setenv"
+%foreign support "idris2_unsetenv"
 prim_unsetEnv : String -> PrimIO Int
 
 export

--- a/support/c/idris_support.c
+++ b/support/c/idris_support.c
@@ -73,3 +73,19 @@ int idris2_time() {
 char* idris2_getEnvPair(int i) {
     return *(environ + i);
 }
+
+int idris2_setenv(const char *name, const char *value, int overwrite) {
+#ifdef _WIN32
+    return win32_modenv(name, value);
+#else
+    return setenv(name);
+#endif
+}
+
+int idris2_unsetenv(const char *name) {
+#ifdef _WIN32
+    return win32_modenv(name, "");
+#else
+    return unsetenv(name);
+#endif
+}

--- a/support/c/idris_support.c
+++ b/support/c/idris_support.c
@@ -77,7 +77,7 @@ char* idris2_getEnvPair(int i) {
 
 int idris2_setenv(const char *name, const char *value, int overwrite) {
 #ifdef _WIN32
-    return win32_modenv(name, value);
+    return win32_modenv(name, value, overwrite);
 #else
     return setenv(name, value, overwrite);
 #endif
@@ -85,7 +85,7 @@ int idris2_setenv(const char *name, const char *value, int overwrite) {
 
 int idris2_unsetenv(const char *name) {
 #ifdef _WIN32
-    return win32_modenv(name, "");
+    return win32_modenv(name, "", 1);
 #else
     return unsetenv(name);
 #endif

--- a/support/c/idris_support.c
+++ b/support/c/idris_support.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
+#include <stdlib.h>
 
 #ifdef _WIN32
 extern char **_environ;

--- a/support/c/idris_support.c
+++ b/support/c/idris_support.c
@@ -78,7 +78,7 @@ int idris2_setenv(const char *name, const char *value, int overwrite) {
 #ifdef _WIN32
     return win32_modenv(name, value);
 #else
-    return setenv(name);
+    return setenv(name, value, overwrite);
 #endif
 }
 

--- a/support/c/windows/win_utils.c
+++ b/support/c/windows/win_utils.c
@@ -67,9 +67,16 @@ void win32_gettime(int64_t* sec, int64_t* nsec)
 
     *nsec = (t.QuadPart % 10000000)*100;
     *sec = t.QuadPart / 10000000;
-    *sec -= 11644473600; // LDAP epoch to Unix epoch 
+    *sec -= 11644473600; // LDAP epoch to Unix epoch
 }
 
 void win32_sleep(int ms) {
     Sleep(ms);
+}
+
+int win32_modenv(const char* name, const char* value) {
+    char buffer[2000];
+    if (strlen(name) + strlen(value) > 1998) return -1;
+    sprintf(buffer, "%s=%s", name, value);
+    return putenv(buffer);
 }

--- a/support/c/windows/win_utils.c
+++ b/support/c/windows/win_utils.c
@@ -75,9 +75,6 @@ void win32_sleep(int ms) {
 }
 
 int win32_modenv(const char* name, const char* value, int overwrite) {
-    char buffer[2000];
     if (!overwrite && getenv(name)) return 0;
-    if (strlen(name) + strlen(value) > 1998) return -1;
-    sprintf(buffer, "%s=%s", name, value);
-    return putenv(buffer);
+    return _putenv_s(name, value);
 }

--- a/support/c/windows/win_utils.c
+++ b/support/c/windows/win_utils.c
@@ -74,8 +74,9 @@ void win32_sleep(int ms) {
     Sleep(ms);
 }
 
-int win32_modenv(const char* name, const char* value) {
+int win32_modenv(const char* name, const char* value, int overwrite) {
     char buffer[2000];
+    if (!overwrite && getenv(name)) return -1;
     if (strlen(name) + strlen(value) > 1998) return -1;
     sprintf(buffer, "%s=%s", name, value);
     return putenv(buffer);

--- a/support/c/windows/win_utils.c
+++ b/support/c/windows/win_utils.c
@@ -76,7 +76,7 @@ void win32_sleep(int ms) {
 
 int win32_modenv(const char* name, const char* value, int overwrite) {
     char buffer[2000];
-    if (!overwrite && getenv(name)) return -1;
+    if (!overwrite && getenv(name)) return 0;
     if (strlen(name) + strlen(value) > 1998) return -1;
     sprintf(buffer, "%s=%s", name, value);
     return putenv(buffer);

--- a/support/c/windows/win_utils.h
+++ b/support/c/windows/win_utils.h
@@ -8,3 +8,4 @@ FILE *win32_u8fopen(const char *path, const char *mode);
 FILE *win32_u8popen(const char *path, const char *mode);
 void win32_gettime(int64_t* sec, int64_t* nsec);
 void win32_sleep(int ms);
+int win32_modenv(const char* name, const char* value);

--- a/support/c/windows/win_utils.h
+++ b/support/c/windows/win_utils.h
@@ -8,4 +8,4 @@ FILE *win32_u8fopen(const char *path, const char *mode);
 FILE *win32_u8popen(const char *path, const char *mode);
 void win32_gettime(int64_t* sec, int64_t* nsec);
 void win32_sleep(int ms);
-int win32_modenv(const char* name, const char* value);
+int win32_modenv(const char* name, const char* value, int overwrite);

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -113,7 +113,7 @@ chezTests
    = ["chez001", "chez002", "chez003", "chez004", "chez005", "chez006",
       "chez007", "chez008", "chez009", "chez010", "chez011", "chez012",
       "chez013", "chez014", "chez015", "chez016", "chez017", "chez018",
-      "chez019", "chez020", "chez021", "chez022", "chez023",
+      "chez019", "chez020", "chez021", "chez022", "chez023", "chez024",
       "reg001"]
 
 ideModeTests : List String

--- a/tests/chez/chez024/Envy.idr
+++ b/tests/chez/chez024/Envy.idr
@@ -4,11 +4,15 @@ import System
 
 main : IO ()
 main = do
-    ok <- setEnv "HELLO" "HI" True
+    ok <- setEnv "HELLO" "HI" False
     printLn ok
     Just str <- getEnv "HELLO"
         | Nothing => pure ()
     putStrLn str
+    ok <- setEnv "HELLO" "HO" False
+    printLn ok
+    ok <- setEnv "HELLO" "EH" True
+    printLn ok
     ok <- unsetEnv "HELLO"
     printLn ok
     Just str <- getEnv "HELLO"

--- a/tests/chez/chez024/Envy.idr
+++ b/tests/chez/chez024/Envy.idr
@@ -11,8 +11,14 @@ main = do
     putStrLn str
     ok <- setEnv "HELLO" "HO" False
     printLn ok
+    Just str <- getEnv "HELLO"
+        | Nothing => pure ()
+    putStrLn str
     ok <- setEnv "HELLO" "EH" True
     printLn ok
+    Just str <- getEnv "HELLO"
+        | Nothing => pure ()
+    putStrLn str
     ok <- unsetEnv "HELLO"
     printLn ok
     Just str <- getEnv "HELLO"

--- a/tests/chez/chez024/Envy.idr
+++ b/tests/chez/chez024/Envy.idr
@@ -1,0 +1,16 @@
+module Main
+
+import System
+
+main : IO ()
+main = do
+    ok <- setEnv "HELLO" "HI" True
+    printLn ok
+    Just str <- getEnv "HELLO"
+        | Nothing => pure ()
+    putStrLn str
+    ok <- unsetEnv "HELLO"
+    printLn ok
+    Just str <- getEnv "HELLO"
+        | Nothing => putStrLn "Nothing there"
+    pure ()

--- a/tests/chez/chez024/Envy.idr
+++ b/tests/chez/chez024/Envy.idr
@@ -4,7 +4,7 @@ import System
 
 main : IO ()
 main = do
-    ok <- setEnv "HELLO" "HI" False
+    ok <- setEnv "HELLO" "HI" True
     printLn ok
     Just str <- getEnv "HELLO"
         | Nothing => pure ()

--- a/tests/chez/chez024/expected
+++ b/tests/chez/chez024/expected
@@ -1,5 +1,7 @@
 True
 HI
+False
+True
 True
 Nothing there
 1/1: Building Envy (Envy.idr)

--- a/tests/chez/chez024/expected
+++ b/tests/chez/chez024/expected
@@ -1,0 +1,6 @@
+True
+HI
+True
+Nothing there
+1/1: Building Envy (Envy.idr)
+Main> Main> Bye for now!

--- a/tests/chez/chez024/expected
+++ b/tests/chez/chez024/expected
@@ -1,7 +1,9 @@
 True
 HI
-False
 True
+HI
+True
+EH
 True
 Nothing there
 1/1: Building Envy (Envy.idr)

--- a/tests/chez/chez024/input
+++ b/tests/chez/chez024/input
@@ -1,0 +1,2 @@
+:exec main
+:q

--- a/tests/chez/chez024/run
+++ b/tests/chez/chez024/run
@@ -1,0 +1,3 @@
+$1 --no-banner Envy.idr < input
+
+rm -rf build


### PR DESCRIPTION
prim__unsetenv was set to the wrong function and there was no windows implementation. Added a test.

Using setenv is bad practice anyhow, but if we have it it should work.