### PR TITLE
Add CI action to build from older version

### DIFF
--- a/.github/workflows/ci-buildprevious.yml
+++ b/.github/workflows/ci-buildprevious.yml
@@ -29,7 +29,7 @@ jobs:
           wget https://www.idris-lang.org/idris2-src/idris2-0.2.2.tgz
           tar zxvf idris2-0.2.2.tgz
           cd Idris2-0.2.2
-          make bootstrap && make install
+          make bootstrap-build && make install
           cd ..
       - name: Build from previous version
         run: make all

--- a/.github/workflows/ci-buildprevious.yml
+++ b/.github/workflows/ci-buildprevious.yml
@@ -1,0 +1,35 @@
+name: Build From Previous Version
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - master
+
+env:
+  SCHEME: scheme
+  IDRIS2_TESTS_CG: chez
+  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install build dependencies
+        run: |
+          sudo apt-get install -y chezscheme
+          echo "::add-path::$HOME/.idris2/bin"
+      - name : Build previous version
+        run: |
+          wget https://www.idris-lang.org/idris2-src/idris2-0.2.2.tgz
+          tar zxvf idris2-0.2.2.tgz
+          cd Idris2-0.2.2
+          make bootstrap && make install
+          cd ..
+      - name: Build from previous version
+        run: make all


### PR DESCRIPTION
Specifically, at the moment, to build from Idris 0.2.2 (which is not yet released, but is basically 0.2.1 plus a few bits that are needed to build the latest version). I suggest we keep this at the earliest version known to work, though there is also no need to be shy about increasing the minimum requirements when we need to.

This CI action skips the tests - it's just about knowing whether the APIs are still up to date.

I'll release 0.2.2 soon, then 0.3.0 not long after, after checking over the latest PRs.