### PR TITLE
Add `countExactly` to Text.Parser in libs/contrib to return a Vect

### DIFF
--- a/libs/contrib/Text/Parser.idr
+++ b/libs/contrib/Text/Parser.idr
@@ -115,9 +115,7 @@ countExactly : (n : Nat) ->
                (p : Grammar tok True a) ->
                Grammar tok (isSucc n) (Vect n a)
 countExactly Z p = Empty []
-countExactly (S k) p = do x <- p
-                          seq (countExactly k p)
-                              (\ xs => pure (x :: xs))
+countExactly (S k) p = [| p :: countExactly k p |]
 
 mutual
   ||| Parse one or more instances of `p` until `end` succeeds, returning the

--- a/libs/contrib/Text/Parser.idr
+++ b/libs/contrib/Text/Parser.idr
@@ -3,6 +3,7 @@ module Text.Parser
 import Data.Bool
 import Data.List
 import Data.Nat
+import Data.Vect
 
 import public Text.Parser.Core
 import public Text.Quantity
@@ -107,6 +108,16 @@ mutual
   count (Qty (S min) Nothing) p = count1 (atLeast min) p
   count (Qty (S min) (Just Z)) _ = fail "Quantity out of order"
   count (Qty (S min) (Just (S max))) p = count1 (between min max) p
+
+||| Parse `p` `n` times, returning the vector of values.
+export
+countExactly : (n : Nat) ->
+               (p : Grammar tok True a) ->
+               Grammar tok (isSucc n) (Vect n a)
+countExactly Z p = Empty []
+countExactly (S k) p = do x <- p
+                          seq (countExactly k p)
+                              (\ xs => pure (x :: xs))
 
 mutual
   ||| Parse one or more instances of `p` until `end` succeeds, returning the


### PR DESCRIPTION
`count` currenty only returns lists with unknown length:
```idris
mutual
  private
  count1 : (q : Quantity) ->
           (p : Grammar tok True a) ->
           Grammar tok True (List a)
  count1 q p = do x <- p
                  seq (count q p)
                      (\xs => pure (x :: xs))
  ||| Parse `p`, repeated as specified by `q`, returning the list of values.
  export
  count : (q : Quantity) ->
          (p : Grammar tok True a) ->
          Grammar tok (isSucc (min q)) (List a)
  count (Qty Z Nothing) p = many p
  count (Qty Z (Just Z)) _ = pure []
  count (Qty Z (Just (S max))) p = option [] $ count1 (atMost max) p
  count (Qty (S min) Nothing) p = count1 (atLeast min) p
  count (Qty (S min) (Just Z)) _ = fail "Quantity out of order"
  count (Qty (S min) (Just (S max))) p = count1 (between min max) p
```


I don't think idris can figure out the length later on, so either we give a proof for the length of the list or we do something like I did in this PR.
So instead I introduced `countExactly` to return a `Vect n` instead of a `List`

Please don't accept it blindly and let me know if you think this can be improved.
