### PR TITLE
Windows color fix

### DIFF
--- a/src/Idris/Driver.idr
+++ b/src/Idris/Driver.idr
@@ -28,6 +28,7 @@ import System
 import System.Directory
 import System.File
 import Utils.Path
+import Utils.Term
 
 import Yaffle.Main
 
@@ -233,9 +234,9 @@ mainWithCodegens cgs = do Right opts <- getCmdOpts
                                              putStrLn usage
                           continue <- quitOpts opts
                           if continue
-                              then
-                                  coreRun (stMain cgs opts)
-                                    (\err : Error => do putStrLn ("Uncaught error: " ++ show err)
-                                                        exitWith (ExitFailure 1))
-                                    (\res => pure ())
+                              then do setupTerm
+                                      coreRun (stMain cgs opts)
+                                        (\err : Error => do putStrLn ("Uncaught error: " ++ show err)
+                                                            exitWith (ExitFailure 1))
+                                        (\res => pure ())
                               else pure ()

--- a/src/Utils/Term.idr
+++ b/src/Utils/Term.idr
@@ -7,11 +7,18 @@ import System.FFI
 libterm : String -> String
 libterm s = "C:" ++ s ++ ", libidris2_support"
 
+%foreign libterm "idris2_setupTerm"
+prim__setupTerm : PrimIO ()
+
 %foreign libterm "idris2_getTermCols"
 prim__getTermCols : PrimIO Int
 
 %foreign libterm "idris2_getTermLines"
 prim__getTermLines : PrimIO Int
+
+export
+setupTerm : IO ()
+setupTerm = primIO prim__setupTerm
 
 export
 getTermCols : IO Int

--- a/support/c/idris_term.c
+++ b/support/c/idris_term.c
@@ -2,6 +2,18 @@
 
 #include <windows.h>
 
+#ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+#define ENABLE_VIRTUAL_TERMINAL_PROCESSING  0x0004
+#endif
+
+void idris2_setupTerm() {
+    HANDLE stdout_handle = GetStdHandle(STD_OUTPUT_HANDLE);
+    DWORD outmode = 0;
+    GetConsoleMode(stdout_handle, &outmode);
+    outmode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+    SetConsoleMode(stdout_handle, outmode);
+}
+
 int idris2_getTermCols() {
     CONSOLE_SCREEN_BUFFER_INFO csbi;
     GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);
@@ -17,6 +29,10 @@ int idris2_getTermLines() {
 #else
 
 #include <sys/ioctl.h>
+
+void idris2_setupTerm() {
+    // NOTE: Currently not needed for non windows systems
+}
 
 int idris2_getTermCols() {
     struct winsize ts;

--- a/support/c/idris_term.h
+++ b/support/c/idris_term.h
@@ -1,6 +1,7 @@
 #ifndef __IDRIS_TERM_H
 #define __IDRIS_TERM_H
 
+void idris2_setupTerm();
 int idris2_getTermCols();
 int idris2_getTermLines();
 


### PR DESCRIPTION
Even if the windows 10 terminal has support for ansi escape codes, it still needs some convincing before actually working.

As I cannot, at the moment, test on windows system, before merging, can someone confirm that indeed on windows 10 colors work automatically with this fix?