### PR TITLE
fix idiom brackets to account for IAlternative

### DIFF
--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -118,6 +118,8 @@ bindBangs ((n, fc, btm) :: bs) tm
                                 (Implicit fc False) tm)
 
 idiomise : FC -> RawImp -> RawImp
+idiomise fc (IAlternative afc u alts)
+  = IAlternative afc (mapAltType (idiomise afc) u) (idiomise afc <$> alts)
 idiomise fc (IApp afc f a)
     = IApp fc (IApp fc (IVar fc (UN "<*>"))
                     (idiomise afc f))

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -285,7 +285,10 @@ mutual
            pure (IVar fc bn)
   desugarB side ps (PIdiom fc term)
       = do itm <- desugarB side ps term
-           pure (idiomise fc itm)
+           logRaw "desugar.idiom" 10 "Desugaring idiom for" itm
+           let val = idiomise fc itm
+           logRaw "desugar.idiom" 10 "Desugared to" val
+           pure val
   desugarB side ps (PList fc args)
       = expandList side ps fc args
   desugarB side ps (PPair fc l r)

--- a/src/TTImp/BindImplicits.idr
+++ b/src/TTImp/BindImplicits.idr
@@ -105,11 +105,7 @@ doBind ns (IQuote fc tm)
 doBind ns (IUnquote fc tm)
     = IUnquote fc (doBind ns tm)
 doBind ns (IAlternative fc u alts)
-    = IAlternative fc (doBindAlt u) (map (doBind ns) alts)
-  where
-    doBindAlt : AltType -> AltType
-    doBindAlt (UniqueDefault t) = UniqueDefault (doBind ns t)
-    doBindAlt u = u
+    = IAlternative fc (mapAltType (doBind ns) u) (map (doBind ns) alts)
 doBind ns tm = tm
 
 export

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -4,6 +4,7 @@ import Core.Binary
 import Core.Context
 import Core.Env
 import Core.Normalise
+import Core.Options
 import Core.Options.Log
 import Core.TT
 import Core.TTC
@@ -1010,3 +1011,16 @@ mutual
                8 => do n <- fromBuf b
                        pure (ILog n)
                _ => corrupt "ImpDecl"
+
+
+-- Log message with a RawImp
+export
+logRaw : {auto c : Ref Ctxt Defs} ->
+         String -> Nat -> Lazy String -> RawImp -> Core ()
+logRaw str n msg tm
+    = do opts <- getSession
+         let lvl = mkLogLevel str n
+         if keepLog lvl (logLevel opts)
+            then do coreLift $ putStrLn $ "LOG " ++ show lvl ++ ": " ++ msg
+                                          ++ ": " ++ show tm
+            else pure ()

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -380,6 +380,11 @@ data ImpREPL : Type where
      Quit : ImpREPL
 
 export
+mapAltType : (RawImp -> RawImp) -> AltType -> AltType
+mapAltType f (UniqueDefault x) = UniqueDefault (f x)
+mapAltType _ u = u
+
+export
 lhsInCurrentNS : {auto c : Ref Ctxt Defs} ->
                  NestedNames vars -> RawImp -> Core RawImp
 lhsInCurrentNS nest (IApp loc f a)

--- a/tests/idris2/basic032/Idiom.idr
+++ b/tests/idris2/basic032/Idiom.idr
@@ -12,4 +12,3 @@ export
 
 addm : Maybe Int -> Maybe Int -> Maybe Int
 addm x y = [| x + y |]
-

--- a/tests/idris2/basic032/Idiom2.idr
+++ b/tests/idris2/basic032/Idiom2.idr
@@ -10,8 +10,3 @@ fez1 = [| MkPair fez (pure ()) |]
 
 fez2 : IO (Int, Maybe Int)
 fez2 = [| ( fez , (pure Nothing) ) |]
-
-fuzz : IO ()
-fuzz = do
-  fez1 >>= printLn
-  fez2 >>= printLn

--- a/tests/idris2/basic032/Idiom2.idr
+++ b/tests/idris2/basic032/Idiom2.idr
@@ -1,0 +1,17 @@
+-- Things like  ( , )  ( ** )  ()   are special in that they denote more than
+-- one thing at once. () can mean Unit or MkUnit, (,) can mean Pair or MkPair
+-- Idiom brackets need to be able to work despite that, which is tested here
+
+fez : IO Int
+fez = pure 1
+
+fez1 : IO (Int, ())
+fez1 = [| MkPair fez (pure ()) |]
+
+fez2 : IO (Int, Maybe Int)
+fez2 = [| ( fez , (pure Nothing) ) |]
+
+fuzz : IO ()
+fuzz = do
+  fez1 >>= printLn
+  fez2 >>= printLn

--- a/tests/idris2/basic032/expected
+++ b/tests/idris2/basic032/expected
@@ -1,5 +1,4 @@
 1/1: Building Idiom (Idiom.idr)
 Main> Just 7
 Main> Bye for now!
-(1, ())
-(1, Nothing)
+1/1: Building Idiom2 (Idiom2.idr)

--- a/tests/idris2/basic032/expected
+++ b/tests/idris2/basic032/expected
@@ -1,3 +1,5 @@
 1/1: Building Idiom (Idiom.idr)
 Main> Just 7
 Main> Bye for now!
+(1, ())
+(1, Nothing)

--- a/tests/idris2/basic032/run
+++ b/tests/idris2/basic032/run
@@ -1,4 +1,4 @@
 $1 --no-color --console-width 0 --no-banner Idiom.idr < input
-$1 --no-color --console-width 0 --no-banner Idiom2.idr --exec fuzz
+$1 --no-color --console-width 0 --no-banner Idiom2.idr --check
 
 rm -rf build

--- a/tests/idris2/basic032/run
+++ b/tests/idris2/basic032/run
@@ -1,3 +1,4 @@
 $1 --no-color --console-width 0 --no-banner Idiom.idr < input
+$1 --no-color --console-width 0 --no-banner Idiom2.idr --exec fuzz
 
 rm -rf build


### PR DESCRIPTION
Things like (,) () aren't straightforward IVar's but are IAlternative's
which present options about how the term should resolve. [| |] was not
accounting for this.

Addressing #676 