### PR TITLE
Avoid traversing all Idris modules twice when installing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ endif
 	mkdir -p ${PREFIX}/bin/${NAME}_app
 	install ${TARGETDIR}/${NAME}_app/* ${PREFIX}/bin/${NAME}_app
 
-install-support: support
+install-support:
 	mkdir -p ${PREFIX}/idris2-${IDRIS2_VERSION}/support/chez
 	mkdir -p ${PREFIX}/idris2-${IDRIS2_VERSION}/support/racket
 	mkdir -p ${PREFIX}/idris2-${IDRIS2_VERSION}/support/gambit
@@ -124,7 +124,7 @@ install-support: support
 	install support/gambit/* ${PREFIX}/idris2-${IDRIS2_VERSION}/support/gambit
 	@${MAKE} -C support/c install
 
-install-libs: libs
+install-libs:
 	${MAKE} -C libs/prelude install IDRIS2=../../${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 	${MAKE} -C libs/base install IDRIS2=../../${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 	${MAKE} -C libs/contrib install IDRIS2=../../${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}


### PR DESCRIPTION
I think it make sense to let the install commands in the `Makefile` only perform installation, similar to `install-idris2`.

In the case of `make install-libs` which runs `idris2 --install <ipkg>`, it will rebuild any changed modules anyway. So calling `idris2 --build <ipkg>` first is just duplicate work. On my computer it takes about 5 seconds to run `make install-libs`. When I remove the dependency on `libs`, the command takes about half the time.