### PR TITLE
Local hints (basic version)

### DIFF
--- a/libs/prelude/Builtin.idr
+++ b/libs/prelude/Builtin.idr
@@ -186,11 +186,11 @@ export partial
 idris_crash : String -> a
 idris_crash = prim__crash _
 
-public export
+public export %inline
 delay : a -> Lazy a
 delay x = Delay x
 
-public export
+public export %inline
 force : Lazy a -> a
 force x = Force x
 

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -936,6 +936,8 @@ record Defs where
   openHints : NameMap ()
      -- ^ currently open global hints; just for the rest of this module (not exported)
      -- and prioritised
+  localHints : NameMap ()
+     -- ^ Hints defined in the current environment
   saveTypeHints : List (Name, Name, Bool)
      -- We don't look up anything in here, it's merely for saving out to TTC.
      -- We save the hints in the 'GlobalDef' itself for faster lookup.
@@ -988,7 +990,7 @@ initDefs : Core Defs
 initDefs
     = do gam <- initCtxt
          pure (MkDefs gam [] mainNS [] defaults empty 100
-                      empty empty empty [] [] empty []
+                      empty empty empty empty [] [] empty []
                       empty 5381 [] [] [] [] [] empty empty empty empty [])
 
 -- Reset the context, except for the options
@@ -1657,6 +1659,14 @@ addGlobalHint hintn_in isdef
 
          put Ctxt (record { autoHints $= insert hintn isdef,
                             saveAutoHints $= ((hintn, isdef) ::) } defs)
+
+export
+addLocalHint : {auto c : Ref Ctxt Defs} ->
+               Name -> Core ()
+addLocalHint hintn_in
+    = do defs <- get Ctxt
+         hintn <- toResolvedNames hintn_in
+         put Ctxt (record { localHints $= insert hintn () } defs)
 
 export
 addOpenHint : {auto c : Ref Ctxt Defs} -> Name -> Core ()

--- a/src/Core/Options/Log.idr
+++ b/src/Core/Options/Log.idr
@@ -116,7 +116,7 @@ defaultLogLevel = singleton [] 0
 
 export
 insertLogLevel : LogLevel -> LogLevels -> LogLevels
-insertLogLevel (MkLogLevel ps n) = insertWith ps (maybe n (max n))
+insertLogLevel (MkLogLevel ps n) = insert ps n
 
 ----------------------------------------------------------------------------------
 -- CHECKING WHETHER TO LOG

--- a/src/Core/Options/Log.idr
+++ b/src/Core/Options/Log.idr
@@ -116,7 +116,7 @@ defaultLogLevel = singleton [] 0
 
 export
 insertLogLevel : LogLevel -> LogLevels -> LogLevels
-insertLogLevel (MkLogLevel ps n) = insert ps n
+insertLogLevel (MkLogLevel ps n) = insertWith ps (maybe n (max n))
 
 ----------------------------------------------------------------------------------
 -- CHECKING WHETHER TO LOG

--- a/src/Core/UnifyState.idr
+++ b/src/Core/UnifyState.idr
@@ -479,7 +479,7 @@ newSearch {vars} fc rig depth def env n ty
     = do let hty = abstractEnvType fc env ty
          let hole = newDef fc n rig [] hty Public (BySearch rig depth def)
          log "unify.search" 10 $ "Adding new search " ++ show fc ++ " " ++ show n
-         logTermNF "unify.search" 10 "New search type" env ty
+         logTermNF "unify.search" 10 "New search type" [] hty
          idx <- addDef n hole
          addGuessName fc n idx
          pure (idx, Meta fc n idx envArgs)

--- a/src/Core/UnifyState.idr
+++ b/src/Core/UnifyState.idr
@@ -89,8 +89,7 @@ record UState where
                 -- we didn't have enough type information to elaborate
                 -- successfully yet.
                 -- 'Nat' is the priority (lowest first)
