### PR TITLE
Allow `HasIO` to not depend on `Monad`.

### DIFF
--- a/libs/base/Data/Buffer.idr
+++ b/libs/base/Data/Buffer.idr
@@ -20,7 +20,7 @@ data Buffer : Type where [external]
 prim__bufferSize : Buffer -> Int
 
 export
-rawSize : HasIO io => Buffer -> io Int
+rawSize : HasMonadIO io => Buffer -> io Int
 rawSize buf = pure (prim__bufferSize buf)
 
 %foreign "scheme:blodwen-new-buffer"
@@ -28,7 +28,7 @@ rawSize buf = pure (prim__bufferSize buf)
 prim__newBuffer : Int -> PrimIO Buffer
 
 export
-newBuffer : HasIO io => Int -> io (Maybe Buffer)
+newBuffer : HasMonadIO io => Int -> io (Maybe Buffer)
 newBuffer size
     = do buf <- primIO (prim__newBuffer size)
          pure $ Just buf
@@ -38,7 +38,7 @@ newBuffer size
 
 -- might be needed if we do this in C...
 export
-freeBuffer : HasIO io => Buffer -> io ()
+freeBuffer : HasMonadIO io => Buffer -> io ()
 freeBuffer buf = pure ()
 
 %foreign "scheme:blodwen-buffer-setbyte"
@@ -51,12 +51,12 @@ prim__setBits8 : Buffer -> Int -> Bits8 -> PrimIO ()
 
 -- Assumes val is in the range 0-255
 export
-setByte : HasIO io => Buffer -> (loc : Int) -> (val : Int) -> io ()
+setByte : HasMonadIO io => Buffer -> (loc : Int) -> (val : Int) -> io ()
 setByte buf loc val
     = primIO (prim__setByte buf loc val)
 
 export
-setBits8 : HasIO io => Buffer -> (loc : Int) -> (val : Bits8) -> io ()
+setBits8 : HasMonadIO io => Buffer -> (loc : Int) -> (val : Bits8) -> io ()
 setBits8 buf loc val
     = primIO (prim__setBits8 buf loc val)
 
@@ -69,12 +69,12 @@ prim__getByte : Buffer -> Int -> PrimIO Int
 prim__getBits8 : Buffer -> Int -> PrimIO Bits8
 
 export
-getByte : HasIO io => Buffer -> (loc : Int) -> io Int
+getByte : HasMonadIO io => Buffer -> (loc : Int) -> io Int
 getByte buf loc
     = primIO (prim__getByte buf loc)
 
 export
-getBits8 : HasIO io => Buffer -> (loc : Int) -> io Bits8
+getBits8 : HasMonadIO io => Buffer -> (loc : Int) -> io Bits8
 getBits8 buf loc
     = primIO (prim__getBits8 buf loc)
 
@@ -83,7 +83,7 @@ getBits8 buf loc
 prim__setBits16 : Buffer -> Int -> Bits16 -> PrimIO ()
 
 export
-setBits16 : HasIO io => Buffer -> (loc : Int) -> (val : Bits16) -> io ()
+setBits16 : HasMonadIO io => Buffer -> (loc : Int) -> (val : Bits16) -> io ()
 setBits16 buf loc val
     = primIO (prim__setBits16 buf loc val)
 
@@ -92,7 +92,7 @@ setBits16 buf loc val
 prim__getBits16 : Buffer -> Int -> PrimIO Bits16
 
 export
-getBits16 : HasIO io => Buffer -> (loc : Int) -> io Bits16
+getBits16 : HasMonadIO io => Buffer -> (loc : Int) -> io Bits16
 getBits16 buf loc
     = primIO (prim__getBits16 buf loc)
 
@@ -101,7 +101,7 @@ getBits16 buf loc
 prim__setBits32 : Buffer -> Int -> Bits32 -> PrimIO ()
 
 export
-setBits32 : HasIO io => Buffer -> (loc : Int) -> (val : Bits32) -> io ()
+setBits32 : HasMonadIO io => Buffer -> (loc : Int) -> (val : Bits32) -> io ()
 setBits32 buf loc val
     = primIO (prim__setBits32 buf loc val)
 
@@ -110,7 +110,7 @@ setBits32 buf loc val
 prim__getBits32 : Buffer -> Int -> PrimIO Bits32
 
 export
-getBits32 : HasIO io => Buffer -> (loc : Int) -> io Bits32
+getBits32 : HasMonadIO io => Buffer -> (loc : Int) -> io Bits32
 getBits32 buf loc
     = primIO (prim__getBits32 buf loc)
 
