### PR TITLE
Add Kleisli arrow operators to contrib

### DIFF
--- a/libs/contrib/Control/Monad/Syntax.idr
+++ b/libs/contrib/Control/Monad/Syntax.idr
@@ -1,0 +1,21 @@
+module Control.Monad.Syntax
+
+%default total
+
+infixr 1 =<<, <=<, >=>
+
+||| Left-to-right Kleisli composition of monads.
+public export
+(>=>) : Monad m => (a -> m b) -> (b -> m c) -> (a -> m c)
+(>=>) f g = \x => f x >>= g
+
+public export
+||| Right-to-left Kleisli composition of monads, flipped version of `>=>`.
+(<=<) : Monad m => (b -> m c) -> (a -> m b) -> (a -> m c)
+(<=<) = flip (>=>)
+
+public export
+||| Right-to-left monadic bind, flipped version of `>>=`.
+(=<<) : Monad m => (a -> m b) -> m a -> m b
+(=<<) = flip (>>=)
+

--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -2,6 +2,7 @@ package contrib
 
 modules = Control.Delayed,
           Control.Linear.LIO,
+          Control.Monad.Syntax,
 
           Data.Linear.Array,
 


### PR DESCRIPTION
Add the kleisli operators to contrib:

```idris
(>=>) : Monad m => (a -> m b) -> (b -> m c) -> (a -> m c)

(<=<) : Monad m => (b -> m c) -> (a -> m b) -> (a -> m c)

(=<<) : Monad m => (a -> m b) -> m a -> m b
```