### PR TITLE
Fix repeated argument check

### DIFF
--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -104,7 +104,7 @@ idrisTests
        "reg008", "reg009", "reg010", "reg011", "reg012", "reg013", "reg014",
        "reg015", "reg016", "reg017", "reg018", "reg019", "reg020", "reg021",
        "reg022", "reg023", "reg024", "reg025", "reg026", "reg027", "reg028",
-       "reg029", "reg030", "reg031", "reg032", "reg033",
+       "reg029", "reg030", "reg031", "reg032", "reg033", "reg034",
        -- Totality checking
        "total001", "total002", "total003", "total004", "total005",
        "total006", "total007", "total008", "total009",

--- a/tests/idris2/reg034/expected
+++ b/tests/idris2/reg034/expected
@@ -1,0 +1,6 @@
+1/1: Building void (void.idr)
+void.idr:18:19--18:20:While processing left hand side of Calc at void.idr:18:1--20:1:
+Can't match on ?y [no locals in scope] (Non linear pattern variable) at
+18	Calc {y} ((~~) {z=y} {y=y} der (MkDPair y Refl)) = Calc der
+	                  ^
+

--- a/tests/idris2/reg034/run
+++ b/tests/idris2/reg034/run
@@ -1,0 +1,3 @@
+$1 --check void.idr
+
+rm -rf build

--- a/tests/idris2/reg034/void.idr
+++ b/tests/idris2/reg034/void.idr
@@ -1,0 +1,21 @@
+infixl 0  ~~
+prefix 1  |~
+infix  1  ...
+
+public export
+(...) : (x : a) -> (y ~=~ x) -> (z : a ** y ~=~ z)
+(...) x pf = (x ** pf)
+
+public export
+data FastDerivation : (x : a) -> (y : b) -> Type where
+  (|~) : (x : a) -> FastDerivation x x
+  (~~) : FastDerivation x y ->
+         (step : (z : c ** y ~=~ z)) -> FastDerivation x z
+
+public export
+Calc : {x : a} -> {y : b} -> FastDerivation x y -> x = y
+Calc (|~ x) = Refl
+Calc {y} ((~~) {z=y} {y=y} der (MkDPair y Refl)) = Calc der
+
+bad : Z = S Z
+bad = Calc $ |~ Z ~~ Z ...(Refl)


### PR DESCRIPTION
As it was, it could break if the argument was repeated more than twice.
When checking dot patterns, we need to check that no further holes are
solved, and that the pattern variable doesn't unify with some other
pattern variable, but if it had already made progress (either for a good
or bad reason) we missed this. Fixes #536