@@ -118,7 +118,7 @@ getBits32 buf loc
 prim__setBits64 : Buffer -> Int -> Bits64 -> PrimIO ()
 
 export
-setBits64 : HasIO io => Buffer -> (loc : Int) -> (val : Bits64) -> io ()
+setBits64 : HasMonadIO io => Buffer -> (loc : Int) -> (val : Bits64) -> io ()
 setBits64 buf loc val
     = primIO (prim__setBits64 buf loc val)
 
@@ -126,7 +126,7 @@ setBits64 buf loc val
 prim__getBits64 : Buffer -> Int -> PrimIO Bits64
 
 export
-getBits64 : HasIO io => Buffer -> (loc : Int) -> io Bits64
+getBits64 : HasMonadIO io => Buffer -> (loc : Int) -> io Bits64
 getBits64 buf loc
     = primIO (prim__getBits64 buf loc)
 
@@ -135,7 +135,7 @@ getBits64 buf loc
 prim__setInt32 : Buffer -> Int -> Int -> PrimIO ()
 
 export
-setInt32 : HasIO io => Buffer -> (loc : Int) -> (val : Int) -> io ()
+setInt32 : HasMonadIO io => Buffer -> (loc : Int) -> (val : Int) -> io ()
 setInt32 buf loc val
     = primIO (prim__setInt32 buf loc val)
 
@@ -144,7 +144,7 @@ setInt32 buf loc val
 prim__getInt32 : Buffer -> Int -> PrimIO Int
 
 export
-getInt32 : HasIO io => Buffer -> (loc : Int) -> io Int
+getInt32 : HasMonadIO io => Buffer -> (loc : Int) -> io Int
 getInt32 buf loc
     = primIO (prim__getInt32 buf loc)
 
@@ -153,7 +153,7 @@ getInt32 buf loc
 prim__setInt : Buffer -> Int -> Int -> PrimIO ()
 
 export
-setInt : HasIO io => Buffer -> (loc : Int) -> (val : Int) -> io ()
+setInt : HasMonadIO io => Buffer -> (loc : Int) -> (val : Int) -> io ()
 setInt buf loc val
     = primIO (prim__setInt buf loc val)
 
@@ -162,7 +162,7 @@ setInt buf loc val
 prim__getInt : Buffer -> Int -> PrimIO Int
 
 export
-getInt : HasIO io => Buffer -> (loc : Int) -> io Int
+getInt : HasMonadIO io => Buffer -> (loc : Int) -> io Int
 getInt buf loc
     = primIO (prim__getInt buf loc)
 
@@ -171,7 +171,7 @@ getInt buf loc
 prim__setDouble : Buffer -> Int -> Double -> PrimIO ()
 
 export
-setDouble : HasIO io => Buffer -> (loc : Int) -> (val : Double) -> io ()
+setDouble : HasMonadIO io => Buffer -> (loc : Int) -> (val : Double) -> io ()
 setDouble buf loc val
     = primIO (prim__setDouble buf loc val)
 
@@ -180,7 +180,7 @@ setDouble buf loc val
 prim__getDouble : Buffer -> Int -> PrimIO Double
 
 export
-getDouble : HasIO io => Buffer -> (loc : Int) -> io Double
+getDouble : HasMonadIO io => Buffer -> (loc : Int) -> io Double
 getDouble buf loc
     = primIO (prim__getDouble buf loc)
 
@@ -194,7 +194,7 @@ stringByteLength : String -> Int
 prim__setString : Buffer -> Int -> String -> PrimIO ()
 
 export
-setString : HasIO io => Buffer -> (loc : Int) -> (val : String) -> io ()
+setString : HasMonadIO io => Buffer -> (loc : Int) -> (val : String) -> io ()
 setString buf loc val
     = primIO (prim__setString buf loc val)
 
@@ -203,14 +203,14 @@ setString buf loc val
 prim__getString : Buffer -> Int -> Int -> PrimIO String
 
 export
-getString : HasIO io => Buffer -> (loc : Int) -> (len : Int) -> io String
+getString : HasMonadIO io => Buffer -> (loc : Int) -> (len : Int) -> io String
 getString buf loc len
     = primIO (prim__getString buf loc len)
 
 
 
 export
-bufferData : HasIO io => Buffer -> io (List Int)
+bufferData : HasMonadIO io => Buffer -> io (List Int)
 bufferData buf
     = do len <- rawSize buf
          unpackTo [] len
@@ -227,7 +227,7 @@ bufferData buf
 prim__copyData : Buffer -> Int -> Int -> Buffer -> Int -> PrimIO ()
 
 export
