### PR TITLE
Added explicit case to headEq to allow matching on Pi Types.

### DIFF
--- a/src/Core/CaseBuilder.idr
+++ b/src/Core/CaseBuilder.idr
@@ -601,6 +601,7 @@ sameType {ns} fc phase fn env (p :: xs)
     firstPat (pinf :: _) = pat pinf
 
     headEq : NF ns -> NF ns -> Phase -> Bool
+    headEq (NBind _ _ (Pi _ _ _) _) (NBind _ _ (Pi _ _ _) _) _ = True
     headEq (NTCon _ n _ _ _) (NTCon _ n' _ _ _) _ = n == n'
     headEq (NPrimVal _ c) (NPrimVal _ c') _ = c == c'
     headEq (NType _) (NType _) _ = True


### PR DESCRIPTION
Add a missing explicit case to Core/CaseBuilder.idr: `headEq` to allow for matching on pi-types as per Edwin.
Code that fails before the fix:
https://gist.github.com/donovancrichton/2838abd65c12dbf0dc01806ac8eafb0f
Has been tested to work after the fix.
See: https://functionalprogramming.slack.com/archives/C043A0KTY/p1595633177089900