### PR TITLE
Add it to REPL

### DIFF
--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -643,9 +643,10 @@ process (Eval itm)
                  ntm <- norm defs [] tm
                  logTermNF "repl.eval" 5 "Normalised" [] ntm
                  itm <- resugar [] ntm
+                 ty <- getTerm gty
+                 addDef (UN "it") (newDef emptyFC (UN "it") top [] ty Private (PMDef defaultPI [] (STerm 0 ntm) (STerm 0 ntm) []))
                  if showTypes opts
-                    then do ty <- getTerm gty
-                            ity <- resugar [] !(norm defs [] ty)
+                    then do ity <- resugar [] !(norm defs [] ty)
                             pure (Evaluated itm (Just ity))
                     else pure (Evaluated itm Nothing)
   where

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -75,7 +75,7 @@ idrisTests = MkTestPool []
        "interface021",
        -- Miscellaneous REPL
        "interpreter001", "interpreter002", "interpreter003", "interpreter004",
-       "interpreter005",
+       "interpreter005", "interpreter006",
        -- Implicit laziness, lazy evaluation
        "lazy001",
        -- QTT and linearity related

--- a/tests/idris2/interpreter006/expected
+++ b/tests/idris2/interpreter006/expected
@@ -1,0 +1,7 @@
+Main> 4
+Main> 4
+Main> 4
+Main> "test"
+Main> it : String
+Main> "test"
+Main> Bye for now!

--- a/tests/idris2/interpreter006/input
+++ b/tests/idris2/interpreter006/input
@@ -1,0 +1,7 @@
+2+2
+it
+it
+"test"
+:t it
+it
+:q

--- a/tests/idris2/interpreter006/run
+++ b/tests/idris2/interpreter006/run
@@ -1,0 +1,1 @@
+$1 --no-color --console-width 0 --no-banner < input


### PR DESCRIPTION
Implement `it` in the REPL. Since this is in the contributions wanted and is easy to implement, I figured I would add it. I would be willing to try improve `:let` and add `:unlet` if that is wanted, but I would need to know if and how the behavior should be different from Idris 1 before I start. I'm not entirely sure if I did this right, but it works.