### PR TITLE
add ability to target scheme flavor in foreign specifiers

### DIFF
--- a/docs/source/ffi/ffi.rst
+++ b/docs/source/ffi/ffi.rst
@@ -27,8 +27,29 @@ the library. In this document, we will assume the default Chez Scheme code
 generator (the examples also work with the Racket or Gambit code generator) and
 that the foreign language is C.
 
-Example
--------
+Scheme Sidenote
+---------------
+
+Scheme foreign specifiers can be written to target particular flavors.
+
+The following example shows a foreign declaration that allocates memory in a
+way specific to the choice of code generator. In this example there is no
+general scheme specifier present that matches every flavor, e.g.
+``scheme:foo``, so it  will only match the specific flavors listed:
+
+.. code-block:: idris
+
+    %foreign "scheme,chez:foreign-alloc"
+             "scheme,racket:malloc"
+             "C:malloc,libc"
+    allocMem : (bytes : Int) -> PrimIO AnyPtr
+
+.. note::
+    If your backend (code generator) is not specified but defines a C FFI
+    it will be able to make use of the ``C:malloc,libc`` specifier.
+
+FFI Example
+-----------
 
 As a running example, we are going to work with a small C file. Save the
 following content to a file ``smallc.c``

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -274,6 +274,9 @@ useCC appdir fc [] args ret
 useCC appdir fc (cc :: ccs) args ret
     = case parseCC cc of
            Nothing => useCC appdir fc ccs args ret
+           Just ("scheme,chez", [sfn]) =>
+               do body <- schemeCall fc sfn (map fst args) ret
+                  pure ("", body)
            Just ("scheme", [sfn]) =>
                do body <- schemeCall fc sfn (map fst args) ret
                   pure ("", body)

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -269,8 +269,7 @@ schemeCall fc sfn argns ret
 useCC : {auto c : Ref Ctxt Defs} ->
         {auto l : Ref Loaded (List String)} ->
         String -> FC -> List String -> List (Name, CFType) -> CFType -> Core (String, String)
-useCC appdir fc [] args ret
-    = throw (GenericMsg fc "No recognised foreign calling convention")
+useCC appdir fc [] args ret = throw (NoForeignCC fc)
 useCC appdir fc (cc :: ccs) args ret
     = case parseCC cc of
            Nothing => useCC appdir fc ccs args ret

--- a/src/Compiler/Scheme/Gambit.idr
+++ b/src/Compiler/Scheme/Gambit.idr
@@ -296,6 +296,7 @@ useCC fc [] args ret
 useCC fc (cc :: ccs) args ret
     = case parseCC cc of
            Nothing => useCC fc ccs args ret
+           Just ("scheme,gambit", [sfn]) => pure (Nothing, (!(schemeCall fc sfn (map fst args) ret), ""))
            Just ("scheme", [sfn]) => pure (Nothing, (!(schemeCall fc sfn (map fst args) ret), ""))
            Just ("C", [cfn, clib]) => pure (Just clib, !(cCall fc cfn (fnWrapName cfn) clib args ret))
            Just ("C", [cfn, clib, chdr]) => pure (Just clib, !(cCall fc cfn (fnWrapName cfn) clib args ret))

--- a/src/Compiler/Scheme/Gambit.idr
+++ b/src/Compiler/Scheme/Gambit.idr
@@ -291,8 +291,7 @@ schemeCall fc sfn argns ret
 useCC : {auto c : Ref Ctxt Defs} ->
         {auto l : Ref Loaded (List String)} ->
         FC -> List String -> List (Name, CFType) -> CFType -> Core (Maybe String, (String, String))
-useCC fc [] args ret
-    = throw (GenericMsg fc "No recognised foreign calling convention")
+useCC fc [] args ret = throw (NoForeignCC fc)
 useCC fc (cc :: ccs) args ret
     = case parseCC cc of
            Nothing => useCC fc ccs args ret

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -255,6 +255,9 @@ useCC appdir fc [] args ret
 useCC appdir fc (cc :: ccs) args ret
     = case parseCC cc of
            Nothing => useCC appdir fc ccs args ret
