### PR TITLE
rename parsePositive, refine docs

### DIFF
--- a/libs/base/Data/Strings.idr
+++ b/libs/base/Data/Strings.idr
@@ -215,17 +215,20 @@ parseNumWithoutSign (c :: cs) acc =
   then parseNumWithoutSign cs ((acc * 10) + (cast ((ord c) - (ord '0'))))
   else Nothing
 
-||| Convert a positive number string to a Num.
+||| Convert a natural number string to a Num.
 |||
 ||| ```idris example
-||| parsePositive "123"
+||| parseNatural "123"
 ||| ```
 ||| ```idris example
-||| parsePositive {a=Int} " +123"
+||| parseNatural {a=Int} " +123"
+||| ```
+||| ```idris example
+||| parseNatural {a=Int} "0"
 ||| ```
 public export
-parsePositive : Num a => String -> Maybe a
-parsePositive s = parsePosTrimmed (trim s)
+parseNatural : Num a => String -> Maybe a
+parseNatural s = parsePosTrimmed (trim s)
   where
     parsePosTrimmed : String -> Maybe a
     parsePosTrimmed s with (strM s)
@@ -237,7 +240,7 @@ parsePositive s = parsePosTrimmed (trim s)
         then  map fromInteger (parseNumWithoutSign (unpack xs)  (cast (ord x - ord '0')))
         else Nothing
 
-||| Convert a number string to a Num.
+||| Convert an integer string to a Num.
 |||
 ||| ```idris example
 ||| parseInteger " 123"
@@ -262,7 +265,7 @@ parseInteger s = parseIntTrimmed (trim s)
               else Nothing
 
 
-||| Convert a number string to a Double.
+||| Convert a floating-point string to a Double.
 |||
 ||| ```idris example
 ||| parseDouble "+123.123e-2"

--- a/src/Idris/CommandLine.idr
+++ b/src/Idris/CommandLine.idr
@@ -112,7 +112,7 @@ ideSocketModeAddress : List CLOpt -> (String, Int)
 ideSocketModeAddress []  = ("localhost", 38398)
 ideSocketModeAddress (IdeModeSocket hp :: _) =
   let (h, p) = Strings.break (== ':') hp
-      port = fromMaybe 38398 (portPart p >>= parsePositive)
+      port = fromMaybe 38398 (portPart p >>= parseNatural)
       host = if h == "" then "localhost" else h
   in (host, port)
   where


### PR DESCRIPTION
I don't know how bad it would be to change it now, but `parsePositive` is incorrect name ...
Also clarified what kind of numbers are meant in `parsePositive`, `parseInteger` and `parseDouble`

We could correct the behaviour of `parsePositive` and introduce `parseNatural` independently if changing names is too big of a deal.

Had to rename one use of `parsePositive` in compiler