### PR TITLE
Add BuildExpressionParser to contrib

### DIFF
--- a/libs/contrib/Data/String/BuildExpressionParser.idr
+++ b/libs/contrib/Data/String/BuildExpressionParser.idr
@@ -20,12 +20,8 @@ data Operator a = Infix (Parser (a -> a -> a)) Assoc
                 | Postfix (Parser (a -> a))
 
 public export
-LO : Type -> Type
-LO a = List (Operator a)
-
-public export
 OperatorTable : Type -> Type
-OperatorTable a = List (LO a)
+OperatorTable a = List (List (Operator a))
 
 public export
 BinaryOperator : Type -> Type
@@ -97,7 +93,7 @@ buildExpressionParser a operators simpleExpr =
     splitOp x (Prefix op) (rassoc, lassoc, nassoc, prefixx, postfix) = (rassoc, lassoc, nassoc, op :: prefixx, postfix)
     splitOp x (Postfix op) (rassoc, lassoc, nassoc, prefixx, postfix) = (rassoc, lassoc, nassoc, prefixx, op :: postfix)
 
-    makeParser : (a : Type) -> Parser a -> LO a -> Parser a
+    makeParser : (a : Type) -> Parser a -> List (Operator a) -> Parser a
     makeParser a term ops =
       let (rassoc,lassoc,nassoc
                ,prefixx,postfix) = foldr (splitOp a) ([],[],[],[],[]) ops

