### PR TITLE
State param order

### DIFF
--- a/docs/source/typedd/typedd.rst
+++ b/docs/source/typedd/typedd.rst
@@ -346,6 +346,8 @@ arguments ``div`` and ``rem``.
 In ``ArithState.idr``, since ``(>>=)`` is ``export``, ``Command`` and ``ConsoleIO``
 also have to be ``export``.
 
+evalState from Control.Monad.State now takes the ``stateType`` argument first.
+
 Chapter 13
 ----------
 

--- a/libs/base/Control/Monad/State.idr
+++ b/libs/base/Control/Monad/State.idr
@@ -15,43 +15,41 @@ interface Monad m => MonadState stateType (m : Type -> Type) | m where
 public export
 record StateT (stateType : Type) (m : Type -> Type) (a : Type) where
   constructor ST
-  runStateT : stateType -> m (a, stateType)
+  runStateT : stateType -> m (stateType, a)
 
 public export
 implementation Functor f => Functor (StateT stateType f) where
-    map f (ST g) = ST (\st => map (mapFst f) (g st)) where
-       mapFst : (a -> x) -> (a, s) -> (x, s)
-       mapFst fn (a, b) = (fn a, b)
+    map f (ST g) = ST (\st => map (map f) (g st)) where
 
 public export
 implementation Monad f => Applicative (StateT stateType f) where
