### PR TITLE
Implement HasIO for StateT

### DIFF
--- a/libs/base/Control/Monad/State.idr
+++ b/libs/base/Control/Monad/State.idr
@@ -58,6 +58,10 @@ implementation (Monad f, Alternative f) => Alternative (StateT st f) where
     empty = lift empty
     (ST f) <|> (ST g) = ST (\st => f st <|> g st)
 
+public export
+implementation HasIO m => HasIO (StateT stateType m) where
+  liftIO io = ST $ \s => liftIO $ io_bind io $ \a => pure (a, s)
+
 ||| Apply a function to modify the context of this computation
 public export
 modify : MonadState stateType m => (stateType -> stateType) -> m ()


### PR DESCRIPTION
It requires a slightly more convoluted implementation, because of `liftIO`'s linear type.

It might make sense to export a linear `io_map : (a -> b) -> (1 _ : IO a) -> IO b` from `PrimIO`, similarly to `io_bind` -- it would make things like this a little nicer to write.