### PR TITLE
Add `Ord` implementation for `Either`

### DIFF
--- a/libs/prelude/Prelude.idr
+++ b/libs/prelude/Prelude.idr
@@ -931,6 +931,13 @@ public export
   Left x == Left x' = x == x'
   Right x == Right x' = x == x'
   _ == _ = False
+  
+public export
+(Ord a, Ord b) => Ord (Either a b) where
+  compare (Left x) (Left x') = compare x x'
+  compare (Left _) (Right _) = LT
+  compare (Right _) (Left _) = GT
+  compare (Right x) (Right x') = compare x x'
 
 %inline
 public export

--- a/tests/idris2/reflection003/expected
+++ b/tests/idris2/reflection003/expected
@@ -1,6 +1,6 @@
 1/1: Building refprims (refprims.idr)
 LOG 0: Name: Prelude.List.++
-LOG 0: Type: (%pi Rig0 Implicit (Just a) %type (%pi Rig1 Explicit (Just xs) (Prelude.List a) (%pi RigW Explicit (Just {arg:6349}) (Prelude.List a) (Prelude.List a))))
+LOG 0: Type: (%pi Rig0 Implicit (Just a) %type (%pi Rig1 Explicit (Just xs) (Prelude.List a) (%pi RigW Explicit (Just {arg:6633}) (Prelude.List a) (Prelude.List a))))
 LOG 0: Name: Prelude.Strings.++
 LOG 0: Type: (%pi Rig1 Explicit (Just x) String (%pi Rig1 Explicit (Just y) String String))
 LOG 0: Resolved name: Prelude.Nat


### PR DESCRIPTION
Noticed this seemed to be missing. If there's a reason this wasn't included, feel free to ignore.