-copyData : HasIO io => (src : Buffer) -> (start, len : Int) ->
+copyData : HasMonadIO io => (src : Buffer) -> (start, len : Int) ->
            (dest : Buffer) -> (loc : Int) -> io ()
 copyData src start len dest loc
     = primIO (prim__copyData src start len dest loc)
@@ -241,7 +241,7 @@ prim__readBufferData : FilePtr -> Buffer -> Int -> Int -> PrimIO Int
 prim__writeBufferData : FilePtr -> Buffer -> Int -> Int -> PrimIO Int
 
 export
-readBufferData : HasIO io => File -> Buffer ->
+readBufferData : HasMonadIO io => File -> Buffer ->
                  (loc : Int) -> -- position in buffer to start adding
                  (maxbytes : Int) -> -- maximums size to read, which must not
                                      -- exceed buffer length
@@ -253,7 +253,7 @@ readBufferData (FHandle h) buf loc max
             else pure (Left FileReadError)
 
 export
-writeBufferData : HasIO io => File -> Buffer ->
+writeBufferData : HasMonadIO io => File -> Buffer ->
                   (loc : Int) -> -- position in buffer to write from
                   (maxbytes : Int) -> -- maximums size to write, which must not
                                       -- exceed buffer length
@@ -265,7 +265,7 @@ writeBufferData (FHandle h) buf loc max
             else pure (Left FileWriteError)
 
 export
-writeBufferToFile : HasIO io => String -> Buffer -> Int -> io (Either FileError ())
+writeBufferToFile : HasMonadIO io => String -> Buffer -> Int -> io (Either FileError ())
 writeBufferToFile fn buf max
     = do Right f <- openFile fn WriteTruncate
              | Left err => pure (Left err)
@@ -275,7 +275,7 @@ writeBufferToFile fn buf max
          pure (Right ok)
 
 export
-createBufferFromFile : HasIO io => String -> io (Either FileError Buffer)
+createBufferFromFile : HasMonadIO io => String -> io (Either FileError Buffer)
 createBufferFromFile fn
     = do Right f <- openFile fn Read
              | Left err => pure (Left err)
@@ -289,7 +289,7 @@ createBufferFromFile fn
          pure (Right buf)
 
 export
-resizeBuffer : HasIO io => Buffer -> Int -> io (Maybe Buffer)
+resizeBuffer : HasMonadIO io => Buffer -> Int -> io (Maybe Buffer)
 resizeBuffer old newsize
     = do Just buf <- newBuffer newsize
               | Nothing => pure Nothing
@@ -304,7 +304,7 @@ resizeBuffer old newsize
 ||| Create a buffer containing the concatenated content from a
 ||| list of buffers.
 export
-concatBuffers : HasIO io => List Buffer -> io (Maybe Buffer)
+concatBuffers : HasMonadIO io => List Buffer -> io (Maybe Buffer)
 concatBuffers xs
     = do let sizes = map prim__bufferSize xs
          let (totalSize, revCumulative) = foldl scanSize (0,[]) sizes
@@ -319,7 +319,7 @@ concatBuffers xs
 
 ||| Split a buffer into two at a position.
 export
-splitBuffer : HasIO io => Buffer -> Int -> io (Maybe (Buffer, Buffer))
+splitBuffer : HasMonadIO io => Buffer -> Int -> io (Maybe (Buffer, Buffer))
 splitBuffer buf pos = do size <- rawSize buf
                          if pos > 0 && pos < size
                              then do Just first <- newBuffer pos

--- a/libs/base/Data/IOArray.idr
+++ b/libs/base/Data/IOArray.idr
@@ -14,19 +14,19 @@ max : IOArray elem -> Int
 max = maxSize
 
 export
-newArray : HasIO io => Int -> io (IOArray elem)
+newArray : HasMonadIO io => Int -> io (IOArray elem)
 newArray size
     = pure (MkIOArray size !(primIO (prim__newArray size Nothing)))
 
 export
-writeArray : HasIO io => IOArray elem -> Int -> elem -> io ()
+writeArray : HasMonadIO io => IOArray elem -> Int -> elem -> io ()
 writeArray arr pos el
     = if pos < 0 || pos >= max arr
          then pure ()
          else primIO (prim__arraySet (content arr) pos (Just el))
 
 export
-readArray : HasIO io => IOArray elem -> Int -> io (Maybe elem)
+readArray : HasMonadIO io => IOArray elem -> Int -> io (Maybe elem)
 readArray arr pos
     = if pos < 0 || pos >= max arr
          then pure Nothing