-    pure x = ST (\st => pure (x, st))
+    pure x = ST (\st => pure (st, x))
 
     (ST f) <*> (ST a)
         = ST (\st =>
-                do (g, r) <- f st
-                   (b, t) <- a r
-                   pure (g b, t))
+                do (r, g) <- f st
+                   (t, b) <- a r
+                   pure (t, g b))
 
 public export
 implementation Monad m => Monad (StateT stateType m) where
     (ST f) >>= k
         = ST (\st =>
-                do (v, st') <- f st
+                do (st', v) <- f st
                    let ST kv = k v
                    kv st')
 
 public export
 implementation Monad m => MonadState stateType (StateT stateType m) where
     get   = ST (\x => pure (x, x))
-    put x = ST (\y => pure ((), x))
+    put x = ST (\y => pure (x, ()))
 
 public export
 implementation MonadTrans (StateT stateType) where
     lift x
         = ST (\st =>
                 do r <- x
-                   pure (r, st))
+                   pure (st, r))
 
 public export
 implementation (Monad f, Alternative f) => Alternative (StateT st f) where
@@ -60,7 +58,7 @@ implementation (Monad f, Alternative f) => Alternative (StateT st f) where
 
 public export
 implementation HasIO m => HasIO (StateT stateType m) where
-  liftIO io = ST $ \s => liftIO $ io_bind io $ \a => pure (a, s)
+  liftIO io = ST $ \s => liftIO $ io_bind io $ \a => pure (s, a)
 
 ||| Apply a function to modify the context of this computation
 public export
@@ -83,15 +81,15 @@ State = \s, a => StateT s Identity a
 
 ||| Unwrap a State monad computation.
 public export
-runState : StateT stateType Identity a -> stateType -> (a, stateType)
+runState : StateT stateType Identity a -> stateType -> (stateType, a)
 runState act = runIdentity . runStateT act
 
 ||| Unwrap a State monad computation, but discard the final state.
 public export
 evalState : State stateType a -> stateType -> a
-evalState m = fst . runState m
+evalState m = snd . runState m
 
 ||| Unwrap a State monad computation, but discard the resulting value.
 public export
 execState : State stateType a -> stateType -> stateType
-execState m = snd . runState m
+execState m = fst . runState m

--- a/libs/base/Control/Monad/State.idr
+++ b/libs/base/Control/Monad/State.idr
@@ -15,7 +15,7 @@ interface Monad m => MonadState stateType (m : Type -> Type) | m where
 public export
 record StateT (stateType : Type) (m : Type -> Type) (a : Type) where
   constructor ST
-  runStateT : stateType -> m (stateType, a)
+  runStateT' : stateType -> m (stateType, a)
 
 public export
 implementation Functor f => Functor (StateT stateType f) where
@@ -74,22 +74,28 @@ gets f
     = do s <- get
          pure (f s)
 
+||| Unwrap and apply a StateT monad computation.
+public export
+%inline
+runStateT : stateType -> StateT stateType m a -> m (stateType, a)
+runStateT s act = runStateT' act s
+
 ||| The State monad. See the MonadState interface
 public export
 State : (stateType : Type) -> (ty : Type) -> Type
 State = \s, a => StateT s Identity a
 
-||| Unwrap a State monad computation.
+||| Unwrap and apply a State monad computation.
 public export
-runState : StateT stateType Identity a -> stateType -> (stateType, a)
-runState act = runIdentity . runStateT act
+runState : stateType -> StateT stateType Identity a -> (stateType, a)
+runState s act = runIdentity (runStateT s act)
 
-||| Unwrap a State monad computation, but discard the final state.
+||| Unwrap and apply a State monad computation, but discard the final state.
 public export
-evalState : State stateType a -> stateType -> a
-evalState m = snd . runState m
+evalState : stateType -> State stateType a -> a
+evalState s = snd . runState s
 
-||| Unwrap a State monad computation, but discard the resulting value.
+||| Unwrap and apply a State monad computation, but discard the resulting value.
 public export
-execState : State stateType a -> stateType -> stateType
-execState m = fst . runState m
+execState : stateType -> State stateType a -> stateType
+execState s = fst . runState s

--- a/src/Idris/Elab/Implementation.idr
+++ b/src/Idris/Elab/Implementation.idr
@@ -343,7 +343,7 @@ elabImplementation {vars} fc vis opts_in pass env nest is cons iname ps impln nu
              -- parameters
              let upds' = !(traverse (applyCon impName) allmeths)
              let mty_in = substNames vars upds' mty_in
-             let (upds, mty_in) = runState (renameIBinds impsp (findImplicits mty_in) mty_in) []
+             let (upds, mty_in) = runState [] (renameIBinds impsp (findImplicits mty_in) mty_in)
              -- Finally update the method type so that implicits from the
              -- parameters are passed through to any earlier methods which
              -- appear in the type

--- a/src/Idris/Elab/Implementation.idr
+++ b/src/Idris/Elab/Implementation.idr
@@ -343,7 +343,7 @@ elabImplementation {vars} fc vis opts_in pass env nest is cons iname ps impln nu
              -- parameters
              let upds' = !(traverse (applyCon impName) allmeths)
              let mty_in = substNames vars upds' mty_in
-             let (mty_in, upds) = runState (renameIBinds impsp (findImplicits mty_in) mty_in) []
+             let (upds, mty_in) = runState (renameIBinds impsp (findImplicits mty_in) mty_in) []
              -- Finally update the method type so that implicits from the
              -- parameters are passed through to any earlier methods which
              -- appear in the type

--- a/tests/typedd-book/chapter12/TreeLabelState.idr
+++ b/tests/typedd-book/chapter12/TreeLabelState.idr
@@ -22,5 +22,5 @@ treeLabelWith (Node left val right)
           pure (Node left_labelled (this, val) right_labelled)
 
 treeLabel : Tree a -> Tree (Integer, a)
-treeLabel tree = evalState (treeLabelWith tree) [1..]
+treeLabel tree = evalState [1..] (treeLabelWith tree)
 


### PR DESCRIPTION
Nipping this historical artifact in the bud before it roots. It's quite often useful to be able to `map` directly to the result of a StateT computation and due to how Functor works this is made harder when the tuple is `(a,state)` vs `(state,a)`
Specifically that `map f (x,y)` applies `f` to `y`.

It's also rare that a person's `state` argument takes up more space than their `StateT s a` argument in `runState`. e.g.
```
foo = runState (do multiline
                   statet
                   thing)
               thestartingstate
```
and so one has to immediately decide if it's worth the extra parens and formatting involved or if they should take the time to pull out `multiline_statet_thing` into a separate definition.

Let's avoid this hassle by providing the state upfront instead and allowing users to write their bulkier code where it will fit better.
```
foo = runState thestartingstate $ do multiline
    statet
    thing
```
This makes for much nicer in-progress code, things can be moved out later on if they grow too large.

Note that while one can write
```idris
(`runState` thestartingstate) $ do ...`
```
this pr is about setting the default. How often is the code making up your `StateT s a` larger than your `state` code? Should users have to write this operator section if putting `StateT s a` last is the majority use case?