### PR TITLE
Record implicit parameters of interfaces

### DIFF
--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -30,7 +30,7 @@ import Data.Buffer
 -- TTC files can only be compatible if the version number is the same
 export
 ttcVersion : Int
-ttcVersion = 34
+ttcVersion = 35
 
 export
 checkTTCVersion : String -> Int -> Int -> Core ()

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -593,6 +593,7 @@ public export
 record IFaceInfo where
   constructor MkIFaceInfo
   iconstructor : Name
+  implParams : List Name
   params : List Name
   parents : List RawImp
   methods : List (Name, RigCount, Maybe TotalReq, Bool, RawImp)
@@ -601,8 +602,9 @@ record IFaceInfo where
 
 export
 TTC IFaceInfo where
-  toBuf b (MkIFaceInfo ic ps cs ms ds)
+  toBuf b (MkIFaceInfo ic impps ps cs ms ds)
       = do toBuf b ic
+           toBuf b impps
            toBuf b ps
            toBuf b cs
            toBuf b ms
@@ -610,11 +612,12 @@ TTC IFaceInfo where
 
   fromBuf b
       = do ic <- fromBuf b
+           impps <- fromBuf b
            ps <- fromBuf b
            cs <- fromBuf b
            ms <- fromBuf b
            ds <- fromBuf b
-           pure (MkIFaceInfo ic ps cs ms ds)
+           pure (MkIFaceInfo ic impps ps cs ms ds)
 
 -- If you update this, update 'extendAs' in Desugar to keep it up to date
 -- when reading imports

--- a/src/TTImp/Utils.idr
+++ b/src/TTImp/Utils.idr
@@ -88,8 +88,6 @@ findAllNames env (IWithApp fc fn av)
     = findAllNames env fn ++ findAllNames env av
 findAllNames env (IAs fc _ n pat)
     = n :: findAllNames env pat
-findAllNames env (IAs fc _ n pat)
-    = findAllNames env pat
 findAllNames env (IMustUnify fc r pat)
     = findAllNames env pat
 findAllNames env (IDelayed fc r t)
@@ -137,97 +135,117 @@ findIBindVars (IAlternative fc u alts)
 findIBindVars tm = []
 
 mutual
-  export
-  substNames : List Name -> List (Name, RawImp) ->
-               RawImp -> RawImp
-  substNames bound ps (IVar fc n)
+  -- Substitute for either an explicit variable name, or a bound variable name
+  substNames' : Bool -> List Name -> List (Name, RawImp) ->
+                RawImp -> RawImp
+  substNames' False bound ps (IVar fc n)
       = if not (n `elem` bound)
            then case lookup n ps of
                      Just t => t
                      _ => IVar fc n
            else IVar fc n
-  substNames bound ps (IPi fc r p mn argTy retTy)
+  substNames' True bound ps (IBindVar fc n)
+      = if not (UN n `elem` bound)
+           then case lookup (UN n) ps of
+                     Just t => t
+                     _ => IBindVar fc n
+           else IBindVar fc n
+  substNames' bvar bound ps (IPi fc r p mn argTy retTy)
       = let bound' = maybe bound (\n => n :: bound) mn in
