### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci-api.yml
+++ b/.github/workflows/ci-api.yml
@@ -12,6 +12,7 @@ on:
 env:
   SCHEME: scheme
   IDRIS2_TESTS_CG: chez
+  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
 jobs:
   build:

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -11,6 +11,7 @@ on:
 env:
   SCHEME: chez
   IDRIS2_TESTS_CG: chez
+  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
 jobs:
   build:

--- a/.github/workflows/ci-ubuntu-racket.yml
+++ b/.github/workflows/ci-ubuntu-racket.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   IDRIS2_TESTS_CG: racket
+  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
 jobs:
   build:

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -12,6 +12,7 @@ on:
 env:
   SCHEME: scheme
   IDRIS2_TESTS_CG: chez
+  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
 jobs:
   build:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -14,6 +14,7 @@ env:
   SCHEME: scheme
   IDRIS2_TESTS_CG: chez
   CC: gcc
+  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
 jobs:
   build:


### PR DESCRIPTION
A quick fix to the recent Github's deprecation of workflow commands that manipulate environment variables.

 Those commands have been marked as unsecure by Github, and workflows still willing to use them, have to explicitly state that by setting a special environment variable: `ACTIONS_ALLOW_UNSECURE_COMMANDS`. As @melted pointed out, we shouldn't be afraid of leaving those unsecure commands as is, because we don't do anything sensitive in the workflows just yet.

For the moment we can take this approach, later if we decide we want to use secrets in our workflows we can revisit this issue.