### PR TITLE
Implement Futures as a Parallelism Primitive

### DIFF
--- a/libs/contrib/System/Future.idr
+++ b/libs/contrib/System/Future.idr
@@ -17,8 +17,8 @@ fork : Lazy a -> Future a
 fork = prim__makeFuture
 
 export
-forkIO : IO a -> IO (Future a)
-forkIO a = io_pure $ fork $ unsafePerformIO a
+forkIO : HasIO io => IO a -> io (Future a)
+forkIO a = primIO $ prim__io_pure $ fork $ unsafePerformIO a
 
 export
 await : Future a -> a

--- a/libs/contrib/System/Future.idr
+++ b/libs/contrib/System/Future.idr
@@ -17,10 +17,6 @@ fork : Lazy a -> Future a
 fork = prim__makeFuture
 
 export
-forkIO : HasIO io => IO a -> io (Future a)
-forkIO a = primIO $ prim__io_pure $ fork $ unsafePerformIO a
-
-export
 await : Future a -> a
 await f = prim__awaitFuture f
 
@@ -37,3 +33,11 @@ public export
 Monad Future where
   join = map await
   v >>= func = join . fork $ func (await v)
+
+export
+performFutureIO : HasIO io => Future (IO a) -> io (Future a)
+performFutureIO = primIO . prim__io_pure . map unsafePerformIO
+
+export
+forkIO : HasIO io => IO a -> io (Future a)
+forkIO a = performFutureIO $ fork a

--- a/libs/contrib/System/Future.idr
+++ b/libs/contrib/System/Future.idr
@@ -1,0 +1,44 @@
+module System.Future
+
+%default total
+
+-- Futures based Concurrency and Parallelism
+
+export
+data Future : Type -> Type where [external]
+
+%extern prim__makeFuture : {0 a : Type} -> Lazy a -> Future a
+%foreign "racket:blodwen-await-future"
+         "scheme:blodwen-await-future"
+prim__awaitFuture : {0 a : Type} -> Future a -> a
+
+export
+fork : Lazy a -> Future a
+fork = prim__makeFuture
+
+export
+forkIO : IO a -> IO (Future a)
+forkIO a = io_pure $ fork $ unsafePerformIO a
+
+export
+await : Future a -> a
+await f = prim__awaitFuture f
+
+public export
+Functor Future where
+  map func future = fork $
+    let result = await future in func result
+
+public export
+Applicative Future where
+  pure v = fork v
+  funcF <*> v = fork $
+    let result = await v
+        func   = await funcF in
+        func result
+
+public export
+Monad Future where
+  join = map await
+  v >>= func = join $ fork $
+    let result = await v in func result

--- a/libs/contrib/System/Future.idr
+++ b/libs/contrib/System/Future.idr
@@ -26,19 +26,14 @@ await f = prim__awaitFuture f
 
 public export
 Functor Future where
-  map func future = fork $
-    let result = await future in func result
+  map func future = fork $ func (await future)
 
 public export
 Applicative Future where
   pure v = fork v
-  funcF <*> v = fork $
-    let result = await v
-        func   = await funcF in
-        func result
+  funcF <*> v = fork $ (await funcF) (await v)
 
 public export
 Monad Future where
   join = map await
-  v >>= func = join $ fork $
-    let result = await v in func result
+  v >>= func = join . fork $ func (await v)

--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -98,6 +98,7 @@ modules = Control.ANSI,
           Text.PrettyPrint.Prettyprinter.Render.String,
           Text.PrettyPrint.Prettyprinter.Render.Terminal,
 
+          System.Future,
           System.Random,
           System.Path,
           Syntax.WithProof,

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -156,6 +156,9 @@ mutual
       = do p' <- schExp chezExtPrim chezString 0 p
            c' <- schExp chezExtPrim chezString 0 c
            pure $ mkWorld $ "(blodwen-register-object " ++ p' ++ " " ++ c' ++ ")"
+  chezExtPrim i MakeFuture [_, work]
+      = do work' <- schExp chezExtPrim chezString 0 work
+           pure $ "(blodwen-make-future " ++ work' ++ ")"
   chezExtPrim i prim args
       = schExtCommon chezExtPrim chezString i prim args
 

