### PR TITLE
Mutate linear values within a limited scope

### DIFF
--- a/src/Compiler/CompileExpr.idr
+++ b/src/Compiler/CompileExpr.idr
@@ -309,9 +309,8 @@ mutual
                             = mkDropSubst 0 (eraseArgs gdef) vars args
                         sc' <- toCExpTree n sc
                         ns' <- conCases n ns
-                        if dcon (definition gdef)
-                           then pure $ MkConAlt xn (Just tag) args' (shrinkCExp sub sc') :: ns'
-                           else pure $ MkConAlt xn Nothing args' (shrinkCExp sub sc') :: ns'
+                        let dconTag = toMaybe (dcon (definition gdef)) tag
+                        pure $ MkConAlt xn dconTag args' (shrinkCExp sub sc') :: ns'
     where
       dcon : Def -> Bool
       dcon (DCon _ _ _ _) = True

--- a/src/Compiler/CompileExpr.idr
+++ b/src/Compiler/CompileExpr.idr
@@ -29,8 +29,8 @@ numArgs defs (Ref _ _ n)
     = do Just gdef <- lookupCtxtExact n (gamma defs)
               | Nothing => pure (Arity 0)
          case definition gdef of
-           DCon _ arity Nothing => pure (EraseArgs arity (eraseArgs gdef))
-           DCon _ arity (Just (_, pos)) => pure (NewTypeBy arity pos)
+           DCon _ _ arity Nothing => pure (EraseArgs arity (eraseArgs gdef))
+           DCon _ _ arity (Just (_, pos)) => pure (NewTypeBy arity pos)
            PMDef _ args _ _ _ => pure (Arity (length args))
            ExternDef arity => pure (Arity arity)
            ForeignDef arity _ => pure (Arity arity)
@@ -219,17 +219,17 @@ mutual
       = pure $ CLocal fc prf
   -- TMP HACK: extend this to all types which look like enumerations
   -- after erasure
-  toCExpTm n (Ref fc (DataCon tag Z) (NS ["Prelude"] (UN "True")))
+  toCExpTm n (Ref fc (DataCon rig tag Z) (NS ["Prelude"] (UN "True")))
       = pure $ CPrimVal fc (I tag)
-  toCExpTm n (Ref fc (DataCon tag Z) (NS ["Prelude"] (UN "False")))
+  toCExpTm n (Ref fc (DataCon rig tag Z) (NS ["Prelude"] (UN "False")))
       = pure $ CPrimVal fc (I tag)
-  toCExpTm n (Ref fc (DataCon tag Z) (NS ["Prelude"] (UN "LT")))
+  toCExpTm n (Ref fc (DataCon rig tag Z) (NS ["Prelude"] (UN "LT")))
       = pure $ CPrimVal fc (I tag)
-  toCExpTm n (Ref fc (DataCon tag Z) (NS ["Prelude"] (UN "EQ")))
+  toCExpTm n (Ref fc (DataCon rig tag Z) (NS ["Prelude"] (UN "EQ")))
       = pure $ CPrimVal fc (I tag)
-  toCExpTm n (Ref fc (DataCon tag Z) (NS ["Prelude"] (UN "GT")))
+  toCExpTm n (Ref fc (DataCon rig tag Z) (NS ["Prelude"] (UN "GT")))
       = pure $ CPrimVal fc (I tag)
-  toCExpTm n (Ref fc (DataCon tag arity) fn)
+  toCExpTm n (Ref fc (DataCon rig tag arity) fn)
       = -- get full name for readability, and the Nat hack
         pure $ CCon fc !(getFullName fn) (Just tag) []
   toCExpTm n (Ref fc (TyCon tag arity) fn)
@@ -303,7 +303,7 @@ mutual
                         pure $ MkConAlt xn Nothing args !(toCExpTree n sc)
                                   :: !(conCases n ns)
            case (definition gdef) of
-                DCon _ arity (Just pos) => conCases n ns -- skip it
+                DCon _ _ arity (Just pos) => conCases n ns -- skip it
                 _ => do xn <- getFullName x
                         let (args' ** sub)
                             = mkDropSubst 0 (eraseArgs gdef) vars args
@@ -314,7 +314,7 @@ mutual
                            else pure $ MkConAlt xn Nothing args' (shrinkCExp sub sc') :: ns'
     where
       dcon : Def -> Bool
-      dcon (DCon _ _ _) = True
+      dcon (DCon _ _ _ _) = True
       dcon _ = False
   conCases n (_ :: ns) = conCases n ns
 
@@ -352,7 +352,7 @@ mutual
                 -- that we've erased, it means it has interacted with the
                 -- outside world, so we need to evaluate to keep the
                 -- side effect.
-                Just (DCon _ arity (Just (noworld, pos))) =>
+                Just (DCon _ _ arity (Just (noworld, pos))) =>
 -- FIXME: We don't need the commented out bit *for now* because io_bind
 -- isn't being inlined, but it does need to be a little bit cleverer to
 -- get the best performance.
@@ -361,7 +361,7 @@ mutual
 -- works in a nice principled way.
 --                      if noworld -- just substitute the scrutinee into
 --                                 -- the RHS
---                         then 
+--                         then
                              let env : SubstCEnv args vars
                                      = mkSubst 0 scr pos args in
                                  pure $ Just (substs env !(toCExpTree n sc))
@@ -589,7 +589,7 @@ toCDef n ty (Builtin {arity} op)
     getVars : ArgList k ns -> Vect k (Var ns)
     getVars NoArgs = []
     getVars (ConsArg a rest) = MkVar First :: map weakenVar (getVars rest)
-toCDef n _ (DCon tag arity pos)
+toCDef n _ (DCon rig tag arity pos)
     = let nt = maybe Nothing (Just . snd) pos in
           pure $ MkCon (Just tag) arity nt
 toCDef n _ (TCon tag arity _ _ _ _ _ _)

--- a/src/Compiler/Inline.idr
+++ b/src/Compiler/Inline.idr
@@ -1,6 +1,7 @@
 module Compiler.Inline
 
 import Compiler.CompileExpr
+import Compiler.Mutate
 
 import Core.CompileExpr
 import Core.Context
@@ -457,6 +458,7 @@ compileAndInlineAll
          traverse_ inlineDef cns
          traverse_ mergeLamDef cns
          traverse_ fixArityDef cns
+         traverse_ addMutatingCases cns
   where
     nonErased : Name -> Core Bool
     nonErased n

--- a/src/Compiler/Inline.idr
+++ b/src/Compiler/Inline.idr
@@ -187,6 +187,8 @@ mutual
                       pure (CLet fc x True val' (refToLocal xn x sc'))
   eval rec env stk (CApp fc f args)
       = eval rec env (!(traverse (eval rec env []) args) ++ stk) f
+  eval rec env stk (CMut fc n args)
+      = pure $ unload stk $ CMut fc n !(traverse (eval rec env []) args)
   eval rec env stk (CCon fc n t args)
       = pure $ unload stk $ CCon fc n t !(traverse (eval rec env []) args)
   eval rec env stk (COp fc p args)

--- a/src/Compiler/LambdaLift.idr
+++ b/src/Compiler/LambdaLift.idr
@@ -29,6 +29,7 @@ mutual
        LLet : FC -> (x : Name) -> Lifted vars ->
               Lifted (x :: vars) -> Lifted vars
        LCon : FC -> Name -> (tag : Maybe Int) -> List (Lifted vars) -> Lifted vars
+       LMut : FC -> Name -> List (Lifted vars) -> Lifted vars
        LOp : {arity : _} ->
              FC -> PrimFn arity -> Vect arity (Lifted vars) -> Lifted vars
        LExtPrim : FC -> (p : Name) -> List (Lifted vars) -> Lifted vars
@@ -77,7 +78,7 @@ mutual
     show (LAppName fc n args)
         = show n ++ "(" ++ showSep ", " (map show args) ++ ")"
     show (LUnderApp fc n m args)
-        = "<" ++ show n ++ " underapp " ++ show m ++ ">(" ++ 
+        = "<" ++ show n ++ " underapp " ++ show m ++ ">(" ++
           showSep ", " (map show args) ++ ")"
     show (LApp fc c arg)
         = show c ++ " @ (" ++ show arg ++ ")"
