### PR TITLE
Allow overriding build and output directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ Command-line options changes:
 
 * Removed `--ide-mode-socket-with` option.  `--ide-mode-socket` now accepts an
   optional `host:port` argument.
+* Added options to override source directory, build directory and output
+  directory: `--source-dir`, `--build-dir`, `--output-dir`.
+  + These options are also available as fields in the package description:
+    `sourcedir`, `builddir`, `outputdir`.
 
 Compiler changes:
 

--- a/docs/source/backends/custom.rst
+++ b/docs/source/backends/custom.rst
@@ -27,13 +27,13 @@ Now create a file containing
     import Compiler.Common
     import Idris.Driver
 
-    compile : Ref Ctxt Defs -> (execDir : String) ->
+    compile : Ref Ctxt Defs -> (tmpDir : String) -> (outputDir : String) ->
             ClosedTerm -> (outfile : String) -> Core (Maybe String)
-    compile defs dir term file = do coreLift $ putStrLn "I'd rather not."
+    compile defs tmpDir outputDir term file = do coreLift $ putStrLn "I'd rather not."
                                     pure $ Nothing
 
-    execute : Ref Ctxt Defs -> (execDir : String) -> ClosedTerm -> Core ()
-    execute defs dir term = do coreLift $ putStrLn "Maybe in an hour."
+    execute : Ref Ctxt Defs -> (tmpDir : String) -> ClosedTerm -> Core ()
+    execute defs tmpDir term = do coreLift $ putStrLn "Maybe in an hour."
 
     lazyCodegen : Codegen
     lazyCodegen = MkCG compile execute

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -407,7 +407,7 @@ compileToSO : {auto c : Ref Ctxt Defs} ->
               String -> (appDirRel : String) -> (outSsAbs : String) -> Core ()
 compileToSO chez appDirRel outSsAbs
     = do let tmpFileAbs = appDirRel </> "compileChez"
-         let build= "(parameterize ([optimize-level 3]) (compile-program " ++
+         let build = "(parameterize ([optimize-level 3] [compile-file-message #f]) (compile-program " ++
                     show outSsAbs ++ "))"
          Right () <- coreLift $ writeFile tmpFileAbs build
             | Left err => throw (FileErr tmpFileAbs err)

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -432,22 +432,22 @@ makeShWindows chez outShRel appdir outAbs
          pure ()
 
 ||| Chez Scheme implementation of the `compileExpr` interface.
-compileExpr : Bool -> Ref Ctxt Defs -> (execDir : String) ->
+compileExpr : Bool -> Ref Ctxt Defs -> (tmpDir : String) -> (outputDir : String) ->
               ClosedTerm -> (outfile : String) -> Core (Maybe String)
-compileExpr makeitso c execDir tm outfile
+compileExpr makeitso c tmpDir outputDir tm outfile
     = do let appDirRel = outfile ++ "_app" -- relative to build dir
-         let appDirGen = execDir </> appDirRel -- relative to here
+         let appDirGen = outputDir </> appDirRel -- relative to here
          coreLift $ mkdirAll appDirGen
          Just cwd <- coreLift currentDir
               | Nothing => throw (InternalError "Can't get current directory")
          let outSsFile = appDirRel </> outfile <.> "ss"
          let outSoFile = appDirRel </> outfile <.> "so"
-         let outSsAbs = cwd </> execDir </> outSsFile
-         let outSoAbs = cwd </> execDir </> outSoFile
+         let outSsAbs = cwd </> outputDir </> outSsFile
+         let outSoAbs = cwd </> outputDir </> outSoFile
          chez <- coreLift $ findChez
          compileToSS c appDirGen tm outSsAbs
          logTime "Make SO" $ when makeitso $ compileToSO chez appDirGen outSsAbs
-         let outShRel = execDir </> outfile
+         let outShRel = outputDir </> outfile
          if isWindows
             then makeShWindows chez outShRel appDirRel (if makeitso then outSoFile else outSsFile)
             else makeSh outShRel appDirRel (if makeitso then outSoFile else outSsFile)
@@ -456,9 +456,9 @@ compileExpr makeitso c execDir tm outfile
 
 ||| Chez Scheme implementation of the `executeExpr` interface.
 ||| This implementation simply runs the usual compiler, saving it to a temp file, then interpreting it.
-executeExpr : Ref Ctxt Defs -> (execDir : String) -> ClosedTerm -> Core ()
-executeExpr c execDir tm
-    = do Just sh <- compileExpr False c execDir tm "_tmpchez"
+executeExpr : Ref Ctxt Defs -> (tmpDir : String) -> ClosedTerm -> Core ()
+executeExpr c tmpDir tm
+    = do Just sh <- compileExpr False c tmpDir tmpDir tm "_tmpchez"
             | Nothing => throw (InternalError "compileExpr returned Nothing")
          coreLift $ system sh
          pure ()

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -1932,10 +1932,10 @@ setBuildDir dir
          put Ctxt (record { options->dirs->build_dir = dir } defs)
 
 export
