### PR TITLE
Progress towards building with Idris 0.2.1

### DIFF
--- a/idris2api.ipkg
+++ b/idris2api.ipkg
@@ -6,6 +6,12 @@ modules =
     Algebra.Semiring,
     Algebra.ZeroOneOmega,
 
+    -- Compatibility libraries; things in the Idris 2 libraries we use, but
+    -- not necessarily available in the version being used for building
+    -- Idris 2 itself
+    Compat.Data.Bifunctor,
+    Compat.Data.These,
+
     Compiler.ANF,
     Compiler.Common,
     Compiler.CompileExpr,

--- a/idris2api.ipkg
+++ b/idris2api.ipkg
@@ -10,6 +10,7 @@ modules =
     -- not necessarily available in the version being used for building
     -- Idris 2 itself
     Compat.Data.Bifunctor,
+    Compat.Data.String.Iterator,
     Compat.Data.These,
 
     Compiler.ANF,

--- a/libs/base/Data/Bifunctor.idr
+++ b/libs/base/Data/Bifunctor.idr
@@ -1,0 +1,45 @@
+module Data.Bifunctor
+
+||| Bifunctors
+||| @f The action of the Bifunctor on pairs of objects
+public export
+interface Bifunctor f where
+  ||| The action of the Bifunctor on pairs of morphisms
+  |||
+  ||| ````idris example
+  ||| bimap (\x => x + 1) reverse (1, "hello") == (2, "olleh")
+  ||| ````
+  |||
+  bimap : (a -> c) -> (b -> d) -> f a b -> f c d
+  bimap f g = mapFst f . mapSnd g
+
+  ||| The action of the Bifunctor on morphisms pertaining to the first object
+  |||
+  ||| ````idris example
+  ||| mapFst (\x => x + 1) (1, "hello") == (2, "hello")
+  ||| ````
+  |||
+  mapFst : (a -> c) -> f a b -> f c b
+  mapFst f = bimap f id
+
+  ||| The action of the Bifunctor on morphisms pertaining to the second object
+  |||
+  ||| ````idris example
+  ||| mapSnd reverse (1, "hello") == (1, "olleh")
+  ||| ````
+  |||
+  mapSnd : (b -> d) -> f a b -> f a d
+  mapSnd = bimap id
+
+public export
+mapHom : Bifunctor f => (a -> b) -> f a a -> f b b
+mapHom f = bimap f f
+
+public export
+Bifunctor Pair where
+  bimap f g (x, y) = (f x, g y)
+
+public export
+Bifunctor Either where
+  bimap f _ (Left x) = Left (f x)
+  bimap _ g (Right y) = Right (g y)

--- a/libs/base/Data/Either.idr
+++ b/libs/base/Data/Either.idr
@@ -1,5 +1,6 @@
 module Data.Either
 
+import Data.Bifunctor
 import Data.List1
 
 %default total

--- a/libs/base/base.ipkg
+++ b/libs/base/base.ipkg
@@ -12,6 +12,7 @@ modules = Control.App,
           Control.Monad.Trans,
           Control.WellFounded,
 
+          Data.Bifunctor,
           Data.Bool,
           Data.Bool.Xor,
           Data.Buffer,

--- a/libs/prelude/Prelude/Interfaces.idr
+++ b/libs/prelude/Prelude/Interfaces.idr
@@ -105,41 +105,6 @@ public export
 ignore : Functor f => f a -> f ()
 ignore = map (const ())
 
-||| Bifunctors
-||| @f The action of the Bifunctor on pairs of objects
-public export
-interface Bifunctor f where
-  ||| The action of the Bifunctor on pairs of morphisms
-  |||
-  ||| ````idris example
-  ||| bimap (\x => x + 1) reverse (1, "hello") == (2, "olleh")
-  ||| ````
-  |||
-  bimap : (a -> c) -> (b -> d) -> f a b -> f c d
-  bimap f g = mapFst f . mapSnd g
-
-  ||| The action of the Bifunctor on morphisms pertaining to the first object
-  |||
-  ||| ````idris example
-  ||| mapFst (\x => x + 1) (1, "hello") == (2, "hello")
-  ||| ````
-  |||
-  mapFst : (a -> c) -> f a b -> f c b
-  mapFst f = bimap f id
-
-  ||| The action of the Bifunctor on morphisms pertaining to the second object
-  |||
-  ||| ````idris example
-  ||| mapSnd reverse (1, "hello") == (1, "olleh")
-  ||| ````
-  |||
-  mapSnd : (b -> d) -> f a b -> f a d
-  mapSnd = bimap id
-
-public export
-mapHom : Bifunctor f => (a -> b) -> f a a -> f b b
-mapHom f = bimap f f
-
 public export
 interface Functor f => Applicative f where
   pure : a -> f a

