### PR TITLE
add multi-way-if syntax sugar

### DIFF
--- a/docs/source/tutorial/typesfuns.rst
+++ b/docs/source/tutorial/typesfuns.rst
@@ -1254,6 +1254,38 @@ we get a default value:
     *UsefulTypes> lookup_default 4 [3,4,5,6] (-1)
     -1 : Integer
 
+Multi-way ``if`` expressions
+----------------------------
+
+Too many nested ``if`` can make code hard to read so Idris provides an
+alternative notation for reducing nesting and making choices easier to
+follow.
+
+The following function ``iffy`` would become quite messy if we want to
+include more choices of what to do with ``i``. It's also a lot of effort to
+insert choices at arbitrary points without repetitive indentation changes.
+Multi-way Ifs solve this in ``okay`` by allowing you to state your choices
+and what to do about them in turn, we're also able to insert a case for ``i
+== 0`` with ease:
+
+.. code-block:: idris
+
+    iffy : Int -> Char
+    iffy i = if i + 3 == 7 then '7'
+               else if i < 0 then 'N'
+                 else 'X'
+
+    okay : Int -> Char
+    okay i = if | i + 3 == 7  => '7'
+                | i == 0 => '0'
+                | i < 0 => 'N'
+                | _ => 'X'
+
+For this to be accepted as total we require the catch-all case ``_ = ...`` as
+the last entry but this isn't required otherwise. This makes it slightly more
+flexible than ``if`` which always requires the ``then`` branch. More on
+totality below.
+
 Totality
 ========
 

--- a/libs/base/Data/List1.idr
+++ b/libs/base/Data/List1.idr
@@ -119,6 +119,10 @@ Foldable List1 where
   foldr c n (x ::: xs) = c x (foldr c n xs)
 
 export
+Traversable List1 where
+  traverse f (x ::: xs) = [| f x ::: traverse f xs |]
+
+export
 Show a => Show (List1 a) where
   show = show . forget
 

--- a/src/Idris/Pretty.idr
+++ b/src/Idris/Pretty.idr
@@ -257,6 +257,7 @@ mutual
       go d (PIfThenElse _ x t e) =
         parenthesise (d > appPrec) $ group $ align $ hang 2 $ vsep
           [keyword "if" <++> go startPrec x, keyword "then" <++> go startPrec t, keyword "else" <++> go startPrec e]
+      go d (PIfMultiWay _ alts) = pretty "TODO MultiWay"
       go d (PComprehension _ ret es) =
           group $ brackets (go startPrec (dePure ret) <++> pipe <++> vsep (punctuate comma (prettyDo . deGuard <$> es)))
         where

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -55,6 +55,8 @@ idrisTests
        "error001", "error002", "error003", "error004", "error005",
        "error006", "error007", "error008", "error009", "error010",
        "error011", "error012", "error013",
+       -- Multi-way-if tests and regressions
+       "ifmultiway001",
        -- Modules and imports
        "import001", "import002", "import003", "import004", "import005",
        -- Interactive editing support

--- a/tests/idris2/ifmultiway001/BadIndent.idr
+++ b/tests/idris2/ifmultiway001/BadIndent.idr
@@ -1,0 +1,8 @@
+-- Check that we're appropriatly parsing as a block
+badIndent : Int -> Char
+badIndent i = if | i + 3       == 7  => '7'
+            | i      == 0
+             => '0'
+            | i < 0 =>
+        'N'
+            | _ => 'X'