-            IPi fc r p mn (substNames bound ps argTy)
-                          (substNames bound' ps retTy)
-  substNames bound ps (ILam fc r p mn argTy scope)
+            IPi fc r p mn (substNames' bvar bound ps argTy)
+                          (substNames' bvar bound' ps retTy)
+  substNames' bvar bound ps (ILam fc r p mn argTy scope)
       = let bound' = maybe bound (\n => n :: bound) mn in
-            ILam fc r p mn (substNames bound ps argTy)
-                           (substNames bound' ps scope)
-  substNames bound ps (ILet fc r n nTy nVal scope)
+            ILam fc r p mn (substNames' bvar bound ps argTy)
+                           (substNames' bvar bound' ps scope)
+  substNames' bvar bound ps (ILet fc r n nTy nVal scope)
       = let bound' = n :: bound in
-            ILet fc r n (substNames bound ps nTy)
-                        (substNames bound ps nVal)
-                        (substNames bound' ps scope)
-  substNames bound ps (ICase fc y ty xs)
-      = ICase fc (substNames bound ps y) (substNames bound ps ty)
-                 (map (substNamesClause bound ps) xs)
-  substNames bound ps (ILocal fc xs y)
+            ILet fc r n (substNames' bvar bound ps nTy)
+                        (substNames' bvar bound ps nVal)
+                        (substNames' bvar bound' ps scope)
+  substNames' bvar bound ps (ICase fc y ty xs)
+      = ICase fc (substNames' bvar bound ps y) (substNames' bvar bound ps ty)
+                 (map (substNamesClause' bvar bound ps) xs)
+  substNames' bvar bound ps (ILocal fc xs y)
       = let bound' = definedInBlock [] xs ++ bound in
-            ILocal fc (map (substNamesDecl bound ps) xs)
-                      (substNames bound' ps y)
-  substNames bound ps (IApp fc fn arg)
-      = IApp fc (substNames bound ps fn) (substNames bound ps arg)
-  substNames bound ps (IImplicitApp fc fn y arg)
-      = IImplicitApp fc (substNames bound ps fn) y (substNames bound ps arg)
-  substNames bound ps (IWithApp fc fn arg)
-      = IWithApp fc (substNames bound ps fn) (substNames bound ps arg)
-  substNames bound ps (IAlternative fc y xs)
-      = IAlternative fc y (map (substNames bound ps) xs)
-  substNames bound ps (ICoerced fc y)
-      = ICoerced fc (substNames bound ps y)
-  substNames bound ps (IAs fc s y pattern)
-      = IAs fc s y (substNames bound ps pattern)
-  substNames bound ps (IMustUnify fc r pattern)
-      = IMustUnify fc r (substNames bound ps pattern)
-  substNames bound ps (IDelayed fc r t)
-      = IDelayed fc r (substNames bound ps t)
-  substNames bound ps (IDelay fc t)
-      = IDelay fc (substNames bound ps t)
-  substNames bound ps (IForce fc t)
-      = IForce fc (substNames bound ps t)
-  substNames bound ps tm = tm
+            ILocal fc (map (substNamesDecl' bvar bound ps) xs)
+                      (substNames' bvar bound' ps y)
+  substNames' bvar bound ps (IApp fc fn arg)
+      = IApp fc (substNames' bvar bound ps fn) (substNames' bvar bound ps arg)
+  substNames' bvar bound ps (IImplicitApp fc fn y arg)
+      = IImplicitApp fc (substNames' bvar bound ps fn) y (substNames' bvar bound ps arg)
+  substNames' bvar bound ps (IWithApp fc fn arg)
+      = IWithApp fc (substNames' bvar bound ps fn) (substNames' bvar bound ps arg)
+  substNames' bvar bound ps (IAlternative fc y xs)
+      = IAlternative fc y (map (substNames' bvar bound ps) xs)
+  substNames' bvar bound ps (ICoerced fc y)
+      = ICoerced fc (substNames' bvar bound ps y)
+  substNames' bvar bound ps (IAs fc s y pattern)
+      = IAs fc s y (substNames' bvar bound ps pattern)
+  substNames' bvar bound ps (IMustUnify fc r pattern)
+      = IMustUnify fc r (substNames' bvar bound ps pattern)
+  substNames' bvar bound ps (IDelayed fc r t)
+      = IDelayed fc r (substNames' bvar bound ps t)
+  substNames' bvar bound ps (IDelay fc t)
+      = IDelay fc (substNames' bvar bound ps t)
+  substNames' bvar bound ps (IForce fc t)
+      = IForce fc (substNames' bvar bound ps t)
+  substNames' bvar bound ps tm = tm
 
-  export
-  substNamesClause : List Name -> List (Name, RawImp) ->
-                     ImpClause -> ImpClause
-  substNamesClause bound ps (PatClause fc lhs rhs)
+  substNamesClause' : Bool -> List Name -> List (Name, RawImp) ->
+                      ImpClause -> ImpClause
+  substNamesClause' bvar bound ps (PatClause fc lhs rhs)
       = let bound' = map UN (map snd (findBindableNames True bound [] lhs))
                         ++ bound in
-            PatClause fc (substNames [] [] lhs)
-                         (substNames bound' ps rhs)
-  substNamesClause bound ps (WithClause fc lhs wval flags cs)
+            PatClause fc (substNames' bvar [] [] lhs)
+                         (substNames' bvar bound' ps rhs)
+  substNamesClause' bvar bound ps (WithClause fc lhs wval flags cs)
       = let bound' = map UN (map snd (findBindableNames True bound [] lhs))
                         ++ bound in
-            WithClause fc (substNames [] [] lhs)
-                          (substNames bound' ps wval) flags cs
-  substNamesClause bound ps (ImpossibleClause fc lhs)
-      = ImpossibleClause fc (substNames bound [] lhs)
+            WithClause fc (substNames' bvar [] [] lhs)
+                          (substNames' bvar bound' ps wval) flags cs
+  substNamesClause' bvar bound ps (ImpossibleClause fc lhs)
+      = ImpossibleClause fc (substNames' bvar bound [] lhs)
 
-  substNamesTy : List Name -> List (Name, RawImp) ->
+  substNamesTy' : Bool -> List Name -> List (Name, RawImp) ->
                   ImpTy -> ImpTy
-  substNamesTy bound ps (MkImpTy fc n ty)
-      = MkImpTy fc n (substNames bound ps ty)
+  substNamesTy' bvar bound ps (MkImpTy fc n ty)
+      = MkImpTy fc n (substNames' bvar bound ps ty)
 
-  substNamesData : List Name -> List (Name, RawImp) ->
-                   ImpData -> ImpData
-  substNamesData bound ps (MkImpData fc n con opts dcons)
-      = MkImpData fc n (substNames bound ps con) opts
-                  (map (substNamesTy bound ps) dcons)
-  substNamesData bound ps (MkImpLater fc n con)
-      = MkImpLater fc n (substNames bound ps con)
+  substNamesData' : Bool -> List Name -> List (Name, RawImp) ->
+                    ImpData -> ImpData
+  substNamesData' bvar bound ps (MkImpData fc n con opts dcons)
+      = MkImpData fc n (substNames' bvar bound ps con) opts
+                  (map (substNamesTy' bvar bound ps) dcons)
+  substNamesData' bvar bound ps (MkImpLater fc n con)
+      = MkImpLater fc n (substNames' bvar bound ps con)
 
-  substNamesDecl : List Name -> List (Name, RawImp ) ->
+  substNamesDecl' : Bool -> List Name -> List (Name, RawImp ) ->
                    ImpDecl -> ImpDecl
-  substNamesDecl bound ps (IClaim fc r vis opts td)
-      = IClaim fc r vis opts (substNamesTy bound ps td)
-  substNamesDecl bound ps (IDef fc n cs)
-      = IDef fc n (map (substNamesClause bound ps) cs)
-  substNamesDecl bound ps (IData fc vis d)
-      = IData fc vis (substNamesData bound ps d)
-  substNamesDecl bound ps (INamespace fc ns ds)
-      = INamespace fc ns (map (substNamesDecl bound ps) ds)
-  substNamesDecl bound ps d = d
+  substNamesDecl' bvar bound ps (IClaim fc r vis opts td)
+      = IClaim fc r vis opts (substNamesTy' bvar bound ps td)
+  substNamesDecl' bvar bound ps (IDef fc n cs)
+      = IDef fc n (map (substNamesClause' bvar bound ps) cs)
+  substNamesDecl' bvar bound ps (IData fc vis d)
+      = IData fc vis (substNamesData' bvar bound ps d)
+  substNamesDecl' bvar bound ps (INamespace fc ns ds)
+      = INamespace fc ns (map (substNamesDecl' bvar bound ps) ds)
+  substNamesDecl' bvar bound ps d = d
+
+export
+substNames : List Name -> List (Name, RawImp) ->
+             RawImp -> RawImp
+substNames = substNames' False
+
+export
+substBindVars : List Name -> List (Name, RawImp) ->
+                RawImp -> RawImp
+substBindVars = substNames' True
+
+export
+substNamesClause : List Name -> List (Name, RawImp) ->
+                   ImpClause -> ImpClause
+substNamesClause = substNamesClause' False
 
 mutual
   export

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -97,7 +97,7 @@ idrisTests
        "reg001", "reg002", "reg003", "reg004", "reg005", "reg006", "reg007",
        "reg008", "reg009", "reg010", "reg011", "reg012", "reg013", "reg014",
        "reg015", "reg016", "reg017", "reg018", "reg019", "reg020", "reg021",
-       "reg022", "reg023", "reg024", "reg025",
+       "reg022", "reg023", "reg024", "reg025", "reg026",
        -- Totality checking
        "total001", "total002", "total003", "total004", "total005",
        "total006", "total007", "total008",

--- a/tests/idris2/reg026/Meh.idr
+++ b/tests/idris2/reg026/Meh.idr
@@ -1,0 +1,12 @@
+module Meh
+
+import public Control.WellFounded
+
+public export
+interface Argh (rel : a -> a -> Type) where
+  argh : (x : a) -> Accessible rel x
+
+data Meh : Nat -> Nat -> Type where
+
+implementation Argh Meh where
+  argh x = ?foo

--- a/tests/idris2/reg026/expected
+++ b/tests/idris2/reg026/expected
@@ -1,0 +1,1 @@
+1/1: Building Meh (Meh.idr)

--- a/tests/idris2/reg026/run
+++ b/tests/idris2/reg026/run
@@ -1,0 +1,3 @@
+$1 --check Meh.idr
+
+rm -rf build


### PR DESCRIPTION
We need to make sure they are inferred again when elaborating methods, so substitute in a _ in method types before substituting in the explicit parameters.

In future, it might (probably will) also be useful to allow giving the implicit parameters explicitly when defining implementations.

Fixes #374