### PR TITLE
Allow `default` to be identifier

### DIFF
--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -536,7 +536,7 @@ mutual
   defaultImplicitPi fname indents
       = do start <- location
            symbol "{"
-           keyword "default"
+           exactIdent "default"
            commit
            t <- simpleExpr fname indents
            binders <- pibindList fname start indents
@@ -1453,7 +1453,7 @@ recordParam fname indents
          info <- the (SourceEmptyRule (PiInfo PTerm))
                  (pure  AutoImplicit <* keyword "auto"
               <|>(do
-                  keyword "default"
+                  exactIdent "default"
                   t <- simpleExpr fname indents
                   pure $ DefImplicit t)
               <|> pure      Implicit)

--- a/src/Parser/Lexer/Source.idr
+++ b/src/Parser/Lexer/Source.idr
@@ -138,7 +138,7 @@ mkDirective str = CGDirective (trim (substr 3 (length str) str))
 -- Reserved words
 keywords : List String
 keywords = ["data", "module", "where", "let", "in", "do", "record",
-            "auto", "default", "implicit", "mutual", "namespace",
+            "auto", "implicit", "mutual", "namespace",
             "parameters", "with", "impossible", "case", "of",
             "if", "then", "else", "forall", "rewrite",
             "using", "interface", "implementation", "open", "import",

--- a/src/TTImp/Parser.idr
+++ b/src/TTImp/Parser.idr
@@ -587,7 +587,7 @@ recordParam fname indents
          info <- the (SourceEmptyRule (PiInfo RawImp))
                  (pure  AutoImplicit <* keyword "auto"
               <|>(do
-                  keyword "default"
+                  exactIdent "default"
                   t <- simpleExpr fname indents
                   pure $ DefImplicit t)
               <|> pure      Implicit)

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -40,7 +40,7 @@ idrisTests
        "basic026", "basic027", "basic028", "basic029", "basic030",
        "basic031", "basic032", "basic033", "basic034", "basic035",
        "basic036", "basic037", "basic038", "basic039", "basic040",
-       "basic041",
+       "basic041", "basic042",
        -- Coverage checking
        "coverage001", "coverage002", "coverage003", "coverage004",
        "coverage005", "coverage006", "coverage007", "coverage008",

--- a/tests/idris2/basic042/Default.idr
+++ b/tests/idris2/basic042/Default.idr
@@ -1,0 +1,21 @@
+module Default
+
+public export
+interface Default ty where
+    default : ty
+
+public export
+Default Nat where
+    default = Z
+
+public export
+Default Bool where
+    default = False
+
+public export
+foo : {default : Bool} -> Bool
+foo {default} = default
+
+public export
+bar : {default True b : Bool} -> Bool
+bar {b} = b

--- a/tests/idris2/basic042/expected
+++ b/tests/idris2/basic042/expected
@@ -1,0 +1,6 @@
+1/1: Building Default (Default.idr)
+Default> 0
+Default> False
+Default> True
+Default> True
+Default> Bye for now!

--- a/tests/idris2/basic042/input
+++ b/tests/idris2/basic042/input
@@ -1,0 +1,5 @@
+the Nat default
+the Bool default
+foo {default=True}
+bar
+:q

--- a/tests/idris2/basic042/run
+++ b/tests/idris2/basic042/run
@@ -1,0 +1,3 @@
+$1 --no-banner Default.idr < input
+
+rm -rf build


### PR DESCRIPTION
Make `default` to be a contextual keyword, which allows `default` to be an identifier when it's not in the position of default implicit argument and default record field.