-setExecDir : {auto c : Ref Ctxt Defs} -> String -> Core ()
-setExecDir dir
+setOutputDir : {auto c : Ref Ctxt Defs} -> Maybe String -> Core ()
+setOutputDir dir
     = do defs <- get Ctxt
-         put Ctxt (record { options->dirs->exec_dir = dir } defs)
+         put Ctxt (record { options->dirs->output_dir = dir } defs)
 
 export
 setSourceDir : {auto c : Ref Ctxt Defs} -> Maybe String -> Core ()

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -1963,7 +1963,7 @@ export
 setPrefix : {auto c : Ref Ctxt Defs} -> String -> Core ()
 setPrefix dir
     = do defs <- get Ctxt
-         put Ctxt (record { options->dirs->dir_prefix = dir } defs)
+         put Ctxt (record { options->dirs->prefix_dir = dir } defs)
 
 export
 setExtension : {auto c : Ref Ctxt Defs} -> LangExt -> Core ()

--- a/src/Core/Directory.idr
+++ b/src/Core/Directory.idr
@@ -136,12 +136,10 @@ makeBuildDirectory ns
 
 export
 covering
-makeExecDirectory : {auto c : Ref Ctxt Defs} ->
-                    Core ()
-makeExecDirectory
-    = do d <- getDirs
-         Right _ <- coreLift $ mkdirAll (exec_dir d)
-            | Left err => throw (FileErr (exec_dir d) err)
+ensureDirectoryExists : String -> Core ()
+ensureDirectoryExists dir
+    = do Right _ <- coreLift $ mkdirAll dir
+            | Left err => throw (FileErr dir err)
          pure ()
 
 -- Given a source file, return the name of the ttc file to generate

--- a/src/Core/Options.idr
+++ b/src/Core/Options.idr
@@ -21,7 +21,7 @@ record Dirs where
   source_dir : Maybe String -- source directory, relative to working directory
   build_dir : String -- build directory, relative to working directory
   output_dir : Maybe String -- output directory, relative to working directory
-  dir_prefix : String -- installation prefix, for finding data files (e.g. run time support)
+  prefix_dir : String -- installation prefix, for finding data files (e.g. run time support)
   extra_dirs : List String -- places to look for import files
   lib_dirs : List String -- places to look for libraries (for code generation)
   data_dirs : List String -- places to look for data file

--- a/src/Idris/CommandLine.idr
+++ b/src/Idris/CommandLine.idr
@@ -50,6 +50,8 @@ data CLOpt
   SetCG String |
    ||| Don't implicitly import Prelude
   NoPrelude |
+   ||| Set source directory
+  SourceDir String |
    ||| Set build directory
   BuildDir String |
    ||| Set output directory
