### PR TITLE
[ new ] comma-separated interface parameters

### DIFF
--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1187,16 +1187,16 @@ implBinds fname indents
          pure ((n, rig, tm) :: more)
   <|> pure []
 
-ifaceParam : FileName -> IndentInfo -> Rule (Name, PTerm)
+ifaceParam : FileName -> IndentInfo -> Rule (List Name, PTerm)
 ifaceParam fname indents
     = do symbol "("
-         n <- name
+         ns <- sepBy1 (symbol ",") name
          symbol ":"
          tm <- expr pdef fname indents
          symbol ")"
-         pure (n, tm)
+         pure (ns, tm)
   <|> do n <- bounds name
-         pure (n.val, PInfer (boundToFC fname n))
+         pure ([n.val], PInfer (boundToFC fname n))
 
 ifaceDecl : FileName -> IndentInfo -> Rule PDecl
 ifaceDecl fname indents
@@ -1207,7 +1207,8 @@ ifaceDecl fname indents
                          commit
                          cons   <- constraints fname indents
                          n      <- name
-                         params <- many (ifaceParam fname indents)
+                         paramss <- many (ifaceParam fname indents)
+                         let params = concatMap (\ (ns, t) => map (\ n => (n, t)) ns) paramss
                          det    <- option []
                                      (do symbol "|"
                                          sepBy (symbol ",") name)

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -67,6 +67,7 @@ idrisTests
        "interface005", "interface006", "interface007", "interface008",
        "interface009", "interface010", "interface011", "interface012",
        "interface013", "interface014", "interface015", "interface016",
+       "interface017",
        -- Miscellaneous REPL
        "interpreter001", "interpreter002", "interpreter003",
        -- Implicit laziness, lazy evaluation

--- a/tests/idris2/interface017/Tricho.idr
+++ b/tests/idris2/interface017/Tricho.idr
@@ -1,0 +1,10 @@
+module Tricho
+
+data Trichotomy : (eq, lt : a -> a -> Type) -> (a -> a -> Type) where
+  LT : {0 x, y : a} -> lt x y -> Trichotomy eq lt x y
+  EQ : {0 x, y : a} -> eq x y -> Trichotomy eq lt x x
+  GT : {0 x, y : a} -> lt y x -> Trichotomy eq lt x y
+
+interface Trichotomous (a : Type) (eq, lt : a -> a -> Type) where
+
+  trichotomy : (x, y : a) -> Trichotomy eq lt x y

--- a/tests/idris2/interface017/TwoNum.idr
+++ b/tests/idris2/interface017/TwoNum.idr
@@ -1,0 +1,4 @@
+f : Num a => a
+f = g where
+  g : Num a => a
+  g = 0

--- a/tests/idris2/interface017/TwoNum.idr
+++ b/tests/idris2/interface017/TwoNum.idr
@@ -1,4 +1,0 @@
-f : Num a => a
-f = g where
-  g : Num a => a
-  g = 0

--- a/tests/idris2/interface017/expected
+++ b/tests/idris2/interface017/expected
@@ -1,0 +1,1 @@
+1/1: Building Tricho (Tricho.idr)

--- a/tests/idris2/interface017/run
+++ b/tests/idris2/interface017/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 Tricho.idr --check
+
+rm -rf build


### PR DESCRIPTION
Coming back to the code that motivated the work on #680 
I got annoyed I could not write

```idris
interface T (a : Type) (lt, eq : a -> a -> Type)
```

like in other telescopes but would be forced to write

```idris
interface T (a : Type) (lt : a -> a -> Type) (eq : a -> a -> Type)
```

instead