### PR TITLE
If the width terminal is zero make it Unbounded

### DIFF
--- a/src/Idris/Pretty.idr
+++ b/src/Idris/Pretty.idr
@@ -290,7 +290,7 @@ render doc = do
   color <- getColor
   opts <- case consoleWidth of
                Nothing => do cols <- coreLift getTermCols
-                             pure $ MkLayoutOptions (AvailablePerLine cols 1)
+                             pure $ MkLayoutOptions (if cols == 0 then Unbounded else AvailablePerLine cols 1)
                Just 0 => pure $ MkLayoutOptions Unbounded
                Just cw => pure $ MkLayoutOptions (AvailablePerLine (cast cw) 1)
   let layout = layoutPretty opts doc
@@ -302,7 +302,7 @@ renderWithoutColor doc = do
   consoleWidth <- getConsoleWidth
   opts <- case consoleWidth of
                Nothing => do cols <- coreLift getTermCols
-                             pure $ MkLayoutOptions (AvailablePerLine cols 1)
+                             pure $ MkLayoutOptions (if cols == 0 then Unbounded else AvailablePerLine cols 1)
                Just 0 => pure $ MkLayoutOptions Unbounded
                Just cw => pure $ MkLayoutOptions (AvailablePerLine (cast cw) 1)
   let layout = layoutPretty opts doc

--- a/src/Idris/Pretty.idr
+++ b/src/Idris/Pretty.idr
@@ -283,27 +283,29 @@ mutual
         parens (dot <+> concatWith (surround dot) (map pretty fields))
       go d (PWithUnambigNames fc ns rhs) = parenthesise (d > appPrec) $ group $ with_ <++> pretty ns <+> line <+> go startPrec rhs
 
+getPageWidth : {auto o : Ref ROpts REPLOpts} -> Core PageWidth
+getPageWidth = do
+  consoleWidth <- getConsoleWidth
+  case consoleWidth of
+    Nothing => do
+      cols <- coreLift getTermCols
+      pure $ if cols == 0 then Unbounded else AvailablePerLine cols 1
+    Just 0 => pure $ Unbounded
+    Just cw => pure $ AvailablePerLine (cast cw) 1
+
 export
 render : {auto o : Ref ROpts REPLOpts} -> Doc IdrisAnn -> Core String
 render doc = do
-  consoleWidth <- getConsoleWidth
   color <- getColor
-  opts <- case consoleWidth of
-               Nothing => do cols <- coreLift getTermCols
-                             pure $ MkLayoutOptions (if cols == 0 then Unbounded else AvailablePerLine cols 1)
-               Just 0 => pure $ MkLayoutOptions Unbounded
-               Just cw => pure $ MkLayoutOptions (AvailablePerLine (cast cw) 1)
+  pageWidth <- getPageWidth
+  let opts = MkLayoutOptions pageWidth
   let layout = layoutPretty opts doc
   pure $ renderString $ if color then reAnnotateS colorAnn layout else unAnnotateS layout
 
 export
 renderWithoutColor : {auto o : Ref ROpts REPLOpts} -> Doc IdrisAnn -> Core String
 renderWithoutColor doc = do
-  consoleWidth <- getConsoleWidth
-  opts <- case consoleWidth of
-               Nothing => do cols <- coreLift getTermCols
-                             pure $ MkLayoutOptions (if cols == 0 then Unbounded else AvailablePerLine cols 1)
-               Just 0 => pure $ MkLayoutOptions Unbounded
-               Just cw => pure $ MkLayoutOptions (AvailablePerLine (cast cw) 1)
+  pageWidth <- getPageWidth
+  let opts = MkLayoutOptions pageWidth
   let layout = layoutPretty opts doc
   pure $ renderString $ unAnnotateS layout


### PR DESCRIPTION
Fixes the extra newlines described in https://github.com/meraymond2/idris-vscode/issues/23