### PR TITLE
Execute tests concurrently

### DIFF
--- a/tests/Lib.idr
+++ b/tests/Lib.idr
@@ -69,6 +69,7 @@ import System
 import System.Clock
 import System.Directory
 import System.File
+import System.Future
 import System.Info
 import System.Path
 
@@ -135,85 +136,80 @@ normalize str =
 |||
 ||| See the module documentation for more information.
 |||
-||| @currdir absolute or relative path to root test directory.
-||| @testpath the directory that contains the test.
+||| @testPath the directory that contains the test.
 export
-runTest : Options -> (currdir, testPath : String) -> IO Bool
-runTest opts currdir testPath
-    = do changeDir testPath
-         isSuccess <- runTest'
-         changeDir currdir
-         pure isSuccess
-    where
-        getAnswer : IO Bool
-        getAnswer = do
-          str <- getLine
-          case str of
-            "y" => pure True
-            "n" => pure False
-            _   => do putStrLn "Invalid Answer."
-                      getAnswer
+runTest : Options -> String -> IO (Future Bool)
+runTest opts testPath = forkIO $ do
+  start <- clockTime Thread
+  let cg = case codegen opts of
+         Nothing => ""
+         Just cg => "env IDRIS2_TESTS_CG=" ++ cg ++ " "
+  system $ "cd " ++ testPath ++ " && " ++
+    cg ++ "sh ./run " ++ exeUnderTest opts ++ " | tr -d '\\r' > output"
+  end <- clockTime Thread
 
-        printExpectedVsOutput : String -> String -> IO ()
-        printExpectedVsOutput exp out = do
-          putStrLn "Expected:"
-          putStrLn exp
-          putStrLn "Given:"
-          putStrLn out
+  Right out <- readFile $ testPath ++ "/output"
+    | Left err => do print err
+                     pure False
 
-        mayOverwrite : Maybe String -> String -> IO ()
-        mayOverwrite mexp out = do
-          the (IO ()) $ case mexp of
-            Nothing => putStr $ unlines
-              [ "Golden value missing. I computed the following result:"
-              , out
-              , "Accept new golden value? [yn]"
-              ]
-            Just exp => do
-              putStrLn "Golden value differs from actual value."
-              code <- system "git diff --no-index --exit-code --word-diff=color expected output"
-              when (code < 0) $ printExpectedVsOutput exp out
-              putStrLn "Accept actual value as new golden value? [yn]"
+  Right exp <- readFile $ testPath ++ "/expected"
+    | Left FileNotFound => do
+        if interactive opts
+          then mayOverwrite Nothing out
+          else print FileNotFound
+        pure False
+    | Left err => do print err
+                     pure False
+
+  let result = normalize out == normalize exp
+  let time = timeDifference end start
+
+  if result
+    then printTiming (timing opts) time $ testPath ++ ": success"
+    else do
+      printTiming (timing opts) time $ testPath ++ ": FAILURE"
+      if interactive opts
+        then mayOverwrite (Just exp) out
+        else putStrLn . unlines $ expVsOut exp out
+
+  pure result
+
+  where
+    getAnswer : IO Bool
+    getAnswer = do
+      str <- getLine
+      case str of
+        "y" => pure True
+        "n" => pure False
+        _   => do putStrLn "Invalid Answer."
+                  getAnswer
+
+    expVsOut : String -> String -> List String
+    expVsOut exp out = ["Expected:", exp, "Given:", out]
+
+    mayOverwrite : Maybe String -> String -> IO ()
+    mayOverwrite mexp out = do
+      case mexp of
+        Nothing => putStr $ unlines
+          [ "Golden value missing. I computed the following result:"
+          , out
+          , "Accept new golden value? [yn]"
+          ]
+        Just exp => do
+          code <- system $ "git diff --no-index --exit-code --word-diff=color " ++
+            testPath ++ "/expected " ++ testPath ++ "/output"
+          putStrLn . unlines $
+            ["Golden value differs from actual value."] ++
+            (if (code < 0) then expVsOut exp out else []) ++
+            ["Accept actual value as new golden value? [yn]"]
           b <- getAnswer
