### PR TITLE
Extract findDataFile code from readDataFile and export it

### DIFF
--- a/src/Core/Directory.idr
+++ b/src/Core/Directory.idr
@@ -28,14 +28,22 @@ firstAvailable (f :: fs)
 
 export
 covering
-readDataFile : {auto c : Ref Ctxt Defs} ->
+findDataFile : {auto c : Ref Ctxt Defs} ->
                String -> Core String
-readDataFile fname
+findDataFile fname
     = do d <- getDirs
          let fs = map (\p => p </> fname) (data_dirs d)
          Just f <- firstAvailable fs
             | Nothing => throw (InternalError ("Can't find data file " ++ fname ++
                                                " in any of " ++ show fs))
+         pure f
+
+export
+covering
+readDataFile : {auto c : Ref Ctxt Defs} ->
+               String -> Core String
+readDataFile fname
+    = do f <- findDataFile fname
          Right d <- coreLift $ readFile f
             | Left err => throw (FileErr f err)
          pure d


### PR DESCRIPTION
For some codegens it is useful to get access to the filename of a supporting data file instead of just the content of that file. For example, this is needed in the case where a subcommand is invoked which expects a path to the support file as argument.

This PR splits the "finding" and "reading" of the data file and exports both. The existing `readDataFile` function works the same as before and thus should not impact any existing code.