### PR TITLE
Important `LazyList`'s operations were made to be truly lazy

### DIFF
--- a/libs/base/Control/Monad/Error/Either.idr
+++ b/libs/base/Control/Monad/Error/Either.idr
@@ -107,6 +107,9 @@ Foldable m => Foldable (EitherT e m) where
   foldr f acc (MkEitherT e)
     = foldr (\x,xs => either (const xs) (`f` xs) x) acc e
 
+  foldrLazy f acc (MkEitherT e)
+    = foldrLazy (\x,xs => either (const xs) (`f` xs) x) acc e
+
   null (MkEitherT e) = null e
 
 public export

--- a/libs/base/Data/List1.idr
+++ b/libs/base/Data/List1.idr
@@ -119,6 +119,7 @@ Monad List1 where
 export
 Foldable List1 where
   foldr c n (x ::: xs) = c x (foldr c n xs)
+  foldrLazy c n (x ::: xs) = c x (foldrLazy c n xs)
   null _ = False
 
 export

--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -418,6 +418,9 @@ public export
 implementation Foldable (Vect n) where
   foldr f e xs = foldrImpl f e id xs
 
+  foldrLazy op init [] = init
+  foldrLazy op init (x::xs) = x `op` foldrLazy op init xs
+
   null [] = True
   null _ = False
 

--- a/libs/contrib/Data/List/Lazy.idr
+++ b/libs/contrib/Data/List/Lazy.idr
@@ -10,6 +10,23 @@ data LazyList : Type -> Type where
   Nil : LazyList a
   (::) : (x : a) -> (xs : Lazy (LazyList a)) -> LazyList a
 
+--- Truly lazy functions ---
+
+public export
+(++) : LazyList a -> Lazy (LazyList a) -> LazyList a
+[]      ++ ys = ys
+(x::xs) ++ ys = x :: (xs ++ ys)
+
+public export
+foldrLazy : (func : elem -> Lazy acc -> acc) -> (init : acc) -> (input : LazyList elem) -> acc
+foldrLazy _  init [] = init
+foldrLazy op init (x::xs) = x `op` foldrLazy op init xs
+
+-- Specialized variant of `concatMap` with both `t` and `m` being `LazyList`.
+public export
+bindLazy : (a -> LazyList b) -> LazyList a -> LazyList b
+bindLazy f = foldrLazy ((++) . f) []
+
 --- Interface implementations ---
 
 public export
@@ -68,7 +85,7 @@ Functor LazyList where
 public export
 Applicative LazyList where
   pure x = [x]
-  fs <*> vs = concatMap (\f => map f vs) fs
+  fs <*> vs = bindLazy (\f => map f vs) fs
 
 public export
 Alternative LazyList where
@@ -77,7 +94,7 @@ Alternative LazyList where
 
 public export
 Monad LazyList where
-  m >>= f = concatMap f m
+  m >>= f = bindLazy f m
 
 -- There is no Traversable instance for lazy lists.
 -- The result of a traversal will be a non-lazy list in general

--- a/libs/contrib/Data/SortedMap.idr
+++ b/libs/contrib/Data/SortedMap.idr
@@ -284,6 +284,8 @@ export
 implementation Foldable (SortedMap k) where
   foldr f z = foldr f z . values
 
+  foldrLazy f z = foldrLazy f z . values
+
   null Empty = True
   null (M _ _) = False
 

--- a/libs/contrib/Data/SortedSet.idr
+++ b/libs/contrib/Data/SortedSet.idr
@@ -34,6 +34,8 @@ export
 Foldable SortedSet where
   foldr f e xs = foldr f e (Data.SortedSet.toList xs)
 
+  foldrLazy f e = foldrLazy f e . toList
+
   null (SetWrapper m) = null m
 
 ||| Set union. Inserts all elements of x into y

--- a/libs/prelude/Prelude/Types.idr
+++ b/libs/prelude/Prelude/Types.idr
@@ -185,6 +185,10 @@ public export
 Foldable Maybe where
   foldr _ z Nothing  = z
   foldr f z (Just x) = f x z
+
+  foldrLazy _ z Nothing  = z
+  foldrLazy f z (Just x) = f x z
+
   null Nothing = True
   null (Just _) = False
 