--- a/libs/contrib/Data/String/BuildExpressionParser.idr
+++ b/libs/contrib/Data/String/BuildExpressionParser.idr
@@ -1,0 +1,129 @@
+module Data.String.BuildExpressionParser
+
+import Control.Monad.Identity
+import Data.String.Parser
+
+fail : Monad m => String -> ParseT m a
+fail x = P $ \s => do pure $ Fail s.pos x
+
+public export
+data Assoc = AssocNone
+           | AssocLeft
+           | AssocRight
+
+public export
+data Operator a = Infix (Parser (a -> a -> a)) Assoc
+                | Prefix (Parser (a -> a))
+                | Postfix (Parser (a -> a))
+
+public export
+LO : Type -> Type
+LO a = List (Operator a)
+
+public export
+OperatorTable : Type -> Type
+OperatorTable a = List (LO a)
+
+public export
+BinaryOperator : Type -> Type
+BinaryOperator a = List (Parser (a -> a -> a))
+
+public export
+UnaryOperator : Type -> Type
+UnaryOperator a = List (Parser (a -> a))
+
+public export
+data Ops a = BinOp (BinaryOperator a) | UnOp (UnaryOperator a)
+
+public export
+ReturnType : Type -> Type
+ReturnType a = (BinaryOperator a, BinaryOperator a, BinaryOperator a, UnaryOperator a, UnaryOperator a)
+
+toParserBin : BinaryOperator a -> Parser (a -> a -> a)
+toParserBin [] = fail "couldn't create binary parser"
+toParserBin (x :: xs) = x <|> toParserBin xs
+
+toParserUn : UnaryOperator a -> Parser (a -> a)
+toParserUn [] = fail "couldn't create unary parser"
+toParserUn (x :: xs) = x <|> toParserUn xs
+
+ambigious : (assoc : String) -> (op : Parser (a -> a -> a)) -> Parser a
+ambigious assoc op = do op
+                        fail ("ambiguous use of a " ++ assoc ++ " associative operator")
+
+mutual
+  mkRassocP : (amLeft : Parser a) -> (amNon : Parser a) -> (rassocOp : Parser (a -> a -> a)) -> (termP : Parser a) -> (x : a) -> Parser a
+  mkRassocP amLeft amNon rassocOp termP x =
+   (do f <- rassocOp
+       y <- do z <- termP ; mkRassocP1 amLeft amNon rassocOp termP z
+       pure (f x y))
+   <|> (amLeft)
+   <|> (amNon)
+
+  mkRassocP1 : (amLeft : Parser a) -> (amNon : Parser a) -> (rassocOp : Parser (a -> a -> a)) -> (termP : Parser a) -> (x : a) -> Parser a
+  mkRassocP1 amLeft amNon rassocOp termP x = (mkRassocP amLeft amNon rassocOp termP x) <|> pure x
+
+mutual
+  mkLassocP : (amRight : Parser a) -> (amNon : Parser a) -> (lassocOp : Parser (a -> a -> a)) -> (termP : Parser a) -> (x : a) -> Parser a
+  mkLassocP amRight amNon lassocOp termP x =
+    (do f <- lassocOp
+        y <- termP
+        mkLassocP1 amRight amNon lassocOp termP (f x y))
+    <|> amRight
+    <|> amNon
+
+  mkLassocP1 : (amRight : Parser a) -> (amNon : Parser a) -> (lassocOp : Parser (a -> a -> a)) -> (termP : Parser a) -> (x : a) -> Parser a
+  mkLassocP1 amRight amNon lassocOp termP x = mkLassocP amRight amNon lassocOp termP x <|> pure x
+
+mkNassocP : (amRight : Parser a) -> (amLeft : Parser a) -> (amNon : Parser a) -> (nassocOp : Parser (a -> a -> a)) -> (termP : Parser a) -> (x : a) -> Parser a
+mkNassocP amRight amLeft amNon nassocOp termP x =
+  do f <- nassocOp
+     y <- termP
+     amRight <|> amLeft <|> amNon
+     pure (f x y)
+
+public export
+buildExpressionParser : (a : Type) -> OperatorTable a -> Parser a -> Parser a
+buildExpressionParser a operators simpleExpr =
+  foldl (makeParser a) simpleExpr operators
+  where
+    splitOp : (a : Type) -> Operator a -> ReturnType a -> ReturnType a
+    splitOp x (Infix op AssocNone) (rassoc, lassoc, nassoc, prefixx, postfix) = (rassoc, lassoc, op :: nassoc, prefixx, postfix)
+    splitOp x (Infix op AssocLeft) (rassoc, lassoc, nassoc, prefixx, postfix) = (rassoc, op :: lassoc, nassoc, prefixx, postfix)
+    splitOp x (Infix op AssocRight) (rassoc, lassoc, nassoc, prefixx, postfix) = (op :: rassoc, lassoc, nassoc, prefixx, postfix)
+    splitOp x (Prefix op) (rassoc, lassoc, nassoc, prefixx, postfix) = (rassoc, lassoc, nassoc, op :: prefixx, postfix)
+    splitOp x (Postfix op) (rassoc, lassoc, nassoc, prefixx, postfix) = (rassoc, lassoc, nassoc, prefixx, op :: postfix)
+
+    makeParser : (a : Type) -> Parser a -> LO a -> Parser a
+    makeParser a term ops =
+      let (rassoc,lassoc,nassoc
+               ,prefixx,postfix) = foldr (splitOp a) ([],[],[],[],[]) ops
+          rassocOp = toParserBin rassoc
+          lassocOp = toParserBin lassoc
+          nassocOp = toParserBin nassoc
+          prefixxOp = toParserUn prefixx
+          postfixOp = toParserUn postfix
+
+          amRight = ambigious "right" rassocOp
+          amLeft = ambigious "left" lassocOp
+          amNon = ambigious "non" nassocOp
+
+          prefixxP = prefixxOp <|> pure (\x => x)
+
+          postfixP = postfixOp <|> pure (\x => x)
+
+          termP = do pre <- prefixxP
+                     x <- term
+                     post <- postfixP
+                     pure (post (pre x))
+
+          rassocP = mkRassocP amLeft amNon rassocOp termP
+          rassocP1 = mkRassocP1 amLeft amNon rassocOp termP
+
+          lassocP = mkLassocP amRight amNon lassocOp termP
+          lassocP1 = mkLassocP1 amRight amNon lassocOp termP
+
+          nassocP = mkNassocP amRight amLeft amNon nassocOp termP
+          in
+          do x <- termP
+             rassocP x <|> lassocP  x <|> nassocP x <|> pure x <?> "operator"

--- a/libs/contrib/Data/String/BuildExpressionParser.idr
+++ b/libs/contrib/Data/String/BuildExpressionParser.idr
@@ -1,3 +1,6 @@
+-- Port of https://hackage.haskell.org/package/parsec-3.1.13.0/docs/Text-Parsec-Expr.html
+-- Original License	BSD-style: https://hackage.haskell.org/package/parsec-3.1.13.0/src/LICENSE
+
 module Data.String.BuildExpressionParser
 
 import Control.Monad.Identity