-          when b $ do Right _ <- writeFile "expected" out
-                          | Left err => print err
+          when b $ do Right _ <- writeFile (testPath ++ "/expected") out
+                        | Left err => print err
                       pure ()
 
-        printTiming : Bool -> Clock type -> String -> IO ()
-        printTiming True  clock msg = putStrLn (unwords [msg, show clock])
-        printTiming False _     msg = putStrLn msg
-
-        runTest' : IO Bool
-        runTest'
-            = do putStr $ testPath ++ ": "
-                 start <- clockTime Thread
-                 let cg = case codegen opts of
-                            Nothing => ""
-                            Just cg => "env IDRIS2_TESTS_CG=" ++ cg ++ " "
-                 system $ cg ++ "sh ./run " ++ exeUnderTest opts ++ " | tr -d '\\r' > output"
-                 end <- clockTime Thread
-                 Right out <- readFile "output"
-                     | Left err => do print err
-                                      pure False
-                 Right exp <- readFile "expected"
-                     | Left FileNotFound => do
-                         if interactive opts
-                           then mayOverwrite Nothing out
-                           else print FileNotFound
-                         pure False
-                     | Left err => do print err
-                                      pure False
-                 let result = normalize out == normalize exp
-                 let time = timeDifference end start
-                 if result
-                    then printTiming (timing opts) time "success"
-                    else do
-                      printTiming (timing opts) time "FAILURE"
-                      if interactive opts
-                         then mayOverwrite (Just exp) out
-                         else printExpectedVsOutput exp out
-
-                 pure result
+    printTiming : Bool -> Clock type -> String -> IO ()
+    printTiming True  clock msg = putStrLn (unwords [msg, show clock])
+    printTiming False _     msg = putStrLn msg
 
 ||| Find the first occurrence of an executable on `PATH`.
 export
@@ -277,8 +273,8 @@ filterTests opts = case onlyNames opts of
 
 ||| A runner for a test pool
 export
-poolRunner : Options -> (currdir : String) -> TestPool -> IO (List Bool)
-poolRunner opts currdir pool
+poolRunner : Options -> TestPool -> IO (List Bool)
+poolRunner opts pool
   = do -- check that we indeed want to run some of these tests
        let tests = filterTests opts (testCases pool)
        let (_ :: _) = tests
@@ -293,7 +289,7 @@ poolRunner opts currdir pool
        let Just _ = the (Maybe (List String)) (sequence cs)
              | Nothing => pure []
        -- if so run them all!
-       traverse (runTest opts currdir) tests
+       map await <$> traverse (runTest opts) tests
 
 
 ||| A runner for a whole test suite
@@ -308,11 +304,8 @@ runner tests
          opts <- case codegen opts of
                    Nothing => pure $ record { codegen = !findCG } opts
                    Just _ => pure opts
-         -- grab the current directory
-         Just pwd <- currentDir
-            | Nothing => putStrLn "FATAL: Could not get current working directory"
          -- run the tests
-         res <- concat <$> traverse (poolRunner opts pwd) tests
+         res <- concat <$> traverse (poolRunner opts) tests
          putStrLn (show (length (filter id res)) ++ "/" ++ show (length res)
                        ++ " tests successful")
          if (any not res)

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -32,8 +32,8 @@ ttimpTests = MkTestPool []
        "qtt001", "qtt003",
        "total001", "total002", "total003"]
 
-idrisTests : TestPool
-idrisTests = MkTestPool []
+idrisTestsBasic : TestPool
+idrisTestsBasic = MkTestPool []
       -- Fundamental language features
       ["basic001", "basic002", "basic003", "basic004", "basic005",
        "basic006", "basic007", "basic008", "basic009", "basic010",
@@ -45,60 +45,91 @@ idrisTests = MkTestPool []
        "basic036", "basic037", "basic038", "basic039", "basic040",
        "basic041", "basic042", "basic043", "basic044", "basic045",
        "basic046", "basic047", "basic048", "basic049", "basic050",
-       "basic051",
+       "basic051"]
+
+idrisTestsCoverage : TestPool
+idrisTestsCoverage = MkTestPool []
        -- Coverage checking
