### PR TITLE
Restore Bool operators precedence

### DIFF
--- a/libs/prelude/Prelude/Ops.idr
+++ b/libs/prelude/Prelude/Ops.idr
@@ -7,8 +7,8 @@ infixl 8 +, -
 infixl 9 *, /
 
 -- Boolean operators
-infixr 4 &&
-infixr 5 ||
+infixr 5 &&
+infixr 4 ||
 
 -- List and String operators
 infixr 7 ::, ++

--- a/src/Core/Normalise.idr
+++ b/src/Core/Normalise.idr
@@ -112,7 +112,7 @@ parameters (defs : Defs, topopts : EvalOpts)
     eval env locs (Bind fc x (Lam r _ ty) scope) (thunk :: stk)
         = eval env (thunk :: locs) scope stk
     eval env locs (Bind fc x b@(Let r val ty) scope) stk
-        = if holesOnly topopts || argHolesOnly topopts && not (tcInline topopts)
+        = if (holesOnly topopts || argHolesOnly topopts) && not (tcInline topopts)
              then do b' <- traverse (\tm => eval env locs tm []) b
                      pure $ NBind fc x b'
                         (\defs', arg => evalWithOpts defs' topopts

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -140,6 +140,10 @@ ideModeTests : List String
 ideModeTests
   =  [ "ideMode001", "ideMode002", "ideMode003" ]
 
+preludeTests : List String
+preludeTests
+  =  [ "reg001" ]
+
 ------------------------------------------------------------------------
 -- Options
 
@@ -321,6 +325,7 @@ main
                  , testPaths "idris2" idrisTests
                  , testPaths "typedd-book" typeddTests
                  , testPaths "ideMode" ideModeTests
+                 , testPaths "prelude" preludeTests
                  ]
          let filteredChezTests = filterTests opts (testPaths "chez" chezTests)
          let filteredNodeTests = filterTests opts (testPaths "node" nodeTests)

--- a/tests/prelude/reg001/expected
+++ b/tests/prelude/reg001/expected
@@ -1,0 +1,1 @@
+1/1: Building fixity (fixity.idr)

--- a/tests/prelude/reg001/fixity.idr
+++ b/tests/prelude/reg001/fixity.idr
@@ -1,0 +1,2 @@
+boolean : a && b || c = (a && b) || c
+boolean = Refl

--- a/tests/prelude/reg001/run
+++ b/tests/prelude/reg001/run
@@ -1,0 +1,3 @@
+$1 --check fixity.idr
+
+rm -rf build


### PR DESCRIPTION
(&&) traditionally has higher precedence than (||).

Note that this commit requires to bootstrap again.