-                -- The 'Int' is the resolved name. Delays can't be nested,
-                -- so we just process them in order.
+                -- The 'Int' is the resolved name.
   logging : Bool
 
 export

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -703,7 +703,8 @@ mutual
                                       doBind bnames (Builtin.snd ntm))) cons'
 
            body' <- traverse (desugarDecl (ps ++ mnames ++ map fst params)) body
-           pure [IPragma (\nest, env =>
+           pure [IPragma (maybe [tn] (\n => [tn, n]) conname)
+                         (\nest, env =>
                              elabInterface fc vis env nest consb
                                            tn paramsb det conname
                                            (concat body'))]
@@ -746,7 +747,8 @@ mutual
            body' <- maybe (pure Nothing)
                           (\b => do b' <- traverse (desugarDecl ps) b
                                     pure (Just (concat b'))) body
-           pure [IPragma (\nest, env =>
+           pure [IPragma (maybe [] (\n => [n]) impname)
+                         (\nest, env =>
                              elabImplementation fc vis opts pass env nest isb consb
                                                 tn paramsb impname nusing
                                                 body')]
@@ -823,27 +825,27 @@ mutual
            pure [IRunElabDecl fc tm']
   desugarDecl ps (PDirective fc d)
       = case d of
-             Hide n => pure [IPragma (\nest, env => hide fc n)]
+             Hide n => pure [IPragma [] (\nest, env => hide fc n)]
              Logging i => pure [ILog (topics i, verbosity i)]
-             LazyOn a => pure [IPragma (\nest, env => lazyActive a)]
+             LazyOn a => pure [IPragma [] (\nest, env => lazyActive a)]
              UnboundImplicits a => do
                setUnboundImplicits a
-               pure [IPragma (\nest, env => setUnboundImplicits a)]
+               pure [IPragma [] (\nest, env => setUnboundImplicits a)]
              PrefixRecordProjections b => do
-               pure [IPragma (\nest, env => setPrefixRecordProjections b)]
-             AmbigDepth n => pure [IPragma (\nest, env => setAmbigLimit n)]
-             AutoImplicitDepth n => pure [IPragma (\nest, env => setAutoImplicitLimit n)]
-             PairNames ty f s => pure [IPragma (\nest, env => setPair fc ty f s)]
-             RewriteName eq rw => pure [IPragma (\nest, env => setRewrite fc eq rw)]
-             PrimInteger n => pure [IPragma (\nest, env => setFromInteger n)]
-             PrimString n => pure [IPragma (\nest, env => setFromString n)]
-             PrimChar n => pure [IPragma (\nest, env => setFromChar n)]
-             CGAction cg dir => pure [IPragma (\nest, env => addDirective cg dir)]
-             Names n ns => pure [IPragma (\nest, env => addNameDirective fc n ns)]
-             StartExpr tm => pure [IPragma (\nest, env => throw (InternalError "%start not implemented"))] -- TODO!
-             Overloadable n => pure [IPragma (\nest, env => setNameFlag fc n Overloadable)]
-             Extension e => pure [IPragma (\nest, env => setExtension e)]
-             DefaultTotality tot => pure [IPragma (\_, _ => setDefaultTotalityOption tot)]
+               pure [IPragma [] (\nest, env => setPrefixRecordProjections b)]
+             AmbigDepth n => pure [IPragma [] (\nest, env => setAmbigLimit n)]
+             AutoImplicitDepth n => pure [IPragma [] (\nest, env => setAutoImplicitLimit n)]
+             PairNames ty f s => pure [IPragma [] (\nest, env => setPair fc ty f s)]
+             RewriteName eq rw => pure [IPragma [] (\nest, env => setRewrite fc eq rw)]
+             PrimInteger n => pure [IPragma [] (\nest, env => setFromInteger n)]
+             PrimString n => pure [IPragma [] (\nest, env => setFromString n)]
+             PrimChar n => pure [IPragma [] (\nest, env => setFromChar n)]
+             CGAction cg dir => pure [IPragma [] (\nest, env => addDirective cg dir)]
+             Names n ns => pure [IPragma [] (\nest, env => addNameDirective fc n ns)]
+             StartExpr tm => pure [IPragma [] (\nest, env => throw (InternalError "%start not implemented"))] -- TODO!
+             Overloadable n => pure [IPragma [] (\nest, env => setNameFlag fc n Overloadable)]
+             Extension e => pure [IPragma [] (\nest, env => setExtension e)]
+             DefaultTotality tot => pure [IPragma [] (\_, _ => setDefaultTotalityOption tot)]
 
   export
   desugar : {auto s : Ref Syn SyntaxInfo} ->

--- a/src/Idris/Elab/Implementation.idr
+++ b/src/Idris/Elab/Implementation.idr
@@ -34,8 +34,9 @@ replaceSep = pack . map toForward . unpack
     toForward '\\' = '/'
     toForward x = x
 
-mkImpl : FC -> Name -> List RawImp -> Name
-mkImpl fc n ps
+export
+mkImplName : FC -> Name -> List RawImp -> Name
+mkImplName fc n ps
     = DN (show n ++ " implementation at " ++ replaceSep (show fc))
          (UN ("__Impl_" ++ show n ++ "_" ++
           showSep "_" (map show ps)))
@@ -110,13 +111,14 @@ elabImplementation : {vars : _} ->
                      (constraints : List (Maybe Name, RawImp)) ->
                      Name ->
                      (ps : List RawImp) ->
-                     (implName : Maybe Name) ->
+                     (namedimpl : Bool) ->
+                     (implName : Name) ->
                      (nusing : List Name) ->
                      Maybe (List ImpDecl) ->
                      Core ()
 -- TODO: Refactor all these steps into separate functions
-elabImplementation {vars} fc vis opts_in pass env nest is cons iname ps impln nusing mbody
-    = do let impName_in = maybe (mkImpl fc iname ps) id impln
+elabImplementation {vars} fc vis opts_in pass env nest is cons iname ps named impName_in nusing mbody
+    = do -- let impName_in = maybe (mkImplName fc iname ps) id impln
          -- If we're in a nested block, update the name
          let impName_nest = case lookup impName_in (names nest) of
                                  Just (Just n', _) => n'
@@ -157,8 +159,9 @@ elabImplementation {vars} fc vis opts_in pass env nest is cons iname ps impln nu
          -- given when using named implementations
          --    (cs : Constraints) -> Impl params
          -- Don't make it a hint if it's a named implementation
-         let opts = maybe ([Inline, Hint True])
-                          (const ([Inline])) impln
+         let opts = if named
+                       then [Inline]
+                       else [Inline, Hint True]
 
          let initTy = bindImpls fc is $ bindConstraints fc AutoImplicit cons
                          (apply (IVar fc iname) ps)
@@ -223,7 +226,9 @@ elabImplementation {vars} fc vis opts_in pass env nest is cons iname ps impln nu
 
                -- If it's a named implementation, add it as a global hint while
                -- elaborating the record and bodies
-               maybe (pure ()) (\x => addOpenHint impName) impln
+               if named
+                  then addOpenHint impName
+                  else pure ()
 
                -- Make sure we don't use this name to solve parent constraints
                -- when elaborating the record, or we'll end up in a cycle!
@@ -334,7 +339,7 @@ elabImplementation {vars} fc vis opts_in pass env nest is cons iname ps impln nu
     methName n
         = DN (show n)
              (UN (show n ++ "_" ++ show iname ++ "_" ++
-                     maybe "" show impln ++ "_" ++
+                     (if named then show impName_in else "") ++
                      showSep "_" (map show ps)))
 
     applyCon : Name -> Name -> Core (Name, RawImp)

--- a/src/Idris/Resugar.idr
+++ b/src/Idris/Resugar.idr
@@ -430,7 +430,7 @@ mutual
                                   !(toPTerm startPrec rhs)))
   toPDecl (IRunElabDecl fc tm)
       = pure (Just (PRunElabDecl fc !(toPTerm startPrec tm)))
-  toPDecl (IPragma _) = pure Nothing
+  toPDecl (IPragma _ _) = pure Nothing
   toPDecl (ILog _) = pure Nothing
 
 export

--- a/src/TTImp/Elab/App.idr
+++ b/src/TTImp/Elab/App.idr
@@ -198,7 +198,7 @@ mutual
                    est <- get EST
                    lim <- getAutoImplicitLimit
                    metaval <- searchVar fc argRig lim (Resolved (defining est))
-                                        env nm metaty
+                                        env nest nm metaty
                    let fntm = App fc tm metaval
                    fnty <- sc defs (toClosure defaultOpts env metaval)
                    checkAppWith rig elabinfo nest env fc

--- a/src/TTImp/Elab/Term.idr
+++ b/src/TTImp/Elab/Term.idr
@@ -164,14 +164,14 @@ checkTerm rig elabinfo nest env (ISearch fc depth) (Just gexpty)
     = do est <- get EST
          nm <- genName "search"
          expty <- getTerm gexpty
-         sval <- searchVar fc rig depth (Resolved (defining est)) env nm expty
+         sval <- searchVar fc rig depth (Resolved (defining est)) env nest nm expty
          pure (sval, gexpty)
 checkTerm rig elabinfo nest env (ISearch fc depth) Nothing
     = do est <- get EST
          nmty <- genName "searchTy"
          ty <- metaVar fc erased env nmty (TType fc)
          nm <- genName "search"
-         sval <- searchVar fc rig depth (Resolved (defining est)) env nm ty
+         sval <- searchVar fc rig depth (Resolved (defining est)) env nest nm ty
          pure (sval, gnf env ty)
 checkTerm rig elabinfo nest env (IAlternative fc uniq alts) exp
     = checkAlternative rig elabinfo nest env fc uniq alts exp

--- a/src/TTImp/ProcessDecls.idr
+++ b/src/TTImp/ProcessDecls.idr
@@ -56,7 +56,7 @@ process eopts nest env (ITransform fc n lhs rhs)
     = processTransform eopts nest env fc n lhs rhs
 process eopts nest env (IRunElabDecl fc tm)
     = processRunElab eopts nest env fc tm
-process eopts nest env (IPragma act)
+process eopts nest env (IPragma _ act)
     = act nest env
 process eopts nest env (ILog lvl)
     = addLogLevel (uncurry unsafeMkLogLevel lvl)

--- a/src/TTImp/Reflect.idr
+++ b/src/TTImp/Reflect.idr
@@ -748,7 +748,7 @@ mutual
              appCon fc defs (reflectionttimp "ITransform") [w', x', y', z']
     reflect fc defs lhs env (IRunElabDecl w x)
         = throw (GenericMsg fc "Can't reflect a %runElab")
-    reflect fc defs lhs env (IPragma x)
+    reflect fc defs lhs env (IPragma _ x)
         = throw (GenericMsg fc "Can't reflect a pragma")
     reflect fc defs lhs env (ILog x)
         = do x' <- reflect fc defs lhs env x

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -344,7 +344,10 @@ mutual
        INamespace : FC -> Namespace -> List ImpDecl -> ImpDecl
        ITransform : FC -> Name -> RawImp -> RawImp -> ImpDecl
        IRunElabDecl : FC -> RawImp -> ImpDecl
-       IPragma : ({vars : _} ->
+       IPragma : List Name -> -- pragmas might define names that wouldn't
+                       -- otherwise be spotted in 'definedInBlock' so they
+                       -- can be flagged here.
+                 ({vars : _} ->
                   NestedNames vars -> Env Term vars -> Core ()) ->
                  ImpDecl
        ILog : (List String, Nat) -> ImpDecl
@@ -365,7 +368,7 @@ mutual
         = "%transform " ++ show n ++ " " ++ show lhs ++ " ==> " ++ show rhs
     show (IRunElabDecl _ tm)
         = "%runElab " ++ show tm
-    show (IPragma _) = "[externally defined pragma]"
+    show (IPragma _ _) = "[externally defined pragma]"
     show (ILog (topic, lvl)) = "%logging " ++ case topic of
       [] => show lvl
       _  => concat (intersperse "." topic) ++ " " ++ show lvl
@@ -610,6 +613,7 @@ definedInBlock ns decls =
         all : List Name
         all = expandNS ns n :: map (expandNS fldns') (fnsRF ++ fnsUN)
 
+    defName ns (IPragma pns _) = map (expandNS ns) pns
     defName _ _ = []
 
 export
@@ -1018,7 +1022,7 @@ mutual
         = do tag 6; toBuf b fc; toBuf b n; toBuf b lhs; toBuf b rhs
     toBuf b (IRunElabDecl fc tm)
         = do tag 7; toBuf b fc; toBuf b tm
-    toBuf b (IPragma f) = throw (InternalError "Can't write Pragma")
+    toBuf b (IPragma _ f) = throw (InternalError "Can't write Pragma")
     toBuf b (ILog n)
         = do tag 8; toBuf b n
 

--- a/tests/idris2/interface018/LocalInterface.idr
+++ b/tests/idris2/interface018/LocalInterface.idr
@@ -1,0 +1,9 @@
+interface Add a where
+  add : a -> a
+
+testAdd : Nat -> Nat -> Nat
+testAdd x y = add x
+  where
+    Add Nat where
+      add Z = y
+      add (S k) = add k

--- a/tests/idris2/interface018/expected
+++ b/tests/idris2/interface018/expected
@@ -1,0 +1,1 @@
+1/1: Building LocalInterface (LocalInterface.idr)

--- a/tests/idris2/interface018/run
+++ b/tests/idris2/interface018/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 LocalInterface.idr --check
+
+rm -rf build

--- a/tests/idris2/interface019/LocalHints.idr
+++ b/tests/idris2/interface019/LocalHints.idr
@@ -1,0 +1,48 @@
+data Foo : Type where [noHints]
+  A : Foo
+  B : Foo
+  
+findA : {auto foo : Foo} -> String
+findA {foo = A} = "Found an A"
+findA {foo = _} = "Failed to find an A"
+
+Baz : String -> Type
+Baz s = s = "Found an A" 
+
+baz : (s : String ** Baz s)
+baz = let %hint arg : Foo
+          arg = A
+      in (findA ** Refl)
+
+interface Gnu where
+  constructor MkGnu
+  hasFoo : Foo
+  
+findB : Gnu => String
+findB = case hasFoo of
+  B => "Found a B"
+  _ => "Failed to find a B"
+
+Bar : String -> Type
+Bar s = s = "Found a B" 
+
+bar : (s : String ** Bar s)
+bar = let %hint arg : Gnu
+          arg = MkGnu B
+      in (findB ** Refl)
+
+interface Gnat a where
+  constructor MkGnat
+  makeFoo : a -> Foo
+
+record More where
+  constructor MkMore
+  0 Ty : Type
+
+%unbound_implicits off
+bug : forall a . a -> (s : String ** Bar s)
+bug {a} x = let M : More
+                M = MkMore a
+                %hint arg : Gnat (Ty M)
+                arg = MkGnat (const B)
+            in (findB ** Refl)

--- a/tests/idris2/interface019/expected
+++ b/tests/idris2/interface019/expected
@@ -1,0 +1,1 @@
+1/1: Building LocalHints (LocalHints.idr)

--- a/tests/idris2/interface019/run
+++ b/tests/idris2/interface019/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 LocalHints.idr --check
+
+rm -rf build


### PR DESCRIPTION
This gives us the ability to define and use implementations locally, in where clauses/local let bindings, as well as flag local definitions as hints.

It's not yet quite equivalent to global hints, however, since it translated the hint to a local let binding, which doesn't reduce, so if something relies on the reduction behaviour of the hint, it won't work. This refinement is coming later.
