### PR TITLE
contrib: Add a 2-holed congruence function

### DIFF
--- a/libs/contrib/Syntax/PreorderReasoning.idr
+++ b/libs/contrib/Syntax/PreorderReasoning.idr
@@ -27,7 +27,7 @@ Calc (|~ x) = Refl
 Calc ((~~) {z=_} {y=_} der (_ ** Refl)) = Calc der
 
 ||| Two-holed congruence
-export 0
+export
 -- These are natural in equational reasoning, less so when rewriting,
 -- so that's why it's here.
 cong2 : (f : t -> s -> u) -> a = b -> c = d -> f a c = f b d

--- a/libs/contrib/Syntax/PreorderReasoning.idr
+++ b/libs/contrib/Syntax/PreorderReasoning.idr
@@ -26,6 +26,13 @@ Calc : {x : a} -> {y : b} -> FastDerivation x y -> x ~=~ y
 Calc (|~ x) = Refl
 Calc ((~~) {z=_} {y=_} der (_ ** Refl)) = Calc der
 
+||| Two-holed congruence
+export 0
+-- These are natural in equational reasoning, less so when rewriting,
+-- so that's why it's here.
+cong2 : (f : t -> s -> u) -> a = b -> c = d -> f a c = f b d
+cong2 f Refl Refl = Refl
+
 {- -- requires import Data.Nat
 0
 example : (x : Nat) -> (x + 1) + 0 = 1 + x


### PR DESCRIPTION
For lack of a better place, I've put it in `Syntax.PreorderReasoning`

These equations are natural in equational reasoning, but less so when
rewriting, so that's why it's there