### PR TITLE
Fixed docs and improved Literate mode. 

### DIFF
--- a/docs/source/reference/literate.rst
+++ b/docs/source/reference/literate.rst
@@ -83,7 +83,7 @@ Each of the following markup is recognised regardless of case:
     #+end_src
 
 CommonMark
-************
+**********
 
 We treat files with an extension of ``.md`` and ``.markdown`` as CommonMark style literate files.
 
@@ -122,3 +122,37 @@ We treat files with an extension of ``.md`` and ``.markdown`` as CommonMark styl
            -> List a
            -> List b
         map f _ = Nil
+
+LaTeX
+*****
+
+We treat files with an extension of ``.tex`` and ``.ltx`` as LaTeX style literate files.
+
++ We treat environments named ``code`` as visible code blocks::
+
+    \begin{code}
+    data Nat = Z | S Nat
+    \end{code}
+
+
++ We treat environments named ``hidden`` as invisible code blocks::
+
+    \begin{hidden}
+    data Nat = Z | S Nat
+    \end{hidden}
+
++ Code lines are not supported.
+
++ Specifications can be given using user defined environments.
+
+We do not provide definitions for these code blocks and ask the user to define them.
+With one such example using ``fancyverbatim`` and ``comment`` packages as::
+
+    \usepackage{fancyvrb}
+    \DefineVerbatimEnvironment
+      {code}{Verbatim}
+      {}
+
+    \usepackage{comment}
+
+    \excludecomment{hidden}

--- a/docs/source/reference/literate.rst
+++ b/docs/source/reference/literate.rst
@@ -9,6 +9,7 @@ Idris2 supports several types of literate mode styles.
 The unlit'n has been designed based such that we assume that we are parsing markdown-like languages
 The unlit'n is performed by a Lexer that uses a provided literate style to recognise code blocks and code lines.
 Anything else is ignored.
+Idris2 also provides support for recognising both 'visible' and 'invisible' code blocks using 'native features' of each literate style.
 
 A literate style consists of:
 
@@ -25,35 +26,99 @@ But more importantly, a more intelligent processing of literate documents using 
 Bird Style Literate Files
 =========================
 
-Bird notation is a classic literate mode found in Haskell, (and Orwell) in which code lines begin with ``>``.
+We treat files with an extension of ``.lidr`` as bird style literate files.
+
+Bird notation is a classic literate mode found in Haskell, (and Orwell) in which visible code lines begin with ``>`` and hidden lines with ``<``.
 Other lines are treated as documentation.
 
-We treat files with an extension of ``.lidr`` as bird style literate files.
+
+
+.. note::
+   We have diverged from ``lhs2tex`` in which ``<`` is traditionally used to display inactive code.
+   Bird-style is presented as is, and we recommended use of the other styles for much more comprehensive literate mode.
 
 Embedding in Markdown-like documents
 ====================================
 
 While Bird Style literate mode is useful, it does not lend itself well
 to more modern markdown-like notations such as Org-Mode and CommonMark.
-
 Idris2 also provides support for recognising both 'visible' and 'invisible'
-code blocks and lines in both CommonMark and OrgMode documents.
+code blocks and lines in both CommonMark and OrgMode documents using native code blocks and lines..
 
-'Visible' content will be kept in the pretty printer's output while
-the 'invisible' blocks and lines will be removed.
+The idea being is that:
+
+1. **Visible** content will be kept in the pretty printer's output;
+2. **Invisible** content will be removed; and
+3. **Specifications** will be displayed *as is* and not touched by the compiler.
 
 OrgMode
 *******
 
-+ Org mode source blocks for idris are recognised as visible code blocks,
-+ Comment blocks that begin with ``#+COMMENT: idris`` are treated as invisible code blocks.
-+ Invisible code lines are denoted with ``#+IDRIS:``.
+We treat files with an extension of ``.org`` as org-style literate files.
+Each of the following markup is recognised regardless of case:
 
-We treat files with an extension of ``.org`` as org-mode style literate files.
++ Org mode source blocks for idris sans options are recognised as visible code blocks::
+
+    #+begin_src idris
+    data Nat = Z | S Nat
+    #+end_src
+
++ Comment blocks that begin with ``#+BEGIN_COMMENT idris`` are treated as invisible code blocks::
+
+    #+begin_comment idris
+    data Nat = Z | S Nat
+    #+end_comment
+
++ Visible code lines, and specifications, are not supported. Invisible code lines are denoted with ``#+IDRIS:``::
+
+    #+IDRIS: data Nat = Z | S Nat
+
++ Specifications can be given using OrgModes plain source or example blocks::
+
+    #+begin_src
+    map : (f : a -> b)
+       -> List a
+       -> List b
+    map f _ = Nil
+    #+end_src
 
 CommonMark
 ************
 
-Only code blocks denoted by standard code blocks labelled as idris are recognised.
-
 We treat files with an extension of ``.md`` and ``.markdown`` as CommonMark style literate files.
