### PR TITLE
Check consructor names are not defined

### DIFF
--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -1747,6 +1747,9 @@ addData vars vis tidx (MkData (MkCon dfc tyn arity tycon) datacons)
     addDataConstructors tag (MkCon fc n a ty :: cs) gam
         = do let condef = newDef fc n top vars ty (conVisibility vis) (DCon tag a Nothing)
              (idx, gam') <- addCtxt n condef gam
+             -- Check 'n' is undefined
+             Nothing <- lookupCtxtExact n gam
+                 | Just gdef => throw (AlreadyDefined fc n)
              addDataConstructors (tag + 1) cs gam'
 
 -- Add a new nested namespace to the current namespace for new definitions

--- a/src/TTImp/ProcessData.idr
+++ b/src/TTImp/ProcessData.idr
@@ -375,4 +375,3 @@ processData {vars} eopts nest env fc vis (MkImpData dfc n_in ty_raw opts cons_ra
               traverse_ (\x => addHintFor fc (Resolved tidx) x True False) connames
 
          traverse_ updateErasable (Resolved tidx :: connames)
-


### PR DESCRIPTION
We do this when elaborating the data type, but not when adding the
individual constructors, so weren't catching the case of repeated
constructors within the same type. Fixes #338