-       "coverage001", "coverage002", "coverage003", "coverage004",
+      ["coverage001", "coverage002", "coverage003", "coverage004",
        "coverage005", "coverage006", "coverage007", "coverage008",
-       "coverage009", "coverage010", "coverage011",
-       -- Documentation strings
-       "docs001", "docs002",
-       -- Evaluator
-       "evaluator001", "evaluator002", "evaluator003", "evaluator004",
+       "coverage009", "coverage010", "coverage011"]
+
+idrisTestsError : TestPool
+idrisTestsError = MkTestPool []
        -- Error messages
-       "error001", "error002", "error003", "error004", "error005",
+      ["error001", "error002", "error003", "error004", "error005",
        "error006", "error007", "error008", "error009", "error010",
        "error011", "error012", "error013", "error014",
-       -- Modules and imports
-       "import001", "import002", "import003", "import004", "import005",
+       -- Parse errors
+       "perror001", "perror002", "perror003", "perror004", "perror005",
+       "perror006"]
+
+idrisTestsInteractive : TestPool
+idrisTestsInteractive = MkTestPool []
        -- Interactive editing support
-       "interactive001", "interactive002", "interactive003", "interactive004",
+      ["interactive001", "interactive002", "interactive003", "interactive004",
        "interactive005", "interactive006", "interactive007", "interactive008",
        "interactive009", "interactive010", "interactive011", "interactive012",
        "interactive013", "interactive014", "interactive015", "interactive016",
-       "interactive017", "interactive018", "interactive019",
+       "interactive017", "interactive018", "interactive019"]
+
+idrisTestsInterface : TestPool
+idrisTestsInterface = MkTestPool []
        -- Interfaces
