### PR TITLE
Tiny fix of the formatting in the recently added documentation.

### DIFF
--- a/docs/source/updates/updates.rst
+++ b/docs/source/updates/updates.rst
@@ -814,7 +814,7 @@ Another novelty - new update syntax (previous one still functional):
     mapSetMap three@(MkThree x y z) f y' g = {x $= f, y := y', z $= g} three
 
 The ``record`` keyword has been discarded for brevity, symbol ``:=`` replaces ``=``
-  in order to not introduce any ambiguity.
+in order to not introduce any ambiguity.
 
 Generate definition
 -------------------


### PR DESCRIPTION
With the original indent the beginning of the sentence is parsed as a named itemization.