### PR TITLE
Refactor Core 

### DIFF
--- a/libs/contrib/Control/Monad/Syntax.idr
+++ b/libs/contrib/Control/Monad/Syntax.idr
@@ -2,7 +2,7 @@ module Control.Monad.Syntax
 
 %default total
 
-infixr 1 =<<, <=<, >=>
+infixr 1 =<<, <<, <=<, >=>
 
 ||| Left-to-right Kleisli composition of monads.
 public export
@@ -18,4 +18,9 @@ public export
 ||| Right-to-left monadic bind, flipped version of `>>=`.
 (=<<) : Monad m => (a -> m b) -> m a -> m b
 (=<<) = flip (>>=)
+
+public export
+||| Flipped version of `>>`.
+(<<) : Monad m => m b -> m a -> m b
+(<<) = flip (>>)
 

--- a/libs/contrib/System/Path.idr
+++ b/libs/contrib/System/Path.idr
@@ -170,7 +170,7 @@ unc = do count (exactly 2) $ match $ PTPunct '\\'
          server <- match PTText
          bodySeparator
          share <- match PTText
-         Core.pure $ UNC server share
+         pure $ UNC server share
 
 -- Example: \\?\server\share
 verbatimUnc : Grammar PathToken True Volume
@@ -178,7 +178,7 @@ verbatimUnc = do verbatim
                  server <- match PTText
                  bodySeparator
                  share <- match PTText
-                 Core.pure $ UNC server share
+                 pure $ UNC server share
 
 -- Example: C:
 disk : Grammar PathToken True Volume

--- a/libs/prelude/Prelude/Interfaces.idr
+++ b/libs/prelude/Prelude/Interfaces.idr
@@ -174,11 +174,13 @@ interface Applicative m => Monad m where
   (>>=) x f = join (f <$> x)
   join x = x >>= id
 
-%allow_overloads (>>=)
-
 public export
-(>>) : (Monad m) => m a -> m b -> m b
+(>>) : Monad m => m a -> m b -> m b
 a >> b = a >>= \_ => b
+
+%allow_overloads join
+%allow_overloads (>>=)
+%allow_overloads (>>)
 
 ||| `guard a` is `pure ()` if `a` is `True` and `empty` if `a` is `False`.
 public export
@@ -190,6 +192,10 @@ public export
 when : Applicative f => Bool -> Lazy (f ()) -> f ()
 when True f = f
 when False f = pure ()
+
+public export
+unless : Applicative f => Bool -> Lazy (f ()) -> f ()
+unless = when . not
 
 ---------------------------
 -- FOLDABLE, TRAVERSABLE --

--- a/src/Core/CaseBuilder.idr
+++ b/src/Core/CaseBuilder.idr
@@ -801,7 +801,7 @@ mutual
            let clauses' = map (shuffleVars next) clauses
            let ps = partition phase clauses'
            maybe (pure (Unmatched "No clauses"))
-                 Core.pure
+                 pure
                 !(mixture fc fn phase ps err)
   match {todo = []} fc fn phase [] err
        = maybe (pure (Unmatched "No patterns"))

--- a/src/Core/TTC.idr
+++ b/src/Core/TTC.idr
@@ -33,12 +33,12 @@ TTC FC where
 export
 TTC Namespace where
   toBuf b = toBuf b . unsafeUnfoldNamespace
-  fromBuf = Core.map unsafeFoldNamespace . fromBuf
+  fromBuf = map unsafeFoldNamespace . fromBuf
 
 export
 TTC ModuleIdent where
   toBuf b = toBuf b . unsafeUnfoldModuleIdent
-  fromBuf = Core.map unsafeFoldModuleIdent . fromBuf
+  fromBuf = map unsafeFoldModuleIdent . fromBuf
 
 export
 TTC Name where

--- a/src/Idris/Error.idr
+++ b/src/Idris/Error.idr
@@ -27,6 +27,7 @@ import System.File
 import Utils.String
 
 %default covering
+%ambiguity_depth 5
 
 -- | Add binding site information if the term is simply a machine-inserted name
 pShowMN : {vars : _} -> Term vars -> Env t vars -> Doc IdrisAnn -> Doc IdrisAnn

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -453,7 +453,7 @@ clean pkg opts -- `opts` is not used but might be in the future
                                   in
                                 insertWith (reverse ks) (maybe [v] (v::)) trie) empty toClean
          foldWithKeysC (deleteFolder builddir)
