### PR TITLE
Fix forward declaration of idris_closeDir

### DIFF
--- a/support/c/idris_directory.h
+++ b/support/c/idris_directory.h
@@ -5,7 +5,7 @@ char* idris2_currentDirectory();
 int idris2_changeDir(char* dir);
 int idris2_createDir(char* dir);
 void* idris2_openDir(char* dir);
-void idris2_closeDIr(void* d);
+void idris2_closeDir(void* d);
 int idris2_removeDir(char* path);
 char* idris2_nextDirEntry(void* d);
 


### PR DESCRIPTION
More of a hotfix. this was clearly not used anywhere before, so one'd either have to think about tests to make sure this kind of thing doesn't happen again, or if it's not needed remove it.