### PR TITLE
Build from stable as a CI step

### DIFF
--- a/.github/workflows/ci-api.yml
+++ b/.github/workflows/ci-api.yml
@@ -12,7 +12,6 @@ on:
 env:
   SCHEME: scheme
   IDRIS2_TESTS_CG: chez
-  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
 jobs:
   build:
@@ -23,7 +22,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get install -y chezscheme
-          echo "::add-path::$HOME/.idris2/bin"
+        echo "$HOME/.idris2/bin" >> $GITHUB_PATH
       - name: Build from bootstrap
         run: make bootstrap && make install && idris2 --clean idris2api.ipkg && make install-api
         shell: bash

--- a/.github/workflows/ci-api.yml
+++ b/.github/workflows/ci-api.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get install -y chezscheme
-        echo "$HOME/.idris2/bin" >> $GITHUB_PATH
+          echo "$HOME/.idris2/bin" >> $GITHUB_PATH
       - name: Build from bootstrap
         run: make bootstrap && make install && idris2 --clean idris2api.ipkg && make install-api
         shell: bash

--- a/.github/workflows/ci-build-from-stable.yml
+++ b/.github/workflows/ci-build-from-stable.yml
@@ -1,0 +1,40 @@
+name: Ubuntu
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - master
+
+env:
+  SCHEME: scheme
+  IDRIS2_TESTS_CG: chez
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install build dependencies
+        run: |
+          sudo apt-get install -y chezscheme
+          echo "$HOME/.idris2/bin" >> $GITHUB_PATH
+      - name: Install stable version
+        run: |
+          mkdir ../stable
+          cd ../stable
+          wget https://www.idris-lang.org/idris2-src/idris2-latest.tgz
+          tar -xf idris2-latest.tgz
+          cd Idris2*
+          make bootstrap SCHEME=chez
+          make install
+      - name: Build current from stable
+        run: make all && make install
+        shell: bash
+      - name: Build and test self-hosted
+        run: make clean && make all && make test INTERACTIVE=''
+        shell: bash

--- a/.github/workflows/ci-build-from-stable.yml
+++ b/.github/workflows/ci-build-from-stable.yml
@@ -1,4 +1,4 @@
-name: Ubuntu
+name: Build from Stable
 on:
   push:
     branches:

--- a/.github/workflows/ci-build-from-stable.yml
+++ b/.github/workflows/ci-build-from-stable.yml
@@ -26,7 +26,7 @@ jobs:
           wget https://www.idris-lang.org/idris2-src/idris2-latest.tgz
           tar -xf idris2-latest.tgz
           cd Idris2*
-          make bootstrap SCHEME=chez
+          make bootstrap SCHEME=scheme
           make install
           rm -rf ./Idris2*
       - name: Checkout

--- a/.github/workflows/ci-build-from-stable.yml
+++ b/.github/workflows/ci-build-from-stable.yml
@@ -17,21 +17,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
       - name: Install build dependencies
         run: |
           sudo apt-get install -y chezscheme
           echo "$HOME/.idris2/bin" >> $GITHUB_PATH
       - name: Install stable version
         run: |
-          mkdir ../stable
-          cd ../stable
           wget https://www.idris-lang.org/idris2-src/idris2-latest.tgz
           tar -xf idris2-latest.tgz
           cd Idris2*
           make bootstrap SCHEME=chez
           make install
+          rm -rf ./Idris2*
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Build current from stable
         run: make all && make install
         shell: bash

--- a/.github/workflows/ci-build-from-stable.yml
+++ b/.github/workflows/ci-build-from-stable.yml
@@ -28,6 +28,7 @@ jobs:
           cd Idris2*
           make bootstrap SCHEME=scheme
           make install
+          cd ..
           rm -rf ./Idris2*
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -11,7 +11,6 @@ on:
 env:
   SCHEME: chez
   IDRIS2_TESTS_CG: chez
-  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
 jobs:
   build:
@@ -23,7 +22,7 @@ jobs:
         run: |
           brew install chezscheme
           brew install coreutils
-          echo "::add-path::$HOME/.idris2/bin"
+          echo "$HOME/.idris2/bin" >> $GITHUB_PATH
       - name: Build and test Idris 2 from bootstrap
         run: make bootstrap && make install
         shell: bash

--- a/.github/workflows/ci-ubuntu-racket.yml
+++ b/.github/workflows/ci-ubuntu-racket.yml
@@ -11,7 +11,6 @@ on:
 
 env:
   IDRIS2_TESTS_CG: racket
-  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
 jobs:
   build:

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -12,7 +12,6 @@ on:
 env:
   SCHEME: scheme
   IDRIS2_TESTS_CG: chez
-  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
 jobs:
   build:
@@ -23,7 +22,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get install -y chezscheme
-          echo "::add-path::$HOME/.idris2/bin"
+          echo "$HOME/.idris2/bin" >> $GITHUB_PATH
       - name: Build from bootstrap
         run: make bootstrap && make install
         shell: bash


### PR DESCRIPTION
Following up with a request by @edwinb (via Slack #idris channel) that new PRs are built by the latest stable compiler as a CI step to ensure that each version can always be built by the previous version.

Unsurprisingly, the new CI workflow will fail until we get `master` back to a compatible state with v0.2.1.

I took the liberty of also removing the uses of `ACTIONS_ALLOW_UNSECURE_COMMANDS` where it was trivial to do so (i.e. everywhere except for the Windows workflow where insecure commands are used more liberally, although it would still be quite reasonable to update that Workflow as well).

I went with Edwin's idea of pulling the latest stable source tar file because that seemed like a pretty reasonable way to ensure we are talking about the stable compiler any user might get if they downloaded it as a standalone package.