### PR TITLE
[re #597] make constructor injectivity proofs use 0 multiplicity

### DIFF
--- a/libs/base/Data/Nat.idr
+++ b/libs/base/Data/Nat.idr
@@ -159,7 +159,7 @@ maximum (S n) (S m) = S (maximum n m)
 -- Proofs on S
 
 export
-eqSucc : (left, right : Nat) -> left = right -> S left = S right
+eqSucc : (0 left, right : Nat) -> left = right -> S left = S right
 eqSucc _ _ Refl = Refl
 
 export

--- a/libs/base/Data/Nat/Order.idr
+++ b/libs/base/Data/Nat/Order.idr
@@ -47,7 +47,7 @@ total zeroAlwaysSmaller : {n : Nat} -> LTE Z n
 zeroAlwaysSmaller = LTEZero
 
 public export
-total ltesuccinjective : {n : Nat} -> {m : Nat} -> (LTE n m -> Void) -> LTE (S n) (S m) -> Void
+total ltesuccinjective : {0 n : Nat} -> {0 m : Nat} -> (LTE n m -> Void) -> LTE (S n) (S m) -> Void
 ltesuccinjective {n} {m} disprf (LTESucc nLTEm) = void (disprf nLTEm)
 ltesuccinjective {n} {m} disprf LTEZero         impossible
 

--- a/libs/contrib/Data/HVect.idr
+++ b/libs/contrib/Data/HVect.idr
@@ -79,11 +79,11 @@ public export
   (x :: xs) == (y :: ys) = x == y && xs == ys
 
 public export
-consInjective1 : {xs, ys: HVect ts} -> {x, y: a} -> (1 _ : x :: xs = y :: ys) -> x = y
+consInjective1 : {0 xs, ys: HVect ts} -> {0 x, y: a} -> (1 _ : x :: xs = y :: ys) -> x = y
 consInjective1 Refl = Refl
 
 public export
-consInjective2 : {xs, ys: HVect ts} -> {x, y: a} -> (1 _ : x :: xs = y :: ys) -> xs = ys
+consInjective2 : {0 xs, ys: HVect ts} -> {0 x, y: a} -> (1 _ : x :: xs = y :: ys) -> xs = ys
 consInjective2 Refl = Refl
 
 public export


### PR DESCRIPTION
[ #597 ] Constructor injectivity proofs don't have to match on their arguments, so they might as well take them at quantity 0. This PR cleans up a couple of places in the libraries where an injectivity proof named its arguments explicitly but left them at multiplicity `ω`.