@@ -85,6 +86,8 @@ mutual
         = "%let " ++ show x ++ " = " ++ show val ++ " in " ++ show sc
     show (LCon fc n t args)
         = "%con " ++ show n ++ "(" ++ showSep ", " (map show args) ++ ")"
+    show (LMut fc n args)
+        = "%mut  " ++ show n ++ "(" ++ showSep ", " (map show args) ++ ")"
     show (LOp fc op args)
         = "%op " ++ show op ++ "(" ++ showSep ", " (toList (map show args)) ++ ")"
     show (LExtPrim fc p args)
@@ -102,7 +105,7 @@ mutual
   export
   {vs : _} -> Show (LiftedConAlt vs) where
     show (MkLConAlt n t args sc)
-        = "%conalt " ++ show n ++ 
+        = "%conalt " ++ show n ++
              "(" ++ showSep ", " (map show args) ++ ") => " ++ show sc
 
   export
@@ -188,6 +191,7 @@ mutual
   liftExp (CApp fc f args)
       = unload fc !(liftExp f) !(traverse liftExp args)
   liftExp (CCon fc n t args) = pure $ LCon fc n t !(traverse liftExp args)
+  liftExp (CMut fc n args) = pure $ LMut fc n !(traverse liftExp args)
   liftExp (COp fc op args)
       = pure $ LOp fc op !(traverseArgs args)
     where

--- a/src/Compiler/Mutate.idr
+++ b/src/Compiler/Mutate.idr
@@ -1,0 +1,55 @@
+module Compiler.Mutate
+
+import Core.CompileExpr
+import Core.Name
+
+import Data.List
+
+mkMutating : (sc : CExp vars) -> Name -> (tag : Maybe Int) -> CExp (vs ++ vars) -> CExp vars
+mkMutating sc nm tag con@(CCon fc nm' tag' args)  =
+  if nm == nm' && tag == tag' then CMut fc nm args
+                              else con
+mkMutating sc nm tag (CLam fc x body) = CLam fc x (mkMutating sc nm tag body)
+mkMutating sc nm tag (CLet fc x i body) = CLet fc x i (mkMutating sc nm tag body)
+mkMutating sc nm tag (COp fc aty args ) = COp fc ary (map (mkMutating sc nm tag) args)
+
+mutateRhs : (sc : CExp vars) -> CConAlt vars -> CConAlt vars
+mutateRhs sc (MkConAlt nm tag args rhs) = MkConAlt nm tag args (mkMutating {vs=[]} sc nm tag rhs)
+
+
+updateTag : Int -> (CConAlt vars) -> (CConAlt vars)
+updateTag offset (MkConAlt nm tag args rhs) = MkConAlt nm ((+ offset) <$> tag) args rhs
+
+||| Duplicate every clause and replace every constructor on the rhs by a mutating version
+||| The transformation on takes place for patterns which are not wildcards
+||| It only replaces constructors that match the ones we match on
+||| The tag for mutating version is simply offest by the amount of matches we have
+||| the following tree:
+||| case v of
+|||      Match1 a => … -- tag 0
+|||      Match2 b => … -- tag 1
+|||      Match3 c => … -- tag 2
+|||
+||| will be replaced by:
+||| case v of
+|||      Match1 a => … -- tag 0
+|||      Match2 b => … -- tag 1
+|||      Match3 c => … -- tag 2
+|||      Match1' a => … -- tag 3 mutating rhs
+|||      Match2' b => … -- tag 4 mutating rhs
+|||      Match3' c => … -- tag 5 mutating rhs
+||| wildcards are not duplicated since they do not match on a known constructor
+||| case v of
+|||      Match1 a => …
+|||      _ => …
+||| will be replaced by:
+||| case v of
+|||      Match1 a => … -- tag 0
+|||      Match1' a => … -- tag 1
+|||      _ => … -- not duplicated since we do not know which constructor to replace
+expandCase : CExp vars -> CExp vars
+expandCase (CConCase fc sc clauses wild) =
+  let newClauses = map (mutateRhs sc) clauses
+      updatedClauses = map (updateTag (cast $ List.length clauses)) newClauses in
+      CConCase fc sc (clauses ++ updatedClauses) wild
+expandCase exp = exp

--- a/src/Compiler/Mutate.idr
+++ b/src/Compiler/Mutate.idr
@@ -1,24 +1,88 @@
 module Compiler.Mutate
 
 import Core.CompileExpr
+import Core.Context
+import Core.Core
+import Core.FC
 import Core.Name
 
 import Data.List
 
-mkMutating : (sc : CExp vars) -> Name -> (tag : Maybe Int) -> CExp (vs ++ vars) -> CExp vars
-mkMutating sc nm tag con@(CCon fc nm' tag' args)  =
-  if nm == nm' && tag == tag' then CMut fc nm args
-                              else con
-mkMutating sc nm tag (CLam fc x body) = CLam fc x (mkMutating sc nm tag body)
-mkMutating sc nm tag (CLet fc x i body) = CLet fc x i (mkMutating sc nm tag body)
-mkMutating sc nm tag (COp fc aty args ) = COp fc ary (map (mkMutating sc nm tag) args)
-
-mutateRhs : (sc : CExp vars) -> CConAlt vars -> CConAlt vars
-mutateRhs sc (MkConAlt nm tag args rhs) = MkConAlt nm tag args (mkMutating {vs=[]} sc nm tag rhs)
-
+%hide Prelude.traverse
 
 updateTag : Int -> (CConAlt vars) -> (CConAlt vars)
 updateTag offset (MkConAlt nm tag args rhs) = MkConAlt nm ((+ offset) <$> tag) args rhs
+
+mutual
+  export
+  mkMutating : {auto c : Ref Ctxt Defs} -> {vars : _} -> Name -> (tag : Maybe Int) -> CExp vars -> Core (CExp vars)
+  mkMutating nm tag (CLam fc x body) =
+    let mutating = (mkMutating nm tag body) in
+        pure $ CLam fc x !mutating
+  mkMutating nm tag (CLet fc n i rhs body) =
+    let rhs' = mkMutating nm tag rhs
+        body' = mkMutating nm tag body in
+        pure $ CLet fc n i !rhs' !body'
+  mkMutating nm tag (CApp fc fn args) = pure $ CApp fc !(mkMutating nm tag fn) !(traverse (mkMutating nm tag) args)
+  -- if the constructor matches name and tag, replace it by mut, otherwise do nothing
+  mkMutating nm tag con@(CCon fc nm' tag' args)  = do
+    coreLift $ putStrLn $ "found CCon " ++ show con
+    coreLift $ putStrLn $ "replace if match " ++ show nm ++ ":" ++ show tag
+    if nm == nm' && tag == tag'
+       then do coreLift $ putStrLn "names match, creating additional case"
+               pure $ CMut fc nm args
+       else do coreLift $ putStrLn "names do not match" ; pure con
+  mkMutating nm tag (COp fc aty args) = pure $ COp fc aty !(traverseVect (mkMutating nm tag) args)
+  mkMutating nm tag (CExtPrim fc n args) = pure $ CExtPrim fc n !(traverse (mkMutating nm tag) args)
+  mkMutating nm tag (CForce fc body) = CForce fc <$> (mkMutating nm tag body)
+  mkMutating nm tag (CDelay fc body) = CDelay fc <$> (mkMutating nm tag body)
+
+  -- when we see a CConCase we need to expand it to allow mutating cases and then we
+  -- modify each new case to allow the additional mutation from the enclosing scope
+  -- this makes a redundant tree traversal, maybe we should do everything in 1 go
+  mkMutating nm tag (CConCase fc sc clauses wc) = do
+        -- add the mutating clauses for the current
+        coreLift $ putStrLn $ "found ConCase with name " ++ show nm ++ ":" ++ show tag
+        newClauses <- traverse mutateCaseAlt clauses
+        let updatedClauses = map (updateTag (cast $ List.length clauses)) newClauses
+        let allClauses = (clauses ++ updatedClauses)
+        pure $ CConCase fc sc !(traverse mutateClause allClauses) wc
+    where
+      -- mutate the clause but this time replace all `nm` and `tag` since nm' and tag'
+      -- have already been added in the lines above
+      mutateClause : CConAlt vars -> Core (CConAlt vars)
+      mutateClause (MkConAlt nm' tag' args rhs) =
+        pure $ MkConAlt nm' tag' args !(mkMutating nm tag rhs)
+  mkMutating nm tag (CConstCase fc sc clauses wc) =
+    let newClauses = traverse mapClauses clauses in
+        pure $ CConstCase fc sc !newClauses wc
+    where
+      mapClauses : CConstAlt vars -> Core (CConstAlt vars)
+      mapClauses (MkConstAlt c rhs) = pure $ MkConstAlt c !(mkMutating nm tag rhs)
+  mkMutating nm tag other@(CCrash _ _) =
+    do coreLift $ putStrLn ("found crash " ++ show other ++ ", ignoring"); pure other
+  mkMutating nm tag other@(CErased _) =
+    do coreLift $ putStrLn ("found erased " ++ show other ++ ", ignoring"); pure other
+  mkMutating nm tag other@(CPrimVal _ _) =
+    do coreLift $ putStrLn ("found primVal " ++ show other ++ ", ignoring"); pure other
+  mkMutating nm tag other@(CLocal _ _) =
+    do coreLift $ putStrLn ("found local " ++ show other ++ ", ignoring"); pure other
+  mkMutating nm tag other@(CRef fc n) = do
+    coreLift $ putStrLn ("found CRef: " ++ show n)
+    defs <- get Ctxt
+    Just gdef <- lookupCtxtExact n (gamma defs) | _ => pure other
+    let Just (MkFun fargs body) = compexpr gdef | _ => pure other
+    newBody <- mkMutating nm tag body
+    setCompiled n (MkFun fargs newBody)
+    pure other
+
+  mkMutating nm tag other@(CMut _ _ _) =
+    do coreLift $ putStrLn ("found mut " ++ show other ++ ", ignoring"); pure other
+
+  ||| Given a name/tag for a constructor, replace all occurences of constructing that value
+  ||| on the rhs of a case alternatuve.
+  mutateCaseAlt : {auto c : Ref Ctxt Defs} -> {vars : _} -> CConAlt vars -> Core (CConAlt vars)
+  mutateCaseAlt (MkConAlt nm tag args rhs) = MkConAlt nm tag args <$> (mkMutating nm tag rhs)
 
 ||| Duplicate every clause and replace every constructor on the rhs by a mutating version
 ||| The transformation on takes place for patterns which are not wildcards