+           Just ("scheme,racket", [sfn]) =>
+               do body <- schemeCall fc sfn (map fst args) ret
+                  pure ("", body)
            Just ("scheme", [sfn]) =>
                do body <- schemeCall fc sfn (map fst args) ret
                   pure ("", body)

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -250,8 +250,7 @@ useCC : {auto f : Ref Done (List String) } ->
         {auto c : Ref Ctxt Defs} ->
         {auto l : Ref Loaded (List String)} ->
         String -> FC -> List String -> List (Name, CFType) -> CFType -> Core (String, String)
-useCC appdir fc [] args ret
-    = throw (GenericMsg fc "No recognised foreign calling convention")
+useCC appdir fc [] args ret = throw (NoForeignCC fc)
 useCC appdir fc (cc :: ccs) args ret
     = case parseCC cc of
            Nothing => useCC appdir fc ccs args ret

--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -140,6 +140,7 @@ data Error : Type where
      ForceNeeded : Error
      InternalError : String -> Error
      UserError : String -> Error
+     NoForeignCC : FC -> Error
 
      InType : FC -> Name -> Error -> Error
      InCon : FC -> Name -> Error -> Error
@@ -302,6 +303,8 @@ Show Error where
   show ForceNeeded = "Internal error when resolving implicit laziness"
   show (InternalError str) = "INTERNAL ERROR: " ++ str
   show (UserError str) = "Error: " ++ str
+  show (NoForeignCC fc) = show fc ++
+       ":The given specifier was not accepted by any available backend."
 
   show (InType fc n err)
        = show fc ++ ":When elaborating type of " ++ show n ++ ":\n" ++
@@ -376,6 +379,7 @@ getErrorLoc (CyclicImports _) = Nothing
 getErrorLoc ForceNeeded = Nothing
 getErrorLoc (InternalError _) = Nothing
 getErrorLoc (UserError _) = Nothing
+getErrorLoc (NoForeignCC loc) = Just loc
 getErrorLoc (InType _ _ err) = getErrorLoc err
 getErrorLoc (InCon _ _ err) = getErrorLoc err
 getErrorLoc (InLHS _ _ err) = getErrorLoc err

--- a/src/Idris/Error.idr
+++ b/src/Idris/Error.idr
@@ -420,6 +420,13 @@ perror (CyclicImports ns)
 perror ForceNeeded = pure $ errorDesc (reflow "Internal error when resolving implicit laziness")
 perror (InternalError str) = pure $ errorDesc (reflow "INTERNAL ERROR" <+> colon) <++> pretty str
 perror (UserError str) = pure $ errorDesc (pretty "Error" <+> colon) <++> pretty str
+perror (NoForeignCC fc) = do
+    let cgs = fst <$> availableCGs (options !(get Ctxt))
+    let res = vsep [ errorDesc (reflow "The given specifier was not accepted by any backend. Available backends" <+> colon)
+                   , indent 2 (concatWith (\x,y => x <+> ", " <+> y) (map reflow cgs))
+                   , reflow "Some backends have additional specifier rules, refer to their documentation."
+                   ] <+> line <+> !(ploc fc)
+    pure res
 
 perror (InType fc n err)
     = pure $ hsep [ errorDesc (reflow "While processing type of" <++> code (pretty !(prettyName n))) <+> dot

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -8,6 +8,7 @@ import Core.Unify
 import Utils.Path
 
 import Idris.CommandLine
+import Idris.Error
 import Idris.REPL
 import Idris.Syntax
 import Idris.Version
@@ -147,9 +148,10 @@ postOptions res (OutputFile outfile :: rest)
          postOptions res rest
          pure False
 postOptions res (ExecFn str :: rest)
-    = do execExp (PRef (MkFC "(script)" (0, 0) (0, 0)) (UN str))
-         postOptions res rest
-         pure False
+    = catch (do execExp (PRef (MkFC "(script)" (0, 0) (0, 0)) (UN str))
+                postOptions res rest
+                pure False)
+            (\err => do perror err >>= printError; pure False)
 postOptions res (CheckOnly :: rest)
     = do postOptions res rest
          pure False

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -128,6 +128,7 @@ chezTests
       "chez013", "chez014", "chez015", "chez016", "chez017", "chez018",
       "chez019", "chez020", "chez021", "chez022", "chez023", "chez024",
       "chez025", "chez026", "chez027", "chez028", "chez029", "chez030",
+      "chez031",
       "reg001"]
 
 nodeTests : List String

