### PR TITLE
Fix how reify treats ForeignFn

### DIFF
--- a/libs/base/Language/Reflection/TTImp.idr
+++ b/libs/base/Language/Reflection/TTImp.idr
@@ -97,7 +97,7 @@ mutual
        GlobalHint : Bool -> FnOpt
        ExternFn : FnOpt
        -- Defined externally, list calling conventions
-       ForeignFn : List String -> FnOpt
+       ForeignFn : List TTImp -> FnOpt
        -- assume safe to cancel arguments in unification
        Invertible : FnOpt
        Totalty : TotalReq -> FnOpt


### PR DESCRIPTION
Addresses https://github.com/idris-lang/Idris2/issues/625
I wasn't sure which the right choice was so you can cherrypick dd128f2 to address this by changing `ForeignFn : List String -> FnOpt` to `ForeignFn : List TTImp -> FnOpt` to match the RawImp, or the PR as a whole can be taken to fix this issue while keeping `libs/base/Language/Reflection/TTImp.idr` as `ForeignFn : List String -> FnOpt`