-                       (\ks => map concat . traverse (deleteBin builddir ks))
+                       (\ks => map concat . Core.traverse (deleteBin builddir ks))
                        pkgTrie
          deleteFolder builddir []
          maybe (pure ()) (\e => delete (outputdir </> e))
@@ -649,4 +649,4 @@ findIpkg fname
     dropHead str (x :: xs)
         = if x == str then xs else x :: xs
     loadDependencies : List String -> Core ()
-    loadDependencies = traverse_ addPkgDir
+    loadDependencies = Core.traverse_ addPkgDir

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -48,9 +48,7 @@ plhs : ParseOpts
 plhs = MkParseOpts False False
 
 %hide Prelude.(>>=)
-%hide Core.Core.(>>=)
 %hide Prelude.pure
-%hide Core.Core.pure
 
 atom : FileName -> Rule PTerm
 atom fname

--- a/src/Idris/ProcessIdr.idr
+++ b/src/Idris/ProcessIdr.idr
@@ -235,7 +235,7 @@ processMod : {auto c : Ref Ctxt Defs} ->
              (sourcecode : String) ->
              Core (Maybe (List Error))
 processMod srcf ttcf msg sourcecode
-    = catch (do
+    = assert_total $ catch (do -- TODO: Check totality
         setCurrentElabSource sourcecode
         -- Just read the header to start with (this is to get the imports and
         -- see if we can avoid rebuilding if none have changed)

--- a/src/TTImp/Elab/Ambiguity.idr
+++ b/src/TTImp/Elab/Ambiguity.idr
@@ -388,7 +388,7 @@ checkAlternative rig elabinfo nest env fc (UniqueDefault def) alts mexpected
                               alts')
 checkAlternative rig elabinfo nest env fc uniq alts mexpected
     = do checkAmbigDepth fc elabinfo
-         alts' <- maybe (Core.pure [])
+         alts' <- maybe (pure [])
                         (\exp => pruneByType env !(getNF exp) alts) mexpected
          case alts' of
            [alt] => checkImp rig elabinfo nest env alt mexpected

--- a/src/TTImp/Elab/As.idr
+++ b/src/TTImp/Elab/As.idr
@@ -18,6 +18,7 @@ import Data.List
 import Data.NameMap
 
 %default covering
+%ambiguity_depth 5
 
 export
 checkAs : {vars : _} ->

--- a/src/TTImp/Elab/ImplicitBind.idr
+++ b/src/TTImp/Elab/ImplicitBind.idr
@@ -20,6 +20,7 @@ import Data.List
 import Data.NameMap
 
 %default covering
+%ambiguity_depth 5
 
 -- Make a hole for an unbound implicit in the outer environment
 export

--- a/src/TTImp/Parser.idr
+++ b/src/TTImp/Parser.idr
@@ -23,9 +23,7 @@ collectDefs : List ImpDecl -> List ImpDecl
 %default covering
 
 %hide Prelude.(>>=)
-%hide Core.Core.(>>=)
 %hide Prelude.pure
-%hide Core.Core.pure
 
 %hide Lexer.Core.(<|>)
 %hide Prelude.(<|>)

--- a/src/Utils/Path.idr
+++ b/src/Utils/Path.idr
@@ -169,7 +169,7 @@ unc = do count (exactly 2) $ match $ PTPunct '\\'
          server <- match PTText
          bodySeparator
          share <- match PTText
-         Core.pure $ UNC server share
+         pure $ UNC server share
 
 -- Example: \\?\server\share
 verbatimUnc : Grammar PathToken True Volume
@@ -177,7 +177,7 @@ verbatimUnc = do verbatim
                  server <- match PTText
                  bodySeparator
                  share <- match PTText
-                 Core.pure $ UNC server share
+                 pure $ UNC server share
 
 -- Example: C:
 disk : Grammar PathToken True Volume


### PR DESCRIPTION
- Despecialize Core's implementation of Functor, Applicative, and Monad
- Add Core's HasIO implementation and an unliftCore (`Core a -> IO (Either Error a)`)

Part of #853.