### PR TITLE
Leave implicit record fields alone on update

### DIFF
--- a/src/TTImp/Elab/Record.idr
+++ b/src/TTImp/Elab/Record.idr
@@ -125,7 +125,11 @@ findPath loc (p :: ps) full (Just tyn) val (Field mn n v)
     mkArgs ((p, imp, _) :: ps)
         = do fldn <- genFieldName p
              args' <- mkArgs ps
-             pure ((p, Field imp fldn (IVar loc (UN fldn))) :: args')
+             -- If it's an implicit argument, leave it as _ by default
+             let arg = maybe (IVar loc (UN fldn))
+                             (const (Implicit loc False))
+                             imp
+             pure ((p, Field imp fldn arg) :: args')
 
 findPath loc (p :: ps) full tyn val (Constr mn con args)
    = do let Just prec = lookup p args

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -99,7 +99,7 @@ idrisTests
        "reg008", "reg009", "reg010", "reg011", "reg012", "reg013", "reg014",
        "reg015", "reg016", "reg017", "reg018", "reg019", "reg020", "reg021",
        "reg022", "reg023", "reg024", "reg025", "reg026", "reg027", "reg028",
-       "reg029", "reg030", "reg031",
+       "reg029", "reg030", "reg031", "reg032",
        -- Totality checking
        "total001", "total002", "total003", "total004", "total005",
        "total006", "total007", "total008", "total009",

--- a/tests/idris2/reg032/expected
+++ b/tests/idris2/reg032/expected
@@ -1,0 +1,1 @@
+1/1: Building recupdate (recupdate.idr)

--- a/tests/idris2/reg032/recupdate.idr
+++ b/tests/idris2/reg032/recupdate.idr
@@ -1,0 +1,6 @@
+record R (a : Type) where
+  constructor MkR
+  x : a
+
+rmap : (a -> b) -> R a -> R b
+rmap f = record { x $= f }

--- a/tests/idris2/reg032/run
+++ b/tests/idris2/reg032/run
@@ -1,0 +1,3 @@
+$1 --check recupdate.idr
+
+rm -rf build


### PR DESCRIPTION
Unless an explicit update is given