### PR TITLE
change how unelabBinder shows names

### DIFF
--- a/src/TTImp/Unelab.idr
+++ b/src/TTImp/Unelab.idr
@@ -247,13 +247,16 @@ mutual
   unelabBinder umode fc env x (Pi rig p ty) sctm sc scty
       = do (ty', _) <- unelabTy umode env ty
            p' <- unelabPi umode env p
-           let nm = if used 0 sctm
+           let nm = if used 0 sctm || isNoSugar umode
                        then Just x
                        else if rig /= top || isDefImp p
                                then Just (UN "_")
                                else Nothing
            pure (IPi fc rig p' nm ty' sc, gType fc)
     where
+      isNoSugar : UnelabMode -> Bool
+      isNoSugar (NoSugar _) = True
+      isNoSugar _ = False
       isDefImp : PiInfo t -> Bool
       isDefImp (DefImplicit _) = True
       isDefImp _ = False

--- a/tests/idris2/reflection003/expected
+++ b/tests/idris2/reflection003/expected
@@ -1,8 +1,8 @@
 1/1: Building refprims (refprims.idr)
 LOG 0: Name: Prelude.List.++
-LOG 0: Type: (%pi Rig0 Implicit (Just a) %type (%pi Rig1 Explicit (Just _) (Prelude.List a) (%pi RigW Explicit Nothing (Prelude.List a) (Prelude.List a))))
+LOG 0: Type: (%pi Rig0 Implicit (Just a) %type (%pi Rig1 Explicit (Just xs) (Prelude.List a) (%pi RigW Explicit (Just {arg:6371}) (Prelude.List a) (Prelude.List a))))
 LOG 0: Name: Prelude.Strings.++
-LOG 0: Type: (%pi Rig1 Explicit (Just _) String (%pi Rig1 Explicit (Just _) String String))
+LOG 0: Type: (%pi Rig1 Explicit (Just x) String (%pi Rig1 Explicit (Just y) String String))
 LOG 0: Resolved name: Prelude.Nat
 LOG 0: Constructors: [Prelude.Z, Prelude.S]
 refprims.idr:43:10--43:27:While processing right hand side of dummy1 at refprims.idr:43:1--45:1:


### PR DESCRIPTION
unelabBinder was losing information for the purpose of displaying names nicely. This is typically wanted but when working with elabortation it's useful to have all the information you can get.  
Things like record field names would be lost when querying with GetType but are now retained.