### PR TITLE
A variety of namespace and import goodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Language changes:
 * Add `import X as Y`
    + This imports the module `X`, adding aliases for the definitions in
      namespace `Y`, so they can be referred to as `Y`.
+* `do` notation can now be qualified with a namespace
+   + `MyDo.do` opens a `do` block where the `>>=` operator used is `MyDo.(>>=)`
 
 Library changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Language changes:
    + Implemented `%macro` function flag, to remove the syntactic noise of
      invoking elaborator scripts. This means the function must always
      be fully applied, and is run under `%runElab`
+* Add `import X as Y`
+   + This imports the module `X`, adding aliases for the definitions in
+     namespace `Y`, so they can be referred to as `Y`.
 
 Library changes:
 

--- a/docs/source/tutorial/interfaces.rst
+++ b/docs/source/tutorial/interfaces.rst
@@ -272,6 +272,23 @@ are both available, or return ``Nothing`` if one or both are not ("fail fast"). 
     Main> m_add (Just 82) Nothing
     Nothing
 
+The translation of ``do`` notation is entirely syntactic, so there is no
+need for the ``(>>=)`` operator to be the operator defined in the ``Monad``
+interface. Idris will, in general, try to disambiguate which ``(>>=)`` you
+mean by type, but you can explicitly choose with qualified do notation,
+for example:
+
+.. code-block:: idris
+
+    m_add : Maybe Int -> Maybe Int -> Maybe Int
+    m_add x y = Prelude.do
+                   x' <- x -- Extract value from x
+                   y' <- y -- Extract value from y
+                   pure (x' + y') -- Add them
+
+The ``Prelude.do`` means that Idris will use the ``(>>=)`` operator defined
+in the ``Prelude``.
+
 Pattern Matching Bind
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/tutorial/modules.rst
+++ b/docs/source/tutorial/modules.rst
@@ -179,6 +179,35 @@ The module ``A`` will export the name ``a``, as well as any public or
 abstract names in module ``C``, but will not re-export anything from
 module ``B``.
 
+Renaming imports
+----------------
+
+Sometimes it is convenient to be able to access the names in another module
+via a different namespace (typically, a shorter one). For this, you can
+use `import...as`. For example:
+
+::
+
+    module A
+
+    import Data.List as L
+
+This module ``A`` has access to the exported names from module ``Data.List``,
+but can also explicitly access them via the module name ``L``. ``import...as``
+can also be combined with ``import public`` to create a module which exports
+a larger API from other sub-modules:
+
+::
+
+    module Books
+
+    import Books.Hardback as Books
+    import Books.Comic as Books
+
+Here, any module which imports ``Books`` will have access to the exported
+interfaces of ``Books.Hardback`` and ``Books.Comic`` both under the namespace
+``Books``.
+
 Explicit Namespaces
 ===================
 

--- a/libs/prelude/Prelude.idr
+++ b/libs/prelude/Prelude.idr
@@ -2,8 +2,8 @@ module Prelude
 
 import public Builtin
 import public PrimIO
-import public Prelude.Basics
-import public Prelude.Uninhabited
+import public Prelude.Basics as Prelude
+import public Prelude.Uninhabited as Prelude
 
 %default total
 

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -431,16 +431,19 @@ readFromTTC nestedns loc reexp fname modNS importAs
                traverse_ addUserHole (userHoles ttc)
                setNS (currentNS ttc)
                when nestedns $ setNestedNS (nestedNS ttc)
+               -- Only do the next batch if the module hasn't been loaded
+               -- in any form
+               when (not (modNS `elem` map (fst . getNSas) (allImported defs))) $
                -- Set up typeHints and autoHints based on the loaded data
-               traverse_ (addTypeHint loc) (typeHints ttc)
-               traverse_ addAutoHint (autoHints ttc)
-               -- Set up pair/rewrite etc names
-               updatePair (pairnames ttc)
-               updateRewrite (rewritenames ttc)
-               updatePrims (primnames ttc)
-               updateNameDirectives (reverse (namedirectives ttc))
-               updateCGDirectives (cgdirectives ttc)
-               updateTransforms (transforms ttc)
+                 do traverse_ (addTypeHint loc) (typeHints ttc)
+                    traverse_ addAutoHint (autoHints ttc)
+                    -- Set up pair/rewrite etc names
+                    updatePair (pairnames ttc)
+                    updateRewrite (rewritenames ttc)
+                    updatePrims (primnames ttc)
+                    updateNameDirectives (reverse (namedirectives ttc))
+                    updateCGDirectives (cgdirectives ttc)
+                    updateTransforms (transforms ttc)
 
                when (not reexp) clearSavedHints
                resetFirstEntry

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -162,14 +162,6 @@ HasNames e => HasNames (TTCFile e) where
       resolvedPrim gam (MkPrimNs mi ms mc)
           = pure $ MkPrimNs !(resolved gam mi) !(resolved gam ms) !(resolved gam mc)
 
