### PR TITLE
Proposal: Relation interfaces

### DIFF
--- a/libs/base/Control/Relation.idr
+++ b/libs/base/Control/Relation.idr
@@ -1,0 +1,20 @@
+||| Properties of binary relations
+module Control.Relation
+
+%default total
+
+public export
+interface Reflexive (ty : Type) (rel : ty -> ty -> Type) where
+  reflexive : (x : ty) -> rel x x
+
+public export
+interface Transitive (ty : Type) (rel : ty -> ty -> Type) where
+  transitive : (x, y, z : ty) -> rel x y -> rel y z -> rel x z
+
+-- Equality implementations ------------
+
+Reflexive ty Equal where
+  reflexive _ = Refl
+
+Transitive ty Equal where
+  transitive _ _ _ xy yz = trans xy yz

--- a/libs/base/Control/Relation.idr
+++ b/libs/base/Control/Relation.idr
@@ -5,16 +5,16 @@ module Control.Relation
 
 public export
 interface Reflexive (ty : Type) (rel : ty -> ty -> Type) where
-  reflexive : (x : ty) -> rel x x
+  reflexive : {x : ty} -> rel x x
 
 public export
 interface Transitive (ty : Type) (rel : ty -> ty -> Type) where
-  transitive : (x, y, z : ty) -> rel x y -> rel y z -> rel x z
+  transitive : {x, y, z : ty} -> rel x y -> rel y z -> rel x z
 
 -- Equality implementations ------------
 
 Reflexive ty Equal where
-  reflexive _ = Refl
+  reflexive = Refl
 
 Transitive ty Equal where
-  transitive _ _ _ xy yz = trans xy yz
+  transitive xy yz = trans xy yz

--- a/libs/base/Control/WellFounded.idr
+++ b/libs/base/Control/WellFounded.idr
@@ -57,7 +57,7 @@ sizeAccessible x = Access (acc $ size x)
   where
     acc : (sizeX : Nat) -> (y : a) -> (size y `LT` sizeX) -> SizeAccessible y
     acc (S x') y (LTESucc yLEx')
