### PR TITLE
Use collect-rendezvous to trigger a collection

### DIFF
--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -84,7 +84,7 @@ schHeader chez libs
     "(let ()\n"
 
 schFooter : String
-schFooter = "(collect 4)\n(blodwen-run-finalisers))\n"
+schFooter = "(collect-rendezvous)\n(blodwen-run-finalisers))\n"
 
 showChezChar : Char -> String -> String
 showChezChar '\\' = ("\\\\" ++)


### PR DESCRIPTION
`collect` requires that only one thread is active, and will
throw an exception otherwise. This is hard to ensure outside
collect-request-handler. `collect-rendezvous` will handle that that and
run the request handler.

This way we can't pass a generation number to collect.. This could be done
a parameter saying if we're exiting if needed.