--- a/src/Compiler/Scheme/Common.idr
+++ b/src/Compiler/Scheme/Common.idr
@@ -206,6 +206,7 @@ data ExtPrim = NewIORef | ReadIORef | WriteIORef
              | SysOS | SysCodegen
              | OnCollect
              | OnCollectAny
+             | MakeFuture
              | Unknown Name
 
 export
@@ -223,6 +224,7 @@ Show ExtPrim where
   show SysCodegen = "SysCodegen"
   show OnCollect = "OnCollect"
   show OnCollectAny = "OnCollectAny"
+  show MakeFuture = "MakeFuture"
   show (Unknown n) = "Unknown " ++ show n
 
 ||| Match on a user given name to get the scheme primitive
@@ -241,7 +243,8 @@ toPrim pn@(NS _ n)
             (n == UN "prim__os", SysOS),
             (n == UN "prim__codegen", SysCodegen),
             (n == UN "prim__onCollect", OnCollect),
-            (n == UN "prim__onCollectAny", OnCollectAny)
+            (n == UN "prim__onCollectAny", OnCollectAny),
+            (n == UN "prim__makeFuture", MakeFuture)
             ]
            (Unknown pn)
 toPrim pn = Unknown pn

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -42,6 +42,7 @@ schHeader : String -> String
 schHeader libs
   = "#lang racket/base\n" ++
     "; @generated\n" ++
+    "(require racket/future)\n" ++ -- for parallelism/concurrency
     "(require racket/math)\n" ++ -- for math ops
     "(require racket/system)\n" ++ -- for system
     "(require rnrs/bytevectors-6)\n" ++ -- for buffers
@@ -95,6 +96,9 @@ mutual
       = do p' <- schExp racketPrim racketString 0 p
            c' <- schExp racketPrim racketString 0 c
            pure $ mkWorld $ "(blodwen-register-object " ++ p' ++ " " ++ c' ++ ")"
+  racketPrim i MakeFuture [_, work]
+      = do work' <- schExp racketPrim racketString 0 work
+           pure $ mkWorld $ "(blodwen-make-future " ++ work' ++ ")"
   racketPrim i prim args
       = schExtCommon racketPrim racketString i prim args
 

--- a/support/chez/support.ss
+++ b/support/chez/support.ss
@@ -217,6 +217,23 @@
 (define (blodwen-condition-signal c) (condition-signal c))
 (define (blodwen-condition-broadcast c) (condition-broadcast c))
 
