### PR TITLE
Suppress banner when running with --ide-mode-socket option

### DIFF
--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -52,6 +52,9 @@ preOptions (ExecFn _ :: opts)
 preOptions (IdeMode :: opts)
     = do setSession (record { nobanner = True } !getSession)
          preOptions opts
+preOptions (IdeModeSocket _ :: opts)
+    = do setSession (record { nobanner = True } !getSession)
+         preOptions opts
 preOptions (CheckOnly :: opts)
     = do setSession (record { nobanner = True } !getSession)
          preOptions opts


### PR DESCRIPTION
At least on Emacs this fixes the following warning:

```
Warning from Idris:    / // __  / ___/ / ___/   __/ /     Version 0.2.1-
error in process filter: open-network-stream: make client process failed: Connection refused, :name, Idris IDE support, :buffer, *idris-connection*, :host, 127.0.0.1, :service, 310, :nowait, nil, :tls-parameters, nil
error in process filter: make client process failed: Connection refused, :name, Idris IDE support, :buffer, *idris-connection*, :host, 127.0.0.1, :service, 310, :nowait, nil, :tls-parameters, nil
```