### PR TITLE
Update JS code generator to remove RF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Compiler changes:
 * It is now possible to create new backends with minimal overhead. `Idris.Driver`
 exposes the function `mainWithCodegens` that takes a list of codegens. The
 feature in documented [here](https://idris2.readthedocs.io/en/latest/backends/custom.html).
+* New code generators `node` and `js`.
 
 REPL changes:
 

--- a/docs/source/backends/index.rst
+++ b/docs/source/backends/index.rst
@@ -60,4 +60,5 @@ or via the `IDRIS2_CG` environment variable.
    chez
    racket
    gambit
+   javascript
    custom

--- a/docs/source/backends/javascript.rst
+++ b/docs/source/backends/javascript.rst
@@ -1,0 +1,5 @@
+***********************************
+Javascript and Node Code Generators
+***********************************
+
+To be added.

--- a/src/Compiler/ES/ES.idr
+++ b/src/Compiler/ES/ES.idr
@@ -84,7 +84,6 @@ jsName (UN n) = keywordSafe $ jsIdent n
 jsName (MN n i) = jsIdent n ++ "_" ++ show i
 jsName (PV n d) = "pat__" ++ jsName n
 jsName (DN _ n) = jsName n
-jsName (RF n) = "rf__" ++ jsIdent n
 jsName (Nested (i, x) n) = "n__" ++ show i ++ "_" ++ show x ++ "_" ++ jsName n
 jsName (CaseBlock x y) = "case__" ++ jsIdent x ++ "_" ++ show y
 jsName (WithBlock x y) = "with__" ++ jsIdent x ++ "_" ++ show y


### PR DESCRIPTION
This name was removed in a recent patch, leading to a small conflict.
Also added a note to the CHANGELOG and a placeholder in the docs.

(Without a typo in the changelog this time...)