-
-asName : List String -> Maybe (List String) -> Name -> Name
-asName mod (Just ns) (NS oldns n)
-    = if mod == oldns
-         then NS ns n -- TODO: What about if there are nested namespaces in a module?
-         else NS oldns n
-asName _ _ n = n
-
 -- NOTE: TTC files are only compatible if the version number is the same,
 -- *and* the 'annot/extra' type are the same, or there are no holes/constraints
 writeTTCFile : (HasNames extra, TTC extra) =>

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -276,7 +276,7 @@ writeToTTC extradata fname
 addGlobalDef : {auto c : Ref Ctxt Defs} ->
                (modns : List String) -> (importAs : Maybe (List String)) ->
                (Name, Binary) -> Core ()
-addGlobalDef modns as (n, def)
+addGlobalDef modns asm (n, def)
     = do defs <- get Ctxt
          codedentry <- lookupContextEntry n (gamma defs)
          -- Don't update the coded entry because some names might not be
@@ -287,8 +287,11 @@ addGlobalDef modns as (n, def)
                         codedentry
          if completeDef entry
             then pure ()
-            else do addContextEntry (asName modns as n) def
+            else do addContextEntry n def
                     pure ()
+         maybe (pure ())
+               (\as => addContextAlias (asName modns as n) n)
+               asm
   where
     -- If the definition already exists, don't overwrite it with an empty
     -- definition or hole. This might happen if a function is declared in one

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -298,6 +298,12 @@ data ContextEntry : Type where
      Coded : Binary -> ContextEntry
      Decoded : GlobalDef -> ContextEntry
 
+data PossibleName : Type where
+     Direct : Name -> Int -> PossibleName -- full name and resolved name id
+     Alias : Name -> -- aliased name (from "import as")
+             Name -> Int -> -- real full name and resolved name, as above
+             PossibleName
+
 -- All the GlobalDefs. We can only have one context, because name references
 -- point at locations in here, and if we have more than one the indices won't
 -- match up. So, this isn't polymorphic.
@@ -309,7 +315,7 @@ record Context where
     -- Map from full name to its position in the context
     resolvedAs : NameMap Int
     -- Map from strings to all the possible names in all namespaces
-    possibles : StringMap (List (Name, Int))
+    possibles : StringMap (List PossibleName)
     -- Reference to the actual content, indexed by Int
     content : Ref Arr (IOArray ContextEntry)
     -- Branching depth, in a backtracking elaborator. 0 is top level; at lower
@@ -355,14 +361,24 @@ initCtxt : Core Context
 initCtxt = initCtxtS initSize
 
 addPossible : Name -> Int ->
-              StringMap (List (Name, Int)) -> StringMap (List (Name, Int))
+              StringMap (List PossibleName) -> StringMap (List PossibleName)
 addPossible n i ps
     = case userNameRoot n of
            Nothing => ps
            Just nr =>
               case lookup nr ps of
-                   Nothing => insert nr [(n, i)] ps
-                   Just nis => insert nr ((n, i) :: nis) ps
+                   Nothing => insert nr [Direct n i] ps
+                   Just nis => insert nr (Direct n i :: nis) ps
+
+addAlias : Name -> Name -> Int ->
+           StringMap (List PossibleName) -> StringMap (List PossibleName)
+addAlias alias full i ps
+    = case userNameRoot alias of
+           Nothing => ps
+           Just nr =>
+              case lookup nr ps of
+                   Nothing => insert nr [Alias alias full i] ps
+                   Just nis => insert nr (Alias alias full i :: nis) ps
 
 export
 newEntry : Name -> Context -> Core (Int, Context)
@@ -389,6 +405,11 @@ getPosition n ctxt
            Just idx =>
               do pure (idx, ctxt)
            Nothing => newEntry n ctxt
+
+newAlias : Name -> Name -> Context -> Core Context
+newAlias alias full ctxt
+    = do (idx, ctxt) <- getPosition full ctxt
+         pure $ record { possibles $= addAlias alias full idx } ctxt
 
 export
 getNameID : Name -> Context -> Maybe Int
@@ -498,27 +519,32 @@ lookupCtxtName n ctxt
            Just r =>
               do let Just ps = lookup r (possibles ctxt)
                       | Nothing => pure []
-                 ps' <- the (Core (List (Maybe (Name, Int, GlobalDef)))) $
-                           traverse (\ (n, i) =>
-                                    do Just res <- lookupCtxtExact (Resolved i) ctxt
-                                            | _ => pure Nothing
-                                       pure (Just (n, i, res))) ps
-                 getMatches ps'
+                 lookupPossibles [] ps
   where