@@ -35,7 +35,7 @@ readArray arr pos
 -- Make a new array of the given size with the elements copied from the
 -- other array
 export
-newArrayCopy : HasIO io =>
+newArrayCopy : HasMonadIO io =>
                (newsize : Int) -> IOArray elem -> io (IOArray elem)
 newArrayCopy newsize arr
     = do let newsize' = if newsize < max arr then max arr else newsize
@@ -54,7 +54,7 @@ newArrayCopy newsize arr
                      assert_total (copyFrom old new (pos - 1))
 
 export
-toList : HasIO io => IOArray elem -> io (List (Maybe elem))
+toList : HasMonadIO io => IOArray elem -> io (List (Maybe elem))
 toList arr = iter 0 (max arr) []
   where
     iter : Int -> Int -> List (Maybe elem) -> io (List (Maybe elem))

--- a/libs/base/Data/IORef.idr
+++ b/libs/base/Data/IORef.idr
@@ -13,14 +13,14 @@ data IORef : Type -> Type where
      MkRef : Mut a -> IORef a
 
 export
-newIORef : HasIO io => a -> io (IORef a)
+newIORef : HasMonadIO io => a -> io (IORef a)
 newIORef val
     = do m <- primIO (prim__newIORef val)
          pure (MkRef m)
 
 %inline
 export
-readIORef : HasIO io => IORef a -> io a
+readIORef : HasMonadIO io => IORef a -> io a
 readIORef (MkRef m) = primIO (prim__readIORef m)
 
 %inline
@@ -29,8 +29,7 @@ writeIORef : HasIO io => IORef a -> (1 val : a) -> io ()
 writeIORef (MkRef m) val = primIO (prim__writeIORef m val)
 
 export
-modifyIORef : HasIO io => IORef a -> (a -> a) -> io ()
+modifyIORef : HasMonadIO io => IORef a -> (a -> a) -> io ()
 modifyIORef ref f
     = do val <- readIORef ref
          writeIORef ref (f val)
-

--- a/libs/base/Data/Ref.idr
+++ b/libs/base/Data/Ref.idr
@@ -10,7 +10,7 @@ interface Ref m r | m where
   writeRef : r a -> a -> m ()
 
 export
-HasIO io => Ref io IORef where
+HasMonadIO io => Ref io IORef where
   newRef = newIORef
   readRef = readIORef
   writeRef = writeIORef

--- a/libs/base/System.idr
+++ b/libs/base/System.idr
@@ -45,7 +45,7 @@ prim__setEnv : String -> String -> Int -> PrimIO Int
 prim__unsetEnv : String -> PrimIO Int
 
 export
-getEnv : HasIO io => String -> io (Maybe String)
+getEnv : HasMonadIO io => String -> io (Maybe String)
 getEnv var
    = do env <- primIO $ prim__getEnv var
         if prim__nullPtr env /= 0
@@ -53,7 +53,7 @@ getEnv var
            else pure (Just (prim__getString env))
 
 export
-getEnvironment : HasIO io => io (List (String, String))
+getEnvironment : HasMonadIO io => io (List (String, String))
 getEnvironment = getAllPairs 0 []
   where
     splitEq : String -> (String, String)
@@ -70,13 +70,13 @@ getEnvironment = getAllPairs 0 []
          else getAllPairs (n + 1) (prim__getString envPair :: acc)
 
 export
-setEnv : HasIO io => String -> String -> Bool -> io Bool
+setEnv : HasMonadIO io => String -> String -> Bool -> io Bool
 setEnv var val overwrite
    = do ok <- primIO $ prim__setEnv var val (if overwrite then 1 else 0)
         pure $ ok == 0
 
 export
-unsetEnv : HasIO io => String -> io Bool
+unsetEnv : HasMonadIO io => String -> io Bool
 unsetEnv var
    = do ok <- primIO $ prim__unsetEnv var
         pure $ ok == 0
@@ -94,7 +94,7 @@ system cmd = primIO (prim__system cmd)
 prim__time : PrimIO Int
 
 export
-time : HasIO io => io Integer
+time : HasMonadIO io => io Integer
 time = pure $ cast !(primIO prim__time)
 
 %foreign libc "exit"

--- a/libs/base/System/Directory.idr
+++ b/libs/base/System/Directory.idr
@@ -13,7 +13,7 @@ support fn = "C:" ++ fn ++ ", libidris2_support"
          "node:support:fileErrno,support_system_directory"
 prim__fileErrno : PrimIO Int
 
