### PR TITLE
Retrieve network address family preprocessor constants from C runtime code

### DIFF
--- a/libs/network/Network/Socket/Data.idr
+++ b/libs/network/Network/Socket/Data.idr
@@ -110,14 +110,27 @@ Show SocketFamily where
   show AF_INET   = "AF_INET"
   show AF_INET6  = "AF_INET6"
 
+-- This is a bit of a hack to get the OS-dependent magic constants out of C and
+-- into Idris without having to faff around on the preprocessor on the Idris
+-- side.
+%foreign "C:idrnet_af_unspec,libidris2_support"
+prim__idrnet_af_unspec : PrimIO Int
+
+%foreign "C:idrnet_af_unix,libidris2_support"
+prim__idrnet_af_unix : PrimIO Int
+
+%foreign "C:idrnet_af_inet,libidris2_support"
+prim__idrnet_af_inet : PrimIO Int
+
+%foreign "C:idrnet_af_inet6,libidris2_support"
+prim__idrnet_af_inet6 : PrimIO Int
+
 export
 ToCode SocketFamily where
-  -- Don't know how to read a constant value from C code in idris2...
-  -- gotta to hardcode those for now
-  toCode AF_UNSPEC = 0 -- unsafePerformIO (cMacro "#AF_UNSPEC" Int)
-  toCode AF_UNIX   = 1
-  toCode AF_INET   = 2
-  toCode AF_INET6  = 10
+  toCode AF_UNSPEC = unsafePerformIO $ primIO $ prim__idrnet_af_unspec
+  toCode AF_UNIX   = unsafePerformIO $ primIO $ prim__idrnet_af_unix
+  toCode AF_INET   = unsafePerformIO $ primIO $ prim__idrnet_af_inet
+  toCode AF_INET6  = unsafePerformIO $ primIO $ prim__idrnet_af_inet6
 
 export
 getSocketFamily : Int -> Maybe SocketFamily

--- a/support/c/idris_net.c
+++ b/support/c/idris_net.c
@@ -76,6 +76,23 @@ int idrnet_socket(int domain, int type, int protocol) {
     return socket(domain, type, protocol);
 }
 
+// Get the address family constants out of C and into Idris
+int idrnet_af_unspec() {
+    return AF_UNSPEC;
+}
+
+int idrnet_af_unix() {
+    return AF_UNIX;
+}
+
+int idrnet_af_inet() {
+    return AF_INET;
+}
+
+int idrnet_af_inet6() {
+    return AF_INET6;
+}
+
 // We call this from quite a few functions. Given a textual host and an int port,
 // populates a struct addrinfo.
 int idrnet_getaddrinfo(struct addrinfo** address_res, char* host, int port,

--- a/support/c/idris_net.h
+++ b/support/c/idris_net.h
@@ -39,6 +39,12 @@ int idrnet_errno();
 
 int idrnet_socket(int domain, int type, int protocol);
 
+// Address family accessors
+int idrnet_af_unspec(void);
+int idrnet_af_unix(void);
+int idrnet_af_inet(void);
+int idrnet_af_inet6(void);
+
 // Bind
 int idrnet_bind(int sockfd, int family, int socket_type, char* host, int port);
 


### PR DESCRIPTION
The current implementation of `ToCode SocketFamily` uses hardcoded constants, which are correct on Linux but not all correct on other systems (though I've only checked OpenBSD, as that's what I have to hand). For portability's sake, it would be a better idea to read the magic constants from the definitions in the system C library, so we don't need to special case every platform we want Idris to run on. I've implemented this by adding some getter functions to the C runtime support library (one for each constant we want to know about) and then calling the appropriate getter to decode each symbolic constant on the Idris side.