### PR TITLE
Import fgetc and listen from libc rather than support libs

### DIFF
--- a/libs/base/System/File.idr
+++ b/libs/base/System/File.idr
@@ -31,7 +31,7 @@ prim_fileErrno : PrimIO Int
 prim__readLine : FilePtr -> PrimIO (Ptr String)
 %foreign support "idris2_readChars"
 prim__readChars : Int -> FilePtr -> PrimIO (Ptr String)
-%foreign support "fgetc"
+%foreign "C:fgetc,libc 6"
 prim__readChar : FilePtr -> PrimIO Int
 %foreign support "idris2_writeLine"
 prim__writeLine : FilePtr -> String -> PrimIO Int

--- a/libs/network/Network/FFI.idr
+++ b/libs/network/Network/FFI.idr
@@ -11,7 +11,7 @@ import Network.Socket.Data
 export
 socket_close : (sockdes : SocketDescriptor) -> PrimIO Int
 
-%foreign "C:listen,libidris2_support"
+%foreign "C:listen,libc 6"
 export
 socket_listen : (sockfd : SocketDescriptor) -> (backlog : Int) -> PrimIO Int
 


### PR DESCRIPTION
Minor correctness fixes.

In particular: Importing fgetc and listen indirectly via support seems not to create issues on Linux (5.6.16, Glibc 2.31, x86_64, with Racket 7.4), and presumably other platforms but prevents building on OpenBSD 6.7 (x86_64 with Racket 7.7) due to linkage issues.

I haven't committed updated bootstrap code in case special vetting is required. It seems that the bootstrap is less frequently updated.

Anyone wishing to benefit from this fix before the bootstrap is updated should build with this PR on a working platform (eg. Linux) then copy across the source tree and rebuild. Alternatively (for Racket, say) in bootstrap/idris2_app/idris2.rkt: substitute the lines
(define-libidris2_support fgetc (_fun _pointer -> _int))
with
(define-libc fgetc (_fun _pointer -> _int))
and
(define-libidris2_support listen (_fun _int _int -> _int))
with
(define-libc listen (_fun _int _int -> _int))
