### PR TITLE
Make sure names derived from case and with blocks get unique names during LambdaLifting

### DIFF
--- a/src/Compiler/LambdaLift.idr
+++ b/src/Compiler/LambdaLift.idr
@@ -143,6 +143,8 @@ genName
     mkName (NS ns b) i = NS ns (mkName b i)
     mkName (UN n) i = MN n i
     mkName (DN _ n) i = mkName n i
+    mkName (CaseBlock outer inner) i = MN ("case block in " ++ outer ++ " (" ++ show inner ++ ")") i
+    mkName (WithBlock outer inner) i = MN ("with block in " ++ outer ++ " (" ++ show inner ++ ")") i
     mkName n i = MN (show n) i
 
 unload : FC -> Lifted vars -> List (Lifted vars) -> Core (Lifted vars)


### PR DESCRIPTION
PR #416 removed the unique index from `show` for `CaseBlock` and `WithBlock`, which is great for tests. But as a result, LambdaLift generates non-unique names, as it uses `show Name` by default to generate names for lifted lambdas. This commit explicitly includes the Case/With block index in the generated name to guarantee that it's unique.