### PR TITLE
Split CFUnsigned into 8/16/32/64 bits versions

### DIFF
--- a/src/Compiler/CompileExpr.idr
+++ b/src/Compiler/CompileExpr.idr
@@ -506,10 +506,10 @@ getNArgs defs n args = pure $ User n args
 nfToCFType : {auto c : Ref Ctxt Defs} ->
              FC -> (inStruct : Bool) -> NF [] -> Core CFType
 nfToCFType _ _ (NPrimVal _ IntType) = pure CFInt
-nfToCFType _ _ (NPrimVal _ Bits8Type) = pure CFUnsigned
-nfToCFType _ _ (NPrimVal _ Bits16Type) = pure CFUnsigned
-nfToCFType _ _ (NPrimVal _ Bits32Type) = pure CFUnsigned
-nfToCFType _ _ (NPrimVal _ Bits64Type) = pure CFUnsigned
+nfToCFType _ _ (NPrimVal _ Bits8Type) = pure CFUnsigned8
+nfToCFType _ _ (NPrimVal _ Bits16Type) = pure CFUnsigned16
+nfToCFType _ _ (NPrimVal _ Bits32Type) = pure CFUnsigned32
+nfToCFType _ _ (NPrimVal _ Bits64Type) = pure CFUnsigned64
 nfToCFType _ False (NPrimVal _ StringType) = pure CFString
 nfToCFType fc True (NPrimVal _ StringType)
     = throw (GenericMsg fc "String not allowed in a foreign struct")

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -167,7 +167,10 @@ data Structs : Type where
 cftySpec : FC -> CFType -> Core String
 cftySpec fc CFUnit = pure "void"
 cftySpec fc CFInt = pure "int"
-cftySpec fc CFUnsigned = pure "unsigned"
+cftySpec fc CFUnsigned8 = pure "unsigned-8"
+cftySpec fc CFUnsigned16 = pure "unsigned-16"
+cftySpec fc CFUnsigned32 = pure "unsigned-32"
+cftySpec fc CFUnsigned64 = pure "unsigned-64"
 cftySpec fc CFString = pure "string"
 cftySpec fc CFDouble = pure "double"
 cftySpec fc CFChar = pure "char"

