### PR TITLE
Have lambda-case available everywhere lambda is

### DIFF
--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -742,6 +742,7 @@ mutual
     <|> implicitPi fname indents
     <|> explicitPi fname indents
     <|> lam fname indents
+    <|> lambdaCase fname indents
 
   typeExpr : ParseOpts -> FileName -> IndentInfo -> Rule PTerm
   typeExpr q fname indents

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -44,7 +44,7 @@ idrisTests = MkTestPool []
        "basic031", "basic032", "basic033", "basic034", "basic035",
        "basic036", "basic037", "basic038", "basic039", "basic040",
        "basic041", "basic042", "basic043", "basic044", "basic045",
-       "basic046", "basic047", "basic048", "basic049",
+       "basic046", "basic047", "basic048", "basic049", "basic050",
        -- Coverage checking
        "coverage001", "coverage002", "coverage003", "coverage004",
        "coverage005", "coverage006", "coverage007", "coverage008",

--- a/tests/idris2/basic050/Ilc.idr
+++ b/tests/idris2/basic050/Ilc.idr
@@ -1,0 +1,15 @@
+f : (Int -> Bool) -> Int
+f p = case (p 0, p 1) of
+        (False, False) => 0
+        (False, True)  => 1
+        (True , False) => 2
+        (True , True)  => 4
+
+il : Int
+il = f \x => x > 0
+
+lc : Int
+lc = f $ \case 0 => True ; _ => False
+
+ilc : Int
+ilc = f \case 0 => True; _ => False

--- a/tests/idris2/basic050/expected
+++ b/tests/idris2/basic050/expected
@@ -1,0 +1,6 @@
+1/1: Building Ilc (Ilc.idr)
+Main> 1
+Main> 2
+Main> 2
+Main> 
+Bye for now!

--- a/tests/idris2/basic050/input
+++ b/tests/idris2/basic050/input
@@ -1,0 +1,3 @@
+il
+lc
+ilc

--- a/tests/idris2/basic050/run
+++ b/tests/idris2/basic050/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 --no-banner Ilc.idr < input
+
+rm -rf build


### PR DESCRIPTION
You can use lambda functions without parenthesis and `$`-operator as the last argument:

```idris
f : (Int -> Bool) -> Int

il : Int
il = f \x => x > 0
```

But at the moment you can't do this for the lambda case.

```idris
lc : Int
lc = f $ \case 0 => True ; _ => False -- ok

ilc : Int
ilc = f \case 0 => True; _ => False -- does not parse
```

This PR fixes this.