### PR TITLE
Reorganise expression search

### DIFF
--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -1198,6 +1198,13 @@ depth
   = do defs <- get Ctxt
        pure (branchDepth (gamma defs))
 
+export
+dumpStaging : {auto c : Ref Ctxt Defs} ->
+              Core ()
+dumpStaging
+    = do defs <- get Ctxt
+         coreLift $ putStrLn $ "Staging area: " ++ show (keys (staging (gamma defs)))
+
 -- Explicitly note that the name should be saved when writing out a .ttc
 export
 addToSave : {auto c : Ref Ctxt Defs} ->

--- a/src/Yaffle/REPL.idr
+++ b/src/Yaffle/REPL.idr
@@ -76,7 +76,7 @@ process (ExprSearch n_in)
          [(n, i, ty)] <- lookupTyName n_in (gamma defs)
               | [] => throw (UndefinedName toplevelFC n_in)
               | ns => throw (AmbiguousName toplevelFC (map fst ns))
-         results <- exprSearch toplevelFC n []
+         results <- exprSearchN toplevelFC 1 n []
          defs <- get Ctxt
          defnfs <- traverse (normaliseHoles defs []) results
          traverse_ (\d => coreLift (printLn !(toFullNames d))) defnfs

--- a/tests/idris2/interactive005/IEdit.idr
+++ b/tests/idris2/interactive005/IEdit.idr
@@ -27,3 +27,9 @@ data Elem : a -> Vect n a -> Type where
      There : (p : Elem x xs) -> Elem x (y :: xs)
 
 lookup : Elem ty vs -> Env vs -> ty
+
+data Tree : (a : Type) -> Type where
+  Leaf : a -> Tree a
+  Node : a -> Tree a -> Tree a -> Tree a
+
+foo : Tree Nat

--- a/tests/idris2/interactive005/expected
+++ b/tests/idris2/interactive005/expected
@@ -10,5 +10,6 @@ Main> zipWith f [] ys = []
 zipWith f (x :: xs) (y :: ys) = f x y :: zipWith f xs ys
 Main> lookup Here (ECons x es) = x
 lookup (There p) (ECons x es) = lookup p es
+Main> foo = Leaf 0
 Main> Main.my_uncurry : (a -> b -> c) -> (a, b) -> c
 Main> Bye for now!

--- a/tests/idris2/interactive005/input
+++ b/tests/idris2/interactive005/input
@@ -5,5 +5,6 @@
 :gd 15 lappend
 :gd 17 zipWith
 :gd 29 lookup
+:gd 35 foo
 :t my_uncurry
 :q


### PR DESCRIPTION
Rather than returning a complete list of results, return a pair of the
first result, and a continuation. The continuation explains how to
continue the search if the given result is deemed unacceptable (either
on encountering an error somewhere, or just if the caller wants the next
result).

This means we don't search needlessly if we're only looking for the
first result. Fixes #228