### PR TITLE
Look at intermediate results in program search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ exposes the function `mainWithCodegens` that takes a list of codegens. The
 feature in documented [here](https://idris2.readthedocs.io/en/latest/backends/custom.html).
 * New code generators `node` and `javascript`.
 
-REPL changes:
+REPL/IDE mode changes:
 
 * Implemented `:module` command, to load a module during a REPL session.
 * Implemented `:doc`, which displays documentation for a name.
@@ -71,6 +71,8 @@ REPL changes:
   next type correct implementation
   + Correspondingly, added the IDE mode command `generate-def-next` (which takes
     no arguments)
+* Improved program search to allow deconstructing intermediate values, and in
+  simple cases, the result of recursive calls.
 
 Changes since Idris 2 v0.1.0
 ----------------------------

--- a/src/Idris/REPLOpts.idr
+++ b/src/Idris/REPLOpts.idr
@@ -29,7 +29,7 @@ record REPLOpts where
   errorLine : Maybe Int
   idemode : OutputMode
   currentElabSource : String
-  psResult : Maybe (Name, Core (Search ClosedTerm)) -- last proof search continuation (and name)
+  psResult : Maybe (Name, Core (Search RawImp)) -- last proof search continuation (and name)
   gdResult : Maybe (Int, Core (Search (FC, List ImpClause))) -- last generate def continuation (and line number)
   -- TODO: Move extraCodegens from here, it doesn't belong, but there's nowhere
   -- better to stick it now.

--- a/src/Idris/Resugar.idr
+++ b/src/Idris/Resugar.idr
@@ -200,7 +200,7 @@ mutual
            imp <- showImplicits
            arg' <- if imp then toPTerm tyPrec arg
                           else pure (PImplicit fc)
-           sc' <- toPTerm p sc
+           sc' <- toPTerm startPrec sc
            pt' <- traverse (toPTerm argPrec) pt
            bracket p startPrec (PLam fc rig pt' (PRef fc n) arg' sc')
   toPTerm p (ILet fc rig n ty val sc)
@@ -211,6 +211,12 @@ mutual
            sc' <- toPTerm startPrec sc
            bracket p startPrec (PLet fc rig (PRef fc n)
                                      ty' val' sc' [])
+  toPTerm p (ICase fc sc scty [PatClause _ lhs rhs])
+      = do sc' <- toPTerm startPrec sc
+           lhs' <- toPTerm startPrec lhs
+           rhs' <- toPTerm startPrec rhs
+           bracket p startPrec
+                   (PLet fc top lhs' (PImplicit fc) sc' rhs' [])
   toPTerm p (ICase fc sc scty alts)
       = do sc' <- toPTerm startPrec sc
            alts' <- traverse toPClause alts

--- a/src/TTImp/Interactive/ExprSearch.idr
+++ b/src/TTImp/Interactive/ExprSearch.idr
@@ -35,6 +35,7 @@ import Data.List
 
 -- Data for building recursive calls - the function name, and the structure
 -- of the LHS. Only recursive calls with a different structure are okay.
+public export -- to keep Idris2-boot happy!
 record RecData where
   constructor MkRecData
   {vars : List Name}

--- a/src/Yaffle/REPL.idr
+++ b/src/Yaffle/REPL.idr
@@ -77,9 +77,7 @@ process (ExprSearch n_in)
               | [] => throw (UndefinedName toplevelFC n_in)
               | ns => throw (AmbiguousName toplevelFC (map fst ns))
          results <- exprSearchN toplevelFC 1 n []
-         defs <- get Ctxt
-         defnfs <- traverse (normaliseHoles defs []) results
-         traverse_ (\d => coreLift (printLn !(toFullNames d))) defnfs
+         traverse_ (\d => coreLift (printLn d)) results
          pure True
 process (GenerateDef line name)
     = do defs <- get Ctxt

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -57,7 +57,8 @@ idrisTests
        "interactive001", "interactive002", "interactive003", "interactive004",
        "interactive005", "interactive006", "interactive007", "interactive008",
        "interactive009", "interactive010", "interactive011", "interactive012",
-       "interactive013", "interactive014", "interactive015",
+       "interactive013", "interactive014", "interactive015", "interactive016",
+       "interactive017",
        -- Interfaces
        "interface001", "interface002", "interface003", "interface004",
        "interface005", "interface006", "interface007", "interface008",

--- a/tests/idris2/basic016/expected
+++ b/tests/idris2/basic016/expected
@@ -1,6 +1,6 @@
 1/1: Building Eta (Eta.idr)
 Eta.idr:14:10--14:14:While processing right hand side of etaBad at Eta.idr:14:1--15:1:
-When unifying \x => (\y => (MkTest ?_ ?_)) = \x => (\y => (MkTest ?_ ?_)) and MkTest = \x => (\y => (MkTest ?_ ?_))
+When unifying \x => \y => MkTest ?_ ?_ = \x => \y => MkTest ?_ ?_ and MkTest = \x => \y => MkTest ?_ ?_
 Mismatch between:
 	Nat
 and
@@ -11,7 +11,7 @@ at:
 
 1/1: Building Eta2 (Eta2.idr)
 Eta2.idr:2:8--2:12:While processing right hand side of test at Eta2.idr:2:1--4:1:
-When unifying \x => (S ?_) = \x => (S ?_) and S = \x => (S ?_)
+When unifying \x => S ?_ = \x => S ?_ and S = \x => S ?_
 Mismatch between:
 	a
 and
@@ -21,7 +21,7 @@ at:
 	       ^^^^
 
 Eta2.idr:5:44--5:48:While processing right hand side of test2 at Eta2.idr:5:1--6:1:
-When unifying \x => (S ?_) = \x => (S ?_) and S = \x => (S ?_)
+When unifying \x => S ?_ = \x => S ?_ and S = \x => S ?_
 Mismatch between:
 	a
 and

--- a/tests/idris2/basic019/expected
+++ b/tests/idris2/basic019/expected
@@ -4,5 +4,5 @@ Main> Prelude.elem : Eq a => a -> List a -> Bool
 elem x [] = False
 elem x (y :: ys) = (x == y) || Delay (elem x ys)
 Main> PrimIO.io_bind : (1 _ : IO a) -> (1 _ : (a -> IO b)) -> IO b
-io_bind (MkIO fn) k = MkIO (\1 w => (case fn w of { MkIORes x' w' => case k x' of { MkIO res => res w' } }))
+io_bind (MkIO fn) k = MkIO (\1 w => let MkIORes x' w' = fn w in let MkIO res = k x' in res w')
 Main> Bye for now!

--- a/tests/idris2/basic023/expected
+++ b/tests/idris2/basic023/expected
@@ -3,7 +3,7 @@ Main> Main.Dict : (a -> a -> Bool) -> Type -> Type
 Main> Main.MkDict : (eq : (a -> a -> Bool)) -> List (a, b) -> Dict eq b
 Main> Main.lookup : (a -> a -> Bool) -> a -> List (a, b) -> Maybe b
 Main> Main.lookupK : (eq : (a -> a -> Bool)) -> a -> Dict eq b -> Maybe b
-Main> MkDict (\{arg:0} => (\{arg:1} => (intToBool (prim__eq_Int arg arg)))) [(0, "foo"), (1, "bar")]
+Main> MkDict (\{arg:0} => \{arg:1} => intToBool (prim__eq_Int arg arg)) [(0, "foo"), (1, "bar")]
 Main> Just "bar"
 Main> Nothing
 Main> Bye for now!

--- a/tests/idris2/interactive009/expected
+++ b/tests/idris2/interactive009/expected
@@ -5,13 +5,13 @@ Main>               (True # d) => ?now_4
 Main>  0 m : Type -> Type
  1 d : Door Open
    x : Integer
- 0 r : Res Bool (\r => (Door (if r then Open else Closed)))
+ 0 r : Res Bool (\r => Door (if r then Open else Closed))
 -------------------------------------
 now_2 : Use Many m ()
 Main>  0 m : Type -> Type
  1 d : Door Closed
    x : Integer
- 0 r : Res Bool (\r => (Door (if r then Open else Closed)))
+ 0 r : Res Bool (\r => Door (if r then Open else Closed))
 -------------------------------------
 now_3 : Use Many m ()
 Main> Bye for now!

--- a/tests/idris2/interactive011/expected
+++ b/tests/idris2/interactive011/expected
@@ -1,6 +1,6 @@
 1/1: Building IEdit (IEdit.idr)
-Main> natElim p x f 0 = x
-natElim p x f (S k) = f k (natElim p x f k)
+Main> natElim p y f 0 = y
+natElim p y f (S k) = f k (natElim p y f k)
 Main> f k (natElim2 p x f k)
 Main> listElim p mnil mcons [] = mnil
 listElim p mnil mcons (x :: xs) = mcons x xs (listElim p mnil mcons xs)

--- a/tests/idris2/interactive016/Cont.idr
+++ b/tests/idris2/interactive016/Cont.idr
@@ -1,0 +1,11 @@
+data Cont : (r : Type) -> (a : Type) -> Type where
+     MkCont : ((k : a -> r) -> r) -> Cont r a
+
+data ContT : (r : Type) -> (m : Type -> Type) -> (a : Type) -> Type where
+     MkContT : ((k : a -> m r) -> m r) -> ContT r m a
+
+cbind : Cont r a -> (a -> Cont r b) -> Cont r b
+
+ctbind : ContT r m a -> (a -> ContT r m b) -> ContT r m b
+
+callCC : ((a -> ContT r m b) -> ContT r m a) -> ContT r m a

--- a/tests/idris2/interactive016/expected
+++ b/tests/idris2/interactive016/expected
@@ -1,0 +1,5 @@
+1/1: Building Cont (Cont.idr)
+Main> cbind (MkCont g) f = MkCont (\k => g (\x => let MkCont f1 = f x in f1 k))
+Main> ctbind (MkContT g) f = MkContT (\k => g (\x => let MkContT f1 = f x in f1 k))
+Main> callCC f = MkContT (\k => let MkContT g = f (\x => MkContT (\g => k x)) in g k)
+Main> Bye for now!

--- a/tests/idris2/interactive016/input
+++ b/tests/idris2/interactive016/input
@@ -1,0 +1,4 @@
+:gd 7 cbind
+:gd 9 ctbind
+:gd 11 callCC
+:q

--- a/tests/idris2/interactive016/run
+++ b/tests/idris2/interactive016/run
@@ -1,0 +1,3 @@
+$1 --no-banner Cont.idr < input
+
+rm -rf build

--- a/tests/idris2/interactive017/RLE.idr
+++ b/tests/idris2/interactive017/RLE.idr
@@ -1,0 +1,95 @@
+module RLE
+
+import Decidable.Equality
+
+rep : Nat -> a -> List a
+
+data RunLength : List a -> Type where
+     Empty : RunLength []
+     Run : (n : Nat) -> (x : a) -> (rest : RunLength more) ->
+           RunLength (rep n x ++ more)
+
+data Singleton : a -> Type where
+     Val : (x : a) -> Singleton x
+
+uncompress : RunLength xs -> Singleton xs
+
+
+
+
+
+
+
+
+
+
+
+
+{-
+
+rle : DecEq a => (xs : List a) -> RLE xs
+rle [] = Empty
+rle (x :: xs) with (rle xs)
+  rle (x :: []) | Empty = Run 1 x Empty
+  rle (x :: (rep n y ++ more)) | (Run n y comp) with (decEq x y)
+    rle (y :: (rep n y ++ more)) | (Run n y comp) | (Yes Refl)
+        = Run (S n) y comp
+    rle (x :: (rep n y ++ more)) | (Run n y comp) | (No contra)
+        = Run 1 x $ Run n y comp
+
+data Singleton : a -> Type where
+     Val : (x : a) -> Singleton x
+
+uncompress : RLE xs -> Singleton xs
+
+-- uncompress Empty = Val []
+-- uncompress (Run n x comp)
+--     = let Val rec = uncompress comp in
+--           Val (rep n x ++ rec)
+
+uncompressHelp : (x : a) -> RLE more -> (n : Nat) -> Singleton more -> Singleton (rep n x ++ more)
+uncompressHelp x comp n (Val _) = Val (rep n x ++ more)
+
+uncompress' : RLE xs -> Singleton xs
+uncompress' Empty = Val []
+uncompress' (Run n x comp)
+    = let rec = uncompress' comp in
+          uncompressHelp x comp n rec
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+{-
+rle [] = Empty
+rle (x :: xs) with (rle xs)
+  rle (x :: []) | Empty = Run 1 x Empty
+  rle (x :: (rep n y ++ more)) | (Run n y comp) with (decEq x y)
+    rle (y :: (rep n y ++ more)) | (Run n y comp) | (Yes Refl)
+        = Run (S n) y comp
+    rle (x :: (rep n y ++ more)) | (Run n y comp) | (No contra)
+        = Run 1 x $ Run n y comp
+
+uncompress Empty = Val []
+uncompress (Run n x comp)
+   = let Val uncomp = uncompress comp in
+         Val (rep n x ++ uncomp)
+-}
+-}

--- a/tests/idris2/interactive017/expected
+++ b/tests/idris2/interactive017/expected
@@ -1,0 +1,4 @@
+1/1: Building RLE (RLE.idr)
+RLE> uncompress Empty = Val []
+uncompress (Run n x rest) = let Val ys = uncompress rest in Val (rep n x ++ ys)
+RLE> Bye for now!

--- a/tests/idris2/interactive017/input
+++ b/tests/idris2/interactive017/input
@@ -1,0 +1,2 @@
+:gd 15 uncompress
+:q

--- a/tests/idris2/interactive017/run
+++ b/tests/idris2/interactive017/run
@@ -1,0 +1,3 @@
+$1 --no-banner RLE.idr < input
+
+rm -rf build

--- a/tests/idris2/literate006/expected
+++ b/tests/idris2/literate006/expected
@@ -5,13 +5,13 @@ Main> >               (True # d) => ?now_4
 Main>  0 m : Type -> Type
  1 d : Door Open
    x : Integer
- 0 r : Res Bool (\r => (Door (if r then Open else Closed)))
+ 0 r : Res Bool (\r => Door (if r then Open else Closed))
 -------------------------------------
 now_2 : Use Many m ()
 Main>  0 m : Type -> Type
  1 d : Door Closed
    x : Integer
- 0 r : Res Bool (\r => (Door (if r then Open else Closed)))
+ 0 r : Res Bool (\r => Door (if r then Open else Closed))
 -------------------------------------
 now_3 : Use Many m ()
 Main> Bye for now!

--- a/tests/idris2/literate008/expected
+++ b/tests/idris2/literate008/expected
@@ -1,6 +1,6 @@
 1/1: Building IEdit (IEdit.lidr)
-Main> > natElim p x f 0 = x
-> natElim p x f (S k) = f k (natElim p x f k)
+Main> > natElim p y f 0 = y
+> natElim p y f (S k) = f k (natElim p y f k)
 Main> f k (natElim2 p x f k)
 Main> > listElim p mnil mcons [] = mnil
 > listElim p mnil mcons (x :: xs) = mcons x xs (listElim p mnil mcons xs)

--- a/tests/idris2/pkg005/expected
+++ b/tests/idris2/pkg005/expected
@@ -1,7 +1,7 @@
 1/1: Building Foo (Foo.idr)
 Foo> Foo.hi : IO String
-Foo> MkIO (\1 w => (MkIORes "Hi!" w))
+Foo> MkIO (\1 w => MkIORes "Hi!" w)
 Foo> Bye for now!
 Foo> Foo.hi : IO String
-Foo> MkIO (\1 w => (MkIORes "Hi!" w))
+Foo> MkIO (\1 w => MkIORes "Hi!" w)
 Foo> Bye for now!


### PR DESCRIPTION
This has involved quite a bit of reorganisation and some improvements in
resugaring so that the results look nice. In summary:

* Expression search now gives back a RawImp rather than a checked term,
  which allows it to include case expressions
* Case with one pattern is resugared to a destructuring let
* Some name generation issues address in function generation

We look at intermediate results for local variables which are functions
that return a concrete type, or recursive calls that return a single
constructor type. In these cases, we:

* let bind the local variable/recursive call
* generate a new definition for the scope, as a 'case' function

When we recursively generate the definition, it's a bit more restricted
so as not to explode the search space. We only take the first result, we
only look one constructor deep, and we go right to left on variable
splitting so only deconstruct the name we've just added.