-returnError : HasIO io => io (Either FileError a)
+returnError : HasMonadIO io => io (Either FileError a)
 returnError
     = do err <- primIO prim__fileErrno
          case err of
@@ -24,7 +24,7 @@ returnError
               4 => pure $ Left FileExists
               _ => pure $ Left (GenericFileError (err-5))
 
-ok : HasIO io => a -> io (Either FileError a)
+ok : HasMonadIO io => a -> io (Either FileError a)
 ok x = pure (Right x)
 
 %foreign support "idris2_currentDirectory"
@@ -56,7 +56,7 @@ data Directory : Type where
      MkDir : DirPtr -> Directory
 
 export
-createDir : HasIO io => String -> io (Either FileError ())
+createDir : HasMonadIO io => String -> io (Either FileError ())
 createDir dir
     = do res <- primIO (prim__createDir dir)
          if res == 0
@@ -64,13 +64,13 @@ createDir dir
             else returnError
 
 export
-changeDir : HasIO io => String -> io Bool
+changeDir : HasMonadIO io => String -> io Bool
 changeDir dir
     = do ok <- primIO (prim__changeDir dir)
          pure (ok == 0)
 
 export
-currentDir : HasIO io => io (Maybe String)
+currentDir : HasMonadIO io => io (Maybe String)
 currentDir
     = do res <- primIO prim__currentDir
          if prim__nullPtr res /= 0
@@ -78,7 +78,7 @@ currentDir
             else pure (Just (prim__getString res))
 
 export
-openDir : HasIO io => String -> io (Either FileError Directory)
+openDir : HasMonadIO io => String -> io (Either FileError Directory)
 openDir d
     = do res <- primIO (prim__openDir d)
          if prim__nullAnyPtr res /= 0
@@ -86,15 +86,15 @@ openDir d
             else ok (MkDir res)
 
 export
-closeDir : HasIO io => Directory -> io ()
+closeDir : HasMonadIO io => Directory -> io ()
 closeDir (MkDir d) = primIO (prim__closeDir d)
 
 export
-removeDir : HasIO io => String -> io ()
+removeDir : HasMonadIO io => String -> io ()
 removeDir dirName = primIO (prim__removeDir dirName)
 
 export
-dirEntry : HasIO io => Directory -> io (Either FileError String)
+dirEntry : HasMonadIO io => Directory -> io (Either FileError String)
 dirEntry (MkDir d)
     = do res <- primIO (prim__dirEntry d)
          if prim__nullPtr res /= 0

--- a/libs/base/System/REPL.idr
+++ b/libs/base/System/REPL.idr
@@ -8,7 +8,7 @@ import System.File
 ||| @ onInput the function to run on reading input, returning a String to
 ||| output and a new state. Returns Nothing if the repl should exit
 export
-replWith : HasIO io =>
+replWith : HasMonadIO io =>
            (state : a) -> (prompt : String) ->
            (onInput : a -> String -> Maybe (String, a)) -> io ()
 replWith acc prompt fn
@@ -29,9 +29,7 @@ replWith acc prompt fn
 ||| @ onInput the function to run on reading input, returning a String to
 ||| output
 export
-repl : HasIO io =>
+repl : HasMonadIO io =>
        (prompt : String) -> (onInput : String -> String) -> io ()
 repl prompt fn
    = replWith () prompt (\x, s => Just (fn s, ()))
-
-

--- a/libs/contrib/Control/Linear/LIO.idr
+++ b/libs/contrib/Control/Linear/LIO.idr
@@ -16,7 +16,7 @@ data Usage = None | Linear | Unrestricted
 
 -- Not sure about this, it is a horrible hack, but it makes the notation
 -- a bit nicer
-public export 
+public export
 fromInteger : (x : Integer) -> {auto _ : Either (x = 0) (x = 1)} -> Usage
 fromInteger 0 = None
 fromInteger 1 = Linear
@@ -120,4 +120,4 @@ export
 
 public export
 LinearIO : (Type -> Type) -> Type
-LinearIO io = (LinearBind io, HasIO io)
+LinearIO io = (LinearBind io, HasMonadIO io)

--- a/libs/contrib/Debug/Buffer.idr
+++ b/libs/contrib/Debug/Buffer.idr
@@ -31,7 +31,7 @@ group n xs = worker [] xs
         worker acc ys = worker ((take n ys)::acc) (drop n ys)
 
 export
-dumpBuffer : HasIO io => Buffer -> io String
+dumpBuffer : HasMonadIO io => Buffer -> io String
 dumpBuffer buf = do
     size <- liftIO $ rawSize buf
     dat <- liftIO $ bufferData buf
