### PR TITLE
add prim__getNullAnyPtr and prim__castPtr

### DIFF
--- a/libs/prelude/PrimIO.idr
+++ b/libs/prelude/PrimIO.idr
@@ -89,6 +89,14 @@ schemeCall ret fn args = fromPrim (prim__schemeCall ret fn args)
 export
 prim__nullAnyPtr : AnyPtr -> Int
 
+%foreign "C:idris2_getNull,libidris2_support"
+export
+prim__getNullAnyPtr : AnyPtr
+
+%foreign "C:idris2_getNull,libidris2_support"
+export
+prim__getNullString : Ptr String
+
 prim__forgetPtr : Ptr t -> AnyPtr
 prim__forgetPtr = believe_me
 

--- a/libs/prelude/PrimIO.idr
+++ b/libs/prelude/PrimIO.idr
@@ -93,10 +93,11 @@ prim__nullAnyPtr : AnyPtr -> Int
 export
 prim__getNullAnyPtr : AnyPtr
 
-%foreign "C:idris2_getNull,libidris2_support"
 export
-prim__getNullString : Ptr String
+prim__castPtr : AnyPtr -> Ptr t
+prim__castPtr = believe_me
 
+export
 prim__forgetPtr : Ptr t -> AnyPtr
 prim__forgetPtr = believe_me
 

--- a/support/c/idris_support.c
+++ b/support/c/idris_support.c
@@ -19,6 +19,10 @@ int idris2_isNull(void* ptr) {
     return (ptr == NULL);
 }
 
+void *idris2_getNull() {
+    return NULL;
+}
+
 char* idris2_getString(void *p) {
     return (char*)p;
 }

--- a/support/c/idris_support.h
+++ b/support/c/idris_support.h
@@ -3,6 +3,8 @@
 
 // Return non-zero if the pointer is null
 int idris2_isNull(void*);
+// Returns a NULL
+void *idris2_getNull();
 // Convert a Ptr String intro a String, assuming the string has been checked
 // to be non-null
 char* idris2_getString(void *p);


### PR DESCRIPTION
This will enable us to get null pointers in Idris2 so that we can pass
them on to other c methods. This is useful when creating FFI bindings
for other libraries that expect optional null pointers to be passed into
the arguments.

For example, the samples/FFI-readline code uses
nullString, a similar method to get a null pointer in Idris2.

https://github.com/idris-lang/Idris2/blob/3d53c2874b4dcfe8ca4b6687b384be261faf74d4/samples/FFI-readline/readline_glue/idris_readline.c#L32-L34

Note: I tried to implement a generic getNullPtr via

```idris
%foreign "C:idris2_getNull,libidris2_support"
export
prim__getNullPtr : Ptr t
```

But I kept getting an error saying:

`Uncaught error: PrimIO.idr:95:1--97:25:Can't pass argument of type Type  to foreign function`

So I just implemented one specific for `String`s.