### PR TITLE
Flush stdout in IDE mode first message

### DIFF
--- a/src/Idris/IDEMode/REPL.idr
+++ b/src/Idris/IDEMode/REPL.idr
@@ -84,6 +84,7 @@ initIDESocketFile h p = do
                   pure (Left ("Failed to listen on socket with error: " ++ show res))
                else
                  do putStrLn (show p)
+                    fflush stdout
                     res <- accept sock
                     case res of
                       Left err =>


### PR DESCRIPTION
This patch simply forces a flush on the IDE mode first message sent on the standard output (the port of the socket). Note that all comunication on the socket are flushed on message basis, which seems reasonable since the IDE mode is meant to be used in a "conversational" manner. While trying to implement a vim plugin based upon the IDE mode instead of the `--client` CLI argument, we encountered two difficulties:
  1. The buffered messages on the stdout (if not using sockets or just for the first message) where not read asynchronously on each message, and required some additional options (in particular that the stdout pipe must be a pseudo-terminal, which is problematic on non-unix). Flushing solved the issue.
  2. When spawning a new idris2 ide mode instance there is no reliable way of getting a notification that the process has been spawned succcesfully. Receiving the port number on the stdout as early as possible can be used by ide-mode clients (i.e. editors) as notification for readiness.