### PR TITLE
[ fix #616 ] Namespaces are stored in reverse order

### DIFF
--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -662,7 +662,7 @@ mutual
                 ("do" :: ns) =>
                    do actions <- bounds (block (doAct fname))
                       pure (PDoBlock (boundToFC fname (mergeBounds nsdo actions))
-                                     (Just (reverse ns)) (concat actions.val))
+                                     (Just ns) (concat actions.val))
                 _ => fail "Not a namespaced 'do'"
 
   lowerFirst : String -> Bool

--- a/tests/idris2/basic041/QDo.idr
+++ b/tests/idris2/basic041/QDo.idr
@@ -7,3 +7,21 @@ foo : IO ()
 foo = MyDo.do
          x <- "Silly"
          putStrLn x
+
+namespace A
+  namespace B
+    export
+    (>>=) : Nat -> (() -> Nat) -> Nat
+    (>>=) x fy = x + (fy ())
+
+test : Nat
+test = B.A.do
+         5
+         6
+         7
+         
+test2 : Nat
+test2 = A.B.do
+         5
+         6
+         7

--- a/tests/idris2/basic041/expected
+++ b/tests/idris2/basic041/expected
@@ -1,1 +1,8 @@
 1/1: Building QDo (QDo.idr)
+Error: While processing right hand side of test. Undefined name B.A.>>=. 
+
+QDo.idr:19:10--19:11
+    |
+ 19 |          5
+    |          ^
+


### PR DESCRIPTION
Quickfix, closes #616 