+(define-record future-internal (result ready mutex signal))
+(define (blodwen-make-future work)
+  (let ([future (make-future-internal #f #f (make-mutex) (make-condition))])
+    (fork-thread (lambda ()
+      (let ([result (work)])
+        (with-mutex (future-internal-mutex future)
+          (set-future-internal-result! future result)
+          (set-future-internal-ready! future #t)
+          (condition-broadcast (future-internal-signal future))))))
+    future))
+(define (blodwen-await-future ty future)
+  (let ([mutex (future-internal-mutex future)])
+    (with-mutex mutex
+      (if (not (future-internal-ready future))
+          (condition-wait (future-internal-signal future) mutex))
+      (future-internal-result future))))
+
 (define (blodwen-sleep s) (sleep (make-time 'time-duration 0 s)))
 (define (blodwen-usleep s)
   (let ((sec (div s 1000000))

--- a/support/racket/support.rkt
+++ b/support/racket/support.rkt
@@ -212,6 +212,7 @@
   (channel-put c 'ready))
 
 (define (blodwen-sleep s) (sleep s))
+(define (blodwen-usleep us) (sleep (* 0.000001 us)))
 
 (define (blodwen-time) (current-seconds))
 

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -137,6 +137,7 @@ chezTests = MkTestPool [Chez]
       "chez019", "chez020", "chez021", "chez022", "chez023", "chez024",
       "chez025", "chez026", "chez027", "chez028", "chez029", "chez030",
       "chez031",
+      "concurrency001",
       "perf001",
       "reg001"]
 

--- a/tests/chez/concurrency001/Futures.idr
+++ b/tests/chez/concurrency001/Futures.idr
@@ -45,3 +45,14 @@ erasureAndNonbindTest = do
   let _ = nonbind
   let n = nonbind
   macsleep 2000 -- Even if not explicitly awaited, we should let threads finish before exiting
+
+map : IO ()
+map = do
+  future1 <- forkIO $ do
+    macsleep 1000
+    putStrLn "#2"
+  let future3 = map (const "#3") future1
+  future2 <- forkIO $ do
+    putStrLn "#1"
+  pure $ await future2
+  putStrLn (await future3)

--- a/tests/chez/concurrency001/Futures.idr
+++ b/tests/chez/concurrency001/Futures.idr
@@ -1,0 +1,26 @@
+module Futures
+
+import Data.List
+import Data.So
+import System
+import System.Future
+import System.Info
+
+constant : IO ()
+constant = do
+  let a = await $ fork "String"
+  putStrLn a
+
+partial
+futureHelloWorld : (Int, String) -> IO (Future Unit)
+futureHelloWorld (us, n) with (choose (us >= 0))
+  futureHelloWorld (us, n) | Left p = forkIO $ do
+    if (os == "darwin") then sleep (us `div` 1000) else usleep us
+    putStrLn $ "Hello " ++ n ++ "!"
+
+partial
+simpleIO : IO (List Unit)
+simpleIO = do
+  futures <- sequence $ futureHelloWorld <$> [(3000, "World"), (1000, "Bar"), (0, "Foo"), (2000, "Idris")]
+  let awaited = await <$> futures
+  pure awaited

--- a/tests/chez/concurrency001/expected
+++ b/tests/chez/concurrency001/expected
@@ -1,0 +1,5 @@
+String
+Hello Foo!
+Hello Bar!
+Hello Idris!
+Hello World!

--- a/tests/chez/concurrency001/expected
+++ b/tests/chez/concurrency001/expected
@@ -5,3 +5,6 @@ Hello Idris!
 Hello World!
 This line is printed
 This line is also printed
+#1
+#2
+#3

--- a/tests/chez/concurrency001/expected
+++ b/tests/chez/concurrency001/expected
@@ -3,3 +3,5 @@ Hello Foo!
 Hello Bar!
 Hello Idris!
 Hello World!
+This line is printed
+This line is also printed

--- a/tests/chez/concurrency001/run
+++ b/tests/chez/concurrency001/run
@@ -1,4 +1,5 @@
 $1 --no-banner --no-color --console-width 0 --cg chez Futures.idr -p contrib --exec constant
 $1 --no-banner --no-color --console-width 0 --cg chez Futures.idr -p contrib --exec simpleIO
+$1 --no-banner --no-color --console-width 0 --cg chez Futures.idr -p contrib --exec erasureAndNonbindTest
 
 rm -r build

--- a/tests/chez/concurrency001/run
+++ b/tests/chez/concurrency001/run
@@ -1,0 +1,4 @@
+$1 --no-banner --no-color --console-width 0 --cg chez Futures.idr -p contrib --exec constant
+$1 --no-banner --no-color --console-width 0 --cg chez Futures.idr -p contrib --exec simpleIO
+
+rm -r build

--- a/tests/chez/concurrency001/run
+++ b/tests/chez/concurrency001/run
@@ -1,5 +1,6 @@
 $1 --no-banner --no-color --console-width 0 --cg chez Futures.idr -p contrib --exec constant
 $1 --no-banner --no-color --console-width 0 --cg chez Futures.idr -p contrib --exec simpleIO
 $1 --no-banner --no-color --console-width 0 --cg chez Futures.idr -p contrib --exec erasureAndNonbindTest
+$1 --no-banner --no-color --console-width 0 --cg chez Futures.idr -p contrib --exec map
 
 rm -r build


### PR DESCRIPTION
This is a simple Chez implementation of a Future Primitive; Since many systems are multicore this might be a good low hanging fruit in improving the Idris2 Compiler Performance.

The idea of adopting Future as a threading primitive rather than a Thread is to facilitate parallelism in the case of pure functions. (Since it makes returning values from a thread easier without needing to worry about mutation/synchronization or other interproccess communication techniques) This is implemented as an OS Thread per future in Chez. So for the time being it is intended to launch tasks in parallel that currently take some time. (Parsing for example)