@@ -279,6 +283,10 @@ public export
 Foldable (Either e) where
   foldr f acc (Left _) = acc
   foldr f acc (Right x) = f x acc
+
+  foldrLazy f acc (Left _) = acc
+  foldrLazy f acc (Right x) = f x acc
+
   null (Left _) = True
   null (Right _) = False
 
@@ -346,6 +354,9 @@ public export
 Foldable List where
   foldr c n [] = n
   foldr c n (x::xs) = c x (foldr c n xs)
+
+  foldrLazy c n [] = n
+  foldrLazy c n (x::xs) = c x (foldrLazy c n xs)
 
   foldl f q [] = q
   foldl f q (x::xs) = foldl f (f q x) xs

--- a/tests/idris2/reg019/expected
+++ b/tests/idris2/reg019/expected
@@ -1,22 +1,29 @@
 1/1: Building lazybug (lazybug.idr)
-Error: While processing right hand side of main. Can't solve constraint between: Bool and Lazy Bool.
+Error: While processing right hand side of main3. Can't infer delay type
 
-lazybug.idr:5:22--5:34
-   |
- 5 | main = printLn $ or (map id bools)
-   |                      ^^^^^^^^^^^^
-
-Error: While processing right hand side of main2. Can't solve constraint between: Bool and Lazy Bool.
-
-lazybug.idr:8:23--8:42
-   |
- 8 | main2 = printLn $ or (map (\x => x) bools)
-   |                       ^^^^^^^^^^^^^^^^^^^
-
-Error: While processing right hand side of main4. Can't solve constraint between: Bool and Lazy Bool.
-
-lazybug.idr:14:22--14:27
+lazybug.idr:11:34--11:41
     |
- 14 | main4 = printLn $ or bools
-    |                      ^^^^^
+ 11 | main3 = printLn $ or (map (\x => Delay x) bools)
+    |                                  ^^^^^^^
+
+Error: While processing right hand side of main'. Can't solve constraint between: Bool and Lazy Bool.
+
+lazybug.idr:17:24--17:36
+    |
+ 17 | main' = printLn $ or' (map id bools)
+    |                        ^^^^^^^^^^^^
+
+Error: While processing right hand side of main2'. Can't solve constraint between: Bool and Lazy Bool.
+
+lazybug.idr:20:25--20:44
+    |
+ 20 | main2' = printLn $ or' (map (\x => x) bools)
+    |                         ^^^^^^^^^^^^^^^^^^^
+
+Error: While processing right hand side of main4'. Can't solve constraint between: Bool and Lazy Bool.
+
+lazybug.idr:26:24--26:29
+    |
+ 26 | main4' = printLn $ or' bools
+    |                        ^^^^^
 

--- a/tests/idris2/reg019/lazybug.idr
+++ b/tests/idris2/reg019/lazybug.idr
@@ -12,3 +12,15 @@ main3 = printLn $ or (map (\x => Delay x) bools)
 
 main4 : IO ()
 main4 = printLn $ or bools
+
+main' : IO ()
+main' = printLn $ or' (map id bools)
+
+main2' : IO ()
+main2' = printLn $ or' (map (\x => x) bools)
+
+main3' : IO ()
+main3' = printLn $ or' (map (\x => Delay x) bools)
+
+main4' : IO ()
+main4' = printLn $ or' bools


### PR DESCRIPTION
The current `LazyList`'s `Applicative` and `Monad` were implemented internally through usual, eager `foldr` (through `concatMap`). This led to lost laziness when using operations from these interfaces.

I propose a special lazy variant of `foldr` for `LazyList`s and reimplementing those operations using it. A function that is used to 
implement through is made `public export` because original implementations or `Applciative` and `Monad` operations were `public export` and are left so.

Lazy `concatMap` could be generalized if we had `LazyFoldable` and `LazyMonoid` interfaces, but it seems that there are not so many potential usages of such interfaces, thus this function is implemented in its specialized form for `LazyList`s.

Also, I left implementation of eager `Semigroup`'s `<+>` untouched despite the implementation of `++` is the same, because I think that lots of delaying and forcing may make computation slower when using this operation.