--- a/tests/idris2/ifmultiway001/IfMultiWay.idr
+++ b/tests/idris2/ifmultiway001/IfMultiWay.idr
@@ -1,0 +1,79 @@
+-- IfMuliWay should not interfere with normal ifs
+barf : Int
+barf = if True then 1 else 0
+
+normalIf : Int -> Char
+normalIf i = if i + 3 == 7 then '7'
+               else if i < 0 then 'N'
+                 else 'X'
+
+total
+multiNormal : Int -> Char
+multiNormal i = if | i + 3 == 7 => '7'
+                   | i < 0 => 'N'
+                   | _ => 'X'
+
+total
+multiOkayIndenation : Int -> Char
+multiOkayIndenation i = if | i + 3       == 7  => '7'
+                           | i      == 0
+                            => '0'
+                           | i < 0
+                            =>
+                            'N'
+                           | _ => 'X'
+
+{-
+-- Some constant True, IfMuliWay should (be able to) consider this as True
+-- but will not since we don't do compile-time evaluation of our cases yet.
+-- TODO look into how functions are reduced in types and use those
+-- rules to allow reduction for multi-if cases. `otherwise` is vacuously total
+-- and there's no reason to not reduce it to True, and also to check that at
+-- least one case of a multi-if is _ or True
+otherwise : Bool
+otherwise = True
+
+-- We don't use this yet, but maybe some day!
+-- In fact with proper checking even `otherwise` would be unneccesary here,
+-- since our cases cover all possibilities of Int.
+total
+constTest : Int -> Char
+constTest i = if | i > 0 => 'P'
+                 | i == 0 => 'Z'
+                 | i < 0 => 'N'
+                 | otherwise = 'X'
+-}
+
+-- Should emit a warning about unreachable cases as 'X' and 'Z' are unreachable
+earlyStop : Int -> Char
+earlyStop i = if | i > 10 => '7'
+                 | _ => '0'
+                 | i == 2 => 'X'
+                 | _ => 'Z'
+
+-- Using multi anywhere an expression is allowed
+arbitraryExpressionPosition1 : Char -> String
+arbitraryExpressionPosition1 c = "abc" ++ (if | c == 'a' => "A"
+                                              | _ => "z") ++ "def"
+
+-- Using multi anywhere an expression is allowed. Also testing `;`.
+-- We're using a block so we don't say `if | i == Z => Bool | _ => Char`
+-- Partly because that's how blocks work and partly because we're just asking
+-- for syntax clashes if we use | as the sole delimiter.
+arbitraryExpressionPosition2 : (i : Nat)
+                            -> if | i == Z => Bool; | _ => Char
+arbitraryExpressionPosition2 0 = True
+arbitraryExpressionPosition2 (S k) = 'F'
+
+
+partial -- Should be accepted as partial.
+partialTest : Int -> Char
+partialTest i = if | i + 3 == 7 => '7'
+                   | i == 0 => '0'
+                   | i < 0 => 'N'
+
+total -- Should not be accepted as total. It's an error so test this last.
+partialTest2 : Int -> Char
+partialTest2 i = if | i + 3 == 7 => '7'
+                    | i == 0 => '0'
+                    | i < 0 => 'N'

--- a/tests/idris2/ifmultiway001/expected
+++ b/tests/idris2/ifmultiway001/expected
@@ -1,0 +1,12 @@
+1/1: Building IfMultiWay (IfMultiWay.idr)
+Error: partialTest2 is not covering.
+
+IfMultiWay.idr:75:1--77:13
+ 75 | total -- Should not be accepted as total. It's an error so test this last.
+ 76 | partialTest2 : Int -> Char
+ 77 | partialTest2 i = if | i + 3 == 7 => '7'
+
+Calls non covering function Main.case block in case block in case block in partialTest2
+1/1: Building BadIndent (BadIndent.idr)
+Error: Parse error at line 4:13:
+Expected end of input (next tokens: [symbol |, identifier i, symbol ==, literal 0, symbol =>, character '0', symbol |, identifier i, symbol <, literal 0])

--- a/tests/idris2/ifmultiway001/run
+++ b/tests/idris2/ifmultiway001/run
@@ -1,0 +1,4 @@
+$1 --no-color --console-width 0 IfMultiWay.idr --check
+$1 --no-color --console-width 0 BadIndent.idr --check
+
+rm -rf build


### PR DESCRIPTION
Adds `if` of the form:
```idris
if | pred1 => expr1
   | pred2 => expr2
```
Refer to added documentation and tests to see its use.

Open questions/task still needing solving are:
How to emit warnings at desugar-time when we have unreachable cases, e.g.
```idris
earlyStop : Int -> Char
earlyStop i = if | i > 10 => '7'
                 | _ => '0'
                 | i == 2 => 'X'
                 | _ => 'Z'
```
How to commit the same level of reduction we do in types for the predicates in a multi-way if, allowing the following to be considered total even without a _ catchall case when combined with a check that at least one branch evaluates to True.
```idris
otherwise : Bool
otherwise = True

constTest : Int -> Char
constTest i = if | i > 0 => 'P'
                 | i == 0 => 'Z'
                 | otherwise = 'X'
```