### PR TITLE
IDEMode syntax option and fixed output

### DIFF
--- a/src/Idris/IDEMode/Commands.idr
+++ b/src/Idris/IDEMode/Commands.idr
@@ -48,6 +48,7 @@ data IDECommand
      | ElaborateTerm     String -- then change String to Term, as in idris1
      | PrintDefinition String
      | ReplCompletions String
+     | EnableSyntax Bool
      | Version
      | GetOptions
 
@@ -135,6 +136,8 @@ getIDECommand (SExpList [SymbolAtom "print-definition", StringAtom n])
     = Just $ PrintDefinition n
 getIDECommand (SExpList [SymbolAtom "repl-completions", StringAtom n])
     = Just $ ReplCompletions n
+getIDECommand (SExpList [SymbolAtom "enable-syntax", BoolAtom b])
+    = Just $ EnableSyntax b
 getIDECommand (SymbolAtom "version") = Just Version
 getIDECommand (SExpList [SymbolAtom "get-options"]) = Just GetOptions
 getIDECommand _ = Nothing
@@ -177,6 +180,7 @@ putIDECommand (ElaborateTerm     tm)          = (SExpList [SymbolAtom "elaborate
 putIDECommand (PrintDefinition n)             = (SExpList [SymbolAtom "print-definition", StringAtom n])
 putIDECommand (ReplCompletions n)             = (SExpList [SymbolAtom "repl-completions", StringAtom n])
 putIDECommand (Directive n)             = (SExpList [SymbolAtom "directive", StringAtom n])
+putIDECommand (EnableSyntax b)                = (SExpList [SymbolAtom "enable-syntax", BoolAtom b])
 putIDECommand GetOptions                      = (SExpList [SymbolAtom "get-options"])
 putIDECommand Version                         = SymbolAtom "version"
 

--- a/src/Idris/IDEMode/Commands.idr
+++ b/src/Idris/IDEMode/Commands.idr
@@ -157,7 +157,7 @@ putIDECommand (ExprSearch line n exprs mode)  = (SExpList [SymbolAtom "proof-sea
   getMode : Bool -> SExp
   getMode True  = SymbolAtom "all"
   getMode False = SymbolAtom "other"
-putIDECommand ExprSearchNext                  = SymbolAtom "proof-search--next"
+putIDECommand ExprSearchNext                  = SymbolAtom "proof-search-next"
 putIDECommand (GenerateDef line n)            = (SExpList [SymbolAtom "generate-def", IntegerAtom line, StringAtom n])
 putIDECommand GenerateDefNext                 = SymbolAtom "generate-def-next"
 putIDECommand (MakeLemma line n)              = (SExpList [SymbolAtom "make-lemma", IntegerAtom line, StringAtom n])

--- a/src/Idris/IDEMode/REPL.idr
+++ b/src/Idris/IDEMode/REPL.idr
@@ -220,6 +220,9 @@ process (PrintDefinition n)
 process (ReplCompletions n)
     = do todoCmd "repl-completions"
          pure $ NameList []
+process (EnableSyntax b)
+    = do setSynHighlightOn b
+         pure $ REPL $ Printed (reflow "Syntax highlight option changed to" <++> pretty b)
 process Version
     = replWrap $ Idris.REPL.process ShowVersion
 process (Metavariables _)
@@ -301,7 +304,7 @@ displayIDEResult outf i  (REPL $ Evaluated x (Just y))
   $ StringAtom $ show x ++ " : " ++ show y
 displayIDEResult outf i  (REPL $ Printed xs)
   = printIDEResultWithHighlight outf i
-  $ StringAtom $ show xs
+  $ StringAtom $ !(renderWithoutColor xs)
 displayIDEResult outf i  (REPL $ TermChecked x y)
   = printIDEResultWithHighlight outf i
   $ StringAtom $ show x ++ " : " ++ show y

--- a/src/Idris/IDEMode/SyntaxHighlight.idr
+++ b/src/Idris/IDEMode/SyntaxHighlight.idr
@@ -123,7 +123,10 @@ outputSyntaxHighlighting : {auto m : Ref MD Metadata} ->
                            REPLResult ->
                            Core REPLResult
 outputSyntaxHighlighting fname loadResult = do
-  allNames <- filter (inFile fname) . names <$> get MD
---  decls <- filter (inFile fname) . tydecls <$> get MD
-  _ <- traverse outputNameSyntax allNames -- ++ decls)
+  opts <- get ROpts
+  when (opts.synHighlightOn) $ do
+    allNames <- filter (inFile fname) . names <$> get MD
+    --  decls <- filter (inFile fname) . tydecls <$> get MD
+    _ <- traverse outputNameSyntax allNames -- ++ decls)
+    pure ()
   pure loadResult

--- a/src/Idris/REPLOpts.idr
+++ b/src/Idris/REPLOpts.idr
@@ -36,12 +36,13 @@ record REPLOpts where
   extraCodegens : List (String, Codegen)
   consoleWidth : Maybe Nat -- Nothing is auto
   color : Bool
+  synHighlightOn : Bool
 
 export
 defaultOpts : Maybe String -> OutputMode -> List (String, Codegen) -> REPLOpts
 defaultOpts fname outmode cgs
     = MkREPLOpts False NormaliseAll fname (litStyle fname) "" "vim"
-                 Nothing outmode "" Nothing Nothing cgs Nothing True
+                 Nothing outmode "" Nothing Nothing cgs Nothing True True
   where
     litStyle : Maybe String -> Maybe LiterateStyle
     litStyle Nothing = Nothing
@@ -163,3 +164,13 @@ export
 setColor : {auto o : Ref ROpts REPLOpts} -> Bool -> Core ()
 setColor b = do opts <- get ROpts
                 put ROpts (record { color = b } opts)
+
+export
+getSynHighlightOn : {auto o : Ref ROpts REPLOpts} -> Core Bool
+getSynHighlightOn = do opts <- get ROpts
+                       pure $ opts.synHighlightOn
+
+export
+setSynHighlightOn : {auto o : Ref ROpts REPLOpts} -> Bool -> Core ()
+setSynHighlightOn b = do opts <- get ROpts
+                         put ROpts (record { synHighlightOn = b } opts)

--- a/tests/ideMode/ideMode001/expected
+++ b/tests/ideMode/ideMode001/expected
@@ -23,4 +23,6 @@
 0000cc(:output (:ok (:highlight-source ((((:filename "LocType.idr") (:start 3 13) (:end 3 14)) ((:name "a") (:namespace "") (:decor :type) (:implicit :False) (:key "") (:doc-overview "") (:type "Type")))))) 1)
 0000cc(:output (:ok (:highlight-source ((((:filename "LocType.idr") (:start 2 19) (:end 2 20)) ((:name "a") (:namespace "") (:decor :type) (:implicit :False) (:key "") (:doc-overview "") (:type "Type")))))) 1)
 000015(:return (:ok ()) 1)
+000040(:return (:ok "Syntax highlight option changed to False" ()) 2)
+000015(:return (:ok ()) 3)
 Alas the file is done, aborting

--- a/tests/ideMode/ideMode001/input
+++ b/tests/ideMode/ideMode001/input
@@ -1,1 +1,3 @@
 00001e((:load-file "LocType.idr") 1)
+((:enable-syntax :False) 2)
+((:load-file "LocType.idr") 3)

--- a/tests/ideMode/ideMode001/input2
+++ b/tests/ideMode/ideMode001/input2
@@ -1,0 +1,1 @@
+00001b((:enable-syntax :False) 2)


### PR DESCRIPTION
Fixed a simple issue where some IDE mode messages where not using the pretty printing options and added a IDE mode exclusive options (not available as a command-line option) to enable/disable syntax output when loading files. Even simple files with few definitions can generate a great amount of messages on the line, and some client may not need those messages.