--- a/libs/contrib/Data/String/Parser.idr
+++ b/libs/contrib/Data/String/Parser.idr
@@ -194,16 +194,16 @@ digit = do x <- satisfy isDigit
                 Just y => P $ \s => Id (OK y s)
   where
     digits : List (Char, Fin 10)
-    digits = [ ('0', FZ)
-             , ('1', (FS (FZ)))
-             , ('2', (FS (FS (FZ))))
-             , ('3', (FS (FS (FS (FZ)))))
-             , ('4', (FS (FS (FS (FS (FZ))))))
-             , ('5', (FS (FS (FS (FS (FS (FZ)))))))
-             , ('6', (FS (FS (FS (FS (FS (FS (FZ))))))))
-             , ('7', (FS (FS (FS (FS (FS (FS (FS (FZ)))))))))
-             , ('8', (FS (FS (FS (FS (FS (FS (FS (FS (FZ))))))))))
-             , ('9', (FS (FS (FS (FS (FS (FS (FS (FS (FS (FZ)))))))))))
+    digits = [ ('0', 0)
+             , ('1', 1)
+             , ('2', 2)
+             , ('3', 3)
+             , ('4', 4)
+             , ('5', 5)
+             , ('6', 6)
+             , ('7', 7)
+             , ('8', 8)
+             , ('9', 9)
              ]
 
 export

--- a/libs/contrib/Data/String/Parser.idr
+++ b/libs/contrib/Data/String/Parser.idr
@@ -153,3 +153,33 @@ option def p = p <|> pure def
 export
 optional : Monad m => ParseT m a -> ParseT m (Maybe a)
 optional p = (p >>= \res => pure $ Just res) <|> pure Nothing
+
+||| Discards the result of a parser
+export
+skip : Parser a -> Parser ()
+skip = map (const ())
+
+||| Parses a space character
+export
+space : Parser Char
+space = satisfy isSpace
+
+||| Parses one or more space characters
+export
+spaces : Parser ()
+spaces = skip (many space) <?> "white space"
+
+||| Discards whitespace after a matching parser
+export
+lexeme : Parser a -> Parser a
+lexeme p = p <* spaces
+
+||| Matches a specific string, then skips following whitespace
+export
+token : String -> Parser ()
+token s = lexeme (skip (string s)) <?> "token " ++ show s
+
+||| Fail with some error message
+export
+fail : Monad m => String -> ParseT m a
+fail x = P $ \s => do pure $ Fail s.pos x

--- a/libs/contrib/Data/String/Parser/Expression.idr
+++ b/libs/contrib/Data/String/Parser/Expression.idr
@@ -1,7 +1,7 @@
 -- Port of https://hackage.haskell.org/package/parsec-3.1.13.0/docs/Text-Parsec-Expr.html
 -- Original License	BSD-style: https://hackage.haskell.org/package/parsec-3.1.13.0/src/LICENSE
 
-module Data.String.BuildExpressionParser
+module Data.String.Parser.Expression
 
 import Control.Monad.Identity
 import Data.String.Parser

--- a/libs/contrib/Data/String/Parser/Expression.idr
+++ b/libs/contrib/Data/String/Parser/Expression.idr
@@ -6,9 +6,6 @@ module Data.String.Parser.Expression
 import Control.Monad.Identity
 import Data.String.Parser
 
-fail : Monad m => String -> ParseT m a
-fail x = P $ \s => do pure $ Fail s.pos x
-
 public export
 data Assoc = AssocNone
            | AssocLeft

--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -41,7 +41,7 @@ modules = Control.ANSI,
           Data.String.Extra,
           Data.String.Interpolation,
           Data.String.Parser,
-          Data.String.BuildExpressionParser,
+          Data.String.Parser.Expression,
 
           Data.Vect.Sort,
 

--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -41,6 +41,7 @@ modules = Control.ANSI,
           Data.String.Extra,
           Data.String.Interpolation,
           Data.String.Parser,
+          Data.String.BuildExpressionParser,
 
           Data.Vect.Sort,
 

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -125,7 +125,7 @@ chezTests
       "chez007", "chez008", "chez009", "chez010", "chez011", "chez012",
       "chez013", "chez014", "chez015", "chez016", "chez017", "chez018",
       "chez019", "chez020", "chez021", "chez022", "chez023", "chez024",
-      "chez025", "chez026", "chez027",
+      "chez025", "chez026", "chez027", "chez028",
       "reg001"]
 
 nodeTests : List String