-    matches : Name -> (Name, Int, a) -> Bool
-    matches (NS ns _) (NS cns _, _, _) = ns `isPrefixOf` cns
+    matches : Name -> Name -> Bool
+    matches (NS ns _) (NS cns _) = ns `isPrefixOf` cns
     matches (NS _ _) _ = True -- no in library name, so root doesn't match
     matches _ _ = True -- no prefix, so root must match, so good
 
-    getMatches : List (Maybe (Name, Int, GlobalDef)) ->
-                 Core (List (Name, Int, GlobalDef))
-    getMatches [] = pure []
-    getMatches (Nothing :: rs) = getMatches rs
-    getMatches (Just r :: rs)
-        = if matches n r
-             then do rs' <- getMatches rs
-                     pure (r :: rs')
-             else getMatches rs
+    resn : (Name, Int, GlobalDef) -> Int
+    resn (_, i, _) = i
+
+    lookupPossibles : List (Name, Int, GlobalDef) -> -- accumulator
+                      List PossibleName ->
+                      Core (List (Name, Int, GlobalDef))
+    lookupPossibles acc [] = pure (reverse acc)
+    lookupPossibles acc (Direct fulln i :: ps)
+       = do Just res <- lookupCtxtExact (Resolved i) ctxt
+                 | Nothing => lookupPossibles acc ps
+            if (matches n fulln) && not (i `elem` map resn acc)
+               then lookupPossibles ((fulln, i, res) :: acc) ps
+               else lookupPossibles acc ps
+    lookupPossibles acc (Alias asn fulln i :: ps)
+       = do Just res <- lookupCtxtExact (Resolved i) ctxt
+                 | Nothing => lookupPossibles acc ps
+            if (matches n asn) && not (i `elem` map resn acc)
+               then lookupPossibles ((fulln, i, res) :: acc) ps
+               else lookupPossibles acc ps
 
 branchCtxt : Context -> Core Context
 branchCtxt ctxt = pure (record { branchDepth $= S } ctxt)
@@ -918,6 +944,38 @@ clearCtxt
     resetElab : Options -> Options
     resetElab = record { elabDirectives = defaultElab }
 
+-- Get the canonical name of something that might have been aliased via
+-- import as
+export
+canonicalName : {auto c : Ref Ctxt Defs} ->
+                FC -> Name -> Core Name
+canonicalName fc n
+    = do defs <- get Ctxt
+         case !(lookupCtxtName n (gamma defs)) of
+              [] => throw (UndefinedName fc n)
+              [(n, _, _)] => pure n
+              ns => throw (AmbiguousName fc (map fst ns))
+
+-- If the name is aliased, get the alias
+export
+aliasName : {auto c : Ref Ctxt Defs} ->
+            Name -> Core Name
+aliasName fulln
+    = do defs <- get Ctxt
+         let Just r = userNameRoot fulln
+                | Nothing => pure fulln
+         let Just ps = lookup r (possibles (gamma defs))
+                | Nothing => pure fulln
+         findAlias ps
+  where
+    findAlias : List PossibleName -> Core Name
+    findAlias [] = pure fulln
+    findAlias (Alias as full i :: ps)
+        = if full == fulln
+             then pure as
+             else findAlias ps
+    findAlias (_ :: ps) = findAlias ps
+
 -- Beware: if your hashable thing contains (potentially resolved) names,
 -- it'll be better to use addHashWithNames to make the hash independent
 -- of the internal numbering of names.
@@ -991,6 +1049,14 @@ addContextEntry n def
          (idx, gam') <- addEntry n (Coded def) (gamma defs)
          put Ctxt (record { gamma = gam' } defs)
          pure idx
+
+export
+addContextAlias : {auto c : Ref Ctxt Defs} ->
+                  Name -> Name -> Core ()
+addContextAlias alias full
+    = do defs <- get Ctxt
+         gam' <- newAlias alias full (gamma defs)
+         put Ctxt (record { gamma = gam' } defs)
 
 export
 addBuiltin : {arity : _} ->

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -1065,6 +1065,8 @@ addContextAlias : {auto c : Ref Ctxt Defs} ->
                   Name -> Name -> Core ()
 addContextAlias alias full
     = do defs <- get Ctxt
+         Nothing <- lookupCtxtExact alias (gamma defs)
+             | _ => pure () -- Don't add the alias if the name exists already
          gam' <- newAlias alias full (gamma defs)
          put Ctxt (record { gamma = gam' } defs)
 

--- a/src/Core/Name.idr
+++ b/src/Core/Name.idr
@@ -21,11 +21,11 @@ data Name : Type where
 -- Update a name imported with 'import as', for creating an alias
 export
 asName : List String -> -- Initial module name
-         Maybe (List String) -> -- 'as' module name
+         List String -> -- 'as' module name
          Name -> -- identifier
          Name
-asName mod (Just ns) (DN s n) = DN s (asName mod (Just ns) n)
-asName mod (Just ns) (NS oldns n)
+asName mod ns (DN s n) = DN s (asName mod ns n)
+asName mod ns (NS oldns n)
     = NS (updateNS mod oldns) n
   where
     updateNS : List String -> List String -> List String

--- a/src/Core/Name.idr
+++ b/src/Core/Name.idr
@@ -18,6 +18,24 @@ data Name : Type where
      WithBlock : Int -> Int -> Name -- with block nested in (resolved) name
      Resolved : Int -> Name -- resolved, index into context
 
+-- Update a name imported with 'import as', for creating an alias
+export
+asName : List String -> -- Initial module name
+         Maybe (List String) -> -- 'as' module name
+         Name -> -- identifier
+         Name
+asName mod (Just ns) (DN s n) = DN s (asName mod (Just ns) n)
+asName mod (Just ns) (NS oldns n)
+    = NS (updateNS mod oldns) n
+  where
+    updateNS : List String -> List String -> List String
+    updateNS mod (m :: ms)
+        = if mod == m :: ms
+             then ns
+             else m :: updateNS mod ms
+    updateNS mod [] = []
+asName _ _ n = n
+
 export
 userNameRoot : Name -> Maybe String
 userNameRoot (NS _ n) = userNameRoot n

--- a/src/Data/ANameMap.idr
+++ b/src/Data/ANameMap.idr
@@ -83,27 +83,14 @@ fromList = fromList' empty
     fromList' acc [] = acc
     fromList' acc ((k, v) :: ns) = fromList' (addName k v acc) ns
 
--- Merge two contexts, with entries in the second overriding entries in
--- the first
+-- Merge two contexts, with entries in the first overriding entries in
+-- the second
 export
 merge : ANameMap a -> ANameMap a -> ANameMap a
-merge ctxt (MkANameMap exact hier)
+merge (MkANameMap exact hier) ctxt
     = insertFrom (toList exact) ctxt
   where
     insertFrom : List (Name, a) -> ANameMap a -> ANameMap a
     insertFrom [] ctxt = ctxt
     insertFrom ((n, val) :: cs) ctxt
         = insertFrom cs (addName n val ctxt)
-
-export
-mergeAs : List String -> List String ->
-          ANameMap a -> ANameMap a -> ANameMap a
-mergeAs oldns newns ctxt (MkANameMap exact hier)
-    = insertFrom (toList exact) ctxt
-  where
-    insertFrom : List (Name, a) -> ANameMap a -> ANameMap a
-    insertFrom [] ctxt = ctxt
-    insertFrom ((n, val) :: cs) ctxt
-        = insertFrom cs (addName n val ctxt)
-
-

--- a/src/Data/ANameMap.idr
+++ b/src/Data/ANameMap.idr
@@ -95,7 +95,6 @@ merge ctxt (MkANameMap exact hier)
     insertFrom ((n, val) :: cs) ctxt
         = insertFrom cs (addName n val ctxt)
 
--- TODO: Update namespaces so 'as' works
 export
 mergeAs : List String -> List String ->
           ANameMap a -> ANameMap a -> ANameMap a

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -54,13 +54,13 @@ ifThenElse True t e = t
 ifThenElse False t e = e
 
 export
-extendAs : {auto s : Ref Syn SyntaxInfo} ->
-           List String -> List String -> SyntaxInfo -> Core ()
-extendAs old as newsyn
+extendSyn : {auto s : Ref Syn SyntaxInfo} ->
+            SyntaxInfo -> Core ()
+extendSyn newsyn
     = do syn <- get Syn
          put Syn (record { infixes $= mergeLeft (infixes newsyn),
                            prefixes $= mergeLeft (prefixes newsyn),
-                           ifaces $= mergeAs old as (ifaces newsyn),
+                           ifaces $= merge (ifaces newsyn),
                            bracketholes $= ((bracketholes newsyn) ++) }
                   syn)
 

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -269,8 +269,8 @@ mutual
       = pure $ IMustUnify fc UserDotted !(desugarB side ps x)
   desugarB side ps (PImplicit fc) = pure $ Implicit fc True
   desugarB side ps (PInfer fc) = pure $ Implicit fc False
-  desugarB side ps (PDoBlock fc block)
-      = expandDo side ps fc block
+  desugarB side ps (PDoBlock fc ns block)
+      = expandDo side ps fc ns block
   desugarB side ps (PBang fc term)
       = do itm <- desugarB side ps term
            bs <- get Bang
@@ -319,7 +319,7 @@ mutual
                    [PatClause fc (IVar fc (UN "True")) !(desugar side ps t),
                     PatClause fc (IVar fc (UN "False")) !(desugar side ps e)]
   desugarB side ps (PComprehension fc ret conds)
-      = desugarB side ps (PDoBlock fc (map guard conds ++ [toPure ret]))
+      = desugarB side ps (PDoBlock fc Nothing (map guard conds ++ [toPure ret]))
     where
       guard : PDo -> PDo
       guard (DoExp fc tm) = DoExp fc (PApp fc (PRef fc (UN "guard")) tm)
@@ -379,56 +379,61 @@ mutual
       = pure $ apply (IVar fc (UN "::"))
                 [!(desugarB side ps x), !(expandList side ps fc xs)]
 
+  addNS : Maybe (List String) -> Name -> Name
+  addNS (Just ns) n@(NS _ _) = n
+  addNS (Just ns) n = NS ns n
+  addNS _ n = n
+
   expandDo : {auto s : Ref Syn SyntaxInfo} ->
              {auto c : Ref Ctxt Defs} ->
              {auto u : Ref UST UState} ->
              {auto m : Ref MD Metadata} ->
-             Side -> List Name -> FC -> List PDo -> Core RawImp
-  expandDo side ps fc [] = throw (GenericMsg fc "Do block cannot be empty")
-  expandDo side ps _ [DoExp fc tm] = desugar side ps tm
-  expandDo side ps fc [e]
+             Side -> List Name -> FC -> Maybe (List String) -> List PDo -> Core RawImp
+  expandDo side ps fc ns [] = throw (GenericMsg fc "Do block cannot be empty")
+  expandDo side ps _ _ [DoExp fc tm] = desugar side ps tm
+  expandDo side ps fc ns [e]
       = throw (GenericMsg (getLoc e)
                   "Last statement in do block must be an expression")
-  expandDo side ps topfc (DoExp fc tm :: rest)
+  expandDo side ps topfc ns (DoExp fc tm :: rest)
       = do tm' <- desugar side ps tm
-           rest' <- expandDo side ps topfc rest
+           rest' <- expandDo side ps topfc ns rest
            -- A free standing 'case' block must return ()
            let ty = case tm' of
                          ICase _ _ _ _ => IVar fc (UN "Unit")
                          _ => Implicit fc False
            gam <- get Ctxt
-           pure $ IApp fc (IApp fc (IVar fc (UN ">>=")) tm')
+           pure $ IApp fc (IApp fc (IVar fc (addNS ns (UN ">>="))) tm')
                           (ILam fc top Explicit Nothing
                                 ty rest')
-  expandDo side ps topfc (DoBind fc n tm :: rest)
+  expandDo side ps topfc ns (DoBind fc n tm :: rest)
       = do tm' <- desugar side ps tm
-           rest' <- expandDo side ps topfc rest
-           pure $ IApp fc (IApp fc (IVar fc (UN ">>=")) tm')
+           rest' <- expandDo side ps topfc ns rest
+           pure $ IApp fc (IApp fc (IVar fc (addNS ns (UN ">>="))) tm')
                      (ILam fc top Explicit (Just n)
                            (Implicit fc False) rest')
-  expandDo side ps topfc (DoBindPat fc pat exp alts :: rest)
+  expandDo side ps topfc ns (DoBindPat fc pat exp alts :: rest)
       = do pat' <- desugar LHS ps pat
            (newps, bpat) <- bindNames False pat'
            exp' <- desugar side ps exp
            alts' <- traverse (desugarClause ps True) alts
            let ps' = newps ++ ps
-           rest' <- expandDo side ps' topfc rest
-           pure $ IApp fc (IApp fc (IVar fc (UN ">>=")) exp')
+           rest' <- expandDo side ps' topfc ns rest
+           pure $ IApp fc (IApp fc (IVar fc (addNS ns (UN ">>="))) exp')
                     (ILam fc top Explicit (Just (MN "_" 0))
                           (Implicit fc False)
                           (ICase fc (IVar fc (MN "_" 0))
                                (Implicit fc False)
                                (PatClause fc bpat rest'
                                   :: alts')))
-  expandDo side ps topfc (DoLet fc n rig ty tm :: rest)
+  expandDo side ps topfc ns (DoLet fc n rig ty tm :: rest)
       = do b <- newRef Bang initBangs
            tm' <- desugarB side ps tm
            ty' <- desugar side ps ty
-           rest' <- expandDo side ps topfc rest
+           rest' <- expandDo side ps topfc ns rest
            let bind = ILet fc rig n ty' tm' rest'
            bd <- get Bang
            pure $ bindBangs (bangNames bd) bind
-  expandDo side ps topfc (DoLetPat fc pat ty tm alts :: rest)
+  expandDo side ps topfc ns (DoLetPat fc pat ty tm alts :: rest)
       = do b <- newRef Bang initBangs
            pat' <- desugar LHS ps pat
            ty' <- desugar side ps ty
@@ -436,18 +441,18 @@ mutual
            tm' <- desugarB side ps tm
            alts' <- traverse (desugarClause ps True) alts
            let ps' = newps ++ ps
-           rest' <- expandDo side ps' topfc rest
+           rest' <- expandDo side ps' topfc ns rest
            bd <- get Bang
            pure $ bindBangs (bangNames bd) $
                     ICase fc tm' ty'
                        (PatClause fc bpat rest'
                                   :: alts')
-  expandDo side ps topfc (DoLetLocal fc decls :: rest)
-      = do rest' <- expandDo side ps topfc rest
+  expandDo side ps topfc ns (DoLetLocal fc decls :: rest)
+      = do rest' <- expandDo side ps topfc ns rest
            decls' <- traverse (desugarDecl ps) decls
            pure $ ILocal fc (concat decls') rest'
-  expandDo side ps topfc (DoRewrite fc rule :: rest)
-      = do rest' <- expandDo side ps topfc rest
+  expandDo side ps topfc ns (DoRewrite fc rule :: rest)
+      = do rest' <- expandDo side ps topfc ns rest
            rule' <- desugar side ps rule
            pure $ IRewrite fc rule' rest'
 

--- a/src/Idris/Elab/Interface.idr
+++ b/src/Idris/Elab/Interface.idr
@@ -238,7 +238,8 @@ updateIfaceSyn iname cn impps ps cs ms ds
     = do syn <- get Syn
          ms' <- traverse totMeth ms
          let info = MkIFaceInfo cn impps ps cs ms' ds
-         put Syn (record { ifaces $= addName iname info } syn)
+         put Syn (record { ifaces $= addName iname info,
+                           saveIFaces $= (iname :: ) } syn)
  where
     findSetTotal : List FnOpt -> Maybe TotalReq
     findSetTotal [] = Nothing

--- a/src/Idris/ProcessIdr.idr
+++ b/src/Idris/ProcessIdr.idr
@@ -75,7 +75,7 @@ readModule full loc vis reexp imp as
          Just (syn, hash, more) <- readFromTTC False {extra = SyntaxInfo}
                                                   loc vis fname imp as
               | Nothing => when vis (setVisible imp) -- already loaded, just set visibility
-         extendAs imp as syn
+         extendSyn syn
 
          defs <- get Ctxt
          modNS <- getNS
@@ -140,7 +140,7 @@ readAsMain fname
               | Nothing => throw (InternalError "Already loaded")
          replNS <- getNS
          replNestedNS <- getNestedNS
-         extendAs replNS replNS syn
+         extendSyn syn
 
          -- Read the main file's top level imported modules, so we have access
          -- to their names (and any of their public imports)

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -85,7 +85,7 @@ displayType : {auto c : Ref Ctxt Defs} ->
               Core String
 displayType defs (n, i, gdef)
     = maybe (do tm <- resugar [] !(normaliseHoles defs [] (type gdef))
-                pure (show (fullname gdef) ++ " : " ++ show tm))
+                pure (show !(aliasName (fullname gdef)) ++ " : " ++ show tm))
             (\num => showHole defs [] n num (type gdef))
             (isHole gdef)
 

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -76,7 +76,7 @@ mutual
 
        -- Syntactic sugar
 
-       PDoBlock : FC -> List PDo -> PTerm
+       PDoBlock : FC -> Maybe (List String) -> List PDo -> PTerm
        PBang : FC -> PTerm -> PTerm
        PIdiom : FC -> PTerm -> PTerm
        PList : FC -> List PTerm -> PTerm
@@ -135,7 +135,7 @@ mutual
   getPTermLoc (PSectionR fc _ _) = fc
   getPTermLoc (PEq fc _ _) = fc
   getPTermLoc (PBracketed fc _) = fc
-  getPTermLoc (PDoBlock fc _) = fc
+  getPTermLoc (PDoBlock fc _ _) = fc
   getPTermLoc (PBang fc _) = fc
   getPTermLoc (PIdiom fc _) = fc
   getPTermLoc (PList fc _) = fc
@@ -546,7 +546,7 @@ mutual
     showPrec d (PSectionR _ x op) = "(" ++ showPrec d x ++ " " ++ showPrec d op ++ ")"
     showPrec d (PEq fc l r) = showPrec d l ++ " = " ++ showPrec d r
     showPrec d (PBracketed _ tm) = "(" ++ showPrec d tm ++ ")"
-    showPrec d (PDoBlock _ ds)
+    showPrec d (PDoBlock _ ns ds)
         = "do " ++ showSep " ; " (map showDo ds)
     showPrec d (PBang _ tm) = "!" ++ showPrec d tm
     showPrec d (PIdiom _ tm) = "[|" ++ showPrec d tm ++ "|]"
@@ -828,8 +828,8 @@ mapPTermM f = goPTerm where
     goPTerm (PBracketed fc x) =
       PBracketed fc <$> goPTerm x
       >>= f
-    goPTerm (PDoBlock fc xs) =
-      PDoBlock fc <$> goPDos xs
+    goPTerm (PDoBlock fc ns xs) =
+      PDoBlock fc ns <$> goPDos xs
       >>= f
     goPTerm (PBang fc x) =
       PBang fc <$> goPTerm x

--- a/src/TTImp/ProcessData.idr
+++ b/src/TTImp/ProcessData.idr
@@ -111,12 +111,6 @@ checkCon {vars} opts nest env vis tn_in tn (MkImpTy fc cn_in ty_raw)
               Public => do addHashWithNames cn
                            addHashWithNames fullty
               _ => pure ()
-
-         -- Check name visibility: unless it's a private name, any names in
-         -- the type must be greater than private
-         when (vis /= Private) $
-              traverse_ (checkRefVisibility fc cn vis Private)
-                        (keys (getRefs (UN "") fullty))
          pure (MkCon fc cn !(getArity defs [] fullty) fullty)
 
 conName : Constructor -> Name
@@ -287,13 +281,6 @@ processData {vars} eopts nest env fc vis (MkImpLater dfc n_in ty_raw)
               Private => pure ()
               _ => do addHashWithNames n
                       addHashWithNames fullty
-
-         -- Check name visibility: unless it's a private name, any names in
-         -- the type must be greater than private
-         when (vis /= Private) $
-              traverse_ (checkRefVisibility fc n vis Private)
-                        (keys (getRefs (UN "") fullty))
-         pure ()
 
 processData {vars} eopts nest env fc vis (MkImpData dfc n_in ty_raw opts cons_raw)
     = do n <- inCurrentNS n_in

--- a/src/TTImp/ProcessType.idr
+++ b/src/TTImp/ProcessType.idr
@@ -275,11 +275,6 @@ processType {vars} eopts nest env fc rig vis opts (MkImpTy tfc n_in ty_raw)
 
          def <- initDef n env ty opts
          let fullty = abstractFullEnvType tfc env ty
-         -- Check name visibility: unless it's a private name, any names in
-         -- the type must be greater than private
-         when (vis /= Private) $
-              traverse_ (checkRefVisibility fc n vis Private)
-                        (keys (getRefs (UN "") fullty))
 
          (erased, dterased) <- findErased fullty
          defs <- get Ctxt

--- a/src/TTImp/Unelab.idr
+++ b/src/TTImp/Unelab.idr
@@ -142,7 +142,7 @@ mutual
                | Nothing => case umode of
                                  ImplicitHoles => pure (Implicit fc True, gErased fc)
                                  _ => pure (IVar fc n, gErased fc)
-           pure (IVar fc !(getFullName n), gnf env (embed ty))
+           pure (IVar fc !(aliasName !(getFullName n)), gnf env (embed ty))
   unelabTy' umode env (Meta fc n i args)
       = do defs <- get Ctxt
            let mkn = nameRoot n

--- a/src/TTImp/Utils.idr
+++ b/src/TTImp/Utils.idr
@@ -350,16 +350,3 @@ uniqueName defs used n
     next str
         = let (n, i) = nameNum str in
               n ++ "_" ++ show (i + 1)
-
-export
-checkRefVisibility : {auto c : Ref Ctxt Defs} ->
-                     FC -> Name ->
-                     Visibility -> -- Visibility of the name
-                     Visibility -> -- Minimum visibility of references
-                     Name -> Core ()
-checkRefVisibility fc fn vis min ref
-    = do defs <- get Ctxt
-         Just gdef <- lookupCtxtExact ref (gamma defs)
-              | Nothing => pure ()
-         when (visibility gdef <= min) $
-              throw (VisibilityError fc vis fn (visibility gdef) ref)

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -40,6 +40,7 @@ idrisTests
        "basic026", "basic027", "basic028", "basic029", "basic030",
        "basic031", "basic032", "basic033", "basic034", "basic035",
        "basic036", "basic037", "basic038", "basic039", "basic040",
+       "basic041",
        -- Coverage checking
        "coverage001", "coverage002", "coverage003", "coverage004",
        "coverage005", "coverage006", "coverage007", "coverage008",

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -49,7 +49,7 @@ idrisTests
        "error006", "error007", "error008", "error009", "error010",
        "error011",
        -- Modules and imports
-       "import001", "import002", "import003", "import004",
+       "import001", "import002", "import003", "import004", "import005",
        -- Interactive editing support
        "interactive001", "interactive002", "interactive003", "interactive004",
        "interactive005", "interactive006", "interactive007", "interactive008",

--- a/tests/idris2/basic041/QDo.idr
+++ b/tests/idris2/basic041/QDo.idr
@@ -1,0 +1,9 @@
+namespace MyDo
+  export
+  (>>=) : a -> (a -> IO b) -> IO b
+  (>>=) val k = k val
+
+foo : IO ()
+foo = MyDo.do
+         x <- "Silly"
+         putStrLn x

--- a/tests/idris2/basic041/expected
+++ b/tests/idris2/basic041/expected
@@ -1,0 +1,1 @@
+1/1: Building QDo (QDo.idr)

--- a/tests/idris2/basic041/run
+++ b/tests/idris2/basic041/run
@@ -1,0 +1,3 @@
+$1 --check QDo.idr
+
+rm -rf build

--- a/tests/idris2/import005/As.idr
+++ b/tests/idris2/import005/As.idr
@@ -1,0 +1,7 @@
+module As
+
+import Test as Toast
+
+Toast.Needle Int where
+  nardle x = x + x
+  noo x = x * x

--- a/tests/idris2/import005/Test.idr
+++ b/tests/idris2/import005/Test.idr
@@ -1,0 +1,23 @@
+module Test
+
+export
+pythag : Int -> List (Int, Int, Int)
+pythag max
+    = [ (x,y,z) | z <- [1..max],
+                  y <- [1..z],
+                  x <- [1..y],
+                  
+                  x * x + y * y == z * z ]
+
+namespace Inside
+  -- Needs to be recursive (or at least refer to a name in this module)
+  -- to check that definitions are updated on import...as
+  export
+  fact : Nat -> Nat
+  fact Z = 1
+  fact (S k) = (S k) * fact k
+
+public export
+interface Needle a where
+  nardle : a -> a
+  noo : a -> a

--- a/tests/idris2/import005/expected
+++ b/tests/idris2/import005/expected
@@ -1,5 +1,7 @@
 1/2: Building Test (Test.idr)
 2/2: Building As (As.idr)
+As> Prelude.id : (1 _ : a) -> a
+As> Prelude.Uninhabited : Type -> Type
 As> Toast.pythag : Int -> List (Int, (Int, Int))
 As> Toast.Inside.fact : Nat -> Nat
 As> Toast.nardle : Needle a => a -> a

--- a/tests/idris2/import005/expected
+++ b/tests/idris2/import005/expected
@@ -1,0 +1,12 @@
+1/2: Building Test (Test.idr)
+2/2: Building As (As.idr)
+As> Toast.pythag : Int -> List (Int, (Int, Int))
+As> Toast.Inside.fact : Nat -> Nat
+As> Toast.nardle : Needle a => a -> a
+As> Toast.noo : Needle a => a -> a
+As> 16
+As> [(3, (4, 5)), (6, (8, 10))]
+As> pythag
+As> 24
+As> 24
+As> Bye for now!

--- a/tests/idris2/import005/input
+++ b/tests/idris2/import005/input
@@ -1,3 +1,5 @@
+:t id
+:t Uninhabited
 :t pythag
 :t fact
 :t nardle

--- a/tests/idris2/import005/input
+++ b/tests/idris2/import005/input
@@ -1,0 +1,10 @@
+:t pythag
+:t fact
+:t nardle
+:t noo
+Toast.nardle (the Int 8)
+Toast.pythag 10
+Test.pythag
+Toast.Inside.fact 4
+Test.Inside.fact 4
+:q

--- a/tests/idris2/import005/run
+++ b/tests/idris2/import005/run
@@ -1,0 +1,3 @@
+$1 --no-banner As.idr < input
+
+rm -rf build


### PR DESCRIPTION
All somehow related, so coming in one PR:

* `import X as Y` now works, aliasing the names exported by X to the namespace Y (including dealing with nested namespaces properly)
* The `Prelude` is now all available via the namespace `Prelude` even though it's split into multiple modules (so now we can go further with separating it more, as it probably should be)
* Removed the restriction that exported names can't refer to private names, because it doesn't seem to achieve anything useful. It was there in an effort to speed up importing, but that's no longer necessary (and it never worked in Idris 1 anyway)
* Added qualified do, where `Namespace.do` introduces a `do` block desugared via `Namespace.(>>=)`, inspired by a similar feature in Purescript