@@ -40,5 +40,5 @@ dumpBuffer buf = do
     pure $ hex ++ "\n\ntotal size = " ++ show size
 
 export
-printBuffer : HasIO io => Buffer -> io ()
+printBuffer : HasMonadIO io => Buffer -> io ()
 printBuffer buf = putStrLn $ !(dumpBuffer buf)

--- a/libs/contrib/System/Random.idr
+++ b/libs/contrib/System/Random.idr
@@ -6,12 +6,12 @@ import Data.List
 
 public export
 interface Random a where
-  randomIO : HasIO io => io a
+  randomIO : HasMonadIO io => io a
 
   -- Takes a range (lo, hi), and returns a random value uniformly
   -- distributed in the closed interval [lo, hi]. It is unspecified what
   -- happens if lo > hi.
-  randomRIO : HasIO io => (a, a) -> io a
+  randomRIO : HasMonadIO io => (a, a) -> io a
 
 %foreign "scheme:blodwen-random"
 prim__randomInt : Int -> PrimIO Int

--- a/libs/network/Network/Socket.idr
+++ b/libs/network/Network/Socket.idr
@@ -14,7 +14,7 @@ import Network.FFI
 ||| Creates a UNIX socket with the given family, socket type and protocol
 ||| number. Returns either a socket or an error.
 export
-socket : HasIO io
+socket : HasMonadIO io
       => (fam  : SocketFamily)
       -> (ty   : SocketType)
       -> (pnum : ProtocolNumber)
@@ -28,14 +28,14 @@ socket sf st pn = do
 
 ||| Close a socket
 export
-close : HasIO io => Socket -> io ()
+close : HasMonadIO io => Socket -> io ()
 close sock = do _ <- primIO $ prim__socket_close $ descriptor sock
                 pure ()
 
 ||| Binds a socket to the given socket address and port.
 ||| Returns 0 on success, an error code otherwise.
 export
-bind : HasIO io
+bind : HasMonadIO io
     => (sock : Socket)
     -> (addr : Maybe SocketAddress)
     -> (port : Port)
@@ -59,7 +59,7 @@ bind sock addr port = do
 ||| Connects to a given address and port.
 ||| Returns 0 on success, and an error number on error.
 export
-connect : HasIO io
+connect : HasMonadIO io
        => (sock : Socket)
        -> (addr : SocketAddress)
        -> (port : Port)
@@ -76,7 +76,7 @@ connect sock addr port = do
 |||
 ||| @sock The socket to listen on.
 export
-listen : HasIO io => (sock : Socket) -> io Int
+listen : HasMonadIO io => (sock : Socket) -> io Int
 listen sock = do
   listen_res <- primIO $ prim__socket_listen (descriptor sock) BACKLOG
   if listen_res == (-1)
@@ -92,7 +92,7 @@ listen sock = do
 |||
 ||| @sock The socket used to establish connection.
 export
-accept : HasIO io
+accept : HasMonadIO io
       => (sock : Socket)
       -> io (Either SocketError (Socket, SocketAddress))
 accept sock = do
@@ -119,7 +119,7 @@ accept sock = do
 ||| @sock The socket on which to send the message.
 ||| @msg  The data to send.
 export
-send : HasIO io
+send : HasMonadIO io
     => (sock : Socket)
     -> (msg  : String)
     -> io (Either SocketError ResultCode)
@@ -140,7 +140,7 @@ send sock dat = do
 ||| @sock The socket on which to receive the message.
 ||| @len  How much of the data to receive.
 export
-recv : HasIO io
+recv : HasMonadIO io
     => (sock : Socket)
     -> (len : ByteLength)
     -> io (Either SocketError (String, ResultCode))
@@ -172,7 +172,7 @@ recv sock len = do
 |||
 ||| @sock The socket on which to receive the message.
 export
-recvAll : HasIO io => (sock : Socket) -> io (Either SocketError String)
+recvAll : HasMonadIO io => (sock : Socket) -> io (Either SocketError String)
 recvAll sock = recvRec sock [] 64
   where
     partial
@@ -194,7 +194,7 @@ recvAll sock = recvRec sock [] 64
 ||| @port The port on which to send the message.
 ||| @msg  The message to send.
 export
-sendTo : HasIO io
+sendTo : HasMonadIO io
       => (sock : Socket)
       -> (addr : SocketAddress)
       -> (port : Port)
