### PR TITLE
Adding a whole bunch of tuple sections

### DIFF
--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -42,6 +42,7 @@ idrisTests
        "basic031", "basic032", "basic033", "basic034", "basic035",
        "basic036", "basic037", "basic038", "basic039", "basic040",
        "basic041", "basic042", "basic043", "basic044", "basic045",
+       "basic046",
        -- Coverage checking
        "coverage001", "coverage002", "coverage003", "coverage004",
        "coverage005", "coverage006", "coverage007", "coverage008",

--- a/tests/idris2/basic046/TupleSections.idr
+++ b/tests/idris2/basic046/TupleSections.idr
@@ -1,0 +1,10 @@
+import Data.Vect
+
+-- distrL : a -> List b -> List (a, b)
+-- distrL a = map (a,)
+
+distrR : b -> List a -> List (a, b)
+distrR b = map (, b)
+
+-- closeVect : List (n ** Vect n Nat)
+-- closeVect = map (** flip replicate 3) [0..10]

--- a/tests/idris2/basic046/TupleSections.idr
+++ b/tests/idris2/basic046/TupleSections.idr
@@ -1,10 +1,14 @@
 import Data.Vect
 
--- distrL : a -> List b -> List (a, b)
--- distrL a = map (a,)
+distrL : a -> List b -> List (a, b)
+distrL a = map (a,)
 
 distrR : b -> List a -> List (a, b)
 distrR b = map (, b)
 
 -- closeVect : List (n ** Vect n Nat)
 -- closeVect = map (** flip replicate 3) [0..10]
+
+insert : List (Nat,Nat,Nat,Nat)
+insert = map (\ f => f (the Nat 0) (the Nat 1))
+         [(,,2,3), (2,,,3), (2,3,,)]

--- a/tests/idris2/basic046/expected
+++ b/tests/idris2/basic046/expected
@@ -1,0 +1,1 @@
+1/1: Building TupleSections (TupleSections.idr)

--- a/tests/idris2/basic046/expected
+++ b/tests/idris2/basic046/expected
@@ -1,1 +1,6 @@
 1/1: Building TupleSections (TupleSections.idr)
+Main> [("begin", 0), ("begin", 1), ("begin", 2)]
+Main> [(0, "end"), (1, "end"), (2, "end")]
+Main> [(0, (1, (2, 3))), (2, (0, (1, 3))), (2, (3, (0, 1)))]
+Main> Main> 
+Bye for now!

--- a/tests/idris2/basic046/input
+++ b/tests/idris2/basic046/input
@@ -1,0 +1,5 @@
+distrL "begin" [0..2]
+distrR "end" [0..2]
+insert
+
+:q

--- a/tests/idris2/basic046/run
+++ b/tests/idris2/basic046/run
@@ -1,3 +1,3 @@
-$1 --no-banner --no-color --console-width 0 TupleSections.idr --check
+$1 --no-banner --no-color --console-width 0 TupleSections.idr < input
 
 rm -rf build

--- a/tests/idris2/basic046/run
+++ b/tests/idris2/basic046/run
@@ -1,0 +1,3 @@
+$1 --no-banner --no-color --console-width 0 TupleSections.idr --check
+
+rm -rf build


### PR DESCRIPTION
The commented out test is aspirational: we should be able to do the same for `DPair`.
Ideally we should also be able to arbitrarily interleave `,` and `**`.