### PR TITLE
[minor] Make `base/Data.Nat.divNatNZ` compile-time reducible

### DIFF
--- a/libs/base/Data/Nat.idr
+++ b/libs/base/Data/Nat.idr
@@ -187,11 +187,13 @@ export partial
 modNat : Nat -> Nat -> Nat
 modNat left (S right) = modNatNZ left (S right) SIsNotZ
 
-export partial
+-- 'public' to allow type-level division
+public export total
 divNatNZ : Nat -> (y: Nat) -> Not (y = Z) -> Nat
 divNatNZ left Z         p = void (p Refl)
-divNatNZ left (S right) _ = div' left left right
+divNatNZ left (S right) p = div' left left right
   where
+    public export
     div' : Nat -> Nat -> Nat -> Nat
     div' Z        centre right = Z
     div' (S left) centre right =

--- a/libs/base/Data/Nat.idr
+++ b/libs/base/Data/Nat.idr
@@ -191,7 +191,7 @@ modNat left (S right) = modNatNZ left (S right) SIsNotZ
 public export total
 divNatNZ : Nat -> (y: Nat) -> Not (y = Z) -> Nat
 divNatNZ left Z         p = void (p Refl)
-divNatNZ left (S right) p = div' left left right
+divNatNZ left (S right) _ = div' left left right
   where
     public export
     div' : Nat -> Nat -> Nat -> Nat


### PR DESCRIPTION
So we could use it for type-level division.

Means changing it and its auxiliary function from `export partial` to
`public export total`