### PR TITLE
Make showParens public

### DIFF
--- a/libs/prelude/Prelude/Show.idr
+++ b/libs/prelude/Prelude/Show.idr
@@ -63,6 +63,7 @@ interface Show ty where
 
 ||| Surround a `String` with parentheses depending on a condition.
 ||| @ b whether to add parentheses
+export
 showParens : (1 b : Bool) -> String -> String
 showParens False s = s
 showParens True  s = "(" ++ s ++ ")"


### PR DESCRIPTION
I'm currently duplicating it in my own project, and it would be nicer to just use the standard library version.