--- a/libs/prelude/Prelude/Types.idr
+++ b/libs/prelude/Prelude/Types.idr
@@ -94,13 +94,8 @@ natToInteger (S k) = 1 + natToInteger k
 
 %inline
 public export
-Bifunctor Pair where
-  bimap f g (x, y) = (f x, g y)
-
-%inline
-public export
 Functor (Pair a) where
-  map = mapSnd
+  map f (x, y) = (x, f y)
 
 -----------
 -- MAYBE --
@@ -249,12 +244,6 @@ public export
 Functor (Either e) where
   map f (Left x) = Left x
   map f (Right x) = Right (f x)
-
-%inline
-public export
-Bifunctor Either where
-  bimap f _ (Left x) = Left (f x)
-  bimap _ g (Right y) = Right (g y)
 
 %inline
 public export

--- a/src/Compat/Data/Bifunctor.idr
+++ b/src/Compat/Data/Bifunctor.idr
@@ -1,0 +1,45 @@
+module Compat.Data.Bifunctor
+
+||| Bifunctors
+||| @f The action of the Bifunctor on pairs of objects
+public export
+interface Bifunctor f where
+  ||| The action of the Bifunctor on pairs of morphisms
+  |||
+  ||| ````idris example
+  ||| bimap (\x => x + 1) reverse (1, "hello") == (2, "olleh")
+  ||| ````
+  |||
+  bimap : (a -> c) -> (b -> d) -> f a b -> f c d
+  bimap f g = mapFst f . mapSnd g
+
+  ||| The action of the Bifunctor on morphisms pertaining to the first object
+  |||
+  ||| ````idris example
+  ||| mapFst (\x => x + 1) (1, "hello") == (2, "hello")
+  ||| ````
+  |||
+  mapFst : (a -> c) -> f a b -> f c b
+  mapFst f = bimap f id
+
+  ||| The action of the Bifunctor on morphisms pertaining to the second object
+  |||
+  ||| ````idris example
+  ||| mapSnd reverse (1, "hello") == (1, "olleh")
+  ||| ````
+  |||
+  mapSnd : (b -> d) -> f a b -> f a d
+  mapSnd = bimap id
+
+public export
+mapHom : Bifunctor f => (a -> b) -> f a a -> f b b
+mapHom f = bimap f f
+
+public export
+Bifunctor Pair where
+  bimap f g (x, y) = (f x, g y)
+
+public export
+Bifunctor Either where
+  bimap f _ (Left x) = Left (f x)
+  bimap _ g (Right y) = Right (g y)

--- a/src/Compat/Data/String/Iterator.idr
+++ b/src/Compat/Data/String/Iterator.idr
@@ -1,0 +1,74 @@
+module Compat.Data.String.Iterator
+
+import public Data.List.Lazy
+
+%default total
+
+-- Backend-dependent string iteration type,
+-- parameterised by the string that it iterates over.
+--
+-- Beware: the index is checked only up to definitional equality.
+-- In theory, you could run `decEq` on two strings
+-- with the same content but allocated in different memory locations
+-- and use the obtained Refl to coerce iterators between them.
+--
+-- The strictly correct solution is to make the iterators independent
+-- from the exact memory location of the string given to `uncons`.
+-- (For example, byte offsets satisfy this requirement.)
+export
+data StringIterator : String -> Type where [external]
+
+-- This function is private
+-- to avoid subverting the linearity guarantees of withString.
+%foreign
+  "scheme:blodwen-string-iterator-new"
+  "javascript:stringIterator:new"
+private
+fromString : (str : String) -> StringIterator str
+
+-- This function uses a linear string iterator
+-- so that backends can use mutating iterators.
+export
+withString : (str : String) -> ((1 it : StringIterator str) -> a) -> a
+withString str f = f (fromString str)
+
+-- We use a custom data type instead of Maybe (Char, StringIterator)
+-- to remove one level of pointer indirection
+-- in every iteration of something that's likely to be a hot loop,
+-- and to avoid one allocation per character.
+--
+-- The Char field of Character is unrestricted for flexibility.
+public export
+data UnconsResult : String -> Type where
+  EOF : UnconsResult str
+  Character : (c : Char) -> (1 it : StringIterator str) -> UnconsResult str
+
+-- We pass the whole string to the uncons function
+-- to avoid yet another allocation per character
+-- because for many backends, StringIterator can be simply an integer
+-- (e.g. byte offset into an UTF-8 string).
+%foreign
+  "scheme:blodwen-string-iterator-next"
+  "javascript:stringIterator:next"
+export
+uncons : (str : String) -> (1 it : StringIterator str) -> UnconsResult str
+
+export
+foldl : (accTy -> Char -> accTy) -> accTy -> String -> accTy
+foldl op acc str = withString str (loop acc)
+  where
+    loop : accTy -> (1 it : StringIterator str) -> accTy
+    loop acc it =
+      case uncons str it of
+        EOF => acc
+        Character c it' => loop (acc `op` c) (assert_smaller it it')
+
+export
+unpack : String -> LazyList Char
+unpack str = withString str unpack'
+  where
+    unpack' : (1 it : StringIterator str) -> LazyList Char
+    unpack' it =
+      case uncons str it of
+        EOF => []
+        Character c it' => c :: Delay (unpack' $ assert_smaller it it')