--- a/tests/chez/chez031/Specifiers.idr
+++ b/tests/chez/chez031/Specifiers.idr
@@ -1,5 +1,15 @@
 module Specifiers
 
+{- This tests both the given specifiers and the error reporting of them.
+   To this end it tests via:
+   --exec main      -- testing cli
+
+   > :exec main     -- testing repl
+
+   > :set eval exec -- repl with eval set to execute
+   > main
+-}
+
 -- Generic match good for any scheme backend
 %foreign "scheme:+"
 plusGeneric : Int -> Int -> Int

--- a/tests/chez/chez031/Specifiers.idr
+++ b/tests/chez/chez031/Specifiers.idr
@@ -1,0 +1,30 @@
+module Specifiers
+
+-- Generic match good for any scheme backend
+%foreign "scheme:+"
+plusGeneric : Int -> Int -> Int
+
+-- We're testing with --cg chez so this specifier should be chosen.
+%foreign "scheme,chez:+"
+plusChez : Int -> Int -> Int
+
+-- We're testing with --cg chez so this should match C because chez accepts C
+-- specifiers but the next test should fail.
+%foreign "scheme,racket:+"
+         "C:notreal,notalib"
+plusRacketOK : Int -> Int -> Int
+
+-- We're testing with --cg chez so this shouldn't find a valid specifier to use.
+%foreign "scheme,racket:+"
+plusRacketFail : Int -> Int -> Int
+
+
+-- We don't actually do any printing this is just to use the specifiers so the
+-- failures are exposed.
+main : IO ()
+main = do
+  printLn $ plusGeneric 2 3
+  printLn $ plusChez 2 3
+  printLn $ plusRacketOK 2 3
+  printLn $ plusRacketFail 2 3
+  pure ()

--- a/tests/chez/chez031/expected
+++ b/tests/chez/chez031/expected
@@ -1,0 +1,1 @@
+Uncaught error: Specifiers.idr:18:1--24:5:No recognised foreign calling convention

--- a/tests/chez/chez031/expected
+++ b/tests/chez/chez031/expected
@@ -1,1 +1,27 @@
-Uncaught error: Specifiers.idr:18:1--24:5:No recognised foreign calling convention
+The given specifier was not accepted by any backend. Available backends:
+  chez, racket, node, javascript, gambit
+Some backends have additional specifier rules, refer to their documentation.
+
+Specifiers.idr:28:1--34:5
+ 28 | %foreign "scheme,racket:+"
+ 29 | plusRacketFail : Int -> Int -> Int
+ 30 | 
+ 31 | 
+ 32 | -- We don't actually do any printing this is just to use the specifiers so the
+ 33 | -- failures are exposed.
+
+Main> Loaded file Specifiers.idr
+Specifiers> Error: The given specifier was not accepted by any backend. Available backends:
+  chez, racket, node, javascript, gambit
+Some backends have additional specifier rules, refer to their documentation.
+
+Specifiers.idr:28:1--34:5
+
+Specifiers> [exec] Specifiers> Error: The given specifier was not accepted by any backend. Available backends:
+  chez, racket, node, javascript, gambit
+Some backends have additional specifier rules, refer to their documentation.
+
+Specifiers.idr:28:1--34:5
+
+[exec] Specifiers> 
+Bye for now!

--- a/tests/chez/chez031/input
+++ b/tests/chez/chez031/input
@@ -1,0 +1,4 @@
+:load Specifiers.idr
+:exec main
+:set eval execute
+main

--- a/tests/chez/chez031/run
+++ b/tests/chez/chez031/run
@@ -1,0 +1,3 @@
+$1 --no-banner --no-color --console-width 0 --cg chez Specifiers.idr --exec main
+
+rm -rf build

--- a/tests/chez/chez031/run
+++ b/tests/chez/chez031/run
@@ -1,3 +1,4 @@
 $1 --no-banner --no-color --console-width 0 --cg chez Specifiers.idr --exec main
+$1 --no-banner --no-color --console-width 0 --cg chez < input
 
 rm -rf build


### PR DESCRIPTION
There's some missing flexibility in how foreign specifiers can be used with scheme that is addressed here with minimal changes to how scheme specifiers are read. This opens up uses for users that they otherwise would have had to modify the compiler's support files to accomplish.