@@ -47,9 +111,37 @@ updateTag offset (MkConAlt nm tag args rhs) = MkConAlt nm ((+ offset) <$> tag) a
 |||      Match1 a => … -- tag 0
 |||      Match1' a => … -- tag 1
 |||      _ => … -- not duplicated since we do not know which constructor to replace
-expandCase : CExp vars -> CExp vars
-expandCase (CConCase fc sc clauses wild) =
-  let newClauses = map (mutateRhs sc) clauses
-      updatedClauses = map (updateTag (cast $ List.length clauses)) newClauses in
-      CConCase fc sc (clauses ++ updatedClauses) wild
-expandCase exp = exp
+export
+expandCases : {vars : List Name} -> {auto c : Ref Ctxt Defs} ->
+              CExp vars -> Core (CExp vars)
+-- expandCases (CLam fc nm body) = (expandCases body)
+-- expandCases (CLet fc nm i rhs body) =
+--   do expandCases rhs
+--      expandCases body
+-- expandCases (CApp fc fn args) = do (expandCases fn) ; (traverse_ expandCases args)
+-- expandCases (CCon fc nm tag args) = (traverse_ expandCases args)
+-- expandCases (COp fc aty args) = map (const ()) (traverseVect expandCases args)
+-- expandCases (CExtPrim fc nm args) = (traverse_ expandCases args)
+-- expandCases (CForce fc expr) = (expandCases expr)
+-- expandCases (CDelay fc expr) = (expandCases expr)
+-- expandCases (CConCase fc sc clauses wc) =
+--   traverse_ (\(MkConAlt _ _ _ rhs) => expandCases rhs) clauses
+-- expandCases (CConstCase fc sc clauses wc) =
+--   traverse_ (\(MkConstAlt c exp) => expandCases exp) clauses
+-- expandCases other@(CCrash _ _) =
+--   do coreLift $ putStrLn ("found crash " ++ show other ++ ", ignoring"); pure ()
+-- expandCases other@(CErased _) =
+--   do coreLift $ putStrLn ("found erased " ++ show other ++ ", ignoring"); pure ()
+-- expandCases other@(CPrimVal _ _) =
+--   do coreLift $ putStrLn ("found primVal " ++ show other ++ ", ignoring"); pure ()
+-- expandCases other@(CLocal _ _) =
+--   do coreLift $ putStrLn ("found local " ++ show other ++ ", ignoring"); pure ()
+-- expandCases other@(CRef fc n) = do
+--   defs <- get Ctxt
+--   Just gdef <- lookupCtxtExact n (gamma defs) | _ => pure ()
+--   let Just (MkFun fargs body) = compexpr gdef | _ => pure ()
+--   expanded <- mkMutating {vars=fargs} (UN "") Nothing body
+--   let newCDef = MkFun fargs expanded
+--   setCompiled n newCDef
+-- expandCases other@(CMut _ _ _) =
+--   do coreLift $ putStrLn ("found mut " ++ show other ++ ", ignoring"); pure ()

