### PR TITLE
Better TTC data is in an older format message

### DIFF
--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -199,14 +199,14 @@ writeTTCFile b file_in
 
 readTTCFile : TTC extra =>
               {auto c : Ref Ctxt Defs} ->
-              List String -> Maybe (List String) ->
+              String -> Maybe (List String) ->
               Ref Bin Binary -> Core (TTCFile extra)
-readTTCFile modns as b
+readTTCFile file as b
       = do hdr <- fromBuf b
            chunk <- get Bin
-           when (hdr /= "TT2") $ corrupt ("TTC header in " ++ show modns ++ " " ++ show hdr)
+           when (hdr /= "TT2") $ corrupt ("TTC header in " ++ file ++ " " ++ show hdr)
            ver <- fromBuf b
-           checkTTCVersion (show modns) ver ttcVersion
+           checkTTCVersion file ver ttcVersion
            ifaceHash <- fromBuf b
            importHashes <- fromBuf b
            defs <- fromBuf b
@@ -423,7 +423,7 @@ readFromTTC nestedns loc reexp fname modNS importAs
          let as = if importAs == modNS
                      then Nothing
                      else Just importAs
-         ttc <- readTTCFile modNS as bin
+         ttc <- readTTCFile fname as bin
 
          -- If it's already imported, but without reexporting, then all we're
          -- interested in is returning which other modules to load.


### PR DESCRIPTION
Locally all of the tests fail with error like: `Error in TTC file: TTC data is in an older format, file: ["Prelude"], expected version: 34, actual version: 33`.

From this description it's hard to find out what's the actual file path, what should I clean to make Idris rebuild something that is cached.

Now the error is: `Error in TTC file: TTC data is in an older format, file: /Users/nga/.idris2/idris2-0.2.0/prelude/Prelude.ttc, expected version: 34, actual version: 33`.