### PR TITLE
Added ability for IDEMode to report location of definition of name

### DIFF
--- a/src/Idris/IDEMode/Commands.idr
+++ b/src/Idris/IDEMode/Commands.idr
@@ -23,6 +23,7 @@ public export
 data IDECommand
      = Interpret String
      | LoadFile String (Maybe Integer)
+     | DefLoc String
      | TypeOf String (Maybe (Integer, Integer))
      | CaseSplit Integer Integer String
      | AddClause Integer String
@@ -66,6 +67,8 @@ getIDECommand (SExpList [SymbolAtom "load-file", StringAtom fname])
     = Just $ LoadFile fname Nothing
 getIDECommand (SExpList [SymbolAtom "load-file", StringAtom fname, IntegerAtom l])
     = Just $ LoadFile fname (Just l)
+getIDECommand (SExpList [SymbolAtom "def-loc", StringAtom n])
+    = Just $ DefLoc n
 getIDECommand (SExpList [SymbolAtom "type-of", StringAtom n])
     = Just $ TypeOf n Nothing
 getIDECommand (SExpList [SymbolAtom "type-of", StringAtom n,
@@ -144,6 +147,7 @@ putIDECommand : IDECommand -> SExp
 putIDECommand (Interpret cmd)                 = (SExpList [SymbolAtom "interpret", StringAtom cmd])
 putIDECommand (LoadFile fname Nothing)        = (SExpList [SymbolAtom "load-file", StringAtom fname])
 putIDECommand (LoadFile fname (Just line))    = (SExpList [SymbolAtom "load-file", StringAtom fname, IntegerAtom line])
+putIDECommand (DefLoc cmd)                    = (SExpList [SymbolAtom "def-loc", StringAtom cmd])
 putIDECommand (TypeOf cmd Nothing)            = (SExpList [SymbolAtom "type-of", StringAtom cmd])
 putIDECommand (TypeOf cmd (Just (line, col))) = (SExpList [SymbolAtom "type-of", StringAtom cmd, IntegerAtom line, IntegerAtom col])
 putIDECommand (CaseSplit line col n)          = (SExpList [SymbolAtom "case-split", IntegerAtom line, IntegerAtom col, StringAtom n])

--- a/src/Idris/IDEMode/REPL.idr
+++ b/src/Idris/IDEMode/REPL.idr
@@ -160,6 +160,8 @@ process (LoadFile fname_in _)
                           Nothing => fname_in
                           Just f' => f'
          replWrap $ Idris.REPL.process (Load fname) >>= outputSyntaxHighlighting fname
+process (DefLoc n)
+    = replWrap $ Idris.REPL.process (Editing (PrintLoc (UN n)))
 process (TypeOf n Nothing)
     = replWrap $ Idris.REPL.process (Check (PRef replFC (UN n)))
 process (TypeOf n (Just (l, c)))
@@ -360,6 +362,16 @@ displayIDEResult outf i (REPL $ Edited (DisplayEdit xs))
   = printIDEResult outf i $ StringAtom $ show xs
 displayIDEResult outf i (REPL $ Edited (EditError x))
   = printIDEError outf i x
+displayIDEResult outf i (REPL $ Edited (LocsFound locs))
+  = printIDEResult outf i $ SExpList (map fcToSExp locs)
+  where 
+    addOne : (Int, Int) -> (Int, Int)
+    addOne (l, c) = (l + 1, c + 1)
+    fcToSExp : FC -> SExp
+    fcToSExp fc = 
+      SExpList [toSExp (file fc),
+                toSExp (addOne (startPos fc)),
+                toSExp (addOne (endPos fc))]
 displayIDEResult outf i (REPL $ Edited (MadeLemma lit name pty pappstr))
   = printIDEResult outf i
   $ StringAtom $ (relit lit $ show name ++ " : " ++ show pty ++ "\n") ++ pappstr

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -229,6 +229,7 @@ data EditResult : Type where
   MadeLemma : Maybe String -> Name -> PTerm -> String -> EditResult
   MadeWith : Maybe String -> List String -> EditResult
   MadeCase : Maybe String -> List String -> EditResult
+  LocsFound : List FC -> EditResult -- result from PrintLoc command
 
 updateFile : {auto r : Ref ROpts REPLOpts} ->
              (List String -> List String) -> Core EditResult
@@ -351,6 +352,12 @@ processEdit : {auto c : Ref Ctxt Defs} ->
               {auto m : Ref MD Metadata} ->
               {auto o : Ref ROpts REPLOpts} ->
               EditCmd -> Core EditResult
+processEdit (PrintLoc fn) 
+    = do defs <- get Ctxt
+         case !(lookupCtxtName fn (gamma defs)) of
+              [] => throw (UndefinedName replFC fn)
+              ts => 
+                  pure (LocsFound $ map (location . snd . snd) ts)
 processEdit (TypeAt line col name)
     = do defs <- get Ctxt
          glob <- lookupCtxtName name (gamma defs)

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -408,6 +408,7 @@ data EditCmd : Type where
      MakeLemma : Bool -> Int -> Name -> EditCmd
      MakeCase : Bool -> Int -> Name -> EditCmd
      MakeWith : Bool -> Int -> Name -> EditCmd
+     PrintLoc : Name -> EditCmd -- get the file location of definition
 
 public export
 data REPLCmd : Type where


### PR DESCRIPTION
This is to create similar functionality of emacs' command 'haskell-mode-jump-to-def
I implemented the clientside portion here: https://github.com/redfish64/idris2-mode