### PR TITLE
Added minimal readline support

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -5,6 +5,10 @@ PREFIX ?= $(HOME)/.idris2
 # For Windows targets. Set to 1 to support Windows 7.
 OLD_WIN ?= 0
 
+# Set to 1 to enable line editing and history functions in the Idris2 REPL,
+# and in System.Readline
+READLINE ?= 0
+
 ##################################################################
 
 RANLIB ?= ranlib

--- a/libs/base/System/Readline.idr
+++ b/libs/base/System/Readline.idr
@@ -1,0 +1,49 @@
+module System.Readline
+
+support : String -> String
+support fn = "C:" ++ fn ++ ", libidris2_support"
+
+%foreign (support "idris2_getString")
+getString : Ptr String -> String
+
+%foreign (support "idris2_mkString")
+mkString : String -> Ptr String
+
+%foreign (support "idris2_nullString")
+nullString : Ptr String
+
+%foreign (support "idris2_isNullString")
+prim__isNullString : Ptr String -> Int
+
+isNullString : Ptr String -> Bool
+isNullString str = not $ prim__isNullString str == 0
+
+%foreign (support "readline")
+prim__readline : String -> PrimIO (Ptr String)
+
+export
+readline : HasIO io => String -> io (Maybe String)
+readline s
+    = do mstr <- primIO $ prim__readline s
+         pure $ if isNullString mstr
+                   then Nothing
+                   else Just (getString mstr)
+
+%foreign (support "add_history")
+prim__add_history : String -> PrimIO ()
+
+export
+addHistory : HasIO io => String -> io ()
+addHistory s = primIO $ prim__add_history s
+
+%foreign (support "idris2_setCompletion")
+prim__setCompletion : (String -> Int -> PrimIO (Ptr String)) -> PrimIO ()
+
+export
+setCompletionFn : HasIO io => (String -> Int -> IO (Maybe String)) -> io ()
+setCompletionFn fn
+    = primIO $ prim__setCompletion $ \s, i => toPrim $ do
+        mstr <- fn s i
+        case mstr of
+             Nothing => pure nullString
+             Just str => pure (mkString str)

--- a/libs/base/base.ipkg
+++ b/libs/base/base.ipkg
@@ -62,4 +62,5 @@ modules = Control.App,
           System.File,
           System.FFI,
           System.Info,
+          System.Readline,
           System.REPL

--- a/support/c/Makefile
+++ b/support/c/Makefile
@@ -18,6 +18,10 @@ endif
 OBJS = $(SRCS:.c=.o)
 DEPS = $(OBJS:.o=.d)
 
+ifeq ($(READLINE), 1)
+	LDFLAGS += -lreadline
+	CFLAGS += -DREADLINE
+endif
 
 all: build
 

--- a/support/c/idris_readline.c
+++ b/support/c/idris_readline.c
@@ -1,0 +1,72 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+/*
+ * Bare minimum readline support.
+ * Supported functions: readline, add_history, idris2_setCompletion
+ * If READLINE is not set, dummy functions are used in their place.
+ */
+
+#ifdef READLINE
+
+#include <readline/readline.h>
+
+rl_compentry_func_t* my_compentry = NULL;
+
+char* compentry_wrapper(const char* text, int i) {
+    char* res = my_compentry(text, i); // Idris frees this
+    if (res != NULL) {
+        char* comp = malloc(strlen(res)+1); // Readline frees this
+        strcpy(comp, res);
+        return comp;
+    }
+    else {
+        return NULL;
+    }
+}
+
+void idris2_setCompletion(rl_compentry_func_t* fn) {
+    rl_completion_entry_function = compentry_wrapper;
+    my_compentry = fn;
+}
+
+#else
+
+void idris2_setCompletion(void* fn) {}
+
+char* readline(char *prompt) {
+  char* buf = NULL;
+  size_t len = 0;
+  printf("%s", prompt);
+  ssize_t linesize = getline(&buf, &len, stdin);
+  if (linesize >= 1 && buf[linesize - 1] == '\n') {
+    buf[linesize - 1] = '\0';
+    #if defined(WIN32) || defined(WIN64)
+    if (linesize >= 2 && buf[linesize - 2] == '\r') {
+      buf[linesize - 2] = '\0';
+    }
+    #endif
+  }
+  if (feof(stdin)) {
+    free(buf);
+    return NULL;
+  }
+  return buf;
+}
+
+void add_history(char* line) {}
+
+#endif
+
+void* idris2_mkString(char* str) {
+    return (void*)str;
+}
+
+void* idris2_nullString() {
+    return NULL;
+}
+
+int idris2_isNullString(void* str) {
+    return str == NULL;
+}

--- a/support/c/idris_readline.h
+++ b/support/c/idris_readline.h
@@ -1,0 +1,12 @@
+#ifndef _IDRIS_READLINE_H
+#define _IDRIS_READLINE_H
+
+#include <readline/readline.h>
+
+void idris2_setCompletion(rl_completion_func_t* fn);
+
+void* idris2_mkString(char* str);
+void* idris2_nullString();
+int idris2_isNullString(void* str);
+
+#endif


### PR DESCRIPTION
Hoping to get the ball rolling on REPL readline support.
This is a very minimal change, with bindings stolen from the `samples/` folder.

It enables rebindable line editing, and session-local history.

It also addresses this comment in `Contributing.md`:
> it'd be nice if Ctrl-C didn't quit the whole system!

Well, now it seems to take two presses of Ctrl-C to exit the system.

Note that when compiled with readline support, the tests fail, due to the prompt not going to stdout.
There doesn't seem to be an easy way around this.
It might be worth creating a REPL monad, which can be interpreted as IO, or tested. I'm hoping this is out of the scope of this PR.