### PR TITLE
Put the appdir first in LD_LIBRARY_PATH

### DIFF
--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -347,7 +347,7 @@ startChez appdir target = unlines
     , "        ;;                    "
     , "esac                          "
     , ""
-    , "export LD_LIBRARY_PATH=\"$LD_LIBRARY_PATH:`dirname \"$DIR\"`/\"" ++ appdir ++ "\"\""
+    , "export LD_LIBRARY_PATH=\"`dirname \"$DIR\"`/\"" ++ appdir ++ "\":$LD_LIBRARY_PATH\""
     , "\"`dirname \"$DIR\"`\"/\"" ++ target ++ "\" \"$@\""
     ]
 


### PR DESCRIPTION
So that we prefer the local support lib before others in the path.