### PR TITLE
Local hints

### DIFF
--- a/idris2api.ipkg
+++ b/idris2api.ipkg
@@ -45,6 +45,7 @@ modules =
     Core.Hash,
     Core.InitPrimitives,
     Core.LinearCheck,
+    Core.Lower,
     Core.Metadata,
     Core.Name,
     Core.Name.Namespace,

--- a/src/Core/AutoSearch.idr
+++ b/src/Core/AutoSearch.idr
@@ -379,7 +379,7 @@ searchName fc rigc defaults trying depth def top env target ((n, ndepth), ndef)
                         TCon tag arity _ _ _ _ _ _ => TyCon tag arity
                         _ => Func
 
-         (ty', ntm) <- Core.lower fc ty (Ref fc namety n) env ndepth
+         (ty', ntm) <- Core.Lower.lower fc ty (Ref fc namety n) env ndepth
          nty <- nf defs env ty'
 
          log "auto" 5 $ "   resulting in: " ++ show ntm

--- a/src/Core/AutoSearch.idr
+++ b/src/Core/AutoSearch.idr
@@ -165,7 +165,10 @@ exactlyOne {vars} fc env top target all
                        commit
                        pure res
               [] => throw (CantSolveGoal fc [] top)
-              rs => throw (AmbiguousSearch fc env !(quote !(get Ctxt) env target)
+              rs => do log "auto" 5 $ "Search: found multiple solutions "
+                       traverse (logTerm "auto" 5 "   ") 
+                                (map fst rs )
+                       throw (AmbiguousSearch fc env !(quote !(get Ctxt) env target)
                              !(traverse normRes rs))
   where
     normRes : (Term vars, Defs, UState) -> Core (Term vars)

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -310,7 +310,7 @@ addTypeHint : {auto c : Ref Ctxt Defs} ->
 addTypeHint fc (tyn, hintn, d)
    = do logC "ttc.read" 10 (pure (show !(getFullName hintn) ++ " for " ++
                             show !(getFullName tyn)))
-        addHintFor fc tyn hintn d True
+        addHintFor fc tyn hintn d 0 True
 
 addAutoHint : {auto c : Ref Ctxt Defs} ->
               (Name, Bool) -> Core ()

--- a/src/Core/Lower.idr
+++ b/src/Core/Lower.idr
@@ -1,0 +1,178 @@
+||| During elaboration, we lift local definitions to the top left, and
+||| replace references to them with calls to the lifted definition
+||| passing the current environment as an argument.
+|||
+||| This causes a problem with AutoSearch calls: we don't know in
+||| advance where we will call these lifted definitions. To do that,
+||| we need the opposite operation for lowering such a lifted
+||| definition back to the environment in which it was defined.
+|||
+||| Lowering gets more complicated since lifted definitions are stored
+||| at the top level, after we already forgot about the current
+||| environment, so we need to reconstruct it. In the current design,
+||| we only store the depth of the environment at the local
+||| definition.
+|||
+||| The whole thing is a hack, the right way to deal with it is
+||| probably to just not lift local definitions and dependent pattern
+||| matching to the top-level, but leave them in-place until code
+||| generation. Perhaps in a future version of Idris.
+module Core.Lower
+
+import Core.Context
+import Core.Context.Log
+import Core.Core
+import Core.Env
+import Core.Normalise
+import Core.TT
+import Core.Value
+
+import Data.Bool.Extra
+import Data.Either
+import Data.List
+import Data.List.Equalities -- Is it ok to depend on contrib?
+import Data.Maybe
+import Data.DPair
+
+import Data.Nat
+import Data.Nat
+import Data.Nat.Order
+import Data.Nat.Order.Properties -- are we comfortable with deps on contrib?
+
+import Syntax.PreorderReasoning  -- ditto
+import Data.List.Equalities      -- ditto
+import Data.List.Reverse         -- ditto
+import Decidable.Order
+ 
+%default covering
+
+InvariantViolation : Nat -> Error
+InvariantViolation n = InternalError 
+                      $ "Internal invariant failed, please report issue referring to"
+                      ++ "cc175bb3bdba:" ++ (show n)
+  
+peelAux : {auto c : Ref Ctxt Defs} -> SizeOf liftedVars -> Term peeledVars 
+     -> Core $ Exists $ \rest => Term rest `Subset` 
+               (const $ rest === (reverseOnto peeledVars liftedVars))
+peelAux {liftedVars = []} {peeledVars} 
+     (MkSizeOf _  Z   ) tm 
+     = pure $ Evidence _ (tm `Element` Refl)
+peelAux {liftedVars = x :: liftedVars} sz@(MkSizeOf (S n) (S n')) 
+     (Bind _ argName (Pi fc _ _ ty) scope) = do
+       tmPrf <- peelAux (MkSizeOf n n') $ renameVars (CompatExt CompatPre) scope
+       pure $ Evidence _ (fst (snd tmPrf) `Element` (snd (snd tmPrf)))
+peelAux {liftedVars = x :: liftedVars} (MkSizeOf _ (S n)) _ = 
+      -- This means that the depth stored in typeHints is somehow wrong, likely the depth
+      -- stored in typeHints is deeper than the current environment.
+           throw $ InvariantViolation 0
+           
+peel : {auto c : Ref Ctxt Defs} -> SizeOf liftedVars -> Term [] -> Core (Term liftedVars)
+peel {liftedVars} n closedTy = do
+  heavyWork <- peelAux (reverse n) closedTy
+  -- Extract the information to convince idris we're done
+  (let 0 rest : List Name
+       rest = fst heavyWork
+       ty : Term rest
+       ty = fst (snd heavyWork)
+       0 rest_is_liftedVars : rest = liftedVars
+       rest_is_liftedVars = Calc $
+         |~ rest
+         ~~ reverse (reverse liftedVars) ...(snd (snd heavyWork))
+         ~~ liftedVars                   ...(reverseReverseId liftedVars)
+   in pure $ rewrite sym rest_is_liftedVars in
+             ty)
+
+partial
+lower : {vars' : _} -> {auto c : Ref Ctxt Defs} -> FC -> Term [] -> Term vars' -> (env' : Env Term vars') -> (envDepth : Nat) 
+     -> Core (Term vars', Term vars') 
+%unbound_implicits off     
+lower         fc liftedTy tm env' 0 = pure (embed liftedTy, tm)
+lower {vars'} fc liftedTy tm env' envDepth = 
+  let len : Nat
+      len = length env'
+  in do
+  let Yes d_lte_len = decideLTE envDepth len
+  | No _ => throw $ InvariantViolation 1
+  log "auto" 10 $ "checksum for lowering fine: " ++ (show envDepth) ++ " <= " ++ (show len)
+  (let prefixLen : Nat
+       prefixLen = len `minus` envDepth
+       -- We're going to need to convince Idris the terms we construct are well-formed
+       -- some arithmetic first
+       0 len_is_len : (length env' = length vars')
+       len_is_len = lengthInvariant env'
+       0 prefixLen_lte_len : prefixLen `LTE` (length vars')
+       prefixLen_lte_len = replace {p = \ n => (len `minus` envDepth) `LTE` n} 
+                              len_is_len $
+                              minusLTE envDepth len
+       0 suffixVars : List Name
+       suffixVars = drop prefixLen vars' 
+       0 keptVars : List Name
+       keptVars = take prefixLen vars' 
+          
+       0 prefixLen_is_len : (length keptVars = prefixLen)
+       prefixLen_is_len = reflectLength $ snd $ specTakeDrop prefixLen vars' prefixLen_lte_len
+          
+       0 varsDecomposition : (vars' = keptVars ++ suffixVars)
+       varsDecomposition = fst $ specTakeDrop prefixLen vars' prefixLen_lte_len
+       0 suffixLen_is_depth : (length suffixVars = envDepth)
+       suffixLen_is_depth = plusLeftCancel prefixLen (length suffixVars) envDepth $ Calc $ 
+            |~ prefixLen       + (length suffixVars)
+            ~~ length keptVars + (length suffixVars)  ...(cong (+ (length suffixVars))
+                                                          $ sym prefixLen_is_len)
+            ~~ length(keptVars ++        suffixVars)  ...(sym $ lengthDistributesOverAppend
+                                                                keptVars suffixVars)
+            ~~ length vars'                           ...(cong length $ sym varsDecomposition)
+            ~~ length env'                            ...(sym len_is_len)
+            ~~ prefixLen + envDepth                   ...(sym $ plusMinusLte envDepth len d_lte_len)
+            
+       
+       0 envDepth_lte_suffixLen : envDepth `LTE` (length suffixVars)
+       envDepth_lte_suffixLen = rewrite suffixLen_is_depth in 
+                                reflexive envDepth
+       
+       liftedEnv : Env Term suffixVars
+       liftedEnv = dropEnv prefixLen env'
+                           
+       0 prefixVars : List Name
+       prefixVars = take envDepth suffixVars 
+       0 remainder : List Name
+       remainder = drop envDepth suffixVars 
+                  
+       0 prefixVars_is_suffixVars : (prefixVars = suffixVars)
+       prefixVars_is_suffixVars = concatRightCancel 
+         prefixVars remainder suffixVars [] 
+         (Calc $
+         |~ length prefixVars
+         ~~ envDepth          ...(reflectLength $ snd $ 
+                                  specTakeDrop envDepth suffixVars envDepth_lte_suffixLen)
+         ~~ length suffixVars ...(sym suffixLen_is_depth))
+         (Calc $ 
+         |~ prefixVars ++ remainder
+         ~~ suffixVars       ...(sym $ fst $ specTakeDrop envDepth suffixVars envDepth_lte_suffixLen)
+         ~~ suffixVars ++ [] ...(sym $ appendNilRightNeutral suffixVars))
+       
+       targetEnv : SubstEnv suffixVars suffixVars
+       targetEnv = replace {p = \v => SubstEnv v suffixVars} prefixVars_is_suffixVars $
+                   takeEnv envDepth liftedEnv
+       
+       SizeOfSuffix : SizeOf suffixVars
+       SizeOfSuffix = MkSizeOf envDepth $ 
+                               replace {p = \n => HasLength n suffixVars} suffixLen_is_depth $
+                               mkHasLength suffixVars
+       
+   in do
+   scope <- peel SizeOfSuffix liftedTy 
+   (let theta : SizeOf keptVars
+        theta = MkSizeOf prefixLen (replace {p = \n => HasLength n keptVars} prefixLen_is_len $
+                                            mkHasLength keptVars)
+        actualTy : Term vars'
+        actualTy = rewrite varsDecomposition in 
+                   weakenNs theta
+                            scope
+        args : List (Term vars')
+        args = rewrite varsDecomposition in 
+               map (weakenNs theta) $ reverse $ listFromSubstEnv targetEnv
+        actualTm : Term vars'
+        actualTm = apply fc tm args
+    in pure (actualTy, actualTm)))
+

--- a/src/Core/Lower.idr
+++ b/src/Core/Lower.idr
@@ -82,7 +82,7 @@ peel {liftedVars} n closedTy = do
    in pure $ rewrite sym rest_is_liftedVars in
              ty)
 
-partial
+partial export
 lower : {vars' : _} -> {auto c : Ref Ctxt Defs} -> FC -> Term [] -> Term vars' -> (env' : Env Term vars') -> (envDepth : Nat) 
      -> Core (Term vars', Term vars') 
 %unbound_implicits off     

--- a/src/Core/TT.idr
+++ b/src/Core/TT.idr
@@ -510,6 +510,11 @@ namespace SizeOf
   take : {n : Nat} -> {0 xs : Stream a} -> SizeOf (take n xs)
   take = MkSizeOf n (take n xs)
 
+  export
+  sizeSucHomo : (n : SizeOf xs) -> size (suc n) = S (size n)
+  sizeSucHomo (MkSizeOf n p) = Refl
+
+
 namespace SizedView
 
   public export
@@ -988,7 +993,7 @@ renameVarList : CompatibleVars xs ys -> Var xs -> Var ys
 renameVarList prf (MkVar p) = renameLocalRef prf p
 
 export
-renameVars : CompatibleVars xs ys -> Term xs -> Term ys
+renameVars : (0 compat : CompatibleVars xs ys) -> Term xs -> Term ys
 renameVars compat tm = believe_me tm -- no names in term, so it's identity
 -- This is how we would define it:
 -- renameVars CompatPre tm = tm
@@ -1294,6 +1299,15 @@ namespace SubstEnv
   export
   substs : SubstEnv drop vars -> Term (drop ++ vars) -> Term vars
   substs env tm = substEnv zero env tm
+  
+  export
+  weakenSubstEnv : SubstEnv drop vars -> SubstEnv drop (x :: vars)
+  weakenSubstEnv [] = []
+  weakenSubstEnv (tm :: env) = weaken tm :: weakenSubstEnv env
+  
+  export
+  substSimul : SubstEnv drop vars -> Term drop -> Term vars
+  substSimul env tm = substs env (embed tm)
 
   export
   subst : Term vars -> Term (x :: vars) -> Term vars

--- a/src/Data/NameMap.idr
+++ b/src/Data/NameMap.idr
@@ -271,11 +271,19 @@ export
 values : NameMap v -> List v
 values = map snd . toList
 
+treeMapWithKey : (Key -> a -> b) -> Tree n a -> Tree n b
+treeMapWithKey f (Leaf k v) = Leaf k (f k v)
+treeMapWithKey f (Branch2 t1 k t2) = Branch2 (treeMapWithKey f t1) k (treeMapWithKey f t2)
+treeMapWithKey f (Branch3 t1 k1 t2 k2 t3) 
+    = Branch3 (treeMapWithKey f t1) k1 (treeMapWithKey f t2) k2 (treeMapWithKey f t3)
+
+export
+mapWithKey : (Name -> a -> b) -> NameMap a -> NameMap b
+mapWithKey f Empty = Empty
+mapWithKey f (M n t) = M _ (treeMapWithKey f t)
+
 treeMap : (a -> b) -> Tree n a -> Tree n b
-treeMap f (Leaf k v) = Leaf k (f v)
-treeMap f (Branch2 t1 k t2) = Branch2 (treeMap f t1) k (treeMap f t2)
-treeMap f (Branch3 t1 k1 t2 k2 t3)
-    = Branch3 (treeMap f t1) k1 (treeMap f t2) k2 (treeMap f t3)
+treeMap f tree = treeMapWithKey (\ _ => f) tree
 
 export
 implementation Functor NameMap where

--- a/src/Idris/DocString.idr
+++ b/src/Idris/DocString.idr
@@ -116,7 +116,7 @@ getDocsFor fc n
              sd <- getSearchData fc False n
              idocs <- case hintGroups sd of
                            [] => pure []
-                           ((_, tophs) :: _) => traverse getImplDoc tophs
+                           ((_, tophs) :: _) => traverse (getImplDoc . fst) tophs
              let insts = case mapMaybe id idocs of
                               [] => ""
                               docs => "\nImplementations:\n" ++ concat docs

--- a/src/TTImp/Elab/App.idr
+++ b/src/TTImp/Elab/App.idr
@@ -70,6 +70,7 @@ getNameType rigc env fc x
                            (throw (LinearMisuse fc !(getFullName x) lhs rhs))
 
 -- Get the type of a variable, looking it up in the nested names first.
+export
 getVarType : {vars : _} ->
              {auto c : Ref Ctxt Defs} ->
              {auto m : Ref MD Metadata} ->

--- a/src/TTImp/Elab/Term.idr
+++ b/src/TTImp/Elab/Term.idr
@@ -269,7 +269,8 @@ checkTerm rig elabinfo nest env (IWithUnambigNames fc ns rhs) exp
 --         {auto m : Ref MD Metadata} ->
 --         {auto u : Ref UST UState} ->
 --         {auto e : Ref EST (EState vars)} ->
---         RigCount -> ElabInfo -> Env Term vars -> RawImp ->
+--         RigCount -> ElabInfo -> 
+--         NestedNames vars -> Env Term vars -> RawImp ->
 --         Maybe (Glued vars) ->
 --         Core (Term vars, Glued vars)
 -- If we've just inserted an implicit coercion (in practice, that's either

--- a/src/TTImp/Interactive/ExprSearch.idr
+++ b/src/TTImp/Interactive/ExprSearch.idr
@@ -740,7 +740,8 @@ searchType fc rig opts env topty _ ty
                 do defs <- get Ctxt
                    if length args == ar
                      then do sd <- getSearchData fc False n
-                             let allHints = concat (map snd (hintGroups sd))
+                             -- TODO: take depth argument into account
+                             let allHints = concat (map (map fst . snd) (hintGroups sd))
                              -- Solutions is either:
                              -- First try the locals,
                              -- Then try the hints in order

--- a/src/TTImp/ProcessData.idr
+++ b/src/TTImp/ProcessData.idr
@@ -361,6 +361,6 @@ processData {vars} eopts nest env fc vis (MkImpData dfc n_in ty_raw opts cons_ra
 
          let connames = map conName cons
          when (not (NoHints `elem` opts)) $
-              traverse_ (\x => addHintFor fc (Resolved tidx) x True False) connames
+              traverse_ (\x => addHintFor fc (Resolved tidx) x True 0 False) connames
 
          traverse_ updateErasable (Resolved tidx :: connames)

--- a/src/TTImp/ProcessType.idr
+++ b/src/TTImp/ProcessType.idr
@@ -34,7 +34,10 @@ processFnOpt fc ndef (Hint d)
          Just ty <- lookupTyExact ndef (gamma defs)
               | Nothing => throw (UndefinedName fc ndef)
          target <- getRetTy defs !(nf defs [] ty)
-         addHintFor fc target ndef d False
+         -- We really should be adding a hint with the depth of the current
+         -- environment, but we don't have that information right now.
+         -- We'll update to the correct depth in TTImp.Elab.Local
+         addHintFor fc target ndef d 0 False
   where
     getRetTy : Defs -> NF [] -> Core Name
     getRetTy defs (NBind fc _ (Pi _ _ _ _) sc)

--- a/src/TTImp/ProcessType.idr
+++ b/src/TTImp/ProcessType.idr
@@ -23,14 +23,6 @@ import Data.NameMap
 
 %default covering
 
-getRetTy : Defs -> NF [] -> Core Name
-getRetTy defs (NBind fc _ (Pi _ _ _ _) sc)
-    = getRetTy defs !(sc defs (toClosure defaultOpts [] (Erased fc False)))
-getRetTy defs (NTCon _ n _ _ _) = pure n
-getRetTy defs ty
-    = throw (GenericMsg (getLoc ty)
-             "Can only add hints for concrete return types")
-
 processFnOpt : {auto c : Ref Ctxt Defs} ->
                FC -> Name -> FnOpt -> Core ()
 processFnOpt fc ndef Inline
@@ -43,6 +35,15 @@ processFnOpt fc ndef (Hint d)
               | Nothing => throw (UndefinedName fc ndef)
          target <- getRetTy defs !(nf defs [] ty)
          addHintFor fc target ndef d False
+  where
+    getRetTy : Defs -> NF [] -> Core Name
+    getRetTy defs (NBind fc _ (Pi _ _ _ _) sc)
+        = getRetTy defs !(sc defs (toClosure defaultOpts [] (Erased fc False)))
+    getRetTy defs (NTCon _ n _ _ _) = pure n
+    getRetTy defs ty
+        = throw (GenericMsg (getLoc ty)
+                 "Can only add hints for concrete return types")
+
 processFnOpt fc ndef (GlobalHint a)
     = addGlobalHint ndef a
 processFnOpt fc ndef ExternFn

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -70,7 +70,7 @@ idrisTests = MkTestPool []
        "interface005", "interface006", "interface007", "interface008",
        "interface009", "interface010", "interface011", "interface012",
        "interface013", "interface014", "interface015", "interface016",
-       "interface017",
+       "interface017", "interface018", "interface019",  
        -- Miscellaneous REPL
        "interpreter001", "interpreter002", "interpreter003", "interpreter004",
        "interpreter005",

--- a/tests/idris2/interface018/LocalHints.idr
+++ b/tests/idris2/interface018/LocalHints.idr
@@ -1,0 +1,48 @@
+data Foo : Type where [noHints]
+  A : Foo
+  B : Foo
+  
+findA : {auto foo : Foo} -> String
+findA {foo = A} = "Found an A"
+findA {foo = _} = "Failed to find an A"
+
+Baz : String -> Type
+Baz s = s = "Found an A" 
+
+baz : (s : String ** Baz s)
+baz = let %hint arg : Foo
+          arg = A
+      in (findA ** Refl)
+
+interface Gnu where
+  constructor MkGnu
+  hasFoo : Foo
+  
+findB : Gnu => String
+findB = case hasFoo of
+  B => "Found a B"
+  _ => "Failed to find a B"
+
+Bar : String -> Type
+Bar s = s = "Found a B" 
+
+bar : (s : String ** Bar s)
+bar = let %hint arg : Gnu
+          arg = MkGnu B
+      in (findB ** Refl)
+
+interface Gnat a where
+  constructor MkGnat
+  makeFoo : a -> Foo
+
+record More where
+  constructor MkMore
+  0 Ty : Type
+
+%unbound_implicits off
+bug : forall a . a -> (s : String ** Bar s)
+bug {a} x = let M : More
+                M = MkMore a
+                %hint arg : Gnat (Ty M)
+                arg = MkGnat (const B)
+            in (findB ** Refl)

--- a/tests/idris2/interface018/expected
+++ b/tests/idris2/interface018/expected
@@ -1,0 +1,1 @@
+1/1: Building LocalHints (LocalHints.idr)

--- a/tests/idris2/interface018/run
+++ b/tests/idris2/interface018/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 LocalHints.idr --check
+
+rm -rf build

--- a/tests/idris2/interface019/AlgebraLocalHints.idr
+++ b/tests/idris2/interface019/AlgebraLocalHints.idr
@@ -1,0 +1,137 @@
+import Syntax.PreorderReasoning
+
+-------- some notation ----------
+infixr 6 .+.,:+:
+infixr 7 .*.,:*:
+
+interface Additive a where
+  constructor MkAdditive
+  (.+.) : a -> a -> a
+  O   : a
+
+interface Additive2 a where
+  constructor MkAdditive2
+  (:+:) : a -> a -> a
+  O2   : a 
+  
+interface Multiplicative a where
+  constructor MkMultiplicative
+  (.*.) : a -> a -> a
+  I     : a
+
+record MonoidOver U where            
+  constructor WithStruct
+  Unit    : U
+  Mult    : U -> U -> U
+  lftUnit : (x : U) -> Unit `Mult` x    = x
+  rgtUnit : (x : U) -> x    `Mult` Unit = x
+  assoc   : (x,y,z : U) 
+                    -> x `Mult` (y `Mult` z) = (x `Mult` y) `Mult` z
+
+record Monoid where
+  constructor MkMonoid
+  U : Type
+  Struct : MonoidOver U
+
+AdditiveStruct : (m : MonoidOver a) -> Additive a
+AdditiveStruct m = MkAdditive (Mult $ m) 
+                              (Unit $ m)
+AdditiveStruct2 : (m : MonoidOver a) -> Additive2 a
+AdditiveStruct2 m = MkAdditive2 (Mult $ m) 
+                                (Unit $ m)
+AdditiveStructs : (ma : MonoidOver a) -> (mb : MonoidOver b) 
+              -> (Additive a, Additive2 b)
+AdditiveStructs ma mb = (AdditiveStruct ma, AdditiveStruct2 mb)
+
+getAdditive : (m : Monoid) -> Additive (U m)
+getAdditive m = AdditiveStruct (Struct m)
+
+MultiplicativeStruct : (m : Monoid) -> Multiplicative (U m)
+MultiplicativeStruct m = MkMultiplicative (Mult $ Struct m)
+                                          (Unit $ Struct m)
+-----------------------------------------------------                   
+
+Commutative : MonoidOver a -> Type
+Commutative m = (x,y : a) -> let _ = AdditiveStruct m in
+                x .+. y = y .+. x
+                
+Commute : (Additive a, Additive2 a) => Type
+Commute =
+          (x11,x12,x21,x22 : a) -> 
+          ((x11 :+: x12) .+. (x21 :+: x22))
+          =
+          ((x11 .+. x21) :+: (x12 .+. x22))
+
+product : (ma, mb : Monoid) -> Monoid 
+product ma mb = 
+  let 
+      %hint aStruct : Additive (U ma)
+      aStruct = getAdditive ma
+      %hint bStruct : Additive (U mb)
+      bStruct = getAdditive mb
+      
+  in MkMonoid (U ma, U mb) $ WithStruct
+     (O, O)
+     (\(x1,y1), (x2, y2)  => (x1 .+. x2, y1 .+. y2))
+     (\(x,y) => rewrite lftUnit (Struct ma) x in 
+                rewrite lftUnit (Struct mb) y in
+                Refl)
+     (\(x,y) => rewrite rgtUnit (Struct ma) x in
+                rewrite rgtUnit (Struct mb) y in
+                Refl)
+     (\(x1,y1),(x2,y2),(x3,y3) => 
+                rewrite assoc (Struct ma) x1 x2 x3 in
+                rewrite assoc (Struct mb) y1 y2 y3 in
+                Refl)
+
+EckmannHilton : forall a . (ma,mb : MonoidOver a) 
+             -> let ops = AdditiveStructs ma mb in
+                Commute @{ops}
+             -> (Commutative ma, (x,y : a) -> x .+. y = x :+: y)
+EckmannHilton ma mb prf = 
+  let %hint first : Additive a
+      first = AdditiveStruct ma
+      %hint second : Additive2 a
+      second = AdditiveStruct2 mb in
+  let SameUnits : (the a O === O2)
+      SameUnits = Calc $
+        |~ O
+        ~~  O         .+.         O  ...(sym $ lftUnit ma O)
+        ~~ (O :+: O2) .+. (O2 :+: O) ...(sym $ cong2 (.+.) 
+                                             (rgtUnit mb O)
+                                             (lftUnit mb O))
+        ~~ (O .+. O2) :+: (O2 .+. O) ...(prf O O2 O2 O)
+        ~~        O2  :+:  O2        ...(cong2 (:+:)
+                                             (lftUnit ma O2)
+                                             (rgtUnit ma O2))
+        ~~ O2                        ...(lftUnit mb O2)
+        
+      SameMults : (x,y : a) -> (x .+. y) === (x :+: y)
+      SameMults x y = Calc $
+        |~ x .+. y
+        ~~ (x :+: O2) .+. (O2 :+: y) ...(sym $ cong2 (.+.)
+                                             (rgtUnit mb x)
+                                             (lftUnit mb y))
+        ~~ (x .+. O2) :+: (O2 .+. y) ...(prf x O2 O2 y)
+        ~~ (x .+. O ) :+: (O  .+. y) ...(cong (\u => 
+                                              (x .+. u) :+: (u .+. y))
+                                              (sym SameUnits))
+        ~~ x :+: y                   ...(cong2 (:+:)
+                                              (rgtUnit ma x)
+                                              (lftUnit ma y))
+                                                    
+      Commutativity : Commutative ma
+      Commutativity x y = Calc $
+        |~ x .+. y
+        ~~ (O2 :+: x) .+. (y :+: O2) ...(sym $ cong2 (.+.)
+                                             (lftUnit mb x)
+                                             (rgtUnit mb y))
+        ~~ (O2 .+. y) :+: (x .+. O2) ...(prf O2 x y O2)
+        ~~ (O  .+. y) :+: (x .+. O ) ...(cong (\u => 
+                                              (u .+. y) :+: (x .+. u))
+                                              (sym SameUnits))
+        ~~ y :+: x                   ...(cong2 (:+:)
+                                              (lftUnit ma y)
+                                              (rgtUnit ma x))
+        ~~ y .+. x                   ...(sym $ SameMults y x)
+  in (Commutativity, SameMults)

--- a/tests/idris2/interface019/expected
+++ b/tests/idris2/interface019/expected
@@ -1,0 +1,1 @@
+1/1: Building AlgebraLocalHints (AlgebraLocalHints.idr)

--- a/tests/idris2/interface019/run
+++ b/tests/idris2/interface019/run
@@ -1,0 +1,3 @@
+$1 --package contrib --no-color --console-width 0 AlgebraLocalHints.idr --check
+
+rm -rf build


### PR DESCRIPTION
Edit: Better support for this is partly implemented in PR #846 , but the translation into a `let` binding is restrictive.

This WIP-PR explores using AutoSearch `hint`s locally, for example (taken from the test [`idris2/interface018`](https://github.com/ohad/Idris2/blob/27b3d3e0007a6a1d5b0e18b42e9eae05825bb52b/tests/idris2/interface018/LocalHints.idr#L1)):
```idris
findA : {auto foo : Foo} -> String
findA {foo = A} = "Found an A"
findA {foo = _} = "Failed to find an A"

Baz : String -> Type
Baz s = s = "Found an A" 

baz : (s : String ** Baz s)
baz = let %hint arg : Foo
          arg = A
      in (findA ** Refl)
```
This is already possible if we use `let`-binding, with the difference that `let`-bound values are kept abstract in types, so the above code really needs a local definition, and won't work with a `let`-binding. This kind of type-level visibility is crucial for programs that do type-level computation.

I can see this kind of feature useful when we need to manipulate sets of notation. For example (taken from the test [`idris2/interface019`](https://github.com/ohad/Idris2/blob/27b3d3e0007a6a1d5b0e18b42e9eae05825bb52b/tests/idris2/interface019/AlgebraLocalHints.idr#L87), in the [Eckmann-Hilton argument](https://en.wikipedia.org/wiki/Eckmann%E2%80%93Hilton_argument), we manipulate two different monoid structures over the same carrier, and with the local hints mechanism we can easily re-map the monoid operations:
```idris
EckmannHilton ma mb prf = 
  let %hint first : Additive a
      first = AdditiveStruct ma
      %hint second : Additive2 a
      second = AdditiveStruct2 mb in
  let SameUnits : (the a O === O2)
      SameUnits = Calc $
        |~ O
        ~~  O         .+.         O  ...(sym $ lftUnit ma O)
        ~~ (O :+: O2) .+. (O2 :+: O) ...(sym $ cong2 (.+.) 
                                             (rgtUnit mb O)
                                             (lftUnit mb O))
    ...
```

This PR is still WP because local hints end up being global still:
```idris
data Foo : Type where [noHints]
  A : Foo
  B : Foo

findFoo : {auto ambient : Foo} -> Foo
findFoo @{foo} = foo

foo1 : Nat -> Foo
foo1 n = let %hint aFoo : Foo
             aFoo = A
         in findFoo

foo2 : Nat -> Foo -- Should fail!
foo2 n = let _ = let %hint bFoo : Foo
                     bFoo = B
                 in ()
         in findFoo         

foo3 : Nat -> Foo
foo3 n = findFoo -- Should fail!
```
Example `foo1` should type-check fine because of the local hint. But both `foo2` and `foo3` should fail because the hints should be localised to their scope. I'll explain below why this happens, but the tl;dr is that currently we never erase hints.
(The reason we don't get an ambiguity error is more subtle.)

The reason this is difficult is that local definitions are not stored as variables in the current environment. Instead, they are lifted to the top-level, where they are type-checked as a top-level definition, and all the variables that reference them from the scope are substituted by a `Ref` to this top-level definition. There are technical and historical reasons why this is the case, and changing it right now is going to be a substantial rewrite.
The reason this complicates auto search is that, unlike variables which are explicit in the source code, we don't quite know where in auto search we'll need these local definitions at the time we elaborate the local definition. By the time we get there, we're somewhere deeper in the scope of the local definition, and we need to do extra work to recover the definition in the form it was before lifting.

We need to undo this lifting because we won't find the correct arguments using auto search, and so auto search won't apply the local hint. For example, in the Eckmann-Hilton argument above, we internally lifted the hint:
```idris
%hint first : (0 a : Type) -> (ma, mb : Monoid a) -> (prf : ...) -> Additive a
```
Since we have two variables of the same type `ma, mb : Monoid a`, auto search will fail to find them as arguments to `first`. Looking for these arguments with auto search is silly, since we already knew what they were before we lifted the definition. So we need to implement a `lower` mechanism to undo the lifting and start auto search from where it's needed.

The way we implement local hints here then is to add an extra argument to the global dictionary that stores hints: the depth in the environment where the local definition was defined. When we leave the scope of this local definition, we will delete the hint from the global dictionary. During auto search, if the local definition is still in the global dictionary, we'll lower it back to the current environment.

What's currently implemented is wrong, because we don't remove local hints when we leave their scope. That's because unification sometimes delay elaboration to a later stage, after some more constraints have been solved. For example, the following line in the [product monoid](https://github.com/ohad/Idris2/blob/27b3d3e0007a6a1d5b0e18b42e9eae05825bb52b/tests/idris2/interface019/AlgebraLocalHints.idr#L65):
```idris
     (\(x1,y1), (x2, y2)  => (x1 .+. x2, y1 .+. y2))
``` 
is delayed until after we leave the scope, probably because we need to synthesise types for the arguments `x1,y1,x2,y2`.

TODO: Whatever we implement should also be replicated in interactive expression search (why not?).

I'm making this PR to get some comments about the mechanism, and suggestions (esp. @gallais and @edwinb ) on how to best implement it without changing the existing Idris2 architecture too much.