### PR TITLE
 [contrib] Add misc libraries to contrib

### DIFF
--- a/libs/base/Data/Rel.idr
+++ b/libs/base/Data/Rel.idr
@@ -31,6 +31,7 @@ All (t :: ts) p = (x : t) -> All ts (p x)
 ||| ```
 ||| Which is the type of a pair of natural numbers along with a proof that the first
 ||| is smaller or equal than the second.
+public export
 Ex : (ts : Vect n Type) -> (p : Rel ts) -> Type
 Ex [] p = p
 Ex (t :: ts) p = (x : t ** Ex ts (p x))

--- a/libs/base/Decidable/Decidable.idr
+++ b/libs/base/Decidable/Decidable.idr
@@ -4,6 +4,7 @@ import Data.Rel
 import Data.Fun
 
 
+
 ||| Interface for decidable n-ary Relations
 public export
 interface Decidable (ts : Vect k Type) (p : Rel ts) where

--- a/libs/contrib/Data/Fun/Extra.idr
+++ b/libs/contrib/Data/Fun/Extra.idr
@@ -105,11 +105,12 @@ introduceWitness (w :: witness) f = (w ** introduceWitness witness f)
 
 ----------------------------------------------------------------------
 public export
-data FunVect : (ts, ss : Vect n Type) -> Type where
-  Nil  : FunVect [] []
-  (::) : (f : t -> s) -> FunVect ts ss -> FunVect (t::ts) (s::ss)
+data Pointwise : (r : a -> b -> Type) -> (ts : Vect n a) -> (ss : Vect n b) -> Type where
+  Nil  : Pointwise r [] []
+  (::) : {0 ss, ts : Vect n Type} -> 
+         (f : r t s) -> Pointwise r ts ss -> Pointwise r (t::ts) (s::ss)
 
 public export
-precompose : FunVect ts ss -> Fun ss cod -> Fun ts cod
+precompose : Pointwise (\a,b => a -> b) ts ss -> Fun ss cod -> Fun ts cod
 precompose [] h = h
 precompose (f :: fs) h = \x => precompose fs (h (f x))

--- a/libs/contrib/Data/Fun/Extra.idr
+++ b/libs/contrib/Data/Fun/Extra.idr
@@ -8,15 +8,15 @@ import Data.HVect
 
 ||| Apply an n-ary function to an n-ary tuple of inputs
 public export
-uncurry : {ts : Vect n Type} -> {cod : Type} -> Fun ts cod -> HVect ts -> cod
-uncurry f [] = f
-uncurry f (t::ts) = uncurry (f t) ts
+uncurry : {n : Nat} -> {0 ts : Vect n Type} -> Fun ts cod -> HVect ts -> cod
+uncurry {n = 0  } f [] = f
+uncurry {n = S n} f (x::xs) = uncurry (f x) xs
 
 ||| Apply an n-ary function to an n-ary tuple of inputs
 public export
-curry : {ts : Vect n Type} -> {cod : Type} -> (HVect ts -> cod) -> Fun ts cod 
-curry {ts = []     } f = f []
-curry {ts = t :: ts} f = \x => curry (\xs => f (x :: xs))
+curry : {n : Nat} -> {0 ts : Vect n Type} -> (HVect ts -> cod) -> Fun ts cod 
+curry {ts = []    } f = f []
+curry {ts = _ :: _} f = \x => curry (\xs => f (x :: xs))
 
 {- 
 
@@ -36,7 +36,7 @@ homoFunNeut_ext : Fun [] cod -> id cod
 homoFunNeut_ext x = x
 
 public export
-homoFunMult_ext : {rs : Vect n Type} -> Fun (rs ++ ss) cod -> (Fun rs . Fun ss) cod
+homoFunMult_ext : {n : Nat} -> {0 rs : Vect n Type} -> Fun (rs ++ ss) cod -> (Fun rs . Fun ss) cod
 homoFunMult_ext {rs = []     }  gs = gs
 homoFunMult_ext {rs = t :: ts} fgs = \x => homoFunMult_ext (fgs x)
 
@@ -45,14 +45,14 @@ homoFunNeut_inv : id cod -> Fun [] cod
 homoFunNeut_inv x = x
 
 public export
-homoFunMult_inv : {rs : Vect n Type} -> (Fun rs . Fun ss) cod -> Fun (rs ++ ss) cod
+homoFunMult_inv : {n : Nat} -> {0 rs : Vect n Type} -> (Fun rs . Fun ss) cod -> Fun (rs ++ ss) cod
 homoFunMult_inv {rs = []     } gs = gs
 homoFunMult_inv {rs = t :: ts} fgs = \x => homoFunMult_inv (fgs x)
 
 
 ||| Apply an n-ary function to an n-ary tuple of inputs
 public export
-applyPartially : {ts : Vect n Type} -> {ss : Vect m Type} 
+applyPartially : {n : Nat} -> {0 ts : Vect n Type} 
                -> {cod : Type} -> Fun (ts ++ ss) cod -> (HVect ts -> Fun ss cod)
 applyPartially fgs = uncurry {ts} {cod = Fun ss cod} (homoFunMult_ext {rs=ts} {ss} {cod} fgs)
 
@@ -62,19 +62,19 @@ applyPartially fgs = uncurry {ts} {cod = Fun ss cod} (homoFunMult_ext {rs=ts} {s
 
 ||| Apply an n-ary dependent function to its tuple of inputs (given by an HVect)
 public export
-uncurryAll : {ts : Vect n Type} -> {cod : Fun ts Type} 
+uncurryAll : {n : Nat} -> {0 ts : Vect n Type} -> {0 cod : Fun ts Type} 
         -> All ts cod -> (xs : HVect ts) -> uncurry cod xs
 uncurryAll f [] = f
 uncurryAll {ts = t :: ts} {cod} f (x :: xs) = uncurryAll {cod= cod x} (f x) xs
 
 public export
-curryAll : {ts : Vect n Type} -> {cod : Fun ts Type}
+curryAll : {n : Nat} -> {0 ts : Vect n Type} -> {0 cod : Fun ts Type}
         -> ((xs : HVect ts) -> uncurry cod xs)
         -> All ts cod
 curryAll {ts = []     } f = f []
 curryAll {ts = t :: ts} f = \x => curryAll (\ xs => f (x:: xs))
 
-chainGenUncurried : {ts : Vect n Type} -> {cod,cod' : Fun ts Type} -> 
+chainGenUncurried : {n : Nat} -> {0 ts : Vect n Type} -> {0 cod,cod' : Fun ts Type} -> 
            ((xs : HVect ts) -> uncurry cod xs -> uncurry cod' xs) ->  
            All ts cod -> All ts cod'
 chainGenUncurried {ts = []} f gs = f [] gs
@@ -87,20 +87,21 @@ homoAllNeut_ext x = x
 -- Not sure it's worth it getting the rest of Cayley's theorem to work
 
 public export
-extractWitness : {ts : Vect n Type} -> {r : Rel ts} -> Ex ts r -> HVect ts
+extractWitness : {n : Nat} -> {0 ts : Vect n Type} -> {0 r : Rel ts} -> Ex ts r -> HVect ts
 extractWitness {ts = []     }  _       = []
 extractWitness {ts = t :: ts} (w ** f) = w :: extractWitness f
 
 public export
-extractWitnessCorrect : {ts : Vect n Type} -> {r : Rel ts} -> (f : Ex ts r) -> 
+extractWitnessCorrect : {n : Nat} -> {0 ts : Vect n Type} -> {0 r : Rel ts} -> (f : Ex ts r) -> 
                         uncurry {ts} r (extractWitness {r} f)
 extractWitnessCorrect {ts = []     } f = f
 extractWitnessCorrect {ts = t :: ts} (w ** f) = extractWitnessCorrect f
 
 public export
-introduceWitness : {ts : Vect n Type} -> {r : Rel ts} -> (witness : HVect ts) -> 
+introduceWitness : {0 ts : Vect n Type} -> {0 r : Rel ts} -> (witness : HVect ts) -> 
   uncurry {ts} r witness -> Ex ts r
 introduceWitness {ts = []     } []             f = f
 introduceWitness {ts = t :: ts} (w :: witness) f = (w ** introduceWitness witness f)
+
 
 

--- a/libs/contrib/Data/Fun/Extra.idr
+++ b/libs/contrib/Data/Fun/Extra.idr
@@ -8,9 +8,9 @@ import Data.HVect
 
 ||| Apply an n-ary function to an n-ary tuple of inputs
 public export
-uncurry : {n : Nat} -> {0 ts : Vect n Type} -> Fun ts cod -> HVect ts -> cod
-uncurry {n = 0  } f [] = f
-uncurry {n = S n} f (x::xs) = uncurry (f x) xs
+uncurry : {0 n : Nat} -> {0 ts : Vect n Type} -> Fun ts cod -> HVect ts -> cod
+uncurry f [] = f
+uncurry f (x::xs) = uncurry (f x) xs
 
 ||| Apply an n-ary function to an n-ary tuple of inputs
 public export
@@ -53,8 +53,8 @@ homoFunMult_inv {rs = t :: ts} fgs = \x => homoFunMult_inv (fgs x)
 ||| Apply an n-ary function to an n-ary tuple of inputs
 public export
 applyPartially : {n : Nat} -> {0 ts : Vect n Type} 
-               -> {cod : Type} -> Fun (ts ++ ss) cod -> (HVect ts -> Fun ss cod)
-applyPartially fgs = uncurry {ts} {cod = Fun ss cod} (homoFunMult_ext {rs=ts} {ss} {cod} fgs)
+               -> Fun (ts ++ ss) cod -> (HVect ts -> Fun ss cod)
+applyPartially fgs = uncurry {ts} {cod = Fun ss cod} (homoFunMult_ext {rs=ts} {ss} fgs)
 
 
 {- -------- (slightly) dependent versions of the above ---------------
@@ -62,10 +62,10 @@ applyPartially fgs = uncurry {ts} {cod = Fun ss cod} (homoFunMult_ext {rs=ts} {s
 
 ||| Apply an n-ary dependent function to its tuple of inputs (given by an HVect)
 public export
-uncurryAll : {n : Nat} -> {0 ts : Vect n Type} -> {0 cod : Fun ts Type} 
+uncurryAll : {0 n : Nat} -> {0 ts : Vect n Type} -> {0 cod : Fun ts Type} 
         -> All ts cod -> (xs : HVect ts) -> uncurry cod xs
 uncurryAll f [] = f
-uncurryAll {ts = t :: ts} {cod} f (x :: xs) = uncurryAll {cod= cod x} (f x) xs
+uncurryAll {ts = t :: ts} f (x :: xs) = uncurryAll {cod= cod x} (f x) xs
 
 public export
 curryAll : {n : Nat} -> {0 ts : Vect n Type} -> {0 cod : Fun ts Type}
@@ -98,10 +98,10 @@ extractWitnessCorrect {ts = []     } f = f
 extractWitnessCorrect {ts = t :: ts} (w ** f) = extractWitnessCorrect f
 
 public export
-introduceWitness : {0 ts : Vect n Type} -> {0 r : Rel ts} -> (witness : HVect ts) -> 
-  uncurry {ts} r witness -> Ex ts r
-introduceWitness {ts = []     } []             f = f
-introduceWitness {ts = t :: ts} (w :: witness) f = (w ** introduceWitness witness f)
+introduceWitness : {0 r : Rel ts} -> (witness : HVect ts) -> 
+                   uncurry {ts} r witness -> Ex ts r
+introduceWitness []             f = f
+introduceWitness (w :: witness) f = (w ** introduceWitness witness f)
 
 
 

--- a/libs/contrib/Data/Fun/Extra.idr
+++ b/libs/contrib/Data/Fun/Extra.idr
@@ -85,3 +85,22 @@ homoAllNeut_ext : Fun [] cod -> id cod
 homoAllNeut_ext x = x
 
 -- Not sure it's worth it getting the rest of Cayley's theorem to work
+
+public export
+extractWitness : {ts : Vect n Type} -> {r : Rel ts} -> Ex ts r -> HVect ts
+extractWitness {ts = []     }  _       = []
+extractWitness {ts = t :: ts} (w ** f) = w :: extractWitness f
+
+public export
+extractWitnessCorrect : {ts : Vect n Type} -> {r : Rel ts} -> (f : Ex ts r) -> 
+                        uncurry {ts} r (extractWitness {r} f)
+extractWitnessCorrect {ts = []     } f = f
+extractWitnessCorrect {ts = t :: ts} (w ** f) = extractWitnessCorrect f
+
+public export
+introduceWitness : {ts : Vect n Type} -> {r : Rel ts} -> (witness : HVect ts) -> 
+  uncurry {ts} r witness -> Ex ts r
+introduceWitness {ts = []     } []             f = f
+introduceWitness {ts = t :: ts} (w :: witness) f = (w ** introduceWitness witness f)
+
+

--- a/libs/contrib/Data/Fun/Extra.idr
+++ b/libs/contrib/Data/Fun/Extra.idr
@@ -1,0 +1,54 @@
+module Data.Fun.Extra
+
+import Data.Fun
+import Data.HVect
+
+||| Apply an n-ary function to an n-ary tuple of inputs
+public export
+apply : {ts : Vect n Type} -> {cod : Type} -> Fun ts cod -> HVect ts -> cod
+apply f [] = f
+apply f (t::ts) = apply (f t) ts
+
+||| Apply an n-ary function to an n-ary tuple of inputs
+public export
+applyPartially : {ts : Vect n Type} -> {ss : Vect m Type} -> {rs : Vect k Type} 
+               -> {auto 0 fordShape : rs = ts ++ ss}
+               -> {cod : Type} -> Fun rs cod -> HVect ts -> Fun ss cod
+applyPartially {fordShape = Refl} f [] = f
+applyPartially {fordShape = Refl} f (x::xs) = applyPartially (f x) xs
+
+
+{- -------- (slightly) dependent versions of the above ---------------
+   As usual, type dependencies make everything complicated          -}
+
+
+||| Build an n-ary dependent function type from a Vect of Types and a dependent result type
+||| NB: the types in the tuple do not depend on each other.
+public export
+GenFun : (ts : Vect n Type) -> (cod : Fun ts Type) -> Type
+GenFun [] cod = cod
+GenFun (t :: ts) cod = (x : t) -> GenFun ts (cod x )
+
+||| Apply an n-ary dependent function to its tuple of inputs (given by an HVect)
+public export
+applyGen : {ts : Vect n Type} -> {cod : Fun ts Type} 
+        -> GenFun ts cod -> (xs : HVect ts) -> apply cod xs
+applyGen f [] = f
+applyGen {ts = t :: ts} {cod} f (x :: xs) = applyGen {cod= cod x} (f x) xs
+
+chainGenUncurried : {ts : Vect n Type} -> {cod,cod' : Fun ts Type} -> 
+           ((xs : HVect ts) -> apply cod xs -> apply cod' xs) ->  
+           GenFun ts cod -> GenFun ts cod'
+chainGenUncurried {ts = []} f gs = f [] gs
+chainGenUncurried {ts = (t :: ts)} f gs = \x => chainGenUncurried (\u => f (x :: u)) (gs x)
+
+||| Partially apply an n-ary dependent function to a tuple of its inputs
+||| Yes, the type is disgusting
+applyPartiallyGen : {ts : Vect n Type} -> {ss : Vect m Type} -> {rs : Vect k Type} 
+                -> {cod : Fun rs Type} 
+                -> {auto 0 fordShape : rs = ts ++ ss}
+                -> GenFun rs cod -> (xs : HVect ts) -> 
+                   GenFun ss $ applyPartially {ts} {ss} {rs} {cod = Type} cod xs
+applyPartiallyGen {ts = []     } {fordShape = Refl} f [] = f
+applyPartiallyGen {ts = t :: ts} {fordShape = Refl} f (x :: xs) = applyPartiallyGen (f x) xs
+  

--- a/libs/contrib/Data/Fun/Extra.idr
+++ b/libs/contrib/Data/Fun/Extra.idr
@@ -102,6 +102,3 @@ introduceWitness : {0 r : Rel ts} -> (witness : HVect ts) ->
                    uncurry {ts} r witness -> Ex ts r
 introduceWitness []             f = f
 introduceWitness (w :: witness) f = (w ** introduceWitness witness f)
-
-
-

--- a/libs/contrib/Data/Fun/Extra.idr
+++ b/libs/contrib/Data/Fun/Extra.idr
@@ -102,3 +102,14 @@ introduceWitness : {0 r : Rel ts} -> (witness : HVect ts) ->
                    uncurry {ts} r witness -> Ex ts r
 introduceWitness []             f = f
 introduceWitness (w :: witness) f = (w ** introduceWitness witness f)
+
+----------------------------------------------------------------------
+public export
+data FunVect : (ts, ss : Vect n Type) -> Type where
+  Nil  : FunVect [] []
+  (::) : (f : t -> s) -> FunVect ts ss -> FunVect (t::ts) (s::ss)
+
+public export
+precompose : FunVect ts ss -> Fun ss cod -> Fun ts cod
+precompose [] h = h
+precompose (f :: fs) h = \x => precompose fs (h (f x))

--- a/libs/contrib/Data/Void.idr
+++ b/libs/contrib/Data/Void.idr
@@ -1,0 +1,13 @@
+module Data.Void
+
+export
+persistentVoid : (0 x : Void) -> Void
+persistentVoid _ impossible
+
+export
+absurdity : Uninhabited t => (0 _ : t) -> s
+absurdity x = absurd (persistentVoid (uninhabited x))
+
+export
+absurdSince : (Uninhabited t) => (0 _ : x -> t) -> (x -> s)
+absurdSince since x = absurdity (since x)

--- a/libs/contrib/Data/Void.idr
+++ b/libs/contrib/Data/Void.idr
@@ -1,13 +1,9 @@
 module Data.Void
 
 export
-persistentVoid : (0 x : Void) -> Void
-persistentVoid _ impossible
-
-export
 absurdity : Uninhabited t => (0 _ : t) -> s
-absurdity x = absurd (persistentVoid (uninhabited x))
+absurdity x = void (uninhabited x)
 
 export
-absurdSince : (Uninhabited t) => (0 _ : x -> t) -> (x -> s)
-absurdSince since x = absurdity (since x)
+contradiction : (Uninhabited t) => (0 _ : x -> t) -> (x -> s)
+contradiction since x = absurdity (since x)

--- a/libs/contrib/Decidable/Decidable/Extra.idr
+++ b/libs/contrib/Decidable/Decidable/Extra.idr
@@ -1,0 +1,25 @@
+module Decidable.Decidable.Extra
+
+import Data.Rel
+import Data.Fun
+import Data.Vect
+import Data.Fun.Extra
+import Decidable.Decidable
+
+public export
+NotNot : {ts : Vect n Type} -> (r : Rel ts) -> Rel ts
+NotNot r = map @{Nary} (Not . Not) r 
+
+[DecidablePartialApplication] {x : t} -> (tts : Decidable (t :: ts) r) => Decidable ts (r x) where
+  decide = decide @{tts} x
+
+public export
+doubleNegation : {ts : Vect n Type} -> {r : Rel ts} -> Decidable ts r =>
+  Ex ts (NotNot {ts} r) -> 
+  Ex ts r
+doubleNegation {ts = []} @{dec} nnxs = case decide @{dec} of 
+  Yes prf => prf
+  No  not => absurd (nnxs not)
+doubleNegation {ts = (t :: ts)} @{dec} (x ** nnxs) = 
+  (x ** doubleNegation {ts} {r = r x} @{ DecidablePartialApplication @{dec} } nnxs)
+ 

--- a/libs/contrib/Decidable/Decidable/Extra.idr
+++ b/libs/contrib/Decidable/Decidable/Extra.idr
@@ -8,14 +8,14 @@ import Data.Fun.Extra
 import Decidable.Decidable
 
 public export
-NotNot : {ts : Vect n Type} -> (r : Rel ts) -> Rel ts
+NotNot : {n : Nat} -> {ts : Vect n Type} -> (r : Rel ts) -> Rel ts
 NotNot r = map @{Nary} (Not . Not) r 
 
 [DecidablePartialApplication] {x : t} -> (tts : Decidable (t :: ts) r) => Decidable ts (r x) where
   decide = decide @{tts} x
 
 public export
-doubleNegationElimination : {ts : Vect n Type} -> {r : Rel ts} -> Decidable ts r =>
+doubleNegationElimination : {n : Nat} -> {0 ts : Vect n Type} -> {r : Rel ts} -> Decidable ts r =>
   (witness : HVect ts) -> 
   uncurry (NotNot {ts} r) witness -> 
   uncurry              r  witness
@@ -26,7 +26,7 @@ doubleNegationElimination {ts = []     } @{dec} [] prfnn =
 doubleNegationElimination {ts = t :: ts} @{dec} (w :: witness) prfnn = 
   doubleNegationElimination {ts} {r = r w} @{ DecidablePartialApplication @{dec} } witness prfnn
 
-doubleNegationForall : {ts : Vect n Type} -> {r : Rel ts} -> Decidable ts r =>
+doubleNegationForall : {n : Nat} -> {0 ts : Vect n Type} -> {r : Rel ts} -> Decidable ts r =>
   All ts (NotNot {ts} r) -> All ts r
 doubleNegationForall @{dec} forall_prf = 
   let prfnn : (witness : HVect ts) -> uncurry (NotNot {ts} r) witness
@@ -36,7 +36,7 @@ doubleNegationForall @{dec} forall_prf =
   in curryAll prf
 
 public export
-doubleNegationExists : {ts : Vect n Type} -> {r : Rel ts} -> Decidable ts r =>
+doubleNegationExists : {n : Nat} -> {0 ts : Vect n Type} -> {r : Rel ts} -> Decidable ts r =>
   Ex ts (NotNot {ts} r) -> 
   Ex ts r
 doubleNegationExists {ts} {r} @{dec} nnxs = 

--- a/libs/contrib/Decidable/Order/Strict.idr
+++ b/libs/contrib/Decidable/Order/Strict.idr
@@ -27,7 +27,7 @@ EqOr spo a b = Either (a = b) (a `spo` b)
 
 -- Can generalise to an arbitrary equivalence, I belive
 public export
-[HackPreorder] {spo : t -> t -> Type} -> StrictPreorder t spo => Preorder t (EqOr spo) where
+[MkPreorder] {spo : t -> t -> Type} -> StrictPreorder t spo => Preorder t (EqOr spo) where
   reflexive a = Left Refl
   transitive a _ c (Left  Refl) bLTEc        = bLTEc
   transitive a b _ (Right aLTb) (Left  Refl) = Right aLTb
@@ -38,8 +38,8 @@ public export
            
 %hint
 public export
-HackPoset : {t : Type} -> {spo : t -> t -> Type} -> StrictPreorder t spo => Poset t (EqOr spo) 
-HackPoset {t} {spo} = MkPoset @{HackPreorder} {antisym = antisym}
+InferPoset : {t : Type} -> {spo : t -> t -> Type} -> StrictPreorder t spo => Poset t (EqOr spo) 
+InferPoset {t} {spo} = MkPoset @{MkPreorder} {antisym = antisym}
   where
     antisym : (a,b : t) -> EqOr spo a b -> EqOr spo b a -> a = b
     antisym a a (Left  Refl) (Left  Refl) = Refl
@@ -62,8 +62,8 @@ interface StrictPreorder t spo => StrictOrdered t (spo : t -> t -> Type) where
 
 %hint
 public export
-HackOrder : {t : Type} -> {spo : t -> t -> Type} -> StrictOrdered t spo => Ordered t (EqOr spo)
-HackOrder {t} {spo} @{so} = MkOrdered @{HackPoset} {ord = ord}
+InferOrder : {t : Type} -> {spo : t -> t -> Type} -> StrictOrdered t spo => Ordered t (EqOr spo)
+InferOrder {t} {spo} @{so} = MkOrdered @{InferPoset} {ord = ord}
   where
     ord : (a,b : t) -> Either (EqOr spo a b) (EqOr spo b a)
     ord  a b with (Strict.order @{so} a b)

--- a/libs/contrib/Decidable/Order/Strict.idr
+++ b/libs/contrib/Decidable/Order/Strict.idr
@@ -7,6 +7,7 @@
 module Decidable.Order.Strict
 
 import Decidable.Order
+import Decidable.Equality
 
 %default total
 
@@ -70,3 +71,14 @@ HackOrder {t} {spo} @{so} = MkOrdered @{HackPoset} {ord = ord}
      ord a b | DecLT aLTb = Left  (Right aLTb)
      ord a b | DecGT bLTa = Right (Right bLTa)
 
+
+public export
+(tot : StrictOrdered t lt) => (pre : StrictPreorder t lt) => DecEq t where
+  decEq x y = case order @{tot} x y of
+    DecEQ x_eq_y => Yes x_eq_y
+    DecLT xlty => No $ \x_eq_y => absurd $ irreflexive @{pre} y 
+                                         $ replace {p = \u => u `lt` y} x_eq_y xlty
+    -- Similarly                                         
+    DecGT yltx => No $ \x_eq_y => absurd $ irreflexive @{pre} y
+                                         $ replace {p = \u => y `lt` u} x_eq_y yltx
+    

--- a/libs/contrib/Decidable/Order/Strict.idr
+++ b/libs/contrib/Decidable/Order/Strict.idr
@@ -1,0 +1,72 @@
+||| An strict preorder (sometimes known as a quasi-order, or an
+||| ordering) is what you get when you remove the diagonal `{(a,b) | a
+||| r b , b r a}` from a preorder. For example a < b is an ordering.
+||| This module extends base's Decidable.Order with the strict versions.
+||| The interface system seems to struggle a bit with some of the constructions,
+||| so I hacked them a bit. Sorry.
+module Decidable.Order.Strict
+
+import Decidable.Order
+
+%default total
+
+public export
+interface StrictPreorder t (spo : t -> t -> Type) where
+  transitive : (a, b, c : t) -> a `spo` b -> b `spo` c -> a `spo` c
+  irreflexive : (a : t) -> Not (a `spo` a)
+  
+public export
+asymmetric : StrictPreorder t spo => (a, b : t) -> a `spo` b -> Not (b `spo` a)
+asymmetric a b aLTb bLTa = irreflexive a $ 
+                           Strict.transitive a b a aLTb bLTa
+
+public export
+EqOr : (spo : t -> t -> Type) -> StrictPreorder t spo => (a,b : t) -> Type
+EqOr spo a b = Either (a = b) (a `spo` b)
+
+-- Can generalise to an arbitrary equivalence, I belive
+public export
+[HackPreorder] {spo : t -> t -> Type} -> StrictPreorder t spo => Preorder t (EqOr spo) where
+  reflexive a = Left Refl
+  transitive a _ c (Left  Refl) bLTEc        = bLTEc
+  transitive a b _ (Right aLTb) (Left  Refl) = Right aLTb
+  transitive a b c (Right aLTb) (Right bLTc) = Right $ Strict.transitive a b c aLTb bLTc
+
+[MkPoset] {antisym : (a,b : t) -> a `leq` b -> b `leq` a -> a = b} -> Preorder t leq => Poset t leq where
+  antisymmetric = antisym
+           
+%hint
+public export
+HackPoset : {t : Type} -> {spo : t -> t -> Type} -> StrictPreorder t spo => Poset t (EqOr spo) 
+HackPoset {t} {spo} = MkPoset @{HackPreorder} {antisym = antisym}
+  where
+    antisym : (a,b : t) -> EqOr spo a b -> EqOr spo b a -> a = b
+    antisym a a (Left  Refl) (Left  Refl) = Refl
+    antisym a a (Left  Refl) (Right bLTa) = absurd (irreflexive a bLTa)
+    antisym b b (Right aLTb) (Left  Refl) = absurd (irreflexive b aLTb)
+    antisym a b (Right aLTb) (Right bLTa) = absurd (asymmetric a b aLTb bLTa)
+
+public export
+data DecOrdering : {lt : t -> t -> Type} -> (a,b : t) -> Type where
+  DecLT : forall lt . (a `lt` b) -> DecOrdering {lt = lt} a b
+  DecEQ : forall lt . (a  =   b) -> DecOrdering {lt = lt} a b
+  DecGT : forall lt . (b `lt` a) -> DecOrdering {lt = lt} a b 
+
+public export
+interface StrictPreorder t spo => StrictOrdered t (spo : t -> t -> Type) where
+  order : (a,b : t) -> DecOrdering {lt = spo} a b 
+
+[MkOrdered] {ord : (a,b : t) -> Either (a `leq` b) (b `leq` a)} -> Poset t leq => Ordered t leq where
+  order = ord
+
+%hint
+public export
+HackOrder : {t : Type} -> {spo : t -> t -> Type} -> StrictOrdered t spo => Ordered t (EqOr spo)
+HackOrder {t} {spo} @{so} = MkOrdered @{HackPoset} {ord = ord}
+  where
+    ord : (a,b : t) -> Either (EqOr spo a b) (EqOr spo b a)
+    ord  a b with (Strict.order @{so} a b)
+     ord a _ | DecEQ Refl = Left  (Left  Refl)
+     ord a b | DecLT aLTb = Left  (Right aLTb)
+     ord a b | DecGT bLTa = Right (Right bLTa)
+

--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -25,6 +25,8 @@ modules = Control.ANSI,
 
           Data.Fin.Extra,
 
+          Data.Fun.Extra,
+
           Data.Logic.Propositional,
 
           Data.Morphisms.Algebra,
@@ -46,9 +48,14 @@ modules = Control.ANSI,
 
           Data.Vect.Sort,
 
+          Data.Void,
+
           Data.HVect,
 
           Debug.Buffer,
+
+          Decidable.Order.Strict,
+          Decidable.Decidable.Extra,
 
           Language.JSON,
           Language.JSON.Data,


### PR DESCRIPTION
Expose some `private` function in libs/base that I needed, and seem like
their visibility was forgotten

I'd appreciate a code review, especially to tell me I'm
re-implementing something that's already elsewhere in the library

Mostly extending existing functionality:
* `Data/Void.idr`: add some utility functions for manipulating absurdity.
* `Decidable/Decidable/Extra.idr`: add support for double negation elimination in decidable relations
* `Data/Fun/Extra.idr`:
  + add `application` (total and partil) for n-ary functions
  + add (slightly) dependent versions of these operations
  + add n-ary function precomposition
* `Decidable/Order/Strict.idr`: a strict preorder is what you get when
  you remove the diagonal from a pre-order. For example, `<` is the
  associated preorder for `<=` over `Nat`.
  Analogous to `Decidable.Order`. The proof search mechanism struggled
  a bit, so I had to hack it --- sorry.