### PR TITLE
Add command line option to typecheck package without codegen

### DIFF
--- a/src/Idris/CommandLine.idr
+++ b/src/Idris/CommandLine.idr
@@ -19,6 +19,7 @@ public export
 data PkgCommand
       = Build
       | Install
+      | Check
       | Clean
       | REPL
 
@@ -26,6 +27,7 @@ export
 Show PkgCommand where
   show Build = "--build"
   show Install = "--install"
+  show Check = "--checkpkg"
   show Clean = "--clean"
   show REPL = "--repl"
 
@@ -180,6 +182,8 @@ options = [MkOpt ["--check", "-c"] [] [CheckOnly]
               (Just "Build modules/executable for the given package"),
            MkOpt ["--install"] [Required "package file"] (\f => [Package Install f])
               (Just "Install the given package"),
+           MkOpt ["--checkpkg"] [Required "package file"] (\f => [Package Check f])
+              (Just "Check the given package without compilation phase"),
            MkOpt ["--clean"] [Required "package file"] (\f => [Package Clean f])
               (Just "Clean intermediate files/executables for the given package"),
            MkOpt ["--repl"] [Required "package file"] (\f => [Package REPL f])

--- a/src/Idris/CommandLine.idr
+++ b/src/Idris/CommandLine.idr
@@ -19,7 +19,7 @@ public export
 data PkgCommand
       = Build
       | Install
-      | Check
+      | Typecheck
       | Clean
       | REPL
 
@@ -27,7 +27,7 @@ export
 Show PkgCommand where
   show Build = "--build"
   show Install = "--install"
-  show Check = "--checkpkg"
+  show Typecheck = "--typecheck"
   show Clean = "--clean"
   show REPL = "--repl"
 
@@ -182,8 +182,8 @@ options = [MkOpt ["--check", "-c"] [] [CheckOnly]
               (Just "Build modules/executable for the given package"),
            MkOpt ["--install"] [Required "package file"] (\f => [Package Install f])
               (Just "Install the given package"),
-           MkOpt ["--checkpkg"] [Required "package file"] (\f => [Package Check f])
-              (Just "Check the given package without compilation phase"),
+           MkOpt ["--typecheck"] [Required "package file"] (\f => [Package Typecheck f])
+              (Just "Typechecks the given package without code generation"),
            MkOpt ["--clean"] [Required "package file"] (\f => [Package Clean f])
               (Just "Clean intermediate files/executables for the given package"),
            MkOpt ["--repl"] [Required "package file"] (\f => [Package REPL f])

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -508,7 +508,7 @@ processPackage cmd file opts
                       Install => do [] <- build pkg opts
                                        | errs => coreLift (exitWith (ExitFailure 1))
                                     install pkg opts
-                      Check => do
+                      Typecheck => do
                         [] <- check pkg opts
                           | errs => coreLift (exitWith (ExitFailure 1))
                         pure ()

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -276,6 +276,27 @@ compileMain mainn mmod exec
          compileExp (PRef replFC mainn) exec
          pure ()
 
+prepareCompilation : {auto c : Ref Ctxt Defs} ->
+                     {auto s : Ref Syn SyntaxInfo} ->
+                     {auto o : Ref ROpts REPLOpts} ->
+                     PkgDesc ->
+                     List CLOpt ->
+                     Core (List Error)
+prepareCompilation pkg opts =
+  do
+    defs <- get Ctxt
+    addDeps pkg
+
+    processOptions (options pkg)
+    preOptions opts
+
+    runScript (prebuild pkg)
+
+    let toBuild = maybe (map snd (modules pkg))
+                        (\m => snd m :: map snd (modules pkg))
+                        (mainmod pkg)
+    buildAll toBuild
+
 build : {auto c : Ref Ctxt Defs} ->
         {auto s : Ref Syn SyntaxInfo} ->
         {auto o : Ref ROpts REPLOpts} ->
@@ -283,16 +304,8 @@ build : {auto c : Ref Ctxt Defs} ->
         List CLOpt ->
         Core (List Error)
 build pkg opts
-    = do defs <- get Ctxt
-         addDeps pkg
-         processOptions (options pkg)
-         preOptions opts
-         runScript (prebuild pkg)
-         let toBuild = maybe (map snd (modules pkg))
-                             (\m => snd m :: map snd (modules pkg))
-                             (mainmod pkg)
-         [] <- buildAll toBuild
-              | errs => pure errs
+    = do [] <- prepareCompilation pkg opts
+            | errs => pure errs
 
          case executable pkg of
               Nothing => pure ()
@@ -301,6 +314,7 @@ build pkg opts
                                | Nothing => throw (GenericMsg emptyFC "No main module given")
                       let mainName = NS mainNS (UN "main")
                       compileMain mainName mainFile exec
+
          runScript (postbuild pkg)
          pure []
 
@@ -369,13 +383,11 @@ check : {auto c : Ref Ctxt Defs} ->
         Core (List Error)
 check pkg opts =
   do
-    defs <- get Ctxt
-    addDeps pkg
-    processOptions (options pkg)
-    let toBuild = maybe (map snd (modules pkg))
-                        (\m => snd m :: map snd (modules pkg))
-                        (mainmod pkg)
-    buildAll toBuild
+    [] <- prepareCompilation pkg opts
+      | errs => pure errs
+
+    runScript (postbuild pkg)
+    pure []
 
 -- Data.These.bitraverse hand specialised for Core
 bitraverseC : (a -> Core c) -> (b -> Core d) -> These a b -> Core (These c d)


### PR DESCRIPTION
```
$ time idris2 --build idris2.ipkg
________________________________________________________
Executed in   46,90 secs   fish           external 
   usr time   44,26 secs  118,00 micros   44,26 secs 
   sys time    2,46 secs  498,00 micros    2,46 secs 

$ time idris2 --checkpkg idris2.pkg
________________________________________________________
Executed in    1,68 secs   fish           external 
   usr time  1482,77 millis  132,00 micros  1482,64 millis 
   sys time  147,89 millis  591,00 micros  147,30 millis 
```

I find this command very helpful for some workflows.