@@ -220,7 +220,7 @@ sendTo sock addr p dat = do
 ||| @len  Size of the expected message.
 |||
 export
-recvFrom : HasIO io
+recvFrom : HasMonadIO io
         => (sock : Socket)
         -> (len  : ByteLength)
         -> io (Either SocketError (UDPAddrInfo, String, ResultCode))

--- a/libs/network/Network/Socket/Data.idr
+++ b/libs/network/Network/Socket/Data.idr
@@ -69,11 +69,11 @@ prim__idrnet_isNull : (ptr : AnyPtr) -> PrimIO Int
 
 
 export
-getErrno : HasIO io => io SocketError
+getErrno : HasMonadIO io => io SocketError
 getErrno = primIO $ prim__idrnet_errno
 
 export
-nullPtr : HasIO io => AnyPtr -> io Bool
+nullPtr : HasMonadIO io => AnyPtr -> io Bool
 nullPtr p = do 0 <- primIO  $ prim__idrnet_isNull p
                | _ => pure True
                pure False

--- a/libs/network/Network/Socket/Raw.idr
+++ b/libs/network/Network/Socket/Raw.idr
@@ -27,39 +27,39 @@ data SockaddrPtr = SAPtr AnyPtr
 
 ||| Put a value in a buffer
 export
-sock_poke : HasIO io => BufPtr -> Int -> Int -> io ()
+sock_poke : HasMonadIO io => BufPtr -> Int -> Int -> io ()
 sock_poke (BPtr ptr) offset val = primIO $ prim__idrnet_poke ptr offset val
 
 ||| Take a value from a buffer
 export
-sock_peek : HasIO io => BufPtr -> Int -> io Int
+sock_peek : HasMonadIO io => BufPtr -> Int -> io Int
 sock_peek (BPtr ptr) offset = primIO $ prim__idrnet_peek ptr offset
 
 ||| Frees a given pointer
 export
-sock_free : HasIO io => BufPtr -> io ()
+sock_free : HasMonadIO io => BufPtr -> io ()
 sock_free (BPtr ptr) = primIO $ prim__idrnet_free ptr
 
 export
-sockaddr_free : HasIO io => SockaddrPtr -> io ()
+sockaddr_free : HasMonadIO io => SockaddrPtr -> io ()
 sockaddr_free (SAPtr ptr) = primIO $ prim__idrnet_free ptr
 
 ||| Allocates an amount of memory given by the ByteLength parameter.
 |||
 ||| Used to allocate a mutable pointer to be given to the Recv functions.
 export
-sock_alloc : HasIO io => ByteLength -> io BufPtr
+sock_alloc : HasMonadIO io => ByteLength -> io BufPtr
 sock_alloc bl = map BPtr $ primIO $ prim__idrnet_malloc bl
 
 ||| Retrieves the port the given socket is bound to
 export
-getSockPort : HasIO io => Socket -> io Port
+getSockPort : HasMonadIO io => Socket -> io Port
 getSockPort sock = primIO $ prim__idrnet_sockaddr_port $ descriptor sock
 
 
 ||| Retrieves a socket address from a sockaddr pointer
 export
-getSockAddr : HasIO io => SockaddrPtr -> io SocketAddress
+getSockAddr : HasMonadIO io => SockaddrPtr -> io SocketAddress
 getSockAddr (SAPtr ptr) = do
   addr_family_int <- primIO $ prim__idrnet_sockaddr_family ptr
 
@@ -73,12 +73,12 @@ getSockAddr (SAPtr ptr) = do
     Just AF_UNSPEC => pure InvalidAddress)
 
 export
-freeRecvStruct : HasIO io => RecvStructPtr -> io ()
+freeRecvStruct : HasMonadIO io => RecvStructPtr -> io ()
 freeRecvStruct (RSPtr p) = primIO $ prim__idrnet_free_recv_struct p
 
 ||| Utility to extract data.
 export
-freeRecvfromStruct : HasIO io => RecvfromStructPtr -> io ()
+freeRecvfromStruct : HasMonadIO io => RecvfromStructPtr -> io ()
 freeRecvfromStruct (RFPtr p) = primIO $ prim__idrnet_free_recvfrom_struct p
 
 ||| Sends the data in a given memory location
@@ -90,7 +90,7 @@ freeRecvfromStruct (RFPtr p) = primIO $ prim__idrnet_free_recvfrom_struct p
 ||| @ptr  The location containing the data to send.
 ||| @len  How much of the data to send.
 export
-sendBuf : HasIO io
+sendBuf : HasMonadIO io
        => (sock : Socket)
        -> (ptr  : BufPtr)
        -> (len  : ByteLength)
