### PR TITLE
Optional where

### DIFF
--- a/libs/prelude/Builtin.idr
+++ b/libs/prelude/Builtin.idr
@@ -104,7 +104,7 @@ namespace DPair
 ||| Use `void` or `absurd` to prove anything if you have a variable of type
 ||| `Void` in scope.
 public export
-data Void : Type where
+data Void : Type
 
 -- Equality
 

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1250,6 +1250,7 @@ implDecl fname indents
                                              (map (collectDefs . concat) body)))
          atEnd indents
          pure (b.val (boundToFC fname b))
+
 fieldDecl : FileName -> IndentInfo -> Rule (List PField)
 fieldDecl fname indents
       = do doc <- option "" documentation

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -42,7 +42,7 @@ idrisTests
        "basic031", "basic032", "basic033", "basic034", "basic035",
        "basic036", "basic037", "basic038", "basic039", "basic040",
        "basic041", "basic042", "basic043", "basic044", "basic045",
-       "basic046",
+       "basic046", "basic047",
        -- Coverage checking
        "coverage001", "coverage002", "coverage003", "coverage004",
        "coverage005", "coverage006", "coverage007", "coverage008",

--- a/tests/idris2/basic047/NoTrailingWhere.idr
+++ b/tests/idris2/basic047/NoTrailingWhere.idr
@@ -1,0 +1,11 @@
+module NoTrailingWhere
+
+data Void : Type
+
+interface Iface
+
+implementation Iface
+
+record Rec
+
+namespace A

--- a/tests/idris2/basic047/expected
+++ b/tests/idris2/basic047/expected
@@ -1,0 +1,1 @@
+1/1: Building NoTrailingWhere (NoTrailingWhere.idr)

--- a/tests/idris2/basic047/run
+++ b/tests/idris2/basic047/run
@@ -1,0 +1,3 @@
+$1 --no-banner --no-color --console-width 0 NoTrailingWhere.idr --check
+
+rm -rf build


### PR DESCRIPTION
Make `where` keyword optional in empty `interface` and `record` declarations
Remove trailing `where` in `Void` declaration (Builtin.idr)

Closes #620 