### PR TITLE
Add count to prelude

### DIFF
--- a/libs/prelude/Prelude/Interfaces.idr
+++ b/libs/prelude/Prelude/Interfaces.idr
@@ -228,6 +228,11 @@ public export
 foldlM : (Foldable t, Monad m) => (funcM: a -> b -> m a) -> (init: a) -> (input: t b) -> m a
 foldlM fm a0 = foldl (\ma,b => ma >>= flip fm b) (pure a0)
 
+||| Maps each element to a value and combine them
+public export
+foldMap : (Foldable t, Monoid m) => (a -> m) -> t a -> m
+foldMap f = foldr ((<+>) . f) neutral
+
 ||| Combine each element of a structure into a monoid.
 public export
 concat : (Foldable t, Monoid a) => t a -> a

--- a/libs/prelude/Prelude/Types.idr
+++ b/libs/prelude/Prelude/Types.idr
@@ -88,6 +88,11 @@ natToInteger (S k) = 1 + natToInteger k
                          -- integer (+) may be non-linear in second
                          -- argument
 
+||| Counts the number of elements that satify a predicate.
+public export
+count : (Foldable t) => (predicate : a -> Bool) -> (t a) -> Nat
+count predicate = foldr (\v => if predicate v then S else id) Z
+
 -----------
 -- PAIRS --
 -----------

--- a/tests/idris2/total006/Total.idr
+++ b/tests/idris2/total006/Total.idr
@@ -1,5 +1,5 @@
-count : Nat -> Stream Nat
-count n = n :: count (S n)
+streamCount : Nat -> Stream Nat
+streamCount n = n :: streamCount (S n)
 
 badCount : Nat -> Stream Nat
 badCount n = n :: map S (badCount n)

--- a/tests/idris2/total006/expected
+++ b/tests/idris2/total006/expected
@@ -1,5 +1,5 @@
 1/1: Building Total (Total.idr)
-Main> Main.count is total
+Main> Main.streamCount is total
 Main> Main.badCount is possibly not terminating due to recursive path Main.badCount
 Main> Main.process is total
 Main> Main.badProcess is possibly not terminating due to recursive path Main.badProcess -> Main.badProcess -> Main.badProcess

--- a/tests/idris2/total006/input
+++ b/tests/idris2/total006/input
@@ -1,4 +1,4 @@
-:total count
+:total streamCount
 :total badCount
 :total process
 :total badProcess


### PR DESCRIPTION
I've needed this function a lot lately so I thought other people might
need it too.

I've placed it in `Types` because it cannot live in `Interfaces`. Indeed,
since the return type is `Nat` it would require importing `Types` making
the imports circular. Another solution would have been to add it to `base`
rather than `prelude` but I could not find a suitable place for it. Finally,
another solution would have been to place it in `Interfaces` and have it 
depend on the `Num` interface and return a member of `Num` rather than
`Nat` but that meant worse inference and inaccurate semantics since the
count can never be negative.