### PR TITLE
Module command to import module in REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ Library changes:
      should be considered experimental with the API able to change at any time!
      Further experiments in `Data.Linear` are welcome :).
 
+REPL changes:
+
+* Implemented `:module` command, to load a module during a REPL session.
+
 Changes since Idris 2 v0.1.0
 ----------------------------
 

--- a/src/Idris/ProcessIdr.idr
+++ b/src/Idris/ProcessIdr.idr
@@ -95,6 +95,17 @@ readImport full imp
     = do readModule full (loc imp) True (reexport imp) (path imp) (nameAs imp)
          addImported (path imp, reexport imp, nameAs imp)
 
+||| Adds new import to the namespace without changing the current top-level namespace
+export
+addImport : {auto c : Ref Ctxt Defs} ->
+            {auto u : Ref UST UState} ->
+            {auto s : Ref Syn SyntaxInfo} ->
+            Import -> Core ()
+addImport imp
+    = do topNS <- getNS
+         readImport True imp
+         setNS topNS
+
 readHash : {auto c : Ref Ctxt Defs} ->
            {auto u : Ref UST UState} ->
            Import -> Core (Bool, (List String, Int))

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -395,6 +395,7 @@ data REPLCmd : Type where
      PrintDef : Name -> REPLCmd
      Reload : REPLCmd
      Load : String -> REPLCmd
+     ImportMod : List String -> REPLCmd
      Edit : REPLCmd
      Compile : PTerm -> String -> REPLCmd
      Exec : PTerm -> REPLCmd

--- a/src/Parser/Rule/Source.idr
+++ b/src/Parser/Rule/Source.idr
@@ -151,6 +151,15 @@ namespacedIdent
             _ => Nothing)
 
 export
+moduleIdent : Rule (List String)
+moduleIdent
+    = terminal "Expected module identifier"
+        (\x => case tok x of
+            DotSepIdent ns => Just ns
+            Ident i => Just $ [i]
+            _ => Nothing)
+
+export
 unqualifiedName : Rule String
 unqualifiedName = identPart
 

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -65,7 +65,7 @@ idrisTests
        "interface009", "interface010", "interface011", "interface012",
        "interface013", "interface014", "interface015", "interface016",
        -- Miscellaneous REPL
-       "interpreter001", "interpreter002",
+       "interpreter001", "interpreter002", "interpreter003",
        -- Implicit laziness, lazy evaluation
        "lazy001",
        -- QTT and linearity related

--- a/tests/idris2/interpreter003/expected
+++ b/tests/idris2/interpreter003/expected
@@ -1,0 +1,11 @@
+Main> (interactive):1:1--1:25:Undefined name fromMaybe at:
+1	fromMaybe "test" Nothing
+	^^^^^^^^^^^^^^^^^^^^^^^^
+
+Main> Imported module Data.Maybe
+Main> "test"
+Main> Imported module Data.Strings
+Main> "hello"
+Main> True
+Main> Error loading module DoesNotExists: DoesNotExists not found
+Main> Bye for now!

--- a/tests/idris2/interpreter003/input
+++ b/tests/idris2/interpreter003/input
@@ -1,0 +1,8 @@
+fromMaybe "test" Nothing
+:module Data.Maybe
+fromMaybe "test" Nothing
+:module Data.Strings
+toLower "HELLO"
+isJust (Just 'x')
+:module DoesNotExists
+:q

--- a/tests/idris2/interpreter003/run
+++ b/tests/idris2/interpreter003/run
@@ -1,0 +1,1 @@
+$1 --no-banner < input


### PR DESCRIPTION
Implemented a `:module <module>` command to load a module during a REPL session.