@@ -153,6 +155,8 @@ options = [MkOpt ["--check", "-c"] [] [CheckOnly]
               (Just $ "Set code generator " ++ showDefault (codegen defaultSession)),
            MkOpt ["--package", "-p"] [Required "package"] (\f => [PkgPath f])
               (Just "Add a package as a dependency"),
+           MkOpt ["--source-dir"] [Required "dir"] (\d => [SourceDir d])
+              (Just $ "Set source directory"),
            MkOpt ["--build-dir"] [Required "dir"] (\d => [BuildDir d])
               (Just $ "Set build directory"),
            MkOpt ["--output-dir"] [Required "dir"] (\d => [OutputDir d])

--- a/src/Idris/CommandLine.idr
+++ b/src/Idris/CommandLine.idr
@@ -50,6 +50,10 @@ data CLOpt
   SetCG String |
    ||| Don't implicitly import Prelude
   NoPrelude |
+   ||| Set build directory
+  BuildDir String |
+   ||| Set output directory
+  OutputDir String |
    ||| Show the installation prefix
   ShowPrefix |
    ||| Display Idris version
@@ -149,6 +153,10 @@ options = [MkOpt ["--check", "-c"] [] [CheckOnly]
               (Just $ "Set code generator " ++ showDefault (codegen defaultSession)),
            MkOpt ["--package", "-p"] [Required "package"] (\f => [PkgPath f])
               (Just "Add a package as a dependency"),
+           MkOpt ["--build-dir"] [Required "dir"] (\d => [BuildDir d])
+              (Just $ "Set build directory"),
+           MkOpt ["--output-dir"] [Required "dir"] (\d => [OutputDir d])
+              (Just $ "Set output directory"),
 
            optSeparator,
            MkOpt ["--prefix"] [] [ShowPrefix]

--- a/src/Idris/Driver.idr
+++ b/src/Idris/Driver.idr
@@ -71,9 +71,9 @@ updateEnv
          defs <- get Ctxt
          addPkgDir "prelude"
          addPkgDir "base"
-         addDataDir (dir_prefix (dirs (options defs)) </>
+         addDataDir (prefix_dir (dirs (options defs)) </>
                         ("idris2-" ++ showVersion False version) </> "support")
-         addLibDir (dir_prefix (dirs (options defs)) </>
+         addLibDir (prefix_dir (dirs (options defs)) </>
                         ("idris2-" ++ showVersion False version) </> "lib")
          Just cwd <- coreLift $ currentDir
               | Nothing => throw (InternalError "Can't get current directory")

--- a/src/Idris/Main.idr
+++ b/src/Idris/Main.idr
@@ -1,4 +1,4 @@
-module Main
+module Idris.Main
 
 import Idris.Driver
 

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -343,7 +343,7 @@ install pkg opts -- not used but might be in the future
          Just srcdir <- coreLift currentDir
              | Nothing => throw (InternalError "Can't get current directory")
          -- Make the package installation directory
-         let installPrefix = dir_prefix (dirs (options defs)) </>
+         let installPrefix = prefix_dir (dirs (options defs)) </>
                              "idris2-" ++ showVersion False version
          True <- coreLift $ changeDir installPrefix
              | False => throw (InternalError ("Can't change directory to " ++ installPrefix))

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -297,10 +297,10 @@ build pkg opts
          case executable pkg of
               Nothing => pure ()
               Just exec =>
-                   do let Just (mainns, mmod) = mainmod pkg
+                   do let Just (mainNS, mainFile) = mainmod pkg
                                | Nothing => throw (GenericMsg emptyFC "No main module given")
-                      let mainn = NS ["Main"] (UN "main")
-                      compileMain mainn mmod exec
+                      let mainName = NS mainNS (UN "main")
+                      compileMain mainName mainFile exec
          runScript (postbuild pkg)
          pure []
 

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -25,13 +25,13 @@ addPkgDir : {auto c : Ref Ctxt Defs} ->
             String -> Core ()
 addPkgDir p
     = do defs <- get Ctxt
-         addExtraDir (dir_prefix (dirs (options defs)) </>
+         addExtraDir (prefix_dir (dirs (options defs)) </>
                              "idris2-" ++ showVersion False version </> p)
 
 dirOption : Dirs -> DirCommand -> Core ()
 dirOption dirs LibDir
     = coreLift $ putStrLn
-         (dir_prefix dirs </> "idris2-" ++ showVersion False version)
+         (prefix_dir dirs </> "idris2-" ++ showVersion False version)
 
 -- Options to be processed before type checking. Return whether to continue.
 export

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -74,6 +74,9 @@ preOptions (SetCG e :: opts)
 preOptions (PkgPath p :: opts)
     = do addPkgDir p
          preOptions opts
+preOptions (SourceDir d :: opts)
+    = do setSourceDir (Just d)
+         preOptions opts
 preOptions (BuildDir d :: opts)
     = do setBuildDir d
          preOptions opts

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -74,6 +74,12 @@ preOptions (SetCG e :: opts)
 preOptions (PkgPath p :: opts)
     = do addPkgDir p
          preOptions opts
+preOptions (BuildDir d :: opts)
+    = do setBuildDir d
+         preOptions opts
+preOptions (OutputDir d :: opts)
+    = do setOutputDir (Just d)
+         preOptions opts
 preOptions (Directory d :: opts)
     = do defs <- get Ctxt
          dirOption (dirs (options defs)) d

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -114,7 +114,7 @@ chezTests
       "chez007", "chez008", "chez009", "chez010", "chez011", "chez012",
       "chez013", "chez014", "chez015", "chez016", "chez017", "chez018",
       "chez019", "chez020", "chez021", "chez022", "chez023", "chez024",
-      "chez025",
+      "chez025", "chez026",
       "reg001"]
 
 ideModeTests : List String

--- a/tests/chez/chez026/Dummy.idr
+++ b/tests/chez/chez026/Dummy.idr
@@ -1,0 +1,16 @@
+module Dummy
+
+import System.Directory
+
+dirExists : String -> IO Bool
+dirExists dir = do
+  Right d <- openDir dir
+    | Left _ => pure False
+  closeDir d
+  pure True
+
+main : IO ()
+main = do
+  True <- dirExists "custom_build"
+    | False => putStrLn "Could not find build directory"
+  putStrLn "Found build directory"

--- a/tests/chez/chez026/dummy.ipkg
+++ b/tests/chez/chez026/dummy.ipkg
@@ -1,0 +1,15 @@
+package dummy
+
+authors = "Joe Bloggs"
+maintainers = "Joe Bloggs"
+license = "BSD3 but see LICENSE for more information"
+brief = "This is a dummy package."
+readme = "README.md"
+
+modules = Dummy
+
+main = Dummy
+executable = check_dir
+
+builddir = "custom_build"
+outputdir = "custom_output"

--- a/tests/chez/chez026/expected
+++ b/tests/chez/chez026/expected
@@ -1,0 +1,2 @@
+1/1: Building Dummy (Dummy.idr)
+Found build directory

--- a/tests/chez/chez026/run
+++ b/tests/chez/chez026/run
@@ -1,0 +1,5 @@
+$1 --build dummy.ipkg
+
+./custom_output/check_dir
+
+rm -rf custom_build custom_output

--- a/tests/idris2/pkg003/expected
+++ b/tests/idris2/pkg003/expected
@@ -10,6 +10,8 @@ Overridable options are:
     --dumpvmcode <file>
     --debug-elab-check
     --codegen <cg>
+    --build-dir <dir>
+    --output-dir <dir>
 
 Packages must have an '.ipkg' extension: "malformed-package-name".
 Uncaught error: File error (non-existent-package.ipkg): File Not Found


### PR DESCRIPTION
This pull request contains more changes than I originally intended:
1. Adds `--build-dir` and `--output-dir` and corresponding fields in the package description (See more detailed description below)
2. Adds `--source-dir` to match the existing `sourcedir` field in the package description (See overview at the bottom)
3. Renamed `dir_prefix` to `prefix_dir` to match the other names in the record
4. Fixes a bug regarding the `main` field in the package description (Previously it always used `Main` as the namespace)
5. Silences the compilation message when compiling Chez programs: `compiling <path>/print_hello.ss with output to <path>/print_hello.so`
   - I should probably emphasize that by silencing this message, there might be cases where you will miss seeing this message, for example when building a new Idris 2 executable. However, I believe silencing this message is for the better, because then we can control when/if we want to print such a message.

Point 4 and 5 showed up when adding the test case for point 1.

I recommend looking at the individual commits to understand the changes in isolation. If you want to I can split this pull request into multiple smaller pull requests.

## Description of `--build-dir` and `--output-dir`

This pull request adds the ability to change the location of the build directory (defaults to `build`) and the location of the output directory (defaults to `build/exec`). I changed the name of "executable directory" to "output directory" because the output isn't necessarily an executable. The output may consist of source files, or even a compiled library, depending on the code generator.

The code generators are now provided with the following path arguments:
- `compileExpr`: `tmpDir` and `outputDir`
- `executeExpr`: `tmpDir`

Since the `outputDir` can be chosen by the user, the code generator can decide to put temporary files in `tmpDir` and put the desired files in `outputDir`. By default, both `tmpDir` and `outputDir` will point to the same directory (`build/exec`). The code generator can assume that both paths exist. In the case of the Chez and Racket code generators, all their files will go to `outputDir`.

Concretely, I have added the following options to the `idris2` CLI:
```
  --source-dir <dir>                  Set source directory
  --build-dir <dir>                   Set build directory
  --output-dir <dir>                  Set output directory
```

And similar fields to the package description (overridable by CLI):
```
builddir = "build"
outputdir = "build/exec"
```

I have added a test (`idris2/pkg005`) that checks that the `builddir` and `outputdir` fields in the package description works. I have manually tested that all 3 code generators works when specifying the `--build-dir` and `--output-dir`.

~~This pull request will most certainly have conflicts with #309: I will rebase this PR after #309 is merged.~~

---

An overview of the available directory paths and how to override them:

| Directory   | CLI                    | REPL             | Package             | ENV |
|-------------|------------------------|------------------|---------------------|-----|
| working_dir |                        | `:cd`            |                     |     |
| source_dir  | `--source-dir` **New** |                  | `sourcedir`         |     |
| build_dir   | `--build-dir` **New**  |                  | `builddir` **New**  |     |
| output_dir  | `--output-dir` **New** |                  | `outputdir` **New** |     |
| prefix_dir  |                        |                  |                     | IDRIS2_PREFIX |
| extra_dirs  | `-p`                   |                  |                     | IDRIS2_PATH   |
| lib_dirs    |                        |                  |                     | IDRIS2_LIBS   |
| data_dirs   |                        |                  |                     | IDRIS2_DATA   |
