### PR TITLE
Fix String->Int cast on Scheme backends

### DIFF
--- a/support/chez/support.ss
+++ b/support/chez/support.ss
@@ -46,18 +46,18 @@
       ((equal? x "") "")
       ((equal? (string-ref x 0) #\#) "")
       (else x))))
+(define exact-floor
+  (lambda (x)
+    (inexact->exact (floor x))))
 (define cast-string-int
   (lambda (x)
-    (floor (cast-num (string->number (destroy-prefix x))))))
+    (exact-floor (cast-num (string->number (destroy-prefix x))))))
 (define cast-int-char
   (lambda (x)
     (if (and (>= x 0)
              (<= x #x10ffff))
         (integer->char x)
         0)))
-(define exact-floor
-  (lambda (x)
-    (inexact->exact (floor x))))
 (define cast-string-double
   (lambda (x)
     (cast-num (string->number (destroy-prefix x)))))

--- a/support/gambit/support.scm
+++ b/support/gambit/support.scm
@@ -66,7 +66,7 @@
   (cast-num (string->number (destroy-prefix x))))
 
 (define-macro (cast-string-int x)
-  `(floor (cast-string-double ,x)))
+  `(exact-floor (cast-string-double ,x)))
 
 (define (from-idris-list xs)
   (if (= (vector-ref xs 0) 0)

--- a/support/racket/support.rkt
+++ b/support/racket/support.rkt
@@ -45,7 +45,7 @@
       (else x))))
 (define cast-string-int
   (lambda (x)
-    (floor (cast-num (string->number (destroy-prefix x))))))
+    (exact-floor (cast-num (string->number (destroy-prefix x))))))
 (define cast-int-char
   (lambda (x)
     (if (and (>= x 0)

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -70,7 +70,7 @@ idrisTests
        "interface013", "interface014", "interface015", "interface016",
        "interface017",
        -- Miscellaneous REPL
-       "interpreter001", "interpreter002", "interpreter003",
+       "interpreter001", "interpreter002", "interpreter003", "interpreter004",
        -- Implicit laziness, lazy evaluation
        "lazy001",
        -- QTT and linearity related

--- a/tests/idris2/interpreter004/expected
+++ b/tests/idris2/interpreter004/expected
@@ -1,0 +1,2 @@
+Main> 12
+Main> Bye for now!

--- a/tests/idris2/interpreter004/expected
+++ b/tests/idris2/interpreter004/expected
@@ -1,2 +1,31 @@
+Main> "Int"
 Main> 12
+Main> 12
+Main> 12
+Main> 12
+Main> "Negative Int"
+Main> -12
+Main> -13
+Main> -13
+Main> -13
+Main> "Integer"
+Main> 12
+Main> 12
+Main> 12
+Main> 12
+Main> "Negative Integer"
+Main> -12
+Main> -13
+Main> -13
+Main> -13
+Main> "Double"
+Main> 12.0
+Main> 12.3
+Main> 12.5
+Main> 12.7
+Main> "Negative Double"
+Main> -12.0
+Main> -12.3
+Main> -12.5
+Main> -12.7
 Main> Bye for now!

--- a/tests/idris2/interpreter004/input
+++ b/tests/idris2/interpreter004/input
@@ -1,0 +1,2 @@
+the Int (cast "12.3")
+:q

--- a/tests/idris2/interpreter004/input
+++ b/tests/idris2/interpreter004/input
@@ -1,2 +1,31 @@
+"Int"
+the Int (cast "12.0")
 the Int (cast "12.3")
+the Int (cast "12.5")
+the Int (cast "12.7")
+"Negative Int"
+the Int (cast "-12.0")
+the Int (cast "-12.3")
+the Int (cast "-12.5")
+the Int (cast "-12.7")
+"Integer"
+the Integer (cast "12.0")
+the Integer (cast "12.3")
+the Integer (cast "12.5")
+the Integer (cast "12.7")
+"Negative Integer"
+the Integer (cast "-12.0")
+the Integer (cast "-12.3")
+the Integer (cast "-12.5")
+the Integer (cast "-12.7")
+"Double"
+the Double (cast "12.0")
+the Double (cast "12.3")
+the Double (cast "12.5")
+the Double (cast "12.7")
+"Negative Double"
+the Double (cast "-12.0")
+the Double (cast "-12.3")
+the Double (cast "-12.5")
+the Double (cast "-12.7")
 :q

--- a/tests/idris2/interpreter004/run
+++ b/tests/idris2/interpreter004/run
@@ -1,0 +1,1 @@
+$1 --no-color --console-width 0 --no-banner < input


### PR DESCRIPTION
Numbers in Scheme have an internal flag: exact/inexact.
This fix flags numbers outputted from `floor` when casting between `String` and `Int` as exact.

Fixes `cast {to = Int} "12.3"` reducing to `12.0` (internally)

I have tested it on my machine with Chez as a backend. I can't properly install Racket for some reason.
So if someone reading this has Racket in working order, could you please check this ?

Not sure how to write a test in such case, as the fix only concerns the internal representation, nor that a test is really needed.