--- a/src/Compiler/Scheme/Gambit.idr
+++ b/src/Compiler/Scheme/Gambit.idr
@@ -142,7 +142,10 @@ cType fc t = throw (GenericMsg fc ("Can't pass argument of type " ++ show t ++
 cftySpec : FC -> CFType -> Core String
 cftySpec fc CFUnit = pure "void"
 cftySpec fc CFInt = pure "int"
-cftySpec fc CFUnsigned = pure "unsigned-int"
+cftySpec fc CFUnsigned8 = pure "unsigned-char"
+cftySpec fc CFUnsigned16 = pure "unsigned-short"
+cftySpec fc CFUnsigned32 = pure "unsigned-int"
+cftySpec fc CFUnsigned64 = pure "unsigned-long"
 cftySpec fc CFString = pure "UTF-8-string"
 cftySpec fc CFDouble = pure "double"
 cftySpec fc CFChar = pure "char"

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -109,7 +109,10 @@ data Done : Type where
 cftySpec : FC -> CFType -> Core String
 cftySpec fc CFUnit = pure "_void"
 cftySpec fc CFInt = pure "_int"
-cftySpec fc CFUnsigned = pure "_uint"
+cftySpec fc CFUnsigned8 = pure "_uint8"
+cftySpec fc CFUnsigned16 = pure "_uint16"
+cftySpec fc CFUnsigned32 = pure "_uint32"
+cftySpec fc CFUnsigned64 = pure "_uint64"
 cftySpec fc CFString = pure "_string/utf-8"
 cftySpec fc CFDouble = pure "_double"
 cftySpec fc CFChar = pure "_int8"

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -30,7 +30,7 @@ import Data.Buffer
 -- TTC files can only be compatible if the version number is the same
 export
 ttcVersion : Int
-ttcVersion = 38
+ttcVersion = 39
 
 export
 checkTTCVersion : String -> Int -> Int -> Core ()

--- a/src/Core/CompileExpr.idr
+++ b/src/Core/CompileExpr.idr
@@ -111,7 +111,10 @@ public export
 data CFType : Type where
      CFUnit : CFType
      CFInt : CFType
-     CFUnsigned : CFType
+     CFUnsigned8 : CFType
+     CFUnsigned16 : CFType
+     CFUnsigned32 : CFType
+     CFUnsigned64 : CFType
      CFString : CFType
      CFDouble : CFType
      CFChar : CFType
@@ -293,7 +296,10 @@ export
 Show CFType where
   show CFUnit = "Unit"
   show CFInt = "Int"
-  show CFUnsigned = "Bits_n"
+  show CFUnsigned8 = "Bits_8"
+  show CFUnsigned16 = "Bits_16"
+  show CFUnsigned32 = "Bits_32"
+  show CFUnsigned64 = "Bits_64"
   show CFString = "String"
   show CFDouble = "Double"
   show CFChar = "Char"

--- a/src/Core/TTC.idr
+++ b/src/Core/TTC.idr
@@ -675,35 +675,41 @@ export
 TTC CFType where
   toBuf b CFUnit = tag 0
   toBuf b CFInt = tag 1
-  toBuf b CFUnsigned = tag 2
-  toBuf b CFString = tag 3
-  toBuf b CFDouble = tag 4
-  toBuf b CFChar = tag 5
-  toBuf b CFPtr = tag 6
-  toBuf b CFWorld = tag 7
-  toBuf b (CFFun s t) = do tag 8; toBuf b s; toBuf b t
-  toBuf b (CFIORes t) = do tag 9; toBuf b t
-  toBuf b (CFStruct n a) = do tag 10; toBuf b n; toBuf b a
-  toBuf b (CFUser n a) = do tag 11; toBuf b n; toBuf b a
-  toBuf b CFGCPtr = tag 12
-  toBuf b CFBuffer = tag 13
+  toBuf b CFUnsigned8 = tag 2
+  toBuf b CFUnsigned16 = tag 3
+  toBuf b CFUnsigned32 = tag 4
+  toBuf b CFUnsigned64 = tag 5
+  toBuf b CFString = tag 6
+  toBuf b CFDouble = tag 7
+  toBuf b CFChar = tag 8
+  toBuf b CFPtr = tag 9
+  toBuf b CFWorld = tag 10
+  toBuf b (CFFun s t) = do tag 11; toBuf b s; toBuf b t
+  toBuf b (CFIORes t) = do tag 12; toBuf b t
+  toBuf b (CFStruct n a) = do tag 13; toBuf b n; toBuf b a
+  toBuf b (CFUser n a) = do tag 14; toBuf b n; toBuf b a
+  toBuf b CFGCPtr = tag 15
+  toBuf b CFBuffer = tag 16
 
   fromBuf b
       = case !getTag of
              0 => pure CFUnit
              1 => pure CFInt
-             2 => pure CFUnsigned
-             3 => pure CFString
-             4 => pure CFDouble
-             5 => pure CFChar
-             6 => pure CFPtr
-             7 => pure CFWorld
-             8 => do s <- fromBuf b; t <- fromBuf b; pure (CFFun s t)
-             9 => do t <- fromBuf b; pure (CFIORes t)
-             10 => do n <- fromBuf b; a <- fromBuf b; pure (CFStruct n a)
-             11 => do n <- fromBuf b; a <- fromBuf b; pure (CFUser n a)
-             12 => pure CFGCPtr
-             13 => pure CFBuffer
+             2 => pure CFUnsigned8
+             3 => pure CFUnsigned16
+             4 => pure CFUnsigned32
+             5 => pure CFUnsigned64
+             6 => pure CFString
+             7 => pure CFDouble
+             8 => pure CFChar
+             9 => pure CFPtr
+             10 => pure CFWorld
+             11 => do s <- fromBuf b; t <- fromBuf b; pure (CFFun s t)
+             12 => do t <- fromBuf b; pure (CFIORes t)
+             13 => do n <- fromBuf b; a <- fromBuf b; pure (CFStruct n a)
+             14 => do n <- fromBuf b; a <- fromBuf b; pure (CFUser n a)
+             15 => pure CFGCPtr
+             16 => pure CFBuffer
              _ => corrupt "CFType"
 
 export


### PR DESCRIPTION
This should fix #549, as well as other potential problems caused by Bits8, Bits16 and Bits64 being treated as Bits32 for foreign functions.

Needs a review by someone who understands the bigger picture, particularly in relation to `TTC.idr` as it is entirely unclear to me what that does.