--- a/src/Compiler/Scheme/Common.idr
+++ b/src/Compiler/Scheme/Common.idr
@@ -318,7 +318,8 @@ parameters (schExtPrim : Int -> ExtPrim -> List NamedCExp -> Core String,
     schExp i (NmCon fc x tag args)
         = pure $ schConstructor schString x tag !(traverse (schExp i) args)
     schExp i (NmMut fc n args)
-        = pure $ schMutate (schName n) !(traverse (schExp i) args)
+        = do coreLift $ putStrLn "found mutation"
+             pure $ schMutate (schName n) !(traverse (schExp i) args)
     schExp i (NmOp fc op args)
         = pure $ schOp op !(schArgs i args)
     schExp i (NmExtPrim fc p args)

--- a/src/Compiler/Scheme/Common.idr
+++ b/src/Compiler/Scheme/Common.idr
@@ -52,7 +52,7 @@ schConstructor schString n Nothing args
 ||| Mutates the given vector at the given index
 mutateValue : (ref : String) -> (index : Nat) -> String -> String
 mutateValue ref idx newVal =
-  "(begin (display \"mutating\" " ++ show ref ++ ") (newline) (vector-set! " ++ ref ++  " " ++ show idx ++ " " ++ newVal ++ "))"
+  "(begin (display \"mutating\") (newline) (vector-set! " ++ ref ++  " " ++ show idx ++ " " ++ newVal ++ "))"
 
 ||| Mutate all fiels of a given construtor
 ||| We skip the first value in the vector because we do not change

--- a/src/Compiler/Scheme/Common.idr
+++ b/src/Compiler/Scheme/Common.idr
@@ -45,14 +45,14 @@ schName (Resolved i) = "fn--" ++ show i
 export
 schConstructor : (String -> String) -> Name -> Maybe Int -> List String -> String
 schConstructor _ _ (Just t) args
-    = "(vector " ++ show t ++ " " ++ showSep " " args ++ ")"
+    = "(begin (display \"constructing\") (newline) (vector " ++ show t ++ " " ++ showSep " " args ++ "))"
 schConstructor schString n Nothing args
     = "(vector " ++ schString (show n) ++ " " ++ showSep " " args ++ ")"
 
 ||| Mutates the given vector at the given index
 mutateValue : (ref : String) -> (index : Nat) -> String -> String
 mutateValue ref idx newVal =
-  "(vector-set! " ++ ref ++  " " ++ show idx ++ " " ++ newVal ++ ")"
+  "(begin (display \"mutating\" " ++ show ref ++ ") (newline) (vector-set! " ++ ref ++  " " ++ show idx ++ " " ++ newVal ++ "))"
 
 ||| Mutate all fiels of a given construtor
 ||| We skip the first value in the vector because we do not change
@@ -266,22 +266,23 @@ parameters (schExtPrim : Int -> ExtPrim -> List NamedCExp -> Core String,
   showTag n Nothing = schString (show n)
 
   mutual
-    schConAlt : Int -> String -> NamedConAlt -> Core String
-    schConAlt i target (MkNConAlt n tag args sc)
-        = pure $ "((" ++ showTag n tag ++ ") "
-                      ++ bindArgs 1 args !(schExp i sc) ++ ")"
+    schConAlt : {mut : List (Name, String)} -> Int -> String -> NamedConAlt -> Core String
+    schConAlt i target (MkNConAlt n tag args rhs)
+        = do coreLift $ putStrLn ("found ConAlt with context " ++ show mut ++ " looking for " ++ show n)
+             pure $ "((" ++ showTag n tag ++ ") "
+                      ++ bindArgs 1 args !(schExp i {mut=(n, target)::mut} rhs) ++ ")"
       where
         bindArgs : Int -> (ns : List Name) -> String -> String
         bindArgs i [] body = body
         bindArgs i (n :: ns) body
-            = if used n sc
+            = if used n rhs
                  then "(let ((" ++ schName n ++ " " ++ "(vector-ref " ++ target ++ " " ++ show i ++ "))) "
                     ++ bindArgs (i + 1) ns body ++ ")"
                  else bindArgs (i + 1) ns body
 
-    schConUncheckedAlt : Int -> String -> NamedConAlt -> Core String
+    schConUncheckedAlt : {mut : List (Name, String)} -> Int -> String -> NamedConAlt -> Core String
     schConUncheckedAlt i target (MkNConAlt n tag args sc)
-        = pure $ bindArgs 1 args !(schExp i sc)
+        = bindArgs 1 args <$> (schExp {mut=(n, target)::mut} i sc)
       where
         bindArgs : Int -> (ns : List Name) -> String -> String
         bindArgs i [] body = body
@@ -291,54 +292,55 @@ parameters (schExtPrim : Int -> ExtPrim -> List NamedCExp -> Core String,
                     ++ bindArgs (i + 1) ns body ++ ")"
                  else bindArgs (i + 1) ns body
 
-    schConstAlt : Int -> String -> NamedConstAlt -> Core String
+    schConstAlt : {mut : List (Name, String)} -> Int -> String -> NamedConstAlt -> Core String
     schConstAlt i target (MkNConstAlt c exp)
-        = pure $ "((equal? " ++ target ++ " " ++ schConstant schString c ++ ") " ++ !(schExp i exp) ++ ")"
+        = pure $ "((equal? " ++ target ++ " " ++ schConstant schString c ++ ") " ++ !(schExp {mut} i exp) ++ ")"
 
     -- oops, no traverse for Vect in Core
-    schArgs : Int -> Vect n NamedCExp -> Core (Vect n String)
+    schArgs : {mut : List (Name, String)} -> Int -> Vect n NamedCExp -> Core (Vect n String)
     schArgs i [] = pure []
-    schArgs i (arg :: args) = pure $ !(schExp i arg) :: !(schArgs i args)
+    schArgs i (arg :: args) = pure $ !(schExp {mut} i arg) :: !(schArgs {mut} i args)
 
     export
-    schExp : Int -> NamedCExp -> Core String
+    schExp : {mut : List (Name, String)} -> Int -> NamedCExp -> Core String
     schExp i (NmLocal fc n) = pure $ schName n
     schExp i (NmRef fc n) = pure $ schName n
     schExp i (NmLam fc x sc)
-       = do sc' <- schExp i  sc
+       = do sc' <- schExp {mut} i  sc
             pure $ "(lambda (" ++ schName x ++ ") " ++ sc' ++ ")"
     schExp i (NmLet fc x val sc)
-       = do val' <- schExp i val
-            sc' <- schExp i sc
+       = do val' <- schExp {mut} i val
+            sc' <- schExp {mut} i sc
             pure $ "(let ((" ++ schName x ++ " " ++ val' ++ ")) " ++ sc' ++ ")"
     schExp i (NmApp fc x [])
-        = pure $ "(" ++ !(schExp i x) ++ ")"
+        = pure $ "(" ++ !(schExp {mut} i x) ++ ")"
     schExp i (NmApp fc x args)
-        = pure $ "(" ++ !(schExp i x) ++ " " ++ showSep " " !(traverse (schExp i) args) ++ ")"
+        = pure $ "(" ++ !(schExp {mut} i x) ++ " " ++ showSep " " !(traverse (schExp {mut} i) args) ++ ")"
     schExp i (NmCon fc x tag args)
-        = pure $ schConstructor schString x tag !(traverse (schExp i) args)
+        = pure $ schConstructor schString x tag !(traverse (schExp {mut} i) args)
     schExp i (NmMut fc n args)
-        = do coreLift $ putStrLn "found mutation"
-             pure $ schMutate (schName n) !(traverse (schExp i) args)
+        = do coreLift $ putStrLn ("found mutation for " ++ show n ++ " in context " ++ show mut)
+             let (Just ref) = lookup n mut | _ => throw (InternalError ("Mutating reference not found : " ++ show n ++ " context " ++ show mut))
+             pure $ schMutate ref !(traverse (schExp {mut} i) args)
     schExp i (NmOp fc op args)
-        = pure $ schOp op !(schArgs i args)
+        = pure $ schOp op !(schArgs {mut} i args)
     schExp i (NmExtPrim fc p args)
         = schExtPrim i (toPrim p) args
-    schExp i (NmForce fc t) = pure $ "(" ++ !(schExp i t) ++ ")"
-    schExp i (NmDelay fc t) = pure $ "(lambda () " ++ !(schExp i t) ++ ")"
+    schExp i (NmForce fc t) = pure $ "(" ++ !(schExp {mut} i t) ++ ")"
+    schExp i (NmDelay fc t) = pure $ "(lambda () " ++ !(schExp {mut} i t) ++ ")"
     schExp i (NmConCase fc sc [] def)
-        = do tcode <- schExp (i+1) sc
-             defc <- maybe (pure "'erased") (schExp i) def
+        = do tcode <- schExp {mut} (i+1) sc
+             defc <- maybe (pure "'erased") (schExp {mut} i) def
              let n = "sc" ++ show i
              pure $ "(let ((" ++ n ++ " " ++ tcode ++ ")) "
                      ++ defc ++ ")"
     schExp i (NmConCase fc sc [alt] Nothing)
-        = do tcode <- schExp (i+1) sc
+        = do tcode <- schExp {mut} (i+1) sc
              let n = "sc" ++ show i
              pure $ "(let ((" ++ n ++ " " ++ tcode ++ ")) " ++
-                    !(schConUncheckedAlt (i+1) n alt) ++ ")"
+                    !(schConUncheckedAlt {mut} (i+1) n alt) ++ ")"
     schExp i (NmConCase fc sc alts Nothing)
-        = do tcode <- schExp (i+1) sc
+        = do tcode <- schExp {mut} (i+1) sc
              let n = "sc" ++ show i
              pure $ "(let ((" ++ n ++ " " ++ tcode ++ ")) (case (vector-ref " ++ n ++ " 0) "
                      ++ !(showAlts n alts) ++
@@ -347,19 +349,19 @@ parameters (schExtPrim : Int -> ExtPrim -> List NamedCExp -> Core String,
         showAlts : String -> List NamedConAlt -> Core String
         showAlts n [] = pure ""
         showAlts n [alt]
-           = pure $ "(else " ++ !(schConUncheckedAlt (i + 1) n alt) ++ ")"
+           = pure $ "(else " ++ !(schConUncheckedAlt {mut} (i + 1) n alt) ++ ")"
         showAlts n (alt :: alts)
-           = pure $ !(schConAlt (i + 1) n alt) ++ " " ++
+           = pure $ !(schConAlt {mut} (i + 1) n alt) ++ " " ++
                     !(showAlts n alts)
     schExp i (NmConCase fc sc alts def)
-        = do tcode <- schExp (i+1) sc
-             defc <- maybe (pure Nothing) (\v => pure (Just !(schExp i v))) def
+        = do tcode <- schExp {mut} (i+1) sc
+             defc <- maybe (pure Nothing) (\v => pure (Just !(schExp {mut} i v))) def
              let n = "sc" ++ show i
              pure $ "(let ((" ++ n ++ " " ++ tcode ++ ")) (case (vector-ref " ++ n ++ " 0) "
-                     ++ showSep " " !(traverse (schConAlt (i+1) n) alts)
+                     ++ showSep " " !(traverse (schConAlt {mut} (i+1) n) alts)
                      ++ schCaseDef defc ++ "))"
     schExp i (NmConstCase fc sc alts Nothing)
-        = do tcode <- schExp (i+1) sc
+        = do tcode <- schExp {mut} (i+1) sc
              let n = "sc" ++ show i
              pure $ "(let ((" ++ n ++ " " ++ tcode ++ ")) (cond "
                       ++ !(showConstAlts n alts)
@@ -368,16 +370,16 @@ parameters (schExtPrim : Int -> ExtPrim -> List NamedCExp -> Core String,
         showConstAlts : String -> List NamedConstAlt -> Core String
         showConstAlts n [] = pure ""
         showConstAlts n [MkNConstAlt c exp]
-           = pure $ "(else " ++ !(schExp (i + 1) exp) ++ ")"
+           = pure $ "(else " ++ !(schExp {mut} (i + 1) exp) ++ ")"
         showConstAlts n (alt :: alts)
-           = pure $ !(schConstAlt (i + 1) n alt) ++ " " ++
+           = pure $ !(schConstAlt {mut} (i + 1) n alt) ++ " " ++
                     !(showConstAlts n alts)
     schExp i (NmConstCase fc sc alts def)
-        = do defc <- maybe (pure Nothing) (\v => pure (Just !(schExp i v))) def
-             tcode <- schExp (i+1) sc
+        = do defc <- maybe (pure Nothing) (\v => pure (Just !(schExp {mut} i v))) def
+             tcode <- schExp {mut} (i+1) sc
              let n = "sc" ++ show i
              pure $ "(let ((" ++ n ++ " " ++ tcode ++ ")) (cond "
-                      ++ showSep " " !(traverse (schConstAlt (i+1) n) alts)
+                      ++ showSep " " !(traverse (schConstAlt {mut} (i+1) n) alts)
                       ++ schCaseDef defc ++ "))"
     schExp i (NmPrimVal fc c) = pure $ schConstant schString c
     schExp i (NmErased fc) = pure "'erased"
@@ -386,7 +388,7 @@ parameters (schExtPrim : Int -> ExtPrim -> List NamedCExp -> Core String,
   -- Need to convert the argument (a list of scheme arguments that may
   -- have been constructed at run time) to a scheme list to be passed to apply
   readArgs : Int -> NamedCExp -> Core String
-  readArgs i tm = pure $ "(blodwen-read-args " ++ !(schExp i tm) ++ ")"
+  readArgs i tm = pure $ "(blodwen-read-args " ++ !(schExp {mut=[]} i tm) ++ ")"
 
   fileOp : String -> String
   fileOp op = "(blodwen-file-op (lambda () " ++ op ++ "))"
@@ -399,26 +401,26 @@ parameters (schExtPrim : Int -> ExtPrim -> List NamedCExp -> Core String,
      = pure $ mkWorld ("(apply " ++ fn ++" "
                   ++ !(readArgs i args) ++ ")")
   schExtCommon i SchemeCall [ret, fn, args, world]
-       = pure $ mkWorld ("(apply (eval (string->symbol " ++ !(schExp i fn) ++")) "
+       = pure $ mkWorld ("(apply (eval (string->symbol " ++ !(schExp {mut=[]} i fn) ++")) "
                     ++ !(readArgs i args) ++ ")")
   schExtCommon i NewIORef [_, val, world]
-      = pure $ mkWorld $ "(box " ++ !(schExp i val) ++ ")"
+      = pure $ mkWorld $ "(box " ++ !(schExp {mut=[]} i val) ++ ")"
   schExtCommon i ReadIORef [_, ref, world]
-      = pure $ mkWorld $ "(unbox " ++ !(schExp i ref) ++ ")"
+      = pure $ mkWorld $ "(unbox " ++ !(schExp {mut=[]} i ref) ++ ")"
   schExtCommon i WriteIORef [_, ref, val, world]
       = pure $ mkWorld $ "(set-box! "
-                           ++ !(schExp i ref) ++ " "
-                           ++ !(schExp i val) ++ ")"
+                           ++ !(schExp {mut=[]} i ref) ++ " "
+                           ++ !(schExp {mut=[]} i val) ++ ")"
   schExtCommon i NewArray [_, size, val, world]
-      = pure $ mkWorld $ "(make-vector " ++ !(schExp i size) ++ " "
-                                         ++ !(schExp i val) ++ ")"
+      = pure $ mkWorld $ "(make-vector " ++ !(schExp {mut=[]} i size) ++ " "
+                                         ++ !(schExp {mut=[]} i val) ++ ")"
   schExtCommon i ArrayGet [_, arr, pos, world]
-      = pure $ mkWorld $ "(vector-ref " ++ !(schExp i arr) ++ " "
-                                        ++ !(schExp i pos) ++ ")"
+      = pure $ mkWorld $ "(vector-ref " ++ !(schExp {mut=[]} i arr) ++ " "
+                                        ++ !(schExp {mut=[]} i pos) ++ ")"
   schExtCommon i ArraySet [_, arr, pos, val, world]
-      = pure $ mkWorld $ "(vector-set! " ++ !(schExp i arr) ++ " "
-                                         ++ !(schExp i pos) ++ " "
-                                         ++ !(schExp i val) ++ ")"
+      = pure $ mkWorld $ "(vector-set! " ++ !(schExp {mut=[]} i arr) ++ " "
+                                         ++ !(schExp {mut=[]} i pos) ++ " "
+                                         ++ !(schExp {mut=[]} i val) ++ ")"
   schExtCommon i VoidElim [_, _]
       = pure "(display \"Error: Executed 'void'\")"
   schExtCommon i SysOS []
@@ -433,9 +435,9 @@ parameters (schExtPrim : Int -> ExtPrim -> List NamedCExp -> Core String,
            Name -> NamedDef -> Core String
   schDef n (MkNmFun args exp)
      = pure $ "(define " ++ schName !(getFullName n) ++ " (lambda (" ++ schArglist args ++ ") "
-                      ++ !(schExp 0 exp) ++ "))\n"
+                         ++ !(schExp {mut=[]} 0 exp) ++ "))\n"
   schDef n (MkNmError exp)
-     = pure $ "(define (" ++ schName !(getFullName n) ++ " . any-args) " ++ !(schExp 0 exp) ++ ")\n"
+      = pure $ "(define (" ++ schName !(getFullName n) ++ " . any-args) " ++ !(schExp {mut=[]}0 exp) ++ ")\n"
   schDef n (MkNmForeign _ _ _) = pure "" -- compiled by specific back end
   schDef n (MkNmCon t a _) = pure "" -- Nothing to compile here
 

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -75,14 +75,14 @@ mutual
       = throw (InternalError ("Can't compile C FFI calls to Racket yet"))
   racketPrim i GetField [NmPrimVal _ (Str s), _, _, struct,
                          NmPrimVal _ (Str fld), _]
-      = do structsc <- schExp racketPrim racketString 0 struct
+      = do structsc <- schExp {mut=[]} racketPrim racketString 0 struct
            pure $ "(" ++ s ++ "-" ++ fld ++ " " ++ structsc ++ ")"
   racketPrim i GetField [_,_,_,_,_,_]
       = pure "(error \"bad getField\")"
   racketPrim i SetField [NmPrimVal _ (Str s), _, _, struct,
                          NmPrimVal _ (Str fld), _, val, world]
-      = do structsc <- schExp racketPrim racketString 0 struct
-           valsc <- schExp racketPrim racketString 0 val
+      = do structsc <- schExp {mut=[]} racketPrim racketString 0 struct
+           valsc <- schExp {mut=[]} racketPrim racketString 0 val
            pure $ mkWorld $
                 "(set-" ++ s ++ "-" ++ fld ++ "! " ++ structsc ++ " " ++ valsc ++ ")"
   racketPrim i SetField [_,_,_,_,_,_,_,_]
@@ -332,7 +332,7 @@ compileToRKT c appdir tm outfile
          fgndefs <- traverse (getFgnCall appdir) ndefs
          compdefs <- traverse (getScheme racketPrim racketString) ndefs
          let code = fastAppend (map snd fgndefs ++ compdefs)
-         main <- schExp racketPrim racketString 0 ctm
+         main <- schExp {mut=[]} racketPrim racketString 0 ctm
          support <- readDataFile "racket/support.rkt"
          let scm = schHeader (concat (map fst fgndefs)) ++
                    support ++ code ++
@@ -367,7 +367,7 @@ compileExpr mkexec c execDir tm outfile
          coreLift $ mkdirs (splitDir appDirGen)
          Just cwd <- coreLift currentDir
               | Nothing => throw (InternalError "Can't get current directory")
-          
+
          let ext = if isWindows then ".exe" else ""
          let outRktFile = appDirRel ++ dirSep ++ outfile ++ ".rkt"
          let outBinFile = appDirRel ++ dirSep ++ outfile ++ ext

--- a/src/Core/AutoSearch.idr
+++ b/src/Core/AutoSearch.idr
@@ -370,7 +370,7 @@ searchName fc rigc defaults trying depth def top env target (n, ndef)
          let ty = type ndef
          let namety : NameType
                  = case definition ndef of
-                        DCon tag arity _ => DataCon tag arity
+                        DCon r tag arity _ => DataCon r tag arity
                         TCon tag arity _ _ _ _ _ _ => TyCon tag arity
                         _ => Func
          nty <- nf defs env (embed ty)

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -28,7 +28,7 @@ import Data.Buffer
 -- TTC files can only be compatible if the version number is the same
 export
 ttcVersion : Int
-ttcVersion = 30
+ttcVersion = 31
 
 export
 checkTTCVersion : String -> Int -> Int -> Core ()

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -28,7 +28,7 @@ import Data.Buffer
 -- TTC files can only be compatible if the version number is the same
 export
 ttcVersion : Int
-ttcVersion = 29
+ttcVersion = 30
 
 export
 checkTTCVersion : String -> Int -> Int -> Core ()

--- a/src/Core/CaseTree.idr
+++ b/src/Core/CaseTree.idr
@@ -193,7 +193,7 @@ getMetas = getNames addMetas empty
 export
 mkPat' : List Pat -> ClosedTerm -> ClosedTerm -> Pat
 mkPat' args orig (Ref fc Bound n) = PLoc fc n
-mkPat' args orig (Ref fc (DataCon t a) n) = PCon fc n t a args
+mkPat' args orig (Ref fc (DataCon r t a) n) = PCon fc n t a args
 mkPat' args orig (Ref fc (TyCon t a) n) = PTyCon fc n a args
 mkPat' args orig (Bind fc x (Pi _ _ s) t)
     = let t' = subst (Erased fc False) t in
@@ -223,7 +223,9 @@ export
 mkTerm : (vars : List Name) -> Pat -> Term vars
 mkTerm vars (PAs fc x y) = mkTerm vars y
 mkTerm vars (PCon fc x tag arity xs)
-    = apply fc (Ref fc (DataCon tag arity) x)
+    -- By default Data constructors are unrestricted
+    --                           v
+    = apply fc (Ref fc (DataCon top tag arity) x)
                (map (mkTerm vars) xs)
 mkTerm vars (PTyCon fc x arity xs)
     = apply fc (Ref fc (TyCon 0 arity) x)

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -69,7 +69,7 @@ data Def : Type where
                                 -- e.g "C:printf,libc,stdlib.h", "scheme:display", ...
                  Def
     Builtin : {arity : Nat} -> PrimFn arity -> Def
-    DCon : (tag : Int) -> (arity : Nat) ->
+    DCon : (rig : RigCount) -> (tag : Int) -> (arity : Nat) ->
            (newtypeArg : Maybe (Bool, Nat)) ->
                -- if only constructor, and only one argument is non-Rig0,
                -- flag it here. The Nat is the unerased argument position.
@@ -112,8 +112,8 @@ Show Def where
   show (PMDef _ args ct rt pats)
       = show args ++ ";\nCompile time tree: " ++ show ct ++
         "\nRun time tree: " ++ show rt
-  show (DCon t a nt)
-      = "DataCon " ++ show t ++ " " ++ show a
+  show (DCon r t a nt)
+      = "DataCon " ++ show r ++ " " ++ show t ++ " " ++ show a
            ++ maybe "" (\n => " (newtype by " ++ show n ++ ")") nt
   show (TCon t a ps ds u ms cons det)
       = "TyCon " ++ show t ++ " " ++ show a ++ " params: " ++ show ps ++
@@ -1729,7 +1729,9 @@ addData vars vis tidx (MkData (MkCon dfc tyn arity tycon) datacons)
                           Context -> Core Context
     addDataConstructors tag [] gam = pure gam
     addDataConstructors tag (MkCon fc n a ty :: cs) gam
-        = do let condef = newDef fc n top vars ty (conVisibility vis) (DCon tag a Nothing)
+        -- Data constructors are unrestricted by default --------------------|
+        --                                                                   v
+        = do let condef = newDef fc n top vars ty (conVisibility vis) (DCon top tag a Nothing)
              (idx, gam') <- addCtxt n condef gam
              addDataConstructors (tag + 1) cs gam'
 

--- a/src/Core/Normalise.idr
+++ b/src/Core/Normalise.idr
@@ -212,7 +212,7 @@ parameters (defs : Defs, topopts : EvalOpts)
               (isMeta : Bool) ->
               FC -> NameType -> Name -> Stack free -> (def : Lazy (NF free)) ->
               Core (NF free)
-    evalRef env meta fc (DataCon tag arity) fn stk def
+    evalRef env meta fc (DataCon rig tag arity) fn stk def
         = pure $ NDCon fc fn tag arity stk
     evalRef env meta fc (TyCon tag arity) fn stk def
         = pure $ NTCon fc fn tag arity stk
@@ -576,7 +576,9 @@ mutual
            pure $ apply fc f' args'
   quoteGenNF q defs bound env (NDCon fc n t ar args)
       = do args' <- quoteArgs q defs bound env args
-           pure $ apply fc (Ref fc (DataCon t ar) n) args'
+           -- DataCon from DCon has unrestricted multiplicity
+           --                                v
+           pure $ apply fc (Ref fc (DataCon top t ar) n) args'
   quoteGenNF q defs bound env (NTCon fc n t ar args)
       = do args' <- quoteArgs q defs bound env args
            pure $ apply fc (Ref fc (TyCon t ar) n) args'

--- a/src/Core/TT.idr
+++ b/src/Core/TT.idr
@@ -17,7 +17,7 @@ public export
 data NameType : Type where
      Bound   : NameType
      Func    : NameType
-     DataCon : (tag : Int) -> (arity : Nat) -> NameType
+     DataCon : (rig : RigCount) -> (tag : Int) -> (arity : Nat) -> NameType
      TyCon   : (tag : Int) -> (arity : Nat) -> NameType
 
 public export
@@ -1226,7 +1226,7 @@ nameAt : {vars : _} ->
 nameAt {vars = n :: ns} Z First = n
 nameAt {vars = n :: ns} (S k) (Later p) = nameAt k p
 
-export 
+export
 {vars : _} -> Show (Term vars) where
   show tm = let (fn, args) = getFnArgs tm in showApp fn args
     where

--- a/src/Core/TTC.idr
+++ b/src/Core/TTC.idr
@@ -590,6 +590,7 @@ mutual
     toBuf b (CPrimVal fc c) = do tag 12; toBuf b fc; toBuf b c
     toBuf b (CErased fc) = do tag 13; toBuf b fc
     toBuf b (CCrash fc msg) = do tag 14; toBuf b fc; toBuf b msg
+    toBuf b (CMut fc n as) = assert_total $ do tag 15; toBuf b fc; toBuf b n; toBuf b as
 
     fromBuf b
         = assert_total $ case !getTag of
@@ -639,6 +640,10 @@ mutual
                14 => do fc <- fromBuf b
                         msg <- fromBuf b
                         pure (CCrash fc msg)
+               15 => do fc <- fromBuf b
+                        n <- fromBuf b
+                        args <- fromBuf b
+                        pure (CMut fc n args)
                _ => corrupt "CExp"
 
   export

--- a/src/Core/TTC.idr
+++ b/src/Core/TTC.idr
@@ -152,14 +152,14 @@ export
 TTC NameType where
   toBuf b Bound = tag 0
   toBuf b Func = tag 1
-  toBuf b (DataCon t arity) = do tag 2; toBuf b t; toBuf b arity
+  toBuf b (DataCon rig t arity) = do tag 2; toBuf b rig; toBuf b t; toBuf b arity
   toBuf b (TyCon t arity) = do tag 3; toBuf b t; toBuf b arity
 
   fromBuf b
       = case !getTag of
              0 => pure Bound
              1 => pure Func
-             2 => do x <- fromBuf b; y <- fromBuf b; pure (DataCon x y)
+             2 => do r <- fromBuf b; x <- fromBuf b; y <- fromBuf b; pure (DataCon r x y)
              3 => do x <- fromBuf b; y <- fromBuf b; pure (TyCon x y)
              _ => corrupt "NameType"
 
@@ -795,7 +795,7 @@ TTC Def where
       = do tag 3; toBuf b a; toBuf b cs
   toBuf b (Builtin a)
       = throw (InternalError "Trying to serialise a Builtin")
-  toBuf b (DCon t arity nt) = do tag 4; toBuf b t; toBuf b arity; toBuf b nt
+  toBuf b (DCon r t arity nt) = do tag 4; toBuf b r; toBuf b t; toBuf b arity; toBuf b nt
   toBuf b (TCon t arity parampos detpos u ms datacons dets)
       = do tag 5; toBuf b t; toBuf b arity; toBuf b parampos
            toBuf b detpos; toBuf b u; toBuf b ms; toBuf b datacons
@@ -823,8 +823,8 @@ TTC Def where
              3 => do a <- fromBuf b
                      cs <- fromBuf b
                      pure (ForeignDef a cs)
-             4 => do t <- fromBuf b; a <- fromBuf b; nt <- fromBuf b
-                     pure (DCon t a nt)
+             4 => do r <- fromBuf b; t <- fromBuf b; a <- fromBuf b; nt <- fromBuf b
+                     pure (DCon r t a nt)
              5 => do t <- fromBuf b; a <- fromBuf b
                      ps <- fromBuf b; dets <- fromBuf b;
                      u <- fromBuf b

--- a/src/Core/Termination.idr
+++ b/src/Core/Termination.idr
@@ -61,7 +61,7 @@ checkIfGuarded fc n
         = do Just gdef <- lookupCtxtExact n (gamma defs)
                   | Nothing => pure False
              case definition gdef of
-                  DCon _ _ _ => pure True
+                  DCon _ _ _ _ => pure True
                   _ => pure (multiplicity gdef == erased
                               || (AllGuarded `elem` flags gdef))
 
@@ -162,7 +162,7 @@ mutual
            case (g, fn', args) of
     -- If we're InDelay and find a constructor (or a function call which is
     -- guaranteed to return a constructor; AllGuarded set), continue as InDelay
-             (InDelay, Ref fc (DataCon _ _) cn, args) =>
+             (InDelay, Ref fc (DataCon _ _ _) cn, args) =>
                  do scs <- traverse (findSC defs env InDelay pats) args
                     pure (concat scs)
              -- If we're InDelay otherwise, just check the arguments, the
@@ -170,10 +170,10 @@ mutual
              (InDelay, _, args) =>
                  do scs <- traverse (findSC defs env Unguarded pats) args
                     pure (concat scs)
-             (Guarded, Ref fc (DataCon _ _) cn, args) =>
+             (Guarded, Ref fc (DataCon _ _ _) cn, args) =>
                  do scs <- traverse (findSC defs env Guarded pats) args
                     pure (concat scs)
-             (Toplevel, Ref fc (DataCon _ _) cn, args) =>
+             (Toplevel, Ref fc (DataCon _ _ _) cn, args) =>
                  do scs <- traverse (findSC defs env Guarded pats) args
                     pure (concat scs)
              (_, Ref fc Func fn, args) =>
@@ -192,7 +192,7 @@ mutual
                  Just gdef <- lookupCtxtExact n (gamma defs)
                       | Nothing => pure $ Ref fc Func n
                  if AllGuarded `elem` flags gdef
-                    then pure $ Ref fc (DataCon 0 0) n
+                    then pure $ Ref fc (DataCon top 0 0) n
                     else pure $ Ref fc Func n
         conIfGuarded tm = pure tm
 
@@ -235,7 +235,7 @@ mutual
       = if assertedSmaller big tm
            then True
            else case getFnArgs tm of
-                     (Ref _ (DataCon t a) cn, args)
+                     (Ref _ (DataCon r t a) cn, args)
                          => any (smaller True defs big s) args
                      _ => case s of
                                App _ f _ => smaller inc defs big f tm

--- a/src/Idris/IDEMode/SyntaxHighlight.idr
+++ b/src/Idris/IDEMode/SyntaxHighlight.idr
@@ -95,11 +95,11 @@ outputNameSyntax (fc, (name, _, term)) =
                  -- data NameType : Type where
                  -- Bound   : NameType
                  -- Func    : NameType
-                 -- DataCon : (tag : Int) -> (arity : Nat) -> NameType
+                 -- DataCon : (rig : RigCount) -> (tag : Int) -> (arity : Nat) -> NameType
                  -- TyCon   : (tag : Int) -> (arity : Nat) -> NameType
                  (Ref fc Bound name) => Just Bound
                  (Ref fc Func name) => Just Function
-                 (Ref fc (DataCon tag arity) name) => Just Data
+                 (Ref fc (DataCon rig tag arity) name) => Just Data
                  (Ref fc (TyCon tag arity) name) => Just Typ
                  (Meta fc x y xs) => Just Bound
                  (Bind fc x b scope) => Just Bound

--- a/src/TTImp/Elab/Ambiguity.idr
+++ b/src/TTImp/Elab/Ambiguity.idr
@@ -109,7 +109,7 @@ expandAmbigName mode nest env orig args (IVar fc x) exp
     -- If it's not a constructor application, dot it
     wrapDot : Bool -> EState vars ->
               ElabMode -> Name -> List RawImp -> Def -> RawImp -> RawImp
-    wrapDot _ _ _ _ _ (DCon _ _ _) tm = tm
+    wrapDot _ _ _ _ _ (DCon _ _ _ _) tm = tm
     wrapDot _ _ _ _ _ (TCon _ _ _ _ _ _ _ _) tm = tm
     -- Leave primitive applications alone, because they'll be inlined
     -- before compiling the case tree

--- a/src/TTImp/Elab/App.idr
+++ b/src/TTImp/Elab/App.idr
@@ -58,7 +58,7 @@ getNameType rigc env fc x
                  rigSafe (multiplicity def) rigc
                  let nt = case definition def of
                                PMDef _ _ _ _ _ => Func
-                               DCon t a _ => DataCon t a
+                               DCon r t a _ => DataCon r t a
                                TCon t a _ _ _ _ _ _ => TyCon t a
                                _ => Func
                  pure (Ref fc nt (Resolved i), gnf env (embed (type def)))
@@ -92,7 +92,7 @@ getVarType rigc nest env fc x
                       Just ndef =>
                          let nt = case definition ndef of
                                        PMDef _ _ _ _ _ => Func
-                                       DCon t a _ => DataCon t a
+                                       DCon r t a _ => DataCon r t a
                                        TCon t a _ _ _ _ _ _ => TyCon t a
                                        _ => Func
                              tm = tmf fc nt

--- a/src/TTImp/Elab/Local.idr
+++ b/src/TTImp/Elab/Local.idr
@@ -127,7 +127,7 @@ checkCaseLocal {vars} rig elabinfo nest env fc uname iname args sc expty
               | Nothing => check rig elabinfo nest env sc expty
          let name = case definition def of
                          PMDef _ _ _ _ _ => Ref fc Func iname
-                         DCon t a _ => Ref fc (DataCon t a) iname
+                         DCon r t a _ => Ref fc (DataCon r t a) iname
                          TCon t a _ _ _ _ _ _ => Ref fc (TyCon t a) iname
                          _ => Ref fc Func iname
          app <- getLocalTerm fc env name args

--- a/src/TTImp/Elab/Local.idr
+++ b/src/TTImp/Elab/Local.idr
@@ -122,7 +122,8 @@ checkCaseLocal : {vars : _} ->
                  (expTy : Maybe (Glued vars)) ->
                  Core (Term vars, Glued vars)
 checkCaseLocal {vars} rig elabinfo nest env fc uname iname args sc expty
-    = do defs <- get Ctxt
+    = do coreLift $ putStrLn ("checking case local " ++ show uname)
+         defs <- get Ctxt
          Just def <- lookupCtxtExact iname (gamma defs)
               | Nothing => check rig elabinfo nest env sc expty
          let name = case definition def of

--- a/src/TTImp/Elab/Term.idr
+++ b/src/TTImp/Elab/Term.idr
@@ -266,10 +266,13 @@ TTImp.Elab.Check.check rigc elabinfo nest env (ICoerced fc tm) exp
     = checkImp rigc elabinfo nest env tm exp
 -- Don't add implicits/coercions on local blocks or record updates
 TTImp.Elab.Check.check rigc elabinfo nest env tm@(ILet fc c n nty nval sc) exp
-    = checkImp rigc elabinfo nest env tm exp
+    = do coreLift $ putStrLn ("checking ILet" ++ show n)
+         v <- checkImp rigc elabinfo nest env tm exp
+         coreLift $ putStrLn ("done checking ILet " ++ show n)
+         pure v
+
 TTImp.Elab.Check.check rigc elabinfo nest env tm@(ILocal fc ds sc) exp
-    = do coreLift $ putStrLn "checking ILocal"
-         checkImp rigc elabinfo nest env tm exp
+    = checkImp rigc elabinfo nest env tm exp
 TTImp.Elab.Check.check rigc elabinfo nest env tm@(IUpdate fc fs rec) exp
     = checkImp rigc elabinfo nest env tm exp
 TTImp.Elab.Check.check rigc elabinfo nest env tm_in exp

--- a/src/TTImp/Elab/Term.idr
+++ b/src/TTImp/Elab/Term.idr
@@ -268,7 +268,8 @@ TTImp.Elab.Check.check rigc elabinfo nest env (ICoerced fc tm) exp
 TTImp.Elab.Check.check rigc elabinfo nest env tm@(ILet fc c n nty nval sc) exp
     = checkImp rigc elabinfo nest env tm exp
 TTImp.Elab.Check.check rigc elabinfo nest env tm@(ILocal fc ds sc) exp
-    = checkImp rigc elabinfo nest env tm exp
+    = do coreLift $ putStrLn "checking ILocal"
+         checkImp rigc elabinfo nest env tm exp
 TTImp.Elab.Check.check rigc elabinfo nest env tm@(IUpdate fc fs rec) exp
     = checkImp rigc elabinfo nest env tm exp
 TTImp.Elab.Check.check rigc elabinfo nest env tm_in exp

--- a/src/TTImp/Interactive/ExprSearch.idr
+++ b/src/TTImp/Interactive/ExprSearch.idr
@@ -123,7 +123,7 @@ searchName fc rigc opts env target topty defining (n, ndef)
          let ty = type ndef
          let namety : NameType
                  = case definition ndef of
-                        DCon tag arity _ => DataCon tag arity
+                        DCon rig tag arity _ => DataCon rig tag arity
                         TCon tag arity _ _ _ _ _ _ => TyCon tag arity
                         _ => Func
          log 5 $ "Trying " ++ show (fullname ndef)
@@ -260,7 +260,7 @@ tryRecursive fc rig opts env ty topty (Just rdata)
 
       appsDiff : Term vs -> Term vs' -> List (Term vs) -> List (Term vs') ->
                  Bool
-      appsDiff (Ref _ (DataCon _ _) f) (Ref _ (DataCon _ _) f') args args'
+      appsDiff (Ref _ (DataCon _ _ _) f) (Ref _ (DataCon _ _ _) f') args args'
          = if f == f' then anyTrue (zipWith argDiff args args')
                       else True
       appsDiff (Ref _ (TyCon _ _) f) (Ref _ (TyCon _ _) f') args args'
@@ -270,8 +270,8 @@ tryRecursive fc rig opts env ty topty (Just rdata)
          = if f == f' && length args == length args'
               then anyTrue (zipWith argDiff args args')
               else False -- can't be sure
-      appsDiff (Ref _ (DataCon _ _) f) (Local _ _ _ _) _ _ = True
-      appsDiff (Local _ _ _ _) (Ref _ (DataCon _ _) f) _ _ = True
+      appsDiff (Ref _ (DataCon _ _ _) f) (Local _ _ _ _) _ _ = True
+      appsDiff (Local _ _ _ _) (Ref _ (DataCon _ _ _) f) _ _ = True
       appsDiff f f' [] [] = argDiff f f'
       appsDiff _ _ _ _ = False -- can't be sure...
 

--- a/src/TTImp/Interactive/MakeLemma.idr
+++ b/src/TTImp/Interactive/MakeLemma.idr
@@ -26,7 +26,7 @@ bindable : Nat -> Term vars -> Bool
 bindable p tm
     = case getFnArgs tm of
            (Ref _ (TyCon _ _) n, args) => any (bindable p) args
-           (Ref _ (DataCon _ _) _, args) => any (bindable p) args
+           (Ref _ (DataCon _ _ _) _, args) => any (bindable p) args
            (TDelayed _ _ t, args) => any (bindable p) (t :: args)
            (TDelay _ _ _ t, args) => any (bindable p) (t :: args)
            (TForce _ _ t, args) => any (bindable p) (t :: args)

--- a/src/TTImp/PartialEval.idr
+++ b/src/TTImp/PartialEval.idr
@@ -580,7 +580,8 @@ mutual
            pure $ apply fc f' args'
   quoteGenNF q defs bound env (NDCon fc n t ar args)
       = do args' <- quoteArgs q defs bound env args
-           pure $ apply fc (Ref fc (DataCon t ar) n) args'
+           -- Data constructor are unrestricted by default
+           pure $ apply fc (Ref fc (DataCon top t ar) n) args'
   quoteGenNF q defs bound env (NTCon fc n t ar args)
       = do args' <- quoteArgs q defs bound env args
            pure $ apply fc (Ref fc (TyCon t ar) n) args'

--- a/src/TTImp/ProcessData.idr
+++ b/src/TTImp/ProcessData.idr
@@ -233,7 +233,7 @@ findNewtype [con]
               | Nothing => pure ()
          updateDef (name con)
                (\d => case d of
-                           DCon t a _ => Just (DCon t a (Just arg))
+                           DCon r t a _ => Just (DCon r t a (Just arg))
                            _ => Nothing)
 findNewtype _ = pure ()
 


### PR DESCRIPTION
This is not a pull request intended for merging, rather I need help with a project I'm working on and linking to parts of the code is much easier here.

I'm trying to optimise the runtime for this specific situation

```idris
let 1 v : Constructed = ConstructValue 3
    1 w = update v in w
```

In this case `ConstructValue` create a linear value, which is then immediately passed to `update : Constructed -> Constructed`.

the `update` function currently creates a new copy of the value, but since we _know_ that the value is _linear_ and created _in scope_ we can deduce that it is _unique_ and therefore subject to mutation.

This patch has therefore 2 changes to make:
1. detect when a value is bound linearly by a constructor and declare it as "safe to mutate"
2. change the codepath for values that are "safe to mutate" to go through a "mutating" version of themselves

`1.` is achieved during [let elaboration](https://github.com/idris-lang/Idris2/compare/master...andrevidela:mutate-case#diff-f5b3bc2e95ce5a568780c8b68464ee1fR182), the right hand side is checked for reference to a constructor and if that's the case, tags the constructor with the intended linearity

`2.` is achieved  by adding "mutating cases" to each pattern match in [CExp](https://github.com/idris-lang/Idris2/compare/master...andrevidela:mutate-case#diff-c10a8933fe146f8734cffba72477feb4R51-R61)
There is an additional `CMut` constructor for CExp that indicates to the backend that the value refered needs to be mutated instead of constructed.

The problem I'm facing now is that when inspecting `DataCon` in [toCExp](https://github.com/idris-lang/Idris2/compare/master...andrevidela:mutate-case#diff-aa65bc544c7551c680d3ba5db189aaeaR235) in order to update the tag to the mutating version of it. Every value I inspect has `RigW`, as if my pass through `1.` didn't go through. However my logs indicate that the rig count has indeed been correctly replaced. Why? What am I missing? Is updating the rig count in `checkLet` not the right way to go?

Please do not waste your time reviewing any of it since all of it is a huge WIP with half baked bits and pieces all over the place. 