### PR TITLE
Export `(~>)` publicly.

### DIFF
--- a/libs/base/Data/Morphisms.idr
+++ b/libs/base/Data/Morphisms.idr
@@ -7,7 +7,7 @@ record Morphism a b where
 
 infixr 1 ~>
 
-export
+public export
 (~>) : Type -> Type -> Type
 (~>) = Morphism
 


### PR DESCRIPTION
If `(~>)` isn't publicly exported, the type checker doesn't know that `Mor` constructs something of type `~>`.