### PR TITLE
[base, contrib] Propose re-organisation of the order (strict, lax) interfaces

### DIFF
--- a/libs/base/Data/Fin/Order.idr
+++ b/libs/base/Data/Fin/Order.idr
@@ -13,12 +13,15 @@ using (k : Nat)
   data FinLTE : Fin k -> Fin k -> Type where
     FromNatPrf : {m : Fin k} -> {n : Fin k} -> LTE (finToNat m) (finToNat n) -> FinLTE m n
 
-  implementation Preorder (Fin k) FinLTE where
+  [finLTE] ComparisonRelation (Fin k) where
+    cmp = FinLTE
+
+  implementation Preorder (Fin k) using finLTE where
     transitive m n o (FromNatPrf p1) (FromNatPrf p2) =
       FromNatPrf (LTEIsTransitive (finToNat m) (finToNat n) (finToNat o) p1 p2)
     reflexive n = FromNatPrf (LTEIsReflexive (finToNat n))
 
-  implementation Poset (Fin k) FinLTE where
+  implementation Poset (Fin k) where
     antisymmetric m n (FromNatPrf p1) (FromNatPrf p2) =
       finToNatInjective m n (LTEIsAntisymmetric (finToNat m) (finToNat n) p1 p2)
 
@@ -27,7 +30,7 @@ using (k : Nat)
       decide m n | Yes prf    = Yes (FromNatPrf prf)
       decide m n | No  disprf = No (\ (FromNatPrf prf) => disprf prf)
 
-  implementation Ordered (Fin k) FinLTE where
+  implementation Ordered (Fin k) where
     order m n =
       either (Left . FromNatPrf)
              (Right . FromNatPrf)

--- a/libs/base/Data/Nat/Order.idr
+++ b/libs/base/Data/Nat/Order.idr
@@ -21,7 +21,11 @@ LTEIsReflexive Z      = LTEZero
 LTEIsReflexive (S n)  = LTESucc (LTEIsReflexive n)
 
 public export
-implementation Preorder Nat LTE where
+[NatLTE] ComparisonRelation Nat where
+  cmp = LTE
+
+public export
+implementation Preorder Nat using NatLTE where
   transitive = LTEIsTransitive
   reflexive  = LTEIsReflexive
 
