### PR TITLE
test: Change function definitions in "Generic.idr".

### DIFF
--- a/tests/typedd-book/chapter02/Generic.idr
+++ b/tests/typedd-book/chapter02/Generic.idr
@@ -11,10 +11,10 @@ identity : ty -> ty
 identity x = x
 
 doubleNat : Nat -> Nat
-doubleNat x = x * x
+doubleNat x = x + x
 
 doubleInteger : Integer -> Integer
-doubleInteger x = x * x
+doubleInteger x = x + x
 
 double : Num ty => ty -> ty
-double x = x * x
+double x = x + x


### PR DESCRIPTION
Seemed like the doubling functions had incorrect function definitions, so I changed them such that they actually double their inputs instead of squaring them.