### PR TITLE
Insert @generated marker into generated Scheme files

### DIFF
--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -71,6 +71,7 @@ escapeString s = pack $ foldr escape [] $ unpack s
 schHeader : String -> List String -> String
 schHeader chez libs
   = (if os /= "windows" then "#!" ++ chez ++ " --script\n\n" else "") ++
+    "; @generated\n" ++
     "(import (chezscheme))\n" ++
     "(case (machine-type)\n" ++
     "  [(i3le ti3le a6le ta6le) (load-shared-object \"libc.so.6\")]\n" ++

--- a/src/Compiler/Scheme/Gambit.idr
+++ b/src/Compiler/Scheme/Gambit.idr
@@ -39,7 +39,8 @@ findGSC =
      pure $ fromMaybe "/usr/bin/env gsc" env
 
 schHeader : String
-schHeader = "(declare (block)
+schHeader = "; @generated\n
+         (declare (block)
          (inlining-limit 450)
          (standard-bindings)
          (extended-bindings)

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -40,6 +40,7 @@ findRacoExe =
 schHeader : String -> String
 schHeader libs
   = "#lang racket/base\n" ++
+    "; @generated\n" ++
     "(require racket/math)\n" ++ -- for math ops
     "(require racket/system)\n" ++ -- for system
     "(require rnrs/bytevectors-6)\n" ++ -- for buffers


### PR DESCRIPTION
* `@generated` is a marked used by Phabricator to mark generated files,
  any other marker would do
* it's easier to explore source tree when it's clear which files are sources
  and which are generated