### PR TITLE
Update starting.rst

### DIFF
--- a/docs/source/tutorial/starting.rst
+++ b/docs/source/tutorial/starting.rst
@@ -89,6 +89,8 @@ which you can run:
     $ idris2 hello.idr -o hello
     $ ./build/exec/hello
     Hello world
+    
+(On Macos you may first need to install realpath: ```brew install coreutils```)
 
 Please note that the dollar sign ``$`` indicates the shell prompt!
 Some useful options to the Idris command are:


### PR DESCRIPTION
Hellow world execute fails on Macos as it doesn't have realpath by default & one needs to install it with coreutils first.