### PR TITLE
Suggestion of alternative list index function

### DIFF
--- a/libs/base/Data/Fin.idr
+++ b/libs/base/Data/Fin.idr
@@ -2,7 +2,7 @@ module Data.Fin
 
 import public Data.Maybe
 import Data.Nat
-import Decidable.Equality
+import Decidable.Equality.Core
 
 %default total
 

--- a/libs/base/Data/List.idr
+++ b/libs/base/Data/List.idr
@@ -2,6 +2,7 @@ module Data.List
 
 import Data.Nat
 import Data.List1
+import Data.Fin
 
 public export
 isNil : List a -> Bool
@@ -61,6 +62,11 @@ public export
 index : (n : Nat) -> (xs : List a) -> {auto 0 ok : InBounds n xs} -> a
 index Z (x :: xs) {ok = InFirst} = x
 index (S k) (_ :: xs) {ok = InLater _} = index k xs
+
+public export
+index' : (xs : List a) -> Fin (length xs) -> a
+index' (x::_)  FZ     = x
+index' (_::xs) (FS i) = index' xs i
 
 ||| Generate a list by repeatedly applying a partial function until exhausted.
 ||| @ f the function to iterate

--- a/libs/base/Decidable/Equality.idr
+++ b/libs/base/Decidable/Equality.idr
@@ -6,33 +6,9 @@ import Data.Nat
 import Data.List
 import Data.List1
 
+import public Decidable.Equality.Core as Decidable.Equality
+
 %default total
-
---------------------------------------------------------------------------------
--- Decidable equality
---------------------------------------------------------------------------------
-
-||| Decision procedures for propositional equality
-public export
-interface DecEq t where
-  ||| Decide whether two elements of `t` are propositionally equal
-  decEq : (x1 : t) -> (x2 : t) -> Dec (x1 = x2)
-
---------------------------------------------------------------------------------
--- Utility lemmas
---------------------------------------------------------------------------------
-
-||| The negation of equality is symmetric (follows from symmetry of equality)
-export
-negEqSym : forall a, b . (a = b -> Void) -> (b = a -> Void)
-negEqSym p h = p (sym h)
-
-||| Everything is decidably equal to itself
-export
-decEqSelfIsYes : DecEq a => {x : a} -> decEq x x = Yes Refl
-decEqSelfIsYes {x} with (decEq x x)
-  decEqSelfIsYes {x} | Yes Refl = Refl
-  decEqSelfIsYes {x} | No contra = absurd $ contra Refl
 
 --------------------------------------------------------------------------------
 --- Unit

--- a/libs/base/Decidable/Equality/Core.idr
+++ b/libs/base/Decidable/Equality/Core.idr
@@ -1,0 +1,29 @@
+module Decidable.Equality.Core
+
+%default total
+
+--------------------------------------------------------------------------------
+-- Decidable equality
+--------------------------------------------------------------------------------
+
+||| Decision procedures for propositional equality
+public export
+interface DecEq t where
+  ||| Decide whether two elements of `t` are propositionally equal
+  decEq : (x1 : t) -> (x2 : t) -> Dec (x1 = x2)
+
+--------------------------------------------------------------------------------
+-- Utility lemmas
+--------------------------------------------------------------------------------
+
+||| The negation of equality is symmetric (follows from symmetry of equality)
+export
+negEqSym : forall a, b . (a = b -> Void) -> (b = a -> Void)
+negEqSym p h = p (sym h)
+
+||| Everything is decidably equal to itself
+export
+decEqSelfIsYes : DecEq a => {x : a} -> decEq x x = Yes Refl
+decEqSelfIsYes {x} with (decEq x x)
+  decEqSelfIsYes {x} | Yes Refl = Refl
+  decEqSelfIsYes {x} | No contra = absurd $ contra Refl

--- a/libs/base/base.ipkg
+++ b/libs/base/base.ipkg
@@ -49,6 +49,7 @@ modules = Control.App,
 
           Decidable.Decidable,
           Decidable.Equality,
+          Decidable.Equality.Core,
           Decidable.Order,
 
           Language.Reflection,


### PR DESCRIPTION
This PR is somewhat controversial because for addition of simple function, well-known and commonly used `Decidable.Equality` module was split on two parts. However, this split does not influence on regular users of this module.

This split was done to avoid circular dependency of module imports since `Decidable.Equality` imports lots of `Data.*` modules for those types that are defined in the `prelude`, thus preventing, e.g. using `Data.Fin` module in the `Data.List` one.