### PR TITLE
Function mapping `Not (x=True)` to `x=False` was added for `Bool`s

### DIFF
--- a/libs/base/Data/Bool.idr
+++ b/libs/base/Data/Bool.idr
@@ -97,3 +97,15 @@ export
 notOrIsAnd : (x, y : Bool) -> not (x || y) = not x && not y
 notOrIsAnd False _ = Refl
 notOrIsAnd True  _ = Refl
+
+-- Interaction with typelevel `Not`
+
+export
+notTrueIsFalse : {1 x : Bool} -> Not (x = True) -> x = False
+notTrueIsFalse {x=False} _ = Refl
+notTrueIsFalse {x=True}  f = absurd $ f Refl
+
+export
+notFalseIsTrue : {1 x : Bool} -> Not (x = False) -> x = True
+notFalseIsTrue {x=True} _  = Refl
+notFalseIsTrue {x=False} f = absurd $ f Refl

--- a/tests/idris2/coverage010/expected
+++ b/tests/idris2/coverage010/expected
@@ -3,4 +3,4 @@ casetot.idr:12:1--13:1:main is not covering at:
 12	main : IO ()
 13	main = do
 
-	Calls non covering function Main.case block in 2101(587)
+	Calls non covering function Main.case block in 2101(617)


### PR DESCRIPTION
This function may be useful when using `decEq` for `Bool`s with `with` where previously `with ... proof` was used, e.g.:

```idris
f : X -> Y
f x with (decEq whatever True)
  | Yes p = rewrite p in ...
  | No n = rewrite notTrueIsFalse n in ...
```
(where previously we were used to write
```idris
f : X -> Y
f x with (whatever) proof p
  | True = rewrite p in ...
  | False = rewrite p in ...
```
)
