### PR TITLE
change namespace parser to have minimum indentation

### DIFF
--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1173,9 +1173,10 @@ namespaceDecl : FileName -> IndentInfo -> Rule PDecl
 namespaceDecl fname indents
     = do start <- location
          doc   <- option "" documentation
+         col   <- column
          ns    <- namespaceHead
          end   <- location
-         ds    <- assert_total (nonEmptyBlock (topDecl fname))
+         ds    <- blockAfter col (topDecl fname)
          pure (PNamespace (MkFC fname start end) ns (concat ds))
 
 transformDecl : FileName -> IndentInfo -> Rule PDecl

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -71,6 +71,8 @@ idrisTests
        -- QTT and linearity related
        "linear001", "linear002", "linear003", "linear004", "linear005",
        "linear006", "linear007", "linear008", "linear009",
+       -- Namespace blocks
+       "namespace001",
        -- Parameters blocks
        "params001",
        -- Performance: things which have been slow in the past, or which

--- a/tests/idris2/namespace001/Dup.idr
+++ b/tests/idris2/namespace001/Dup.idr
@@ -1,0 +1,14 @@
+-- Namespaces are currently allowed to be empty, as modules are, but also
+-- require their contents to be indented to denote where they end.
+-- Whereas a module's end is the end of the file.
+
+-- Since there's no indentation each namespace ends imediately. So each Test
+-- defines things at the module level, causing an `already defined` error.
+
+namespace X
+private
+data Test = A | B
+
+namespace Y
+private
+data Test = A | B

--- a/tests/idris2/namespace001/Scope.idr
+++ b/tests/idris2/namespace001/Scope.idr
@@ -1,0 +1,15 @@
+-- Namespaces are currently allowed to be empty, as modules are, but also
+-- require their contents to be indented to denote where they end.
+-- Whereas a module's end is the end of the file.
+
+-- Since there's no indentation on the latter definitions, this file should have
+-- Test in scope under Main.X.Test, Test in scope under Main.Test, and nothing
+-- in scope in Main.Y because namespace Y ends immediately.
+
+namespace X
+  private
+  data Test = A | B
+
+namespace Y
+private
+data Test = A | B

--- a/tests/idris2/namespace001/expected
+++ b/tests/idris2/namespace001/expected
@@ -1,0 +1,8 @@
+1/1: Building Dup (Dup.idr)
+Dup.idr:14:13--14:15:Main.A is already defined
+Main> Bye for now!
+1/1: Building Scope (Scope.idr)
+Main> Main.Test : Type
+Main.X.Test : Type
+Main> 
+Bye for now!

--- a/tests/idris2/namespace001/run
+++ b/tests/idris2/namespace001/run
@@ -1,0 +1,4 @@
+echo ':q' | $1 --no-banner Dup.idr
+echo ':t Test' | $1 --no-banner Scope.idr
+
+rm -rf build


### PR DESCRIPTION
The namespace parser was not requiring a minimum indentation and instead
based its indentation on the following line, which meant that a line like:
```
namespace Foo
foodef : Int
```
placed `foodef` into namespace `Foo` instead of the module's top level.
And so made it unclear when a namespace ends.