### PR TITLE
Document samples/ffi, and change name of .so to better suit convention. 

### DIFF
--- a/samples/ffi/Small.idr
+++ b/samples/ffi/Small.idr
@@ -1,5 +1,5 @@
 libsmall : String -> String
-libsmall fn = "C:" ++ fn ++ ",libsmall"
+libsmall fn = "C:" ++ fn ++ ",libsmallc"
 
 %foreign (libsmall "add")
 add : Int -> Int -> Int

--- a/samples/ffi/Struct.idr
+++ b/samples/ffi/Struct.idr
@@ -1,7 +1,7 @@
 import System.FFI
 
 libsmall : String -> String
-libsmall fn = "C:" ++ fn ++ ",libsmall"
+libsmall fn = "C:" ++ fn ++ ",libsmallc"
 
 Point : Type
 Point = Struct "point" [("x", Int), ("y", Int)]

--- a/samples/ffi/smallc.c
+++ b/samples/ffi/smallc.c
@@ -5,7 +5,7 @@
 //      gcc smallc.o -shared -o libsmallc.so
 //      idris2 Small.idr
 // For an example of using Idris packages to build external (FFI) libraries, see the `FFI-readline`
-// smaple, and specifically `readline.ipkg`
+// sample, and specifically `readline.ipkg`
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -45,4 +45,3 @@ point* mkPoint(int x, int y) {
 void freePoint(point* pt) {
     free(pt);
 }
-

--- a/samples/ffi/smallc.c
+++ b/samples/ffi/smallc.c
@@ -1,3 +1,12 @@
+// For an example of using Idris packages to build external (FFI) libraries, see the `FFI-readline`
+// smaple, and specifically `readline.ipkg`
+// To compile this file for the samples `sample/ffi/Small.dir` and `sample/ffi/Struct.idr`, you will
+// need to manually compile and link it into a `.so` file, and place it in a location where the
+// resulting exectuable can find it. For example:
+//      gcc -c -fPIC smallc.c -o smallc.o
+//      gcc smallc.o -shared -o libsmallc.so
+//      idris2 Small.idr
+
 #include <stdlib.h>
 #include <stdio.h>
 

--- a/samples/ffi/smallc.c
+++ b/samples/ffi/smallc.c
@@ -1,11 +1,11 @@
-// For an example of using Idris packages to build external (FFI) libraries, see the `FFI-readline`
-// smaple, and specifically `readline.ipkg`
 // To compile this file for the samples `sample/ffi/Small.dir` and `sample/ffi/Struct.idr`, you will
 // need to manually compile and link it into a `.so` file, and place it in a location where the
 // resulting exectuable can find it. For example:
 //      gcc -c -fPIC smallc.c -o smallc.o
 //      gcc smallc.o -shared -o libsmallc.so
 //      idris2 Small.idr
+// For an example of using Idris packages to build external (FFI) libraries, see the `FFI-readline`
+// smaple, and specifically `readline.ipkg`
 
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
This (very) small PR adds some documentation and clarification around a sample that I was quite confused by when initially looking around at the source for Idris2. Specifically, it adds some documentation specifying that the *user* must build `libsmallc.so`[1], and changes the name of the `.so` in `Small.idr` and `Struct.idr` to better reflect the convention of `X.c` producing `libX.so`. 

[1] Although this might seem obvious, it tripped me up somewhat, as Idris 2's build process generates a file called `small.so` when compiling `Small.idr`. This, however, isn't a shared object, but (as far as I can tell) compiled scheme code, and aside from a "cannot find shared object..." error, there is no other indication that the user should build the correct `.so` themselves. Moreover, as the (old) name for the linked library in `Small.idr` was `libsmall`, not `libsmallc`, I initially made the assumption that the Idris compiler was simply generating an incorrectly named `.so` file for `smallc` - I was expecting `libsmallc.so`, not `libsmall.so`. Overall, the way the example was previously structured and un-documented meant that I had much wider expectations regarding what Idris2 actually does, FFI-wise, which should now hopefully be cleared up! 