### PR TITLE
Make reference and source agree about literate markdown

### DIFF
--- a/docs/source/reference/literate.rst
+++ b/docs/source/reference/literate.rst
@@ -52,4 +52,4 @@ CommonMark
 
 Only code blocks denoted by standard code blocks labelled as idris are recognised.
 
-We treat files with an extension of ``.md`` and ``.markdown`` as org-mode style literate files.
+We treat files with an extension of ``.md`` and ``.markdown`` as CommonMark style literate files.

--- a/src/Parser/Unlit.idr
+++ b/src/Parser/Unlit.idr
@@ -24,7 +24,7 @@ styleOrg = MkLitStyle
 
 export
 styleCMark : LiterateStyle
-styleCMark = MkLitStyle [("```idris", "```")] Nil [".md"]
+styleCMark = MkLitStyle [("```idris", "```")] Nil [".md", ".markdown"]
 
 export
 isLitFile : String -> Maybe LiterateStyle


### PR DESCRIPTION
In the CommonMark section of the reference for literate Idris, it says that both `.md` files and `.markdown` files are treated as Org-Mode style literate Idris.  I believe this should say CommonMark style.

When looking at the source to back this up, however, I saw that it only interprets `.md` files as CommonMark-style literate Idris files, and doesn't allow `.markdown` files.

This PR fixes both of these.