### PR TITLE
Add support for --log flag

### DIFF
--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -112,6 +112,9 @@ preOptions (DumpANF f :: opts)
 preOptions (DumpVMCode f :: opts)
     = do setSession (record { dumpvmcode = Just f } !getSession)
          preOptions opts
+preOptions (Logging n :: opts)
+    = do setSession (record { logLevel = n } !getSession)
+         preOptions opts
 preOptions (_ :: opts) = preOptions opts
 
 -- Options to be processed after type checking. Returns whether execution


### PR DESCRIPTION
The flag takes a natural number as argument
It would be ideal to generalise the argument parser to be able
to parse any argument of any type, but right now we only add
`RequiredNat` as a new flag option.