### PR TITLE
[ fix #643 ] Make `NmLet` names unique in `Compiler.ES.Imperative`

### DIFF
--- a/src/Compiler/ES/Imperative.idr
+++ b/src/Compiler/ES/Imperative.idr
@@ -156,8 +156,17 @@ mutual
     do
       (s1, v) <- impExp False val
       (s2, sc_) <- impExp False sc
-      let decl  = if isNameUsed x sc then ConstDecl x v else EvalExpStatement v
-      pairToReturn toReturn (s1 <+> decl <+> s2, sc_)
+      if isNameUsed x sc
+        then do
+          x_ <- genName
+          let reps = [(x, IEVar x_)]
+          let s2_ = replaceNamesExpS reps s2
+          let sc__ = replaceNamesExp reps sc_
+          let decl = ConstDecl x_ v
+          pairToReturn toReturn (s1 <+> decl <+> s2_, sc__)
+        else do
+          let decl = EvalExpStatement v
+          pairToReturn toReturn (s1 <+> decl <+> s2, sc_)
   impExp toReturn (NmErased fc) =
     expToReturn toReturn $ IENull
   impExp toReturn (NmCrash fc msg) =

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -145,6 +145,7 @@ nodeTests
     , "reg001"
     , "syntax001"
     , "tailrec001"
+    , "idiom001"
     ]
 
 ideModeTests : List String

--- a/tests/node/idiom001/Main.idr
+++ b/tests/node/idiom001/Main.idr
@@ -1,0 +1,4 @@
+main : IO ()
+main = do
+  [| (const $ pure MkUnit) (pure ()) |]
+  pure ()

--- a/tests/node/idiom001/expected
+++ b/tests/node/idiom001/expected
@@ -1,0 +1,2 @@
+1/1: Building Main (Main.idr)
+Main> Main> Bye for now!

--- a/tests/node/idiom001/input
+++ b/tests/node/idiom001/input
@@ -1,0 +1,2 @@
+:exec main
+:q

--- a/tests/node/idiom001/run
+++ b/tests/node/idiom001/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 --cg node --no-banner Main.idr < input
+
+rm -rf build


### PR DESCRIPTION
Since the imperative form has no nesting of scopes.

Fixes #643