@@ -111,7 +111,7 @@ sendBuf sock (BPtr ptr) len = do
 ||| @ptr  The location containing the data to receive.
 ||| @len  How much of the data to receive.
 export
-recvBuf : HasIO io
+recvBuf : HasMonadIO io
        => (sock : Socket)
        -> (ptr  : BufPtr)
        -> (len  : ByteLength)
@@ -134,7 +134,7 @@ recvBuf sock (BPtr ptr) len = do
 ||| @ptr  A Pointer to the buffer containing the message.
 ||| @len  The size of the message.
 export
-sendToBuf : HasIO io
+sendToBuf : HasMonadIO io
          => (sock : Socket)
          -> (addr : SocketAddress)
          -> (port : Port)
@@ -151,19 +151,19 @@ sendToBuf sock addr p (BPtr dat) len = do
 
 ||| Utility function to get the payload of the sent message as a `String`.
 export
-foreignGetRecvfromPayload : HasIO io => RecvfromStructPtr -> io String
+foreignGetRecvfromPayload : HasMonadIO io => RecvfromStructPtr -> io String
 foreignGetRecvfromPayload (RFPtr p) = primIO $ prim__idrnet_get_recvfrom_payload p
 
 ||| Utility function to return senders socket address.
 export
-foreignGetRecvfromAddr : HasIO io => RecvfromStructPtr -> io SocketAddress
+foreignGetRecvfromAddr : HasMonadIO io => RecvfromStructPtr -> io SocketAddress
 foreignGetRecvfromAddr (RFPtr p) = do
   sockaddr_ptr <- map SAPtr $ primIO $ prim__idrnet_get_recvfrom_sockaddr p
   getSockAddr sockaddr_ptr
 
 ||| Utility function to return sender's IPV4 port.
 export
-foreignGetRecvfromPort : HasIO io => RecvfromStructPtr -> io Port
+foreignGetRecvfromPort : HasMonadIO io => RecvfromStructPtr -> io Port
 foreignGetRecvfromPort (RFPtr p) = do
   sockaddr_ptr <- primIO $ prim__idrnet_get_recvfrom_sockaddr p
   port         <- primIO $ prim__idrnet_sockaddr_ipv4_port sockaddr_ptr
@@ -181,7 +181,7 @@ foreignGetRecvfromPort (RFPtr p) = do
 ||| @len  Size of the expected message.
 |||
 export
-recvFromBuf : HasIO io
+recvFromBuf : HasMonadIO io
            => (sock : Socket)
            -> (ptr  : BufPtr)
            -> (len  : ByteLength)

--- a/libs/prelude/Prelude/IO.idr
+++ b/libs/prelude/Prelude/IO.idr
@@ -31,8 +31,12 @@ Monad IO where
   b >>= k = io_bind b k
 
 public export
-interface Monad io => HasIO io where
+interface HasIO io where
   liftIO : (1 _ : IO a) -> io a
+
+public export
+HasMonadIO : (io : Type -> Type) -> Type
+HasMonadIO io = (Monad io, HasIO io)
 
 public export %inline
 HasIO IO where

--- a/tests/idris2/interface018/Sized.idr
+++ b/tests/idris2/interface018/Sized.idr
@@ -17,9 +17,9 @@ data ForeignPtr : Type -> Type where
 public export
 interface Storable (0 a : Type) (n : Nat) | a where
   constructor MkStorable
-  peekByteOff : HasIO io => ForeignPtr a -> Int -> io a
+  peekByteOff : HasMonadIO io => ForeignPtr a -> Int -> io a
 
-  peekElemOff : HasIO io => ForeignPtr a -> Int -> io a
+  peekElemOff : HasMonadIO io => ForeignPtr a -> Int -> io a
   peekElemOff fp off = peekByteOff fp (off * cast n)
 
 Storable Bits8 8 where


### PR DESCRIPTION
The definition of `HasIO` depends on `Monad` to provide sequencing of `HasIO` like things.
A strict dependency on `Monad` makes it difficult to provide correct implementatons of `HasIO` for indexed computation contexts in which there are type-level operations.
Idris2's standard interface definitions are, unfortunatly, too restrictive and will pin type-level values unnecessarily as such making the wrong assumptions when defining Applicative, Monad, or even Show implementations.
Moreover, the type required by the interface is not the last type-level parameter.

Here we remove the explicit dependency, and provide an alias (`HasMonadIO`) to regain the dependency and thus allow one to regain 'Do-notation' by overloading `(>>=)` and `pure`.