### PR TITLE
Make Text.Parser.between lazy

### DIFF
--- a/libs/contrib/Text/Parser.idr
+++ b/libs/contrib/Text/Parser.idr
@@ -254,7 +254,7 @@ endBy1' {c} sep p = some' $ rewrite sym (orTrueTrue c) in
 export
 between : {c : _} ->
           (left : Grammar tok True l) ->
-          (right : Grammar tok True r) ->
-          (p : Grammar tok c a) ->
+          (right : Inf (Grammar tok True r)) ->
+          (p : Inf (Grammar tok c a)) ->
           Grammar tok True a
 between left right contents = left *> contents <* right


### PR DESCRIPTION
Previously, the following code would run forever, or at least until it had eaten all my RAM.   Making `between` appropriately lazy fixes it.

(It has what I assume is the same behavior in Idris 1, where it segfaults in what is likely a stack overflow.  However, switching to a lazy `between` did not fix it like in Idris 2.)

```idris
import Text.Parser

openParen : Grammar Char True Char
openParen = terminal "wanted (" $ \x => if x == '(' then Just '(' else Nothing

closeParen : Grammar Char True Char
closeParen = terminal "wanted )" $ \x => if x == ')' then Just ')' else Nothing

otherChar : Grammar Char True Char
otherChar = terminal "did not want ()" $ \x => if x `elem` ['(',')'] then Nothing else Just x

data Tree = Leaf Char
          | Branch (List Tree)

mutual
  thingsInParens : Grammar Char True (List Tree)
  thingsInParens = between openParen closeParen $ many tree

  tree : Grammar Char True Tree
  tree = map Leaf otherChar <|> map Branch thingsInParens

main : IO ()
main = case parse tree (unpack "a") of
            Right _ => putStrLn "ok"
            Left _ => putStrLn "no"
```