--- a/tests/chez/chez028/ExpressionParser.idr
+++ b/tests/chez/chez028/ExpressionParser.idr
@@ -1,0 +1,79 @@
+module Main
+
+import Control.Monad.Identity
+import Control.Monad.Trans
+
+import Data.Maybe
+import Data.Fin
+import Data.Nat
+import Data.String.Parser
+import Data.String.BuildExpressionParser
+
+%default partial
+
+addDigit : Nat -> Nat -> Nat
+addDigit num d = 10*num + d
+
+fromDigits : List Nat -> Nat
+fromDigits xs = foldl addDigit 0 xs
+
+digit : Parser Nat
+digit = do x <- satisfy isDigit
+           case fromChar x of
+                Nothing => P $ \s => do pure $ Fail s.pos "not a digit"
+                Just y => P $ \s => Id (OK y s)
+  where fromChar : Char -> Maybe Nat
+        fromChar '0' = Just 0
+        fromChar '1' = Just 1
+        fromChar '2' = Just 2
+        fromChar '3' = Just 3
+        fromChar '4' = Just 4
+        fromChar '5' = Just 5
+        fromChar '6' = Just 6
+        fromChar '7' = Just 7
+        fromChar '8' = Just 8
+        fromChar '9' = Just 9
+        fromChar _ = Nothing
+
+natural : Parser Nat
+natural = do x <- some digit
+             pure (fromDigits x)
+
+skip : Parser a -> Parser ()
+skip = map (const ())
+
+space : Parser Char
+space = satisfy isSpace
+
+spaces : Parser ()
+spaces = skip (many space) <?> "white space"
+
+lexeme : Parser a -> Parser a
+lexeme p = p <* spaces
+
+token : String -> Parser ()
+token s = lexeme (skip (string s)) <?> "token " ++ show s
+
+table : OperatorTable Nat
+table =
+  [ [Infix (do token "^"; pure (power) ) AssocRight]
+  , [Infix (do token "*"; pure (*) ) AssocLeft]
+  , [Infix (do token "+"; pure (+) ) AssocLeft]]
+
+mutual
+  term : Parser Nat
+  term = (natural <|> expr) <* spaces
+         <?> "simple expression"
+
+  expr : Parser Nat
+  expr = buildExpressionParser Nat table term
+
+showRes : Show a => Either String (a, Int) -> IO ()
+showRes res = case res of
+                Left err => putStrLn err
+                Right (xs, rem) => printLn xs
+
+main : IO ()
+main = do showRes (parse natural "5678")
+          showRes (parse expr "1 + 2 * 3")
+          showRes (parse expr "1+4^3^2^1")

--- a/tests/chez/chez028/ExpressionParser.idr
+++ b/tests/chez/chez028/ExpressionParser.idr
@@ -7,7 +7,7 @@ import Data.Maybe
 import Data.Fin
 import Data.Nat
 import Data.String.Parser
-import Data.String.BuildExpressionParser
+import Data.String.Parser.Expression
 
 %default partial
 

--- a/tests/chez/chez028/ExpressionParser.idr
+++ b/tests/chez/chez028/ExpressionParser.idr
@@ -39,21 +39,6 @@ natural : Parser Nat
 natural = do x <- some digit
              pure (fromDigits x)
 
-skip : Parser a -> Parser ()
-skip = map (const ())
-
-space : Parser Char
-space = satisfy isSpace
-
-spaces : Parser ()
-spaces = skip (many space) <?> "white space"
-
-lexeme : Parser a -> Parser a
-lexeme p = p <* spaces
-
-token : String -> Parser ()
-token s = lexeme (skip (string s)) <?> "token " ++ show s
-
 table : OperatorTable Nat
 table =
   [ [Infix (do token "^"; pure (power) ) AssocRight]

--- a/tests/chez/chez028/ExpressionParser.idr
+++ b/tests/chez/chez028/ExpressionParser.idr
@@ -12,8 +12,19 @@ import Data.String.Parser.Expression
 table : OperatorTable Nat
 table =
   [ [Infix (do token "^"; pure (power) ) AssocRight]
-  , [Infix (do token "*"; pure (*) ) AssocLeft]
-  , [Infix (do token "+"; pure (+) ) AssocLeft]]
+  , [ Infix (do token "*"; pure (*) ) AssocLeft ]
+  , [ Infix (do token "+"; pure (+) ) AssocLeft ]
+  ]
+
+table' : OperatorTable Integer
+table' =
+  [ [ Infix (do token "*"; pure (*) ) AssocLeft
+    , Infix (do token "/"; pure (div) ) AssocLeft
+    ]
+  , [ Infix (do token "+"; pure (+) ) AssocLeft
+    , Infix (do token "-"; pure (-) ) AssocLeft
+    ]
+  ]
 
 mutual
   term : Parser Nat
