### PR TITLE
Inconsistent std IO

### DIFF
--- a/libs/prelude/Prelude/IO.idr
+++ b/libs/prelude/Prelude/IO.idr
@@ -88,17 +88,17 @@ export
 getLine : HasIO io => io String
 getLine = primIO prim__getStr
 
-||| Write a single character to stdout.
+||| Write one single-byte character to stdout.
 export
 putChar : HasIO io => Char -> io ()
 putChar c = primIO (prim__putChar c)
 
-||| Write a single character to stdout, with a trailing newline.
+||| Write one multi-byte character to stdout, with a trailing newline.
 export
 putCharLn : HasIO io => Char -> io ()
 putCharLn c = putStrLn (prim__cast_CharString c)
 
-||| Read a single character from stdin.
+||| Read one single-byte character from stdin.
 export
 getChar : HasIO io => io Char
 getChar = primIO prim__getChar


### PR DESCRIPTION
`getChar, putChar` reads/writes exactly one byte from/to stdio
`putChar` writes exactly one byte
`putCharLn` writes the whole codepoint + \n

I think that should be pointed out more vigorously as their behaviour currently is confusing