### PR TITLE
Fix returned sexp for make-lemma command result in IDE mode

### DIFF
--- a/src/Idris/IDEMode/REPL.idr
+++ b/src/Idris/IDEMode/REPL.idr
@@ -360,7 +360,10 @@ displayIDEResult outf i (REPL $ Edited (EditError x))
   = printIDEError outf i x
 displayIDEResult outf i (REPL $ Edited (MadeLemma lit name pty pappstr))
   = printIDEResult outf i
-  $ StringAtom $ (relit lit $ show name ++ " : " ++ show pty ++ "\n") ++ pappstr
+  $ SExpList [ SymbolAtom "metavariable-lemma"
+             , SExpList [ SymbolAtom "replace-metavariable", StringAtom pappstr ]
+             , SExpList [ SymbolAtom "definition-type", StringAtom $ relit lit $ show name ++ " : " ++ show pty ]
+             ]
 displayIDEResult outf i (REPL $ Edited (MadeWith lit wapp))
   = printIDEResult outf i
   $ StringAtom $ showSep "\n" (map (relit lit) wapp)


### PR DESCRIPTION
the returned structure is inline with what Emacs idris-mode expects, so this fix allows using `C-c C-e` on a hole and get it lifted as a toplevel definition