### PR TITLE
Revert addition of (>>) operator.

### DIFF
--- a/libs/prelude/Prelude/Interfaces.idr
+++ b/libs/prelude/Prelude/Interfaces.idr
@@ -176,10 +176,6 @@ interface Applicative m => Monad m where
 
 %allow_overloads (>>=)
 
-public export
-(>>) : (Monad m) => m a -> m b -> m b
-a >> b = a >>= \_ => b
-
 ||| `guard a` is `pure ()` if `a` is `True` and `empty` if `a` is `False`.
 public export
 guard : Alternative f => Bool -> f ()

--- a/libs/prelude/Prelude/Ops.idr
+++ b/libs/prelude/Prelude/Ops.idr
@@ -14,7 +14,7 @@ infixr 4 ||
 infixr 7 ::, ++
 
 -- Functor/Applicative/Monad/Algebra operators
-infixl 1 >>=, >>
+infixl 1 >>=
 infixr 2 <|>
 infixl 3 <*>, *>, <*
 infixr 4 <$>, $>, <$


### PR DESCRIPTION
See the GitHub comments on 7d5ec53b53d2, and the IRC conversation in the commit message. `(*>)` exists in `Applicative` already, so `(>>)` is redundant.

Thanks to @MarcelineVQ for pointing this out.