### PR TITLE
Remove lamdaRequire

### DIFF
--- a/docs/source/backends/javascript.rst
+++ b/docs/source/backends/javascript.rst
@@ -30,11 +30,10 @@ expression.
 
 .. code-block:: idris
 
-    %foreign "node:lambdaRequire:fs:fp=>__require_fs.fstatSync(fp.fd, {bigint: true}).size"
+    %foreign "node:lambda:fp=>require('fs').fstatSync(fp.fd, {bigint: true}).size"
     prim__fileSize : FilePtr -> PrimIO Int
 
-``lambdaRequire`` also accepts a list of separated modules and assigns
-them the name ``__require_<module name>``.
+``require`` can be used to import javascript modules.
 
 For completion below an example of a foreign available only with ``browser`` codegen:
 

--- a/libs/base/Data/Buffer.idr
+++ b/libs/base/Data/Buffer.idr
@@ -233,11 +233,11 @@ copyData src start len dest loc
     = primIO (prim__copyData src start len dest loc)
 
 %foreign "C:idris2_readBufferData,libidris2_support"
-         "node:lambdaRequire:fs:(f,b,l,m) => BigInt(__require_fs.readSync(f.fd,b,Number(l), Number(m)))"
+         "node:lambda:(f,b,l,m) => BigInt(require('fs').readSync(f.fd,b,Number(l), Number(m)))"
 prim__readBufferData : FilePtr -> Buffer -> Int -> Int -> PrimIO Int
 
 %foreign "C:idris2_writeBufferData,libidris2_support"
-         "node:lambdaRequire:fs:(f,b,l,m) => BigInt(__require_fs.writeSync(f.fd,b,Number(l), Number(m)))"
+         "node:lambda:(f,b,l,m) => BigInt(require('fs').writeSync(f.fd,b,Number(l), Number(m)))"
 prim__writeBufferData : FilePtr -> Buffer -> Int -> Int -> PrimIO Int
 
 export

--- a/libs/base/System/File.idr
+++ b/libs/base/System/File.idr
@@ -22,7 +22,7 @@ libc fn = "C:" ++ fn ++ ", libc 6"
 prim__open : String -> String -> PrimIO FilePtr
 
 %foreign support "idris2_closeFile"
-         "node:lambdaRequire:fs:(fp) => __require_fs.closeSync(fp.fd)"
+         "node:lambda:(fp) => require('fs').closeSync(fp.fd)"
 prim__close : FilePtr -> PrimIO ()
 
 %foreign support "idris2_fileError"
@@ -43,7 +43,7 @@ prim__readChars : Int -> FilePtr -> PrimIO (Ptr String)
 prim__readChar : FilePtr -> PrimIO Int
 
 %foreign support "idris2_writeLine"
-         "node:lambdaRequire:fs:(filePtr, line) => __require_fs.writeSync(filePtr.fd, line, undefined, 'utf-8')"
+         "node:lambda:(filePtr, line) => require('fs').writeSync(filePtr.fd, line, undefined, 'utf-8')"
 prim__writeLine : FilePtr -> String -> PrimIO Int
 
 %foreign support "idris2_eof"
@@ -61,7 +61,7 @@ prim__pclose : FilePtr -> PrimIO ()
 prim__removeFile : String -> PrimIO Int
 
 %foreign support "idris2_fileSize"
-         "node:lambdaRequire:fs:fp=>__require_fs.fstatSync(fp.fd, {bigint: true}).size"
+         "node:lambda:fp=>require('fs').fstatSync(fp.fd, {bigint: true}).size"
 prim__fileSize : FilePtr -> PrimIO Int
 
 %foreign support "idris2_fileSize"
@@ -71,7 +71,7 @@ prim__fPoll : FilePtr -> PrimIO Int
 prim__fileAccessTime : FilePtr -> PrimIO Int
 
 %foreign support "idris2_fileModifiedTime"
-         "node:lambdaRequire:fs:fp=>__require_fs.fstatSync(fp.fd, {bigint: true}).mtimeMs / 1000n"
+         "node:lambda:fp=>require('fs').fstatSync(fp.fd, {bigint: true}).mtimeMs / 1000n"
 prim__fileModifiedTime : FilePtr -> PrimIO Int
 
 %foreign support "idris2_fileStatusTime"


### PR DESCRIPTION
Currently `lambdaRequire`  is [buggy](https://github.com/idris-lang/Idris2/issues/849) and it requires users type out the mangled name. Since Node caches `require`s I do not see any reason to keep it. If the tiny performance hit (0.000172294ms per require) is really an issue, I can adapt this to search for `require`s with a static string as an argument and replace them with a variable.