--- a/src/Compat/Data/These.idr
+++ b/src/Compat/Data/These.idr
@@ -1,6 +1,6 @@
-module Data.These
+module Compat.Data.These
 
-import Data.Bifunctor
+import Compat.Data.Bifunctor
 
 %default total
 

--- a/src/Core/Hash.idr
+++ b/src/Core/Hash.idr
@@ -1,5 +1,7 @@
 module Core.Hash
 
+import Compat.Data.String.Iterator
+
 import Core.CaseTree
 import Core.TT
 
@@ -7,7 +9,6 @@ import Data.List
 import Data.List1
 import Data.List.Lazy
 import Data.Strings
-import Data.String.Iterator
 
 %default covering
 

--- a/src/Core/Options/Log.idr
+++ b/src/Core/Options/Log.idr
@@ -6,7 +6,7 @@ import Data.Maybe
 import Data.StringMap
 import Data.StringTrie
 import Data.Strings
-import Data.These
+import Compat.Data.These
 import Text.PrettyPrint.Prettyprinter
 
 %default total

--- a/src/Data/StringTrie.idr
+++ b/src/Data/StringTrie.idr
@@ -1,6 +1,7 @@
 module Data.StringTrie
 
-import Data.These
+import Compat.Data.Bifunctor
+import Compat.Data.These
 import Data.StringMap
 
 %default total

--- a/src/Idris/Error.idr
+++ b/src/Idris/Error.idr
@@ -1,5 +1,7 @@
 module Idris.Error
 
+import Compat.Data.Bifunctor
+
 import Core.CaseTree
 import Core.Core
 import Core.Context

--- a/src/Idris/IDEMode/CaseSplit.idr
+++ b/src/Idris/IDEMode/CaseSplit.idr
@@ -1,5 +1,7 @@
 module Idris.IDEMode.CaseSplit
 
+import Compat.Data.Bifunctor
+
 import Core.Context
 import Core.Env
 import Core.Metadata

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -1,5 +1,7 @@
 module Idris.Package
 
+import Compat.Data.These
+
 import Compiler.Common
 
 import Core.Context
@@ -15,7 +17,6 @@ import Data.So
 import Data.StringMap
 import Data.Strings
 import Data.StringTrie
-import Data.These
 
 import Parser.Package
 import System

--- a/src/Idris/Parser/Let.idr
+++ b/src/Idris/Parser/Let.idr
@@ -1,5 +1,7 @@
 module Idris.Parser.Let
 
+import Compat.Data.Bifunctor
+
 import Idris.Syntax
 import Text.Bounded
 

--- a/tests/idris2/interface006/Apply.idr
+++ b/tests/idris2/interface006/Apply.idr
@@ -1,5 +1,7 @@
 module Apply
 
+import Data.Bifunctor
+
 -- These are not Biapplicatives.  Those are in Data.Biapplicative
 
 infixl 4 <<$>>, <<&>>, <<.>>, <<., .>>, <<..>>

--- a/tests/idris2/interface006/Biapplicative.idr
+++ b/tests/idris2/interface006/Biapplicative.idr
@@ -1,6 +1,7 @@
 module Biapplicative
 
 import Apply
+import Data.Bifunctor
 
 infixl 4 <<*>>, <<*, *>>, <<**>>
 

--- a/tests/idris2/interface006/Bimonad.idr
+++ b/tests/idris2/interface006/Bimonad.idr
@@ -1,6 +1,7 @@
 module Bimonad
 
 import Biapplicative
+import Data.Bifunctor
 
 infixl 4 >>==
 


### PR DESCRIPTION
We've lost the ability to build with the previous version, largely due to some library changes. This is a start at making things compatible again, mostly by adding a compatibility layer in the source. At least some of these should probably be removed again after 0.2.2 is released. We should also add a step to CI that builds with https://www.idris-lang.org/idris2-src/idris2-latest.tgz so we don't get into this hole again.

The biggest remaining challenge is how to deal with the change of constructor in `Data.List1`. It might be that the easiest solution is to release a 0.2.1.1 which does little other than update the List1 API.