@@ -34,7 +38,7 @@ LTEIsAntisymmetric (S n) (S m) (LTESucc mLTEn) (LTESucc nLTEm) with (LTEIsAntisy
 
 
 public export
-implementation Poset Nat LTE where
+implementation Poset Nat where
   antisymmetric = LTEIsAntisymmetric
 
 public export
@@ -76,9 +80,10 @@ shift : (m : Nat) -> (n : Nat) -> LTE m n -> LTE (S m) (S n)
 shift m n mLTEn = LTESucc mLTEn
 
 public export
-implementation Ordered Nat LTE where
+implementation Ordered Nat where
   order Z      n = Left LTEZero
   order m      Z = Right LTEZero
-  order (S k) (S j) with (order {to=LTE} k j)
+  order (S k) (S j) with (order k j)
     order (S k) (S j) | Left  prf = Left  (shift k j prf)
     order (S k) (S j) | Right prf = Right (shift j k prf)
+

--- a/libs/base/Decidable/Order.idr
+++ b/libs/base/Decidable/Order.idr
@@ -23,28 +23,23 @@ interface ComparisonRelation t where
 
 public export
 interface ComparisonRelation t => Preorder t where
-  constructor MkPreorder
   total transitive : (a : t) -> (b : t) -> (c : t) -> a `cmp` b -> b `cmp` c -> a `cmp` c
   total reflexive : (a : t) -> a `cmp` a
 
 public export
 interface (Preorder t) => Poset t where
-  constructor MkPoset
   total antisymmetric : (a : t) -> (b : t) -> a `cmp` b -> b `cmp` a -> a = b
 
 public export
 interface (Poset t) => Ordered t where
-  constructor MkOrdered
   total order : (a : t) -> (b : t) -> Either (a `cmp` b) (b `cmp` a)
 
 public export
 interface (Preorder t) => Equivalence t where
-  constructor MkEquivalence
   total symmetric : (a : t) -> (b : t) -> a `cmp` b -> b `cmp` a
 
 public export
 interface (Equivalence t) => Congruence t (f : t -> t) where
-  constructor MkCongruence
   total congruent : (a : t) ->
                     (b : t) ->
                        a  `cmp`    b ->

--- a/libs/contrib/Data/Nat/Division.idr
+++ b/libs/contrib/Data/Nat/Division.idr
@@ -227,15 +227,15 @@ multiplesModuloZero  (S fuel) predn (S k) enough =
   let n : Nat
       n = S predn
       n_lte_skn : n `LTE` (1 + k)*n
-      n_lte_skn = CalcWith {leq = LTE} $ 
+      n_lte_skn = CalcWith $ 
         |~ n
         ~~ n  + 0     ...(sym $ plusZeroRightNeutral n)
         ~~ (1 + 0)*n ...(Refl)
         <~ (1 + k)*n   ...(multLteMonotoneLeft (1+0) (1+k) n $ 
                            plusLteMonotoneLeft 1 0 k LTEZero)
   in case @@(Data.Nat.lte ((1 + k)*n) predn) of
-    (True  ** skn_lte_predn) => absurd $ irreflexive {spo = Data.Nat.LT} predn 
-                                       $ CalcWith {leq = LTE} $
+    (True  ** skn_lte_predn) => absurd $ irreflexive predn 
+                                       $ CalcWith $
       |~ 1 + predn
       ~~ n         ...(Refl)
       ~~ n + 0     ...(sym $ plusZeroRightNeutral n)
@@ -275,7 +275,7 @@ addMultipleMod' (S fuel1) fuel2 predn a (S k) enough1 enough2 =
   let n : Nat
       n = S predn
       lhsarg_geq_predn : ((1 + k)*n + a) `GT` predn
-      lhsarg_geq_predn = CalcWith {leq = LTE} $
+      lhsarg_geq_predn = CalcWith $
         |~ n
         ~~ (1+0)*n     ...(sym $ plusZeroRightNeutral n)
         <~ (1+k)*n     ...(multLteMonotoneLeft 1 (1+k) n $
@@ -303,7 +303,7 @@ addMultipleMod : (a, b, n : Nat) -> (n_neq_z1, n_neq_z2 : Not (n = 0))
               -> snd (divmodNatNZ (a*n + b) n n_neq_z1) = snd (divmodNatNZ b n n_neq_z2)
 addMultipleMod a b 0           n_neq_z1  n_neq_z2 = void (n_neq_z1 Refl)
 addMultipleMod a b n@(S predn) n_neq_z1  n_neq_z2 = 
-  addMultipleMod' (a*n + b) b predn b a (reflexive {po = LTE} _) (reflexive {po = LTE} _)
+  addMultipleMod' (a*n + b) b predn b a (reflexive $ the Nat _) (reflexive $ the Nat _)
 
 modBelowDenom : (r, n : Nat) -> (n_neq_z : Not (n = 0))
              -> (r `LT` n) 

--- a/libs/contrib/Data/Nat/Order/Properties.idr
+++ b/libs/contrib/Data/Nat/Order/Properties.idr
@@ -53,7 +53,7 @@ export
 GTIsnotlte : (a, b : Nat) -> b `LT` a -> a `lte` b = False
 GTIsnotlte a b b_lt_a = 
   let not_a_lte_b : Not (a `LTE` b)
-      not_a_lte_b = \a_lte_b => irreflexive {spo = Nat.LT} a $ CalcWith {leq = LTE} $ 
+      not_a_lte_b = \a_lte_b => irreflexive a $ CalcWith $ 
         |~ 1 + a
         <~ 1 + b ...(plusLteMonotoneLeft 1 a b a_lte_b)
         <~ a     ...(b_lt_a)
@@ -79,7 +79,7 @@ minusPosLT (S a) (S b) z_lt_sa          a_lte_b = LTESucc (minusLTE a b)
 export
 multLteMonotoneRight : (l, a, b : Nat) -> a `LTE` b -> l*a `LTE` l*b
 multLteMonotoneRight  0    a b _ = LTEZero
-multLteMonotoneRight (S k) a b a_lte_b = CalcWith {leq = LTE} $
+multLteMonotoneRight (S k) a b a_lte_b = CalcWith $
   |~ (1 + k) * a
   ~~ a +  k*a    ...(Refl)
   <~ b +  k*a    ...(plusLteMonotoneRight (k*a) a b a_lte_b)

--- a/libs/contrib/Data/Nat/Order/Strict.idr
+++ b/libs/contrib/Data/Nat/Order/Strict.idr
@@ -12,12 +12,16 @@ irreflexiveLTE : (a : Nat) -> Not (a `LT` a)
 irreflexiveLTE 0     z_lt_z impossible
 irreflexiveLTE (S a) (LTESucc a_lt_a) = irreflexiveLTE a a_lt_a
 
+public export
+[NatLT] StrictComparison Nat where
+  scmp = LT
+
 export
-StrictPreorder Nat LT where
+StrictPreorder Nat using NatLT where
   irreflexive = irreflexiveLTE
-  transitive a b c a_lt_b b_lt_c = transitive {po = LTE} (S a) b c
+  transitive a b c a_lt_b b_lt_c = Order.transitive (S a) b c
                                              a_lt_b
-                                             (transitive {po = LTE} b (S b) c
+                                             (Order.transitive b (S b) c
                                                 (lteSuccRight (reflexive b))
                                                 b_lt_c)
 
@@ -32,5 +36,5 @@ decLT (S a) (S b) = case decLT a b of
   DecGT b_lt_a => DecGT (LTESucc b_lt_a)
 
 public export
-StrictOrdered Nat LT where
+StrictOrdered Nat where
   order = decLT

--- a/libs/contrib/Decidable/Order/Strict.idr
+++ b/libs/contrib/Decidable/Order/Strict.idr
@@ -12,40 +12,40 @@ import Decidable.Equality
 %default total
 
 public export
-interface StrictPreorder t (spo : t -> t -> Type) where
-  transitive : (a, b, c : t) -> a `spo` b -> b `spo` c -> a `spo` c
-  irreflexive : (a : t) -> Not (a `spo` a)
-  
+interface StrictComparison t where
+  scmp : t -> t -> Type
+
 public export
-asymmetric : StrictPreorder t spo => (a, b : t) -> a `spo` b -> Not (b `spo` a)
+interface StrictComparison t => StrictPreorder t where
+  transitive : (a, b, c : t) -> a `scmp` b -> b `scmp` c -> a `scmp` c
+  irreflexive : (a : t) -> Not (a `scmp` a)
+
+public export
+asymmetric : StrictPreorder t => (a, b : t) -> a `scmp` b -> Not (b `scmp` a)
 asymmetric a b aLTb bLTa = irreflexive a $ 
                            Strict.transitive a b a aLTb bLTa
 
 public export
-EqOr : (spo : t -> t -> Type) -> StrictPreorder t spo => (a,b : t) -> Type
+EqOr : (spo : t -> t -> Type) -> (a,b : t) -> Type
 EqOr spo a b = Either (a = b) (a `spo` b)
+
+public export
+[EqOrCmp] (StrictComparison t) => ComparisonRelation t where
+  cmp = EqOr scmp
 
 -- Can generalise to an arbitrary equivalence, I belive
 public export
-[MkPreorder] {spo : t -> t -> Type} -> StrictPreorder t spo => Preorder t (EqOr spo) where
+[EqOrPreorder] StrictPreorder t => Preorder t using EqOrCmp where
   reflexive a = Left Refl
   transitive a _ c (Left  Refl) bLTEc        = bLTEc
   transitive a b _ (Right aLTb) (Left  Refl) = Right aLTb
   transitive a b c (Right aLTb) (Right bLTc) = Right $ Strict.transitive a b c aLTb bLTc
 
-[MkPoset] {antisym : (a,b : t) -> a `leq` b -> b `leq` a -> a = b} -> Preorder t leq => Poset t leq where
-  antisymmetric = antisym
-           
-%hint
-public export
-InferPoset : {t : Type} -> {spo : t -> t -> Type} -> StrictPreorder t spo => Poset t (EqOr spo) 
-InferPoset {t} {spo} = MkPoset @{MkPreorder} {antisym = antisym}
-  where
-    antisym : (a,b : t) -> EqOr spo a b -> EqOr spo b a -> a = b
-    antisym a a (Left  Refl) (Left  Refl) = Refl
-    antisym a a (Left  Refl) (Right bLTa) = absurd (irreflexive a bLTa)
-    antisym b b (Right aLTb) (Left  Refl) = absurd (irreflexive b aLTb)
-    antisym a b (Right aLTb) (Right bLTa) = absurd (asymmetric a b aLTb bLTa)
+[EqOrPoset] StrictPreorder t => Poset t using EqOrPreorder where
+  antisymmetric a a (Left  Refl) (Left  Refl) = Refl
+  antisymmetric a a (Left  Refl) (Right bLTa) = absurd (irreflexive a bLTa)
+  antisymmetric b b (Right aLTb) (Left  Refl) = absurd (irreflexive b aLTb)
+  antisymmetric a b (Right aLTb) (Right bLTa) = absurd (asymmetric a b aLTb bLTa)
 
 public export
 data DecOrdering : {lt : t -> t -> Type} -> (a,b : t) -> Type where
@@ -54,31 +54,24 @@ data DecOrdering : {lt : t -> t -> Type} -> (a,b : t) -> Type where
   DecGT : forall lt . (b `lt` a) -> DecOrdering {lt = lt} a b 
 
 public export
-interface StrictPreorder t spo => StrictOrdered t (spo : t -> t -> Type) where
-  order : (a,b : t) -> DecOrdering {lt = spo} a b 
+interface (StrictPreorder t) => StrictOrdered t where
+  order : (a,b : t) -> DecOrdering {lt = Strict.scmp} a b
 
-[MkOrdered] {ord : (a,b : t) -> Either (a `leq` b) (b `leq` a)} -> Poset t leq => Ordered t leq where
-  order = ord
-
-%hint
 public export
-InferOrder : {t : Type} -> {spo : t -> t -> Type} -> StrictOrdered t spo => Ordered t (EqOr spo)
-InferOrder {t} {spo} @{so} = MkOrdered @{InferPoset} {ord = ord}
-  where
-    ord : (a,b : t) -> Either (EqOr spo a b) (EqOr spo b a)
-    ord  a b with (Strict.order @{so} a b)
-     ord a _ | DecEQ Refl = Left  (Left  Refl)
-     ord a b | DecLT aLTb = Left  (Right aLTb)
-     ord a b | DecGT bLTa = Right (Right bLTa)
+implementation StrictOrdered t => Ordered t using EqOrPoset where
+  order  a b with (Strict.order a b)
+   order a _ | DecEQ Refl = Left  (Left  Refl)
+   order a b | DecLT aLTb = Left  (Right aLTb)
+   order a b | DecGT bLTa = Right (Right bLTa)
 
 
 public export
-(tot : StrictOrdered t lt) => (pre : StrictPreorder t lt) => DecEq t where
-  decEq x y = case order @{tot} x y of
+implementation (tot : StrictOrdered t) => DecEq t where
+  decEq x y = case order x y of
     DecEQ x_eq_y => Yes x_eq_y
-    DecLT xlty => No $ \x_eq_y => absurd $ irreflexive @{pre} y 
-                                         $ replace {p = \u => u `lt` y} x_eq_y xlty
+    DecLT xlty => No $ \x_eq_y => absurd $ irreflexive y 
+                                         $ replace {p = \u => u `scmp` y} x_eq_y xlty
     -- Similarly                                         
-    DecGT yltx => No $ \x_eq_y => absurd $ irreflexive @{pre} y
-                                         $ replace {p = \u => y `lt` u} x_eq_y yltx
+    DecGT yltx => No $ \x_eq_y => absurd $ irreflexive y
+                                         $ replace {p = \u => y `scmp` u} x_eq_y yltx
     

--- a/libs/contrib/Syntax/PreorderReasoning/Generic.idr
+++ b/libs/contrib/Syntax/PreorderReasoning/Generic.idr
@@ -18,9 +18,9 @@ data FastDerivation : {leq : a -> a -> Type} -> (x : a) -> (y : a) -> Type where
          -> FastDerivation {leq = leq} x z
 
 public export  
-CalcWith : Preorder dom leq => {x,y : dom} -> FastDerivation {leq = leq} x y -> x `leq` y
+CalcWith : Preorder dom => {x,y : dom} -> FastDerivation {leq = Order.cmp} x y -> x `cmp` y
 CalcWith (|~ x) = reflexive x
-CalcWith ((<~) der (z ... step)) = transitive {po = leq} _ _ _ (CalcWith der) step
+CalcWith ((<~) der (z ... step)) = transitive _ _ _ (CalcWith der) step
 
 public export
 (~~) : {x,y : dom} 


### PR DESCRIPTION
The issue I'm addressing is that the order relation (`po`, or `spo`, etc) cannot be
inferred from the carrier of the preorder, and needs to be passed explicitly.

I propose to add two interfaces:
* `Order.ComparisonRelation t` for order relations (like `Data.Nat.LTE`); and
* `Strict.StrictComparison t` for strict order relations (like `Data.Nat.LT`);

We need two interfaces because we sometimes want to use both at the
same time, and at the moment this ends up being very confusing for
interface resolution. We can revisit this decision once #607 is merged,
since then we'll have more flexibility in manipulating interfaces.

Thanks to @berewt for discussing this proposal!