### PR TITLE
Add rlwrap information to docs

### DIFF
--- a/docs/source/faq/faq.rst
+++ b/docs/source/faq/faq.rst
@@ -35,7 +35,7 @@ Can Idris 2 generate Javascript? What about plug-in code generators?
 Yes! A `JavaScript code generator <https://idris2.readthedocs.io/en/latest/backends/javascript.html>`_
 is built in, and can target either the browser or NodeJS.
 
-Like Idris 1, Idris 2 
+Like Idris 1, Idris 2
 `supports plug-in code generation <https://idris2.readthedocs.io/en/latest/backends/custom.html>`_
 to allow you to write a back end for the platform of your choice.
 
@@ -54,6 +54,15 @@ Also, being implemented in Idris, we've been able to take advantage of the
 type system to remove some significant sources of bugs!
 
 You can find more details in Section :ref:`updates-index`.
+
+How do I get command history in the Idris2 REPL?
+================================================
+
+The Idris2 repl does not support readline in the interest of
+keeping dependencies minimal. A useful work around is to
+install `rlwrap <https://linux.die.net/man/1/rlwrap>`_, this
+utility provides command history simply by invoking the Idris2
+repl as an argument to the utility ``rlwrap idris2``.
 
 Where can I find more answers?
 ==============================

--- a/docs/source/tutorial/interactive.rst
+++ b/docs/source/tutorial/interactive.rst
@@ -26,9 +26,8 @@ available (though not yet updated for Idris 2).
 Editing at the REPL
 ===================
 
-.. pull-quote::
-  Readline functionality in REPL:
-  the Idris2 repl does not support readline in the interest of
+.. note::
+  The Idris2 repl does not support readline in the interest of
   keeping dependencies minimal. Unfortunately this precludes some
   niceties such as line editing, persistent history and completion.
   A useful work around is to install `rlwrap <https://linux.die.net/man/1/rlwrap>`_,

--- a/docs/source/tutorial/interactive.rst
+++ b/docs/source/tutorial/interactive.rst
@@ -26,6 +26,15 @@ available (though not yet updated for Idris 2).
 Editing at the REPL
 ===================
 
+.. pull-quote::
+  Readline functionality in REPL:
+  the Idris2 repl does not support readline in the interest of
+  keeping dependencies minimal. Unfortunately this precludes some
+  niceties such as line editing, persistent history and completion.
+  A useful work around is to install `rlwrap <https://linux.die.net/man/1/rlwrap>`_,
+  this utility provides all the aforementioned features simply by
+  invoking the Idris2 repl as an argument to the utility ``rlwrap idris2``
+
 The REPL provides a number of commands, which we will describe
 shortly, which generate new program fragments based on the currently
 loaded module. These take the general form:
@@ -251,6 +260,6 @@ Corresponding commands are also available in the Emacs mode. Support
 for other editors can be added in a relatively straightforward manner
 by using ``idris2 -–client``.
 More sophisticated support can be added by using the IDE protocol (yet to
-be documented for Idris 2, but which mostly extends to protocol documented for 
+be documented for Idris 2, but which mostly extends to protocol documented for
 `Idris 1 <https://docs.idris-lang.org/en/latest/reference/ide-protocol.html>`_.
 


### PR DESCRIPTION
This PR adds some documentation about how one can get command history in the Idris2 repl by using the rlwrap utility.