@@ -23,6 +34,14 @@ mutual
   expr : Parser Nat
   expr = buildExpressionParser Nat table term
 
+mutual
+  term' : Parser Integer
+  term' = (integer <|> expr') <* spaces
+         <?> "simple expression"
+
+  expr' : Parser Integer
+  expr' = buildExpressionParser Integer table' term'
+
 showRes : Show a => Either String (a, Int) -> IO ()
 showRes res = case res of
                 Left err => putStrLn err
@@ -30,5 +49,7 @@ showRes res = case res of
 
 main : IO ()
 main = do showRes (parse natural "5678")
-          showRes (parse expr "1 + 2 * 3")
+          showRes (parse integer "-3")
           showRes (parse expr "1+4^3^2^1")
+          showRes (parse expr' "4 + 2 * 3")
+          showRes (parse expr' "13-3+1*2-10/2")

--- a/tests/chez/chez028/ExpressionParser.idr
+++ b/tests/chez/chez028/ExpressionParser.idr
@@ -3,41 +3,11 @@ module Main
 import Control.Monad.Identity
 import Control.Monad.Trans
 
-import Data.Maybe
-import Data.Fin
 import Data.Nat
 import Data.String.Parser
 import Data.String.Parser.Expression
 
 %default partial
-
-addDigit : Nat -> Nat -> Nat
-addDigit num d = 10*num + d
-
-fromDigits : List Nat -> Nat
-fromDigits xs = foldl addDigit 0 xs
-
-digit : Parser Nat
-digit = do x <- satisfy isDigit
-           case fromChar x of
-                Nothing => P $ \s => do pure $ Fail s.pos "not a digit"
-                Just y => P $ \s => Id (OK y s)
-  where fromChar : Char -> Maybe Nat
-        fromChar '0' = Just 0
-        fromChar '1' = Just 1
-        fromChar '2' = Just 2
-        fromChar '3' = Just 3
-        fromChar '4' = Just 4
-        fromChar '5' = Just 5
-        fromChar '6' = Just 6
-        fromChar '7' = Just 7
-        fromChar '8' = Just 8
-        fromChar '9' = Just 9
-        fromChar _ = Nothing
-
-natural : Parser Nat
-natural = do x <- some digit
-             pure (fromDigits x)
 
 table : OperatorTable Nat
 table =

--- a/tests/chez/chez028/expected
+++ b/tests/chez/chez028/expected
@@ -1,0 +1,5 @@
+5678
+7
+262145
+1/1: Building ExpressionParser (ExpressionParser.idr)
+Main> Main> Bye for now!

--- a/tests/chez/chez028/expected
+++ b/tests/chez/chez028/expected
@@ -1,5 +1,7 @@
 5678
-7
+-3
 262145
+10
+7
 1/1: Building ExpressionParser (ExpressionParser.idr)
 Main> Main> Bye for now!

--- a/tests/chez/chez028/input
+++ b/tests/chez/chez028/input
@@ -1,0 +1,2 @@
+:exec main
+:q

--- a/tests/chez/chez028/run
+++ b/tests/chez/chez028/run
@@ -1,0 +1,3 @@
+$1 --no-banner -p contrib ExpressionParser.idr < input
+
+rm -rf build


### PR DESCRIPTION
Idris port of haskell's [`BuildExpressionParser`](https://hackage.haskell.org/package/parsec-3.1.13.0/docs/Text-Parsec-Expr.html). I figured with the parser combinators in contrib this might be a useful addition, but I'm not sure what the rules are for what ends up in contrib so feel free to close this PR if it's not relevant.

Also this is my first attempt at idris2, so I may have gotten a lot of stuff wrong, and I may have gone overboard with the `public export`s. The test seems reasonable but could probably be improved upon, plus I had to add a few combinators just to test (`natural`, `token`...) which maybe don't belong in the test file. Open to any feedback on how to improve this anyway. 