### PR TITLE
VMCODE: Carry over required type names for named constructors without a tag

### DIFF
--- a/src/Compiler/VMCode.idr
+++ b/src/Compiler/VMCode.idr
@@ -30,7 +30,7 @@ data VMInst : Type where
      DECLARE : Reg -> VMInst
      START : VMInst -- start of the main body of the function
      ASSIGN : Reg -> Reg -> VMInst
-     MKCON : Reg -> (tag : Maybe Int) -> (args : List Reg) -> VMInst
+     MKCON : Reg -> (tag : Either Int Name) -> (args : List Reg) -> VMInst
      MKCLOSURE : Reg -> Name -> (missing : Nat) -> (args : List Reg) -> VMInst
      MKCONSTANT : Reg -> Constant -> VMInst
      
@@ -117,8 +117,10 @@ toVM t res (AApp fc f a)
     = [APPLY res (toReg f) (toReg a)]
 toVM t res (ALet fc var val body)
     = toVM False (Loc var) val ++ toVM t res body
-toVM t res (ACon fc n tag args)
-    = [MKCON res tag (map toReg args)]
+toVM t res (ACon fc n (Just tag) args)
+    = [MKCON res (Left tag) (map toReg args)]
+toVM t res (ACon fc n Nothing args)
+    = [MKCON res (Right n) (map toReg args)]
 toVM t res (AOp fc op args)
     = [OP res op (map toReg args)]
 toVM t res (AExtPrim fc p args)


### PR DESCRIPTION
For constructors which don't have a tag (so case matching needs to be done based on the `Name`), the `Name` information is correctly carried over into the `CASE` instructions (in form of an `Either Int Name`), but is lost when converting the ANF `ACon` to a VMCode `MKCON`.

For reference, the current conversion from ANF to VMCode `CASE` looks like this:
```idris
    toVMConAlt (MkAConAlt n (Just tag) args code)
        = (Left tag, projectArgs 0 args ++ toVM t res code)
    toVMConAlt (MkAConAlt n Nothing args code)
        = (Right n, projectArgs 0 args ++ toVM t res code)
```

This commit slightly changes the constructor for the `MKCON` instruction to match the type of the `CASE` alternatives and changes the conversion from ANF to keep the original constructor name. As before, backends still need to do the `Name` -> unique Int mapping, if they want to perform the case match on "named constructors" efficiently.