### PR TITLE
Add a simple DYI f-string / string interpolation library

### DIFF
--- a/libs/contrib/Data/String/Interpolation.idr
+++ b/libs/contrib/Data/String/Interpolation.idr
@@ -1,0 +1,33 @@
+||| A DYI version of 'string interpolation', mimicking Python 3's 'f-string' syntax
+||| Not as fancy 
+module Data.String.Interpolation
+
+import Data.Strings
+
+namespace Data.String.Interpolation.Basic
+  %inline
+  public export
+  F : List String -> String
+  F strs = concat (strs)
+
+namespace Data.String.Interpolation.Nested
+  %inline
+  public export
+  F : List (List String) -> String
+  F strss = F (concat strss)
+
+{- Examples: 
+fstring : String
+fstring = let apples = "apples" in 
+          F["I have some ", apples," here."]                     --- cf. f"I have some {apples} here."
+
+multiline : String
+multiline = let name = "Edwin"
+                profession = "Hacker"
+                affiliation = "the University of St. Andrews" in --- cf. 
+                F [["Hi ",name,". "             ]                --- f"Hi {name}. "              \
+                  ,["You are a ",profession,". "]                --- f"You are a {profession}. " \
+                  ,["You were in ",affiliation,"."]              --- f"You were in {affiliation}."
+                  ]
+          
+-}

--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -24,6 +24,7 @@ modules = Control.Delayed,
           Data.SortedMap,
           Data.SortedSet,
           Data.String.Extra,
+          Data.String.Interpolation,
 
           Debug.Buffer,
 


### PR DESCRIPTION
Apparently the concrete syntax is controversial ("{apples}"
vs. "$oranges"), so I'm just adding a simple DYI version until we
agree on a concrete syntax

Some people wrote about it at [some lengths](https://en.wikipedia.org/wiki/String_interpolation), and note that you should probably sanitize any user-given string substitute.