### PR TITLE
Fix ide mode repl not converting escaped characters

### DIFF
--- a/src/Idris/IDEMode/Parser.idr
+++ b/src/Idris/IDEMode/Parser.idr
@@ -5,10 +5,12 @@ module Idris.IDEMode.Parser
 
 import Idris.IDEMode.Commands
 
+import Data.Maybe
 import Data.List
 import Data.Strings
 import Parser.Lexer.Source
 import Parser.Source
+import Parser.Support
 import Text.Lexer
 import Text.Parser
 import Utils.Either
@@ -26,7 +28,7 @@ ideTokens : TokenMap Token
 ideTokens =
     map (\x => (exact x, Symbol)) symbols ++
     [(digits, \x => IntegerLit (cast x)),
-     (stringLit, \x => StringLit (stripQuotes x)),
+     (stringLit, \x => StringLit (fromMaybe "" (escape (stripQuotes x)))),
      (identAllowDashes, \x => Ident x),
      (space, Comment)]
 

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -143,7 +143,7 @@ nodeTests
 
 ideModeTests : List String
 ideModeTests
-  =  [ "ideMode001", "ideMode002", "ideMode003" ]
+  =  [ "ideMode001", "ideMode002", "ideMode003", "ideMode004" ]
 
 preludeTests : List String
 preludeTests

--- a/tests/ideMode/ideMode004/expected
+++ b/tests/ideMode/ideMode004/expected
@@ -1,0 +1,3 @@
+000018(:protocol-version 2 0)
+000021(:return (:ok "\"Test\"" ()) 32)
+Alas the file is done, aborting

--- a/tests/ideMode/ideMode004/input
+++ b/tests/ideMode/ideMode004/input
@@ -1,0 +1,1 @@
+00001C((:interpret "\"Test\"") 32)

--- a/tests/ideMode/ideMode004/run
+++ b/tests/ideMode/ideMode004/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 --ide-mode < input
+
+rm -rf build


### PR DESCRIPTION
Escaped characters sent via idris-mode were not being converted cleanly, resulting in errors.
This PR fixes the issue.

Before this fix:
```
$ build/exec/idris2 --ide-mode
000018(:protocol-version 2 0)
00001C((:interpret "\"Test\"") 32)
0000d8(:return (:error "Parse error at line 1:1:
Expected 'case', 'if', 'do', application or operator expression (next tokens: [symbol \\, Unrecognised \", identifier Test, symbol \\, Unrecognised \", end of input])") 32)
^CFailed to read a character
```
After this fix:
```
$ build/exec/idris2 --ide-mode
000018(:protocol-version 2 0)
00001C((:interpret "\"Test\"") 32)
000021(:return (:ok "\"Test\"" ()) 32)
^DAlas the file is done, aborting
```