### PR TITLE
revert binary character literal

### DIFF
--- a/src/Text/Lexer.idr
+++ b/src/Text/Lexer.idr
@@ -344,7 +344,6 @@ charLit = let q = '\'' in
                       "DLE", "DC1", "DC2", "DC3", "DC4", "NAK", "SYN", "ETB",
                       "CAN", "EM",  "SUB", "ESC", "FS",  "GS",  "RS",  "US",
                       "SP",  "DEL"]
-                <|> (is 'b' <+> binDigits)
                 <|> (is 'x' <+> hexDigits)
                 <|> (is 'o' <+> octDigits)
                 <|> digits


### PR DESCRIPTION
introduced in #619 but wasn't actually doing anything

this wasn't doing anything anyway as it's first handled while
escaping in src/Parser/Support.idr and ends up clashing with \b

This doesn't affect being able to write `0b10101`, only `'\b10101'` which it wasn't doing anyway