-       "interface001", "interface002", "interface003", "interface004",
+      ["interface001", "interface002", "interface003", "interface004",
        "interface005", "interface006", "interface007", "interface008",
        "interface009", "interface010", "interface011", "interface012",
        "interface013", "interface014", "interface015", "interface016",
        "interface017", "interface018", "interface019", "interface020",
-       "interface021",
+       "interface021"]
+
+idrisTestsLinear : TestPool
+idrisTestsLinear = MkTestPool []
+       -- QTT and linearity related
+       ["linear001", "linear002", "linear003", -- "linear004" -- disabled due to requiring linearity subtyping
+        "linear005", "linear006", "linear007", "linear008",
+        "linear009", "linear010", "linear011", "linear012"]
+
+idrisTestsLiterate : TestPool
+idrisTestsLiterate = MkTestPool []
+       -- Literate
+      ["literate001", "literate002", "literate003", "literate004",
+       "literate005", "literate006", "literate007", "literate008",
+       "literate009", "literate010", "literate011", "literate012",
+       "literate013", "literate014", "literate015", "literate016"]
+
+idrisTestsPerformance : TestPool
+idrisTestsPerformance = MkTestPool []
+       -- Performance: things which have been slow in the past, or which
+       -- pose interesting challenges for the elaborator
+      ["perf001", "perf002", "perf003", "perf004", "perf005", "perf006"]
+
+idrisTestsRegression : TestPool
+idrisTestsRegression = MkTestPool []
+       -- Miscellaneous regressions
+      ["reg001", "reg002", "reg003", "reg004", "reg005", "reg006", "reg007",
+       "reg008", "reg009", "reg010", "reg011", "reg012", "reg013", "reg014",
+       "reg015", "reg016", "reg017", "reg018", "reg019", "reg020", "reg021",
+       "reg022", "reg023", "reg024", "reg025", "reg026", "reg027", "reg028",
+       "reg029", "reg030", "reg031", "reg032", "reg033", "reg034", "reg035"]
+
+idrisTests : TestPool
+idrisTests = MkTestPool []
+       -- Documentation strings
+      ["docs001", "docs002",
+       -- Evaluator
+       "evaluator001", "evaluator002", "evaluator003", "evaluator004",
+       -- Modules and imports
+       "import001", "import002", "import003", "import004", "import005",
        -- Miscellaneous REPL
        "interpreter001", "interpreter002", "interpreter003", "interpreter004",
        "interpreter005", "interpreter006",
        -- Implicit laziness, lazy evaluation
        "lazy001",
-       -- QTT and linearity related
-       "linear001", "linear002", "linear003",
-       -- "linear004" -- disabled due to requiring linearity subtyping
-       "linear005",
-       "linear006", "linear007", "linear008", "linear009", "linear010",
-       "linear011", "linear012",
-       -- Literate
-       "literate001", "literate002", "literate003", "literate004",
-       "literate005", "literate006", "literate007", "literate008",
-       "literate009", "literate010", "literate011", "literate012",
-       "literate013", "literate014", "literate015", "literate016",
        -- Namespace blocks
        "namespace001",
        -- Parameters blocks
        "params001",
-       -- Performance: things which have been slow in the past, or which
-       -- pose interesting challenges for the elaborator
-       "perf001", "perf002", "perf003", "perf004", "perf005", "perf006",
-       -- Parse errors
-       "perror001", "perror002", "perror003", "perror004", "perror005",
-       "perror006",
        -- Packages and ipkg files
        "pkg001", "pkg002", "pkg003", "pkg004", "pkg005",
        -- Positivity checking
@@ -113,12 +144,6 @@ idrisTests = MkTestPool []
        "reflection001", "reflection002", "reflection003", "reflection004",
        "reflection005", "reflection006", "reflection007", "reflection008",
        "reflection009",
-       -- Miscellaneous regressions
-       "reg001", "reg002", "reg003", "reg004", "reg005", "reg006", "reg007",
-       "reg008", "reg009", "reg010", "reg011", "reg012", "reg013", "reg014",
-       "reg015", "reg016", "reg017", "reg018", "reg019", "reg020", "reg021",
-       "reg022", "reg023", "reg024", "reg025", "reg026", "reg027", "reg028",
-       "reg029", "reg030", "reg031", "reg032", "reg033", "reg034", "reg035",
        -- Totality checking
        "total001", "total002", "total003", "total004", "total005",
        "total006", "total007", "total008", "total009", "total010",
@@ -151,9 +176,10 @@ racketTests = MkTestPool [Racket]
 
 nodeTests : TestPool
 nodeTests = MkTestPool [Node]
-    [ "node001", "node002", "node003", "node004", "node005", "node006", "node007", "node008", "node009"
-    , "node011", "node012", "node015", "node017", "node018", "node019" -- node014
-    , "node021", "node022" --, "node020"
+    [ "node001", "node002", "node003", "node004", "node005", "node006"
+    , "node007", "node008", "node009", "node011", "node012", "node015"
+    , "node017", "node018", "node019", "node021", "node022"
+    -- , "node14", "node020"
     , "reg001"
     , "syntax001"
     , "tailrec001"
@@ -175,6 +201,15 @@ templateTests = MkTestPool []
 main : IO ()
 main = runner
   [ testPaths "ttimp" ttimpTests
+  , testPaths "idris2" idrisTestsBasic
+  , testPaths "idris2" idrisTestsCoverage
+  , testPaths "idris2" idrisTestsError
+  , testPaths "idris2" idrisTestsInteractive
+  , testPaths "idris2" idrisTestsInterface
+  , testPaths "idris2" idrisTestsLiterate
+  , testPaths "idris2" idrisTestsLinear
+  , testPaths "idris2" idrisTestsPerformance
+  , testPaths "idris2" idrisTestsRegression
   , testPaths "idris2" idrisTests
   , testPaths "typedd-book" typeddTests
   , testPaths "ideMode" ideModeTests


### PR DESCRIPTION
This executes all tests in a single test-suite concurrently, there were several refactors to avoid output being mangled between different test-units and changeDir was removed since several systems have a per-process working directory rather than a per-thread/future working directory.

test-suits are still executed sequentially.

In my system total test time went down from 148 seconds to 35 seconds. (A 76% decrease in test time)

```
________________________________________________________
Executed in   34.56 secs   fish           external 
   usr time  376.58 secs    0.00 micros  376.58 secs 
   sys time   57.88 secs  345.00 micros   57.88 secs 
```

vs

```
________________________________________________________
Executed in  147.41 secs   fish           external 
   usr time  123.86 secs  264.00 micros  123.86 secs 
   sys time   22.97 secs   67.00 micros   22.97 secs
```

CI won't pass for the time being since the bootstrap step cannot succeed.