### PR TITLE
Add comment about TTC files in TTC error

### DIFF
--- a/src/Idris/Error.idr
+++ b/src/Idris/Error.idr
@@ -263,7 +263,7 @@ perror (BadImplicit fc str)
 perror (BadRunElab fc env script)
     = pure $ "Bad elaborator script " ++ !(pshow env script) ++ " at:\n" ++ !(ploc fc)
 perror (GenericMsg fc str) = pure $ str ++ " at:\n" ++ !(ploc fc)
-perror (TTCError msg) = pure $ "Error in TTC file: " ++ show msg
+perror (TTCError msg) = pure $ "Error in TTC file: " ++ show msg ++ " (the most likely case is that the ./build directory in your current project contains files from a previous build of idris2 or the idris2 executable is from a different build than the installed .ttc files)"
 perror (FileErr fname err)
     = pure $ "File error in " ++ fname ++ ": " ++ show err
 perror (ParseFail _ err)


### PR DESCRIPTION
In using local builds of idris2 I often forget that there's a build dir containing TTC files and lose time to thinking something other than "you last compiled this with a previous version of idris2" is wrong.  This just adds to the error message.