### PR TITLE
Fix Preorder reasoning 

### DIFF
--- a/libs/contrib/Syntax/PreorderReasoning.idr
+++ b/libs/contrib/Syntax/PreorderReasoning.idr
@@ -24,7 +24,7 @@ data FastDerivation : (x : a) -> (y : b) -> Type where
 public export 
 Calc : {x : a} -> {y : b} -> FastDerivation x y -> x ~=~ y
 Calc (|~ x) = Refl
-Calc {y} ((~~) {z=_} {y=_} der (_ ** Refl)) = Calc der
+Calc ((~~) {z=_} {y=_} der (_ ** Refl)) = Calc der
 
 {- -- requires import Data.Nat
 0

--- a/libs/contrib/Syntax/PreorderReasoning.idr
+++ b/libs/contrib/Syntax/PreorderReasoning.idr
@@ -19,12 +19,12 @@ public export
 public export
 data FastDerivation : (x : a) -> (y : b) -> Type where
   (|~) : (x : a) -> FastDerivation x x
-  (~~) : FastDerivation x y -> (step : (z : c ** y ~=~ z)) -> FastDerivation x z
+  (~~) : FastDerivation x y -> (step : (z : c ** y ~=~ z)) -> FastDerivation x (fst step)
   
 public export 
 Calc : {x : a} -> {y : b} -> FastDerivation x y -> x ~=~ y
 Calc (|~ x) = Refl
-Calc {y} ((~~) {z=y} {y=y} der (y ** Refl)) = Calc der
+Calc {y} ((~~) {z=_} {y=_} der (_ ** Refl)) = Calc der
 
 {- -- requires import Data.Nat
 0


### PR DESCRIPTION
Fix the `contrib:Syntax.PreorderReasoning` error from #536 (there's still a bug in idris that `PreorderReasning` no longer exposes).

Correct the dependency in `FastDerivation` to use the RHS in `step`
Try to avoid shadowing `y` in the LHS of `Calc`

I've pushed this through frex, too, if that's a measure for anything