+
++ CommonMark source blocks for idris sans options are recognised as visible code blocks::
+
+    ```idris
+    data Nat = Z | S Nat
+    ```
+
+    ~~~idris
+    data Nat = Z | S Nat
+    ~~~
+
++ Comment blocks of the form ``<!-- idris\n ... \n -->`` are treated as invisible code blocks::
+
+    <!-- idris
+    data Nat = Z | S Nat
+    -->
+
++ Code lines are not supported.
+
++ Specifications can be given using CommonMark's pre-formatted blocks (indented by four spaces) or unlabelled code blocks.::
+
+    Compare
+
+    ```
+    map : (f : a -> b)
+       -> List a
+       -> List b
+    map f _ = Nil
+    ```
+
+    with
+
+        map : (f : a -> b)
+           -> List a
+           -> List b
+        map f _ = Nil

--- a/src/Parser/Unlit.idr
+++ b/src/Parser/Unlit.idr
@@ -30,13 +30,22 @@ styleCMark = MkLitStyle
               [".md", ".markdown"]
 
 export
+styleTeX : LiterateStyle
+styleTeX = MkLitStyle
+              [("\\begin{code}", "\\end{code}"), ("\\begin{hidden}", "\\end{hidden}")]
+              Nil
+              [".tex", ".ltx"]
+
+export
 isLitFile : String -> Maybe LiterateStyle
 isLitFile fname =
     case isStyle styleBird of
       Just s => Just s
       Nothing => case isStyle styleOrg of
                      Just s => Just s
-                     Nothing => isStyle styleCMark
+                     Nothing => case isStyle styleCMark of
+                                     Just s => Just s
+                                     Nothing => isStyle styleTeX
 
   where
    hasSuffix : String -> Bool
@@ -57,7 +66,9 @@ isLitLine str =
                     (Just l, s) => (Just l, s)
                     otherwise => case isLiterateLine styleCMark str of
                                    (Just l, s) => (Just l, s)
-                                   otherwise => (Nothing, str)
+                                   otherwise => case isLiterateLine styleTeX str of
+                                                   (Just l, s) => (Just l, s)
+                                                   otherwise => (Nothing, str)
 
 export
 unlit : Maybe LiterateStyle -> String -> Either LiterateError String

--- a/src/Parser/Unlit.idr
+++ b/src/Parser/Unlit.idr
@@ -17,15 +17,15 @@ styleOrg : LiterateStyle
 styleOrg = MkLitStyle
               [ ("#+BEGIN_SRC idris","#+END_SRC")
               , ("#+begin_src idris","#+end_src")
-              , ("#+COMMENT idris","#+END_COMMENT")
-              , ("#+comment idris","#+end_comment")]
+              , ("#+BEGIN_COMMENT idris","#+END_COMMENT")
+              , ("#+begin_comment idris","#+end_comment")]
               ["#+IDRIS:"]
               [".org"]
 
 export
 styleCMark : LiterateStyle
 styleCMark = MkLitStyle
-              [("```idris", "```"), ("~~~idris", "~~~")]
+              [("```idris", "```"), ("~~~idris", "~~~"), ("<!-- idris", "-->")]
               Nil
               [".md", ".markdown"]
 

--- a/tests/idris2/literate011/IEdit.md
+++ b/tests/idris2/literate011/IEdit.md
@@ -4,13 +4,26 @@ data Vect : Nat -> Type -> Type where
      (::) : a -> Vect k a -> Vect (S k) a
 ```
 
-```idris
+<!-- idris
 %name Vect xs, ys, zs
-```
+-->
 
 ```idris
 dupAll : Vect n a -> Vect n (a, a)
 dupAll xs = zipHere xs xs
   where
     zipHere : forall n . Vect n a -> Vect n b -> Vect n (a, b)
+```
+
+
+<!-- idris
+
+data Foobar = MkFoo
+
+-->
+
+
+```idris
+showFooBar : Foobar -> String
+showFooBar MkFoo = "MkFoo"
 ```

--- a/tests/idris2/literate013/LitTeX.tex
+++ b/tests/idris2/literate013/LitTeX.tex
@@ -1,0 +1,36 @@
+\documentclass{article}
+
+\usepackage{fancyvrb}
+
+\usepackage{comment}
+
+\DefineVerbatimEnvironment
+  {code}{Verbatim}
+  {} % Add fancy options here if you like.
+
+\excludecomment{hidden}
+
+\begin{hidden}
+module LitTeX
+
+%default total
+\end{hidden}
+
+\begin{document}
+
+\begin{code}
+data V a = Empty | Extend a (V a)
+\end{code}
+
+\begin{code}
+isCons : V a -> Bool
+isCons Empty = False
+isCons (Extend _ _) = True
+\end{code}
+
+\begin{hidden}
+namespace Hidden
+  data U a = Empty | Extend a (U a)
+\end{hidden}
+
+\end{document}

--- a/tests/idris2/literate013/expected
+++ b/tests/idris2/literate013/expected
@@ -1,1 +1,2 @@
 1/1: Building Lit (Lit.lidr)
+1/1: Building LitTeX (LitTeX.tex)

--- a/tests/idris2/literate013/run
+++ b/tests/idris2/literate013/run
@@ -1,3 +1,3 @@
 $1 --no-color --console-width 0 --no-banner --check Lit.lidr
-
+$1 --no-color --console-width 0 --no-banner --check LitTeX.tex
 rm -rf build


### PR DESCRIPTION
+ Expanded the documentation on how to use literate modes.
+ Added invisible code blocks in Markdown using specially tagged comment blocks: `<!-- idris -->`.
+ Fixed OrgMode specificaton to recognise comment blocks properly.
+ Extended Literate support to include LaTeX.