-        = Access (\z, zLTy => acc x' z (transitive (S (size z)) (size y) x' zLTy yLEx'))
+        = Access (\z, zLTy => acc x' z (transitive {x = (S (size z))} {y = (size y)} {z = x'} zLTy yLEx'))
 
 export
 sizeInd : Sized a => {0 P : a -> Type} ->

--- a/libs/base/Control/WellFounded.idr
+++ b/libs/base/Control/WellFounded.idr
@@ -1,5 +1,6 @@
 module Control.WellFounded
 
+import Control.Relation
 import Data.Nat
 import Data.List
 
@@ -56,7 +57,7 @@ sizeAccessible x = Access (acc $ size x)
   where
     acc : (sizeX : Nat) -> (y : a) -> (size y `LT` sizeX) -> SizeAccessible y
     acc (S x') y (LTESucc yLEx')
-        = Access (\z, zLTy => acc x' z (lteTransitive zLTy yLEx'))
+        = Access (\z, zLTy => acc x' z (transitive (S (size z)) (size y) x' zLTy yLEx'))
 
 export
 sizeInd : Sized a => {0 P : a -> Type} ->

--- a/libs/base/Data/List/Views.idr
+++ b/libs/base/Data/List/Views.idr
@@ -15,7 +15,7 @@ lengthSuc (x :: xs) y ys = cong S (lengthSuc xs y ys)
 
 lengthLT : (xs : List a) -> (ys : List a) ->
            LTE (length xs) (length (ys ++ xs))
-lengthLT xs [] = reflexive $ length xs
+lengthLT xs [] = reflexive {x = length xs}
 lengthLT xs (x :: ys) = lteSuccRight (lengthLT _ _)
 
 smallerLeft : (ys : List a) -> (y : a) -> (zs : List a) ->

--- a/libs/base/Data/List/Views.idr
+++ b/libs/base/Data/List/Views.idr
@@ -1,5 +1,6 @@
 module Data.List.Views
 
+import Control.Relation
 import Control.WellFounded
 import Data.List
 import Data.Nat
@@ -14,7 +15,7 @@ lengthSuc (x :: xs) y ys = cong S (lengthSuc xs y ys)
 
 lengthLT : (xs : List a) -> (ys : List a) ->
            LTE (length xs) (length (ys ++ xs))
-lengthLT xs [] = lteRefl
+lengthLT xs [] = reflexive $ length xs
 lengthLT xs (x :: ys) = lteSuccRight (lengthLT _ _)
 
 smallerLeft : (ys : List a) -> (y : a) -> (zs : List a) ->

--- a/libs/base/Data/Nat.idr
+++ b/libs/base/Data/Nat.idr
@@ -1,5 +1,7 @@
 module Data.Nat
 
+import Control.Relation
+
 %default total
 
 export
@@ -68,6 +70,17 @@ Uninhabited (LTE (S n) Z) where
   uninhabited LTEZero impossible
 
 public export
+Reflexive Nat LTE where
+  reflexive Z = LTEZero
+  reflexive (S k) = LTESucc $ reflexive k
+
+public export
+Transitive Nat LTE where
+  transitive Z _ _ LTEZero _ = LTEZero
+  transitive (S x) (S y) (S z) (LTESucc xy) (LTESucc yz) =
+    LTESucc $ transitive x y z xy yz
+
+public export
 GTE : Nat -> Nat -> Type
 GTE left right = LTE right left
 
@@ -97,11 +110,6 @@ isLTE (S k) (S j)
            Yes prf => Yes (LTESucc prf)
 
 export
-lteRefl : {n : Nat} -> LTE n n
-lteRefl {n = Z}   = LTEZero
-lteRefl {n = S k} = LTESucc lteRefl
-
-export
 lteSuccRight : LTE n m -> LTE n (S m)
 lteSuccRight LTEZero     = LTEZero
 lteSuccRight (LTESucc x) = LTESucc (lteSuccRight x)
@@ -109,11 +117,6 @@ lteSuccRight (LTESucc x) = LTESucc (lteSuccRight x)
 export
 lteSuccLeft : LTE (S n) m -> LTE n m
 lteSuccLeft (LTESucc x) = lteSuccRight x
-
-export
-lteTransitive : LTE n m -> LTE m p -> LTE n p
-lteTransitive LTEZero y = LTEZero
-lteTransitive (LTESucc x) (LTESucc y) = LTESucc (lteTransitive x y)
 
 export
 lteAddRight : (n : Nat) -> LTE n (n + m)

--- a/libs/base/Data/Nat.idr
+++ b/libs/base/Data/Nat.idr
@@ -71,14 +71,13 @@ Uninhabited (LTE (S n) Z) where
 
 public export
 Reflexive Nat LTE where
-  reflexive Z = LTEZero
-  reflexive (S k) = LTESucc $ reflexive k
+  reflexive {x = Z} = LTEZero
+  reflexive {x = S k} = LTESucc $ reflexive {x = k}
 
 public export
 Transitive Nat LTE where
-  transitive Z _ _ LTEZero _ = LTEZero
-  transitive (S x) (S y) (S z) (LTESucc xy) (LTESucc yz) =
-    LTESucc $ transitive x y z xy yz
+  transitive LTEZero _ = LTEZero
+  transitive (LTESucc xy) (LTESucc yz) = LTESucc $ transitive {rel = LTE} xy yz
 
 public export
 GTE : Nat -> Nat -> Type

--- a/libs/base/base.ipkg
+++ b/libs/base/base.ipkg
@@ -9,6 +9,7 @@ modules = Control.App,
           Control.Monad.State,
           Control.Monad.Trans,
           Control.WellFounded,
+          Control.Relation,
 
           Data.Bool,
           Data.Bool.Xor,

--- a/libs/contrib/Data/Nat/Factor.idr
+++ b/libs/contrib/Data/Nat/Factor.idr
@@ -86,17 +86,17 @@ oneSoleFactorOfOne (S (S k)) (CofactorExists (S j) prf) =
 ||| Every natural number is factor of itself.
 export
 Reflexive Nat Factor where
-  reflexive n = CofactorExists 1 $ rewrite multOneRightNeutral n in Refl
+  reflexive {x} = CofactorExists 1 $ rewrite multOneRightNeutral x in Refl
 
 ||| Factor relation is transitive. If b is factor of a and c is b factor of c
 ||| is also a factor of a.
 export
 Transitive Nat Factor where
-  transitive a b c (CofactorExists qb prfAB) (CofactorExists qc prfBC) =
+  transitive {x} (CofactorExists qb prfAB) (CofactorExists qc prfBC) =
     CofactorExists (qb * qc) $
         rewrite prfBC in
         rewrite prfAB in
-        rewrite multAssociative a qb qc in
+        rewrite multAssociative x qb qc in
         Refl
 
 multOneSoleNeutral : (a, b : Nat) -> S a = S a * b -> b = 1
@@ -264,7 +264,7 @@ minusFactor {a} {b} (CofactorExists qab prfAB) (CofactorExists qa prfA) =
 ||| A decision procedure for whether of not p is a factor of n.
 export
 decFactor : (n, d : Nat) -> DecFactor d n
-decFactor Z Z = ItIsFactor $ reflexive Z
+decFactor Z Z = ItIsFactor $ reflexive {x = Z}
 decFactor (S k) Z = ItIsNotFactor $ ZeroNotFactorS k
 decFactor n (S d) =
         let Fraction n (S d) q r prf = Data.Fin.Extra.divMod n (S d) in
@@ -334,7 +334,7 @@ oneCommonFactor a b = CommonFactorExists 1
 export
 selfIsCommonFactor : (a : Nat) -> {auto ok : LTE 1 a} -> CommonFactor a a a
 selfIsCommonFactor Z {ok} = absurd $ succNotLTEzero ok
-selfIsCommonFactor (S k) = CommonFactorExists (S k) (reflexive $ S k) (reflexive $ S k)
+selfIsCommonFactor (S k) = CommonFactorExists (S k) (reflexive {x = S k}) (reflexive {x = S k})
 
 
 -- Some helpers for the gcd function.
@@ -358,7 +358,7 @@ notLteAndGt (S k) (S j) aLteB aGtB = notLteAndGt k j (fromLteSucc aLteB) (fromLt
 gcd_step : (x : Search) ->
     (rec : (y : Search) -> Smaller y x ->  (f : Nat ** GCD f (left y) (right y))) ->
     (f : Nat ** GCD f (left x) (right x))
-gcd_step (SearchArgs Z a bLteA {bNonZero}) _ = absurd . succNotLTEzero $ transitive (S Z) a Z bNonZero bLteA
+gcd_step (SearchArgs Z _ bLteA {bNonZero}) _ = absurd . succNotLTEzero $ transitive {rel = LTE} bNonZero bLteA
 gcd_step (SearchArgs _ Z _ {bNonZero}) _ = absurd $ succNotLTEzero bNonZero
 gcd_step (SearchArgs (S a) (S b) bLteA {bNonZero}) rec = case divMod (S a) (S b) of
     Fraction (S a) (S b) q FZ prf =>
@@ -367,7 +367,7 @@ gcd_step (SearchArgs (S a) (S b) bLteA {bNonZero}) rec = case divMod (S a) (S b)
                 rewrite sym $ multRightSuccPlus q b in
                 replace {p = \x => S a = x} (plusZeroRightNeutral (q * S b)) $ sym prf
             skDividesA = CofactorExists q sbIsFactor
-            skDividesB = reflexive (S b)
+            skDividesB = reflexive {x = S b}
             greatest = the
                 ((q' : Nat) -> CommonFactor q' (S a) (S b) -> Factor q' (S b))
                 (\q', (CommonFactorExists q' _ qfb) => qfb)
@@ -382,7 +382,7 @@ gcd_step (SearchArgs (S a) (S b) bLteA {bNonZero}) rec = case divMod (S a) (S b)
                     (S k) => LTESucc LTEZero
                 smaller = the (LTE (S (S (plus b (S (finToNat r))))) (S (plus a (S b)))) $
                     rewrite plusCommutative a (S b) in
-                    LTESucc . LTESucc . plusLteLeft b . fromLteSucc $ transitive {rel=LTE} (S (finToNat (FS r))) (S b) (S a) (elemSmallerThanBound $ FS r) bLteA
+                    LTESucc . LTESucc . plusLteLeft b . fromLteSucc $ transitive {rel = LTE} (elemSmallerThanBound $ FS r) bLteA
                 (f ** MkGCD (CommonFactorExists f prfSb prfRem) greatestSbSr) =
                     rec (SearchArgs (S b) (S $ finToNat r) rLtSb) smaller
                 prfSa = the (Factor f (S a)) $
@@ -398,7 +398,7 @@ gcd_step (SearchArgs (S a) (S b) bLteA {bNonZero}) rec = case divMod (S a) (S b)
                                 multFactor (S b) q
                             rightPrf = minusFactor {a = q * S b} {b = S (finToNat r)}
                                 (rewrite prf in qfa)
-                                (transitive q' (S b) (q * S b) qfb sbfqSb)
+                                (transitive {rel = Factor} qfb sbfqSb)
                         in
                         greatestSbSr q' (CommonFactorExists q' qfb rightPrf)
                     )
@@ -413,11 +413,11 @@ export
 gcd : (a, b : Nat) -> {auto ok : NotBothZero a b} -> (f : Nat ** GCD f a b)
 gcd Z Z impossible
 gcd Z b =
-    (b ** MkGCD (CommonFactorExists b (anythingFactorZero b) (reflexive b)) $
+    (b ** MkGCD (CommonFactorExists b (anythingFactorZero b) (reflexive {x = b})) $
         \q, (CommonFactorExists q _ prf) => prf
     )
 gcd a Z =
-    (a ** MkGCD (CommonFactorExists a (reflexive a) (anythingFactorZero a)) $
+    (a ** MkGCD (CommonFactorExists a (reflexive {x = a}) (anythingFactorZero a)) $
         \q, (CommonFactorExists q prf _) => prf
     )
 gcd (S a) (S b) with (cmp (S a) (S b))

--- a/libs/contrib/Data/Nat/Factor.idr
+++ b/libs/contrib/Data/Nat/Factor.idr
@@ -1,5 +1,6 @@
 module Data.Nat.Factor
 
+import Control.Relation
 import Control.WellFounded
 import Data.Fin
 import Data.Fin.Extra
@@ -84,20 +85,19 @@ oneSoleFactorOfOne (S (S k)) (CofactorExists (S j) prf) =
 
 ||| Every natural number is factor of itself.
 export
-factorReflexive : (n : Nat) -> Factor n n
-factorReflexive a = CofactorExists 1 (rewrite multOneRightNeutral a in Refl)
+Reflexive Nat Factor where
+  reflexive n = CofactorExists 1 $ rewrite multOneRightNeutral n in Refl
 
 ||| Factor relation is transitive. If b is factor of a and c is b factor of c
 ||| is also a factor of a.
 export
-factorTransitive : (a, b, c : Nat) -> Factor a b -> Factor b c -> Factor a c
-factorTransitive a b c (CofactorExists qb prfAB) (CofactorExists qc prfBC) =
-    CofactorExists (qb * qc) (
+Transitive Nat Factor where
+  transitive a b c (CofactorExists qb prfAB) (CofactorExists qc prfBC) =
+    CofactorExists (qb * qc) $
         rewrite prfBC in
         rewrite prfAB in
         rewrite multAssociative a qb qc in
         Refl
-    )
 
 multOneSoleNeutral : (a, b : Nat) -> S a = S a * b -> b = 1
 multOneSoleNeutral Z b prf =
@@ -264,7 +264,7 @@ minusFactor {a} {b} (CofactorExists qab prfAB) (CofactorExists qa prfA) =
 ||| A decision procedure for whether of not p is a factor of n.
 export
 decFactor : (n, d : Nat) -> DecFactor d n
-decFactor Z Z = ItIsFactor $ factorReflexive Z
+decFactor Z Z = ItIsFactor $ reflexive Z
 decFactor (S k) Z = ItIsNotFactor $ ZeroNotFactorS k
 decFactor n (S d) =
         let Fraction n (S d) q r prf = Data.Fin.Extra.divMod n (S d) in
@@ -334,7 +334,7 @@ oneCommonFactor a b = CommonFactorExists 1
 export
 selfIsCommonFactor : (a : Nat) -> {auto ok : LTE 1 a} -> CommonFactor a a a
 selfIsCommonFactor Z {ok} = absurd $ succNotLTEzero ok
-selfIsCommonFactor (S k) = CommonFactorExists (S k) (factorReflexive $ S k) (factorReflexive $ S k)
+selfIsCommonFactor (S k) = CommonFactorExists (S k) (reflexive $ S k) (reflexive $ S k)
 
 
 -- Some helpers for the gcd function.
@@ -358,7 +358,7 @@ notLteAndGt (S k) (S j) aLteB aGtB = notLteAndGt k j (fromLteSucc aLteB) (fromLt
 gcd_step : (x : Search) ->
     (rec : (y : Search) -> Smaller y x ->  (f : Nat ** GCD f (left y) (right y))) ->
     (f : Nat ** GCD f (left x) (right x))
-gcd_step (SearchArgs Z _ bLteA {bNonZero}) _ = absurd . succNotLTEzero $ lteTransitive bNonZero bLteA
+gcd_step (SearchArgs Z a bLteA {bNonZero}) _ = absurd . succNotLTEzero $ transitive (S Z) a Z bNonZero bLteA
 gcd_step (SearchArgs _ Z _ {bNonZero}) _ = absurd $ succNotLTEzero bNonZero
 gcd_step (SearchArgs (S a) (S b) bLteA {bNonZero}) rec = case divMod (S a) (S b) of
     Fraction (S a) (S b) q FZ prf =>
@@ -367,7 +367,7 @@ gcd_step (SearchArgs (S a) (S b) bLteA {bNonZero}) rec = case divMod (S a) (S b)
                 rewrite sym $ multRightSuccPlus q b in
                 replace {p = \x => S a = x} (plusZeroRightNeutral (q * S b)) $ sym prf
             skDividesA = CofactorExists q sbIsFactor
-            skDividesB = factorReflexive (S b)
+            skDividesB = reflexive (S b)
             greatest = the
                 ((q' : Nat) -> CommonFactor q' (S a) (S b) -> Factor q' (S b))
                 (\q', (CommonFactorExists q' _ qfb) => qfb)
@@ -382,7 +382,7 @@ gcd_step (SearchArgs (S a) (S b) bLteA {bNonZero}) rec = case divMod (S a) (S b)
                     (S k) => LTESucc LTEZero
                 smaller = the (LTE (S (S (plus b (S (finToNat r))))) (S (plus a (S b)))) $
                     rewrite plusCommutative a (S b) in
-                    LTESucc . LTESucc . plusLteLeft b . fromLteSucc $ lteTransitive (elemSmallerThanBound $ FS r) bLteA
+                    LTESucc . LTESucc . plusLteLeft b . fromLteSucc $ transitive {rel=LTE} (S (finToNat (FS r))) (S b) (S a) (elemSmallerThanBound $ FS r) bLteA
                 (f ** MkGCD (CommonFactorExists f prfSb prfRem) greatestSbSr) =
                     rec (SearchArgs (S b) (S $ finToNat r) rLtSb) smaller
                 prfSa = the (Factor f (S a)) $
@@ -398,7 +398,7 @@ gcd_step (SearchArgs (S a) (S b) bLteA {bNonZero}) rec = case divMod (S a) (S b)
                                 multFactor (S b) q
                             rightPrf = minusFactor {a = q * S b} {b = S (finToNat r)}
                                 (rewrite prf in qfa)
-                                (factorTransitive q' (S b) (q * S b) qfb sbfqSb)
+                                (transitive q' (S b) (q * S b) qfb sbfqSb)
                         in
                         greatestSbSr q' (CommonFactorExists q' qfb rightPrf)
                     )
@@ -413,11 +413,11 @@ export
 gcd : (a, b : Nat) -> {auto ok : NotBothZero a b} -> (f : Nat ** GCD f a b)
 gcd Z Z impossible
 gcd Z b =
-    (b ** MkGCD (CommonFactorExists b (anythingFactorZero b) (factorReflexive b)) $
+    (b ** MkGCD (CommonFactorExists b (anythingFactorZero b) (reflexive b)) $
         \q, (CommonFactorExists q _ prf) => prf
     )
 gcd a Z =
-    (a ** MkGCD (CommonFactorExists a (factorReflexive a) (anythingFactorZero a)) $
+    (a ** MkGCD (CommonFactorExists a (reflexive a) (anythingFactorZero a)) $
         \q, (CommonFactorExists q prf _) => prf
     )
 gcd (S a) (S b) with (cmp (S a) (S b))


### PR DESCRIPTION
Currently some proofs have names like `lteRefl`, `lteTransitive`, `factorReflexive`, etc. These names say the same thing, namely that some relation is reflexive or transitive, but they do so in an ad-hoc and disorganized manner.

This PR adds some interfaces that can act as a universal language for these kinds of relations. Specifically, it adds the interfaces `Reflexive` and `Transitive`. There are more that could be added, like `Symmetric` and `Antisymmetric`, but this is a start. `Reflexive` and `Transitive` are implemented for `LTE` and `Factor`. Again, there are more of these to do, but this is a start.

Two questions to discuss are whether this is a good at all, and if so, whether this is the right way to do it. Obviously I think this is a good idea, but I'm not wed to the particular design. Initially I tried an approach that used explicit arguments all around, then I switched to implicit arguments, which match the existing relations better. Compare the two commits here to see the difference.

Idris 1 contained a `contrib` module called `Order`. It defined things like partial order directly in terms of these properties. This approach is more flexible, allowing for properties to be composed in different ways (along the lines of [this suggestion](https://groups.google.com/d/msg/idris-lang/VZVpi-QUyUc/reZxLJSOAQAJ)). This PR doesn't deal with orders, but they could be defined easily enough.