### PR TITLE
[ refactor ] suggested during SPLV 

### DIFF
--- a/libs/base/Data/List.idr
+++ b/libs/base/Data/List.idr
@@ -632,3 +632,8 @@ dropFusion (S n) (S m) []     = Refl
 dropFusion (S n) (S m) (x::l) = rewrite plusAssociative n 1 m in
                                 rewrite plusCommutative n 1 in
                                 dropFusion (S n) m l
+
+export
+lengthMap : (xs : List a) -> length (map f xs) = length xs
+lengthMap [] = Refl
+lengthMap (x :: xs) = cong S (lengthMap xs)

--- a/libs/base/Data/Nat.idr
+++ b/libs/base/Data/Nat.idr
@@ -163,7 +163,7 @@ eqSucc : (left, right : Nat) -> left = right -> S left = S right
 eqSucc _ _ Refl = Refl
 
 export
-succInjective : (left, right : Nat) -> S left = S right -> left = right
+succInjective : (0 left, right : Nat) -> S left = S right -> left = right
 succInjective _ _ Refl = Refl
 
 export

--- a/libs/base/Data/Stream.idr
+++ b/libs/base/Data/Stream.idr
@@ -114,3 +114,10 @@ export
 Monad Stream where
   s >>= f = diag (map f s)
 
+--------------------------------------------------------------------------------
+-- Properties
+--------------------------------------------------------------------------------
+
+lengthTake : (1 n : Nat) -> (xs : Stream a) -> length (take n xs) = n
+lengthTake Z _ = Refl
+lengthTake (S n) (x :: xs) = cong S (lengthTake n xs)

--- a/src/Compiler/LambdaLift.idr
+++ b/src/Compiler/LambdaLift.idr
@@ -73,11 +73,11 @@ data LiftedDef : Type where
 mutual
   export
   {vs : _} -> Show (Lifted vs) where
-    show (LLocal {idx} _ p) = "!" ++ show (nameAt idx p)
+    show (LLocal {idx} _ p) = "!" ++ show (nameAt p)
     show (LAppName fc n args)
         = show n ++ "(" ++ showSep ", " (map show args) ++ ")"
     show (LUnderApp fc n m args)
-        = "<" ++ show n ++ " underapp " ++ show m ++ ">(" ++ 
+        = "<" ++ show n ++ " underapp " ++ show m ++ ">(" ++
           showSep ", " (map show args) ++ ")"
     show (LApp fc c arg)
         = show c ++ " @ (" ++ show arg ++ ")"
@@ -102,7 +102,7 @@ mutual
   export
   {vs : _} -> Show (LiftedConAlt vs) where
     show (MkLConAlt n t args sc)
-        = "%conalt " ++ show n ++ 
+        = "%conalt " ++ show n ++
              "(" ++ showSep ", " (map show args) ++ ") => " ++ show sc
 
   export

--- a/src/Compiler/Scheme/Gambit.idr
+++ b/src/Compiler/Scheme/Gambit.idr
@@ -211,7 +211,7 @@ cCall fc cfn fnWrapName clib args ret
          let body = setBoxes ++ "\n" ++ call
 
          pure $ case ret of -- XXX
-                     CFIORes _ => (handleRet retType body, wrapDeclarations) 
+                     CFIORes _ => (handleRet retType body, wrapDeclarations)
                      _ => (body, wrapDeclarations)
   where
     mkNs : Int -> List CFType -> List (Maybe String)
@@ -387,7 +387,7 @@ compileExpr c tmpDir outputDir tm outfile
          libsname <- compileToSCM c tm srcPath
          libsfile <- traverse findLibraryFile $ map (<.> "a") (nub libsname)
          gsc <- coreLift findGSC
-         let cmd = gsc ++ 
+         let cmd = gsc ++
                    " -exe -cc-options \"-Wno-implicit-function-declaration\" -ld-options \"" ++
                    (showSep " " libsfile) ++ "\" -o \"" ++ execPath ++ "\" \"" ++ srcPath ++ "\""
          ok <- coreLift $ system cmd

--- a/src/Core/CaseTree.idr
+++ b/src/Core/CaseTree.idr
@@ -82,8 +82,8 @@ mutual
   export
   eqTree : CaseTree vs -> CaseTree vs' -> Bool
   eqTree (Case i _ _ alts) (Case i' _ _ alts')
-      = i == i
-       && length alts == length alts
+      = i == i'
+       && length alts == length alts'
        && allTrue (zipWith eqAlt alts alts')
   eqTree (STerm _ t) (STerm _ t') = eqTerm t t'
   eqTree (Unmatched _) (Unmatched _) = True

--- a/src/Core/Env.idr
+++ b/src/Core/Env.idr
@@ -80,7 +80,7 @@ getBinderUnder : Weaken tm =>
                  (0 p : IsVar x idx vars) -> Env tm vars ->
                  Binder (tm (reverseOnto vars ns))
 getBinderUnder {idx = Z} {vars = v :: vs} ns First (b :: env)
-    = rewrite revOnto vs (v :: ns) in map (weakenNs (reverse (v :: ns))) b
+    = rewrite revOnto vs (v :: ns) in map (weakenNs (reverse (mkSizeOf (v :: ns)))) b
 getBinderUnder {idx = S k} {vars = v :: vs} ns (Later lp) (b :: env)
     = getBinderUnder (v :: ns) lp env
 

--- a/src/Core/Normalise.idr
+++ b/src/Core/Normalise.idr
@@ -1036,8 +1036,7 @@ mutual
         = convGen q defs env !(evalClosure defs x) !(evalClosure defs y)
 
 export
-getValArity : {vars : _} ->
-              Defs -> Env Term vars -> NF vars -> Core Nat
+getValArity : Defs -> Env Term vars -> NF vars -> Core Nat
 getValArity defs env (NBind fc x (Pi _ _ _ _) sc)
     = pure (S !(getValArity defs env !(sc defs (toClosure defaultOpts env (Erased fc False)))))
 getValArity defs env val = pure 0

--- a/src/Idris/Error.idr
+++ b/src/Idris/Error.idr
@@ -31,7 +31,7 @@ import Utils.String
 -- | Add binding site information if the term is simply a machine-inserted name
 pShowMN : {vars : _} -> Term vars -> Env t vars -> Doc IdrisAnn -> Doc IdrisAnn
 pShowMN t env acc = case t of
-  Local fc _ idx p => case dropAllNS (nameAt idx p) of
+  Local fc _ idx p => case dropAllNS (nameAt p) of
       MN _ _ => acc <++> parens ("implicitly bound at" <++> pretty (getBinderLoc p env))
       _ => acc
   _ => acc
@@ -95,7 +95,7 @@ ploc2 (MkFC fn1 s1 e1) (MkFC fn2 s2 e2) =
        let (sr2, sc2) = bimap (fromInteger . cast) s2
        let (er1, ec1) = bimap (fromInteger . cast) e1
        let (er2, ec2) = bimap (fromInteger . cast) e2
-       if (er2 > er1 + 5)
+       if (er2 > the Nat (er1 + 5))
           then pure $ !(ploc (MkFC fn1 s1 e1)) <+> line <+> !(ploc (MkFC fn2 s2 e2))
           else do let nsize = length $ show (er2 + 1)
                   let head = annotate FileCtxt (pretty $ MkFC fn1 s1 e2)

--- a/src/TTImp/Elab.idr
+++ b/src/TTImp/Elab.idr
@@ -24,7 +24,7 @@ import Data.NameMap
 findPLetRenames : {vars : _} ->
                   Term vars -> List (Name, (RigCount, Name))
 findPLetRenames (Bind fc n (PLet _ c (Local _ _ idx p) ty) sc)
-    = case nameAt idx p of
+    = case nameAt p of
            x@(MN _ _) => (x, (c, n)) :: findPLetRenames sc
            _ => findPLetRenames sc
 findPLetRenames (Bind fc n _ sc) = findPLetRenames sc

--- a/src/TTImp/Elab/ImplicitBind.idr
+++ b/src/TTImp/Elab/ImplicitBind.idr
@@ -238,8 +238,7 @@ bindImplVars {vars} fc mode gam env imps_in scope scty
     tidyName (Nested n inner) = tidyName inner
     tidyName n = n
 
-    getBinds : {new : _} ->
-               (imps : List (Name, Name, ImplBinding vs)) ->
+    getBinds : (imps : List (Name, Name, ImplBinding vs)) ->
                Bounds new -> (tm : Term vs) -> (ty : Term vs) ->
                (Term (new ++ vs), Term (new ++ vs))
     getBinds [] bs tm ty = (refsToLocals bs tm, refsToLocals bs ty)
@@ -251,7 +250,7 @@ bindImplVars {vars} fc mode gam env imps_in scope scty
                       (Bind fc _ (Pi fc c Implicit bty') tm',
                        TType fc)
                    _ =>
-                      (Bind fc _ (PVar fc c (map (weakenNs new) p) bty') tm',
+                      (Bind fc _ (PVar fc c (map (weakenNs (sizeOf bs)) p) bty') tm',
                        Bind fc _ (PVTy fc c bty') ty')
     getBinds ((n, metan, AsBinding c _ _ bty bpat) :: imps) bs tm ty
         = let (tm', ty') = getBinds imps (Add n metan bs) tm ty

--- a/src/TTImp/Elab/Rewrite.idr
+++ b/src/TTImp/Elab/Rewrite.idr
@@ -135,7 +135,7 @@ checkRewrite {vars} rigc elabinfo nest env fc rule tm (Just expected)
                                                         IVar fc rname,
                                                         tm])
                                 (Just (gnf env'
-                                         (weakenNs [rname, pname] expTy)))
+                                         (weakenNs (mkSizeOf [rname, pname]) expTy)))
                          ))
            rwty <- getTerm grwty
            pure (Bind fc pname pbind (Bind fc rname rbind rwtm),

--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -196,7 +196,7 @@ findLinear top bound rig tm
           = findLinArg rig ty (p :: as)
       findLinArg rig (NBind _ x (Pi _ c _ _) sc) (Local {name=a} fc _ idx prf :: as)
           = do defs <- get Ctxt
-               let a = nameAt idx prf
+               let a = nameAt prf
                if idx < bound
                  then do sc' <- sc defs (toClosure defaultOpts [] (Ref fc Bound x))
                          pure $ (a, rigMult c rig) ::

--- a/src/TTImp/Unelab.idr
+++ b/src/TTImp/Unelab.idr
@@ -135,7 +135,7 @@ mutual
               Env Term vars -> Term vars ->
               Core (RawImp, Glued vars)
   unelabTy' umode env (Local fc _ idx p)
-      = pure (IVar fc (nameAt idx p), gnf env (binderType (getBinder p env)))
+      = pure (IVar fc (nameAt p), gnf env (binderType (getBinder p env)))
   unelabTy' umode env (Ref fc nt n)
       = do defs <- get Ctxt
            Just ty <- lookupTyExact n (gamma defs)
@@ -308,7 +308,7 @@ unelab env (Meta fc n i args)
          pure (IHole fc mkn)
   where
     toName : Term vars -> Maybe Name
-    toName (Local _ _ idx p) = Just (nameAt idx p)
+    toName (Local _ _ idx p) = Just (nameAt p)
     toName _ = Nothing
 
     showNScope : List Name -> String


### PR DESCRIPTION
Main change
===========

The main change is to the type of functions dealing with an untouched
segment of the local scope. e.g.

```idris
weak : {outer, vars : _} -> (ns : List Name) ->
       tm (outer ++ inner) -> tm (outer ++ ns ++ inner)
```

Instead we now write

```idris
weak : SizeOf outer -> SizeOf ns -> tm (outer ++ inner) -> tm (outer ++ ns ++ inner)
```

meaning that we do not need the values of `outer`, `inner` and `ns`
at runtime. Instead we only demand a `SizeOf outer` and `SizeOf ns`
which are essentially a `Nat` each together with an (erased) proof
that the list in question is of that length.


Other modifications
===================

Quadratic behaviour
-------------------

A side effect of this refactor is the removal of two sources of
quadratic behaviour. They typically arise in a situation where
work is done on a scope of the form

```idris
outer ++ done ++ ns ++ inner
```

When `ns` is non-empty, some work is performed and then the variable
is moved to the pile of things we are `done` with. This leads to
recursive calls of the form `f done` -> `f (done ++ [v])` leading
to a cost quadratic in the size of `ns`.

Now that we only care about `SizeOf done`, the recursive call is
(once all the runtime irrelevant content is erased) for the form
`f n` -> `f (S n)`!

More runtime irrelevance
------------------------

In some places we used to rely on a list of names `vars` being
available. However once we only care about the length of `vars`,
the fact it is not available is not a limitation.

For instance a `SizeOf vars` can be reconstructed from an environment
assigning values to `vars` even if `vars` is irrelevant. Indeed the
size of the environment is the same as that of `vars`.

Consequences
============

My non-scientific benchmarking gives me a ~9% improvement on the test
suite (before: 2m45s, after: 2m30s). I haven't tried to look at allocation
although this was one of the questions given that this replaces a `List`
with a `Nat`.

The run on the test suite is much less impressive: 1m41s for master,
1m40s for the refactoring. Not sure that 1% is significant.