### PR TITLE
Add extra parsers

### DIFF
--- a/tests/chez/chez027/StringParser.idr
+++ b/tests/chez/chez027/StringParser.idr
@@ -4,6 +4,7 @@ import Control.Monad.Identity
 import Control.Monad.Trans
 
 import Data.Maybe
+import Data.Vect
 import Data.String.Parser
 
 %default partial
@@ -44,7 +45,7 @@ main = do
     res <- parseT (string "hi") "hiyaaaaaa"
     case res of
         Left err => putStrLn "NOOOOOOO!"
-        Right ((), i) => printLn i
+        Right (_, i) => printLn i
     bad <- parseT (satisfy isDigit) "a"
     showRes bad
     bad2 <- parseT (string "good" <?> "Not good") "bad bad bad"
@@ -61,5 +62,13 @@ main = do
     res <- parseT maybeParser "abcdef"
     showRes res
     res <- parseT maybeParser "def"
+    showRes res
+    res <- parseT (commaSep alphaNum) "a,1,b,2"
+    showRes res
+    res <- parseT (ntimes 4 letter) "abcd"
+    showRes res
+    res <- parseT (requireFailure letter) "1"
+    showRes res
+    res <- parseT (requireFailure letter) "a" -- Should error
     showRes res
     pure ()

--- a/tests/chez/chez027/expected
+++ b/tests/chez/chez027/expected
@@ -9,5 +9,9 @@ Parse failed at position 0: Not good
 ""
 True
 False
+['a', '1', 'b', '2']
+['a', 'b', 'c', 'd']
+()
+Parse failed at position 0: Purposefully changed OK to Fail
 1/1: Building StringParser (StringParser.idr)
 Main> Main> Bye for now!


### PR DESCRIPTION
The combinators are mostly those found in [Lightyear](https://github.com/ziman/lightyear) that I was missing when porting a parser to `Data.String.Parser`. I'm not sure that I implemented `requireFailure` 100% correctly, so would be best to take a close look at that.

This also changes the return type of `char` and `string`. They previously returned `()`, they now return `Char` and `String` repectively. I can change it back if this is not desired behaviour, but this seems to be the normal return type for `char` and `string` as found in [Lightyear](https://github.com/ziman/lightyear/blob/master/Lightyear/Char.idr#L23), [attoparsec](http://hackage.haskell.org/package/attoparsec-0.8.1.0/docs/Data-Attoparsec-Char8.html#v:char) and [parsec](https://hackage.haskell.org/package/parsec-3.1.11/docs/Text-Parsec-Char.html#v:char). Ran into that issue when trying to parse `(char '+') <|> (char '-')` and realizing I couldn't inspect the result usefully. 

Signed-off-by: Alex Humphreys <alex.humphreys@here.com>