### PR TITLE
Auto-implicit `__con` now added before implicits.

### DIFF
--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -104,7 +104,7 @@ idrisTests
        "reg008", "reg009", "reg010", "reg011", "reg012", "reg013", "reg014",
        "reg015", "reg016", "reg017", "reg018", "reg019", "reg020", "reg021",
        "reg022", "reg023", "reg024", "reg025", "reg026", "reg027", "reg028",
-       "reg029", "reg030", "reg031", "reg032", "reg033", "reg034",
+       "reg029", "reg030", "reg031", "reg032", "reg033", "reg034", "reg035",
        -- Totality checking
        "total001", "total002", "total003", "total004", "total005",
        "total006", "total007", "total008", "total009",

--- a/tests/idris2/reg035/Implicit.idr
+++ b/tests/idris2/reg035/Implicit.idr
@@ -1,0 +1,3 @@
+interface A where
+  x : Nat
+  f : {auto pf : x = 0} -> ()

--- a/tests/idris2/reg035/expected
+++ b/tests/idris2/reg035/expected
@@ -1,0 +1,1 @@
+1/1: Building Implicit (Implicit.idr)

--- a/tests/idris2/reg035/run
+++ b/tests/idris2/reg035/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 Implicit.idr --check
+
+rm -rf build


### PR DESCRIPTION
The interface constraint variable `__con` was added after all implicit
variables before during interface elaboration, resulting in the variable
being unavailable in implicit arguments to interface methods.

For example, when type-checking

    interface A where
      x : Nat
      f : {pf : x = 0} -> ()

the type-checker would complain with

    Error: While processing type of f. Undefined name __con.

, whereas

    interface A where
      x : Nat
      f : (pf : x = 0) -> ()

would type-check just fine.

Note that the first example still doesn't type-check, but that's because
of another error.

**Remark**: This fixes #658.