### PR TITLE
New positional implicit lambda arguments syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,17 @@ Language and compiler changes:
   definitions can be searched in auto implicit search.
   + Note, though, that there are still some known limitations (with both local
     hints and local implementations) which will be resolved in the next version.
+
+* Added new syntax for positional implicit arguments in lambda expressions:
+
+     `\exparg1, ${1 imparg1 : imptype, ...}, exparg2, ... => ...`
+
+* Added primitives to the parsing library used in the compiler to get more precise
+  boundaries to the AST nodes `FC`.
+
 * New experimental ``refc`` code generator, which generates C with reference
   counting.
+
 * Added primitives to the parsing library used in the compiler to get more precise
   boundaries to the AST nodes `FC`.
 

--- a/docs/source/updates/updates.rst
+++ b/docs/source/updates/updates.rst
@@ -579,6 +579,32 @@ Idris 1 took a different approach here: names which were parameters to data
 types were in scope, other names were not. The Idris 2 approach is, we hope,
 more consistent and easier to understand.
 
+.. _sect-imp-lambda-args:
+
+Implicit lambda arguments
+-------------------------
+
+In Idris2 you can now declare implicit arguments for lambda expressions:
+
+.. code-block:: idris
+
+    \{1 len : Nat}, val => replicate len val
+
+As for explicit arguments, you can specify the multiplicity and the type
+also for implicit arguments, and the two type of arguments can be
+interleaved:
+
+.. code-block:: idris
+
+    \exp1, {imp1}, exp2, {imp2}, ..., {imp3} => ...
+
+Sequence of consecutive implicit arguments can be grouped in a single pair
+of braces:
+
+.. code-block:: idris
+
+    \exp1, {imp1, imp2 : Type, 1 imp3, 0 imp4 : Type}, exp2, {imp5} => ...
+
 .. _sect-app-syntax-additions:
 
 Function application syntax additions

--- a/docs/source/updates/updates.rst
+++ b/docs/source/updates/updates.rst
@@ -581,29 +581,32 @@ more consistent and easier to understand.
 
 .. _sect-imp-lambda-args:
 
-Implicit lambda arguments
+Positional implicit lambda arguments
 -------------------------
 
-In Idris2 you can now declare implicit arguments for lambda expressions:
+In Idris2 you can now declare positional implicit arguments for lambda expressions,
+where positional means that whichever names you choose for the arguments, the i-th
+positional implicit argument will always correspond to the i-th implicit binder in
+the type of the lambda:
 
 .. code-block:: idris
 
-    \{1 len : Nat}, val => replicate len val
+    \${1 len : Nat}, val => replicate len val
 
 As for explicit arguments, you can specify the multiplicity and the type
-also for implicit arguments, and the two type of arguments can be
+also for positional implicit arguments, and the two type of arguments can be
 interleaved:
 
 .. code-block:: idris
 
-    \exp1, {imp1}, exp2, {imp2}, ..., {imp3} => ...
+    \exp1, ${imp1}, exp2, ${imp2}, ..., ${imp3} => ...
 
-Sequence of consecutive implicit arguments can be grouped in a single pair
+Sequence of consecutive positional implicit arguments can be grouped in a single pair
 of braces:
 
 .. code-block:: idris
 
-    \exp1, {imp1, imp2 : Type, 1 imp3, 0 imp4 : Type}, exp2, {imp5} => ...
+    \exp1, ${imp1, imp2 : Type, 1 imp3, 0 imp4 : Type}, exp2, ${imp5} => ...
 
 .. _sect-app-syntax-additions:
 

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -443,7 +443,7 @@ mutual
                              (symbol ":" *> opExpr pdef fname indents)
                     rig <- getMult rigc
                     pure [(rig, Explicit, pat, ty)])
-                <|> (do start <- symbol "{"
+                <|> (do start <- symbol "${"
                         ns <- sepBy1 (symbol ",") (do
                           rigc <- multiplicity
                           pat <- bounds (simpleExpr fname indents)

--- a/src/Idris/Pretty.idr
+++ b/src/Idris/Pretty.idr
@@ -192,12 +192,12 @@ mutual
           getLamNames acc sc = (reverse acc, sc)
           prettyBindings : List (RigCount, PiInfo PTerm, PTerm, PTerm) -> Doc IdrisAnn
           prettyBindings [] = neutral
-          prettyBindings [(rig, Implicit, n, (PImplicit _))] = braces (prettyRig rig <+> go startPrec n)
-          prettyBindings [(rig, Implicit, n, ty)] = braces (prettyRig rig <+> go startPrec n <++> colon <++> go startPrec ty)
+          prettyBindings [(rig, Implicit, n, (PImplicit _))] = "$" <+> braces (prettyRig rig <+> go startPrec n)
+          prettyBindings [(rig, Implicit, n, ty)] = "$" <+> braces (prettyRig rig <+> go startPrec n <++> colon <++> go startPrec ty)
           prettyBindings [(rig, p, n, (PImplicit _))] = prettyRig rig <+> go startPrec n
           prettyBindings [(rig, p, n, ty)] = prettyRig rig <+> go startPrec n <++> colon <++> go startPrec ty
-          prettyBindings ((rig, Implicit, n, (PImplicit _)) :: ns) = braces (prettyRig rig <+> go startPrec n) <+> comma <+> line <+> prettyBindings ns
-          prettyBindings ((rig, Implicit, n, ty) :: ns) = braces (prettyRig rig <+> go startPrec n) <++> colon <++> go startPrec ty <+> comma <+> line <+> prettyBindings ns
+          prettyBindings ((rig, Implicit, n, (PImplicit _)) :: ns) = "$" <+> braces (prettyRig rig <+> go startPrec n) <+> comma <+> line <+> prettyBindings ns
+          prettyBindings ((rig, Implicit, n, ty) :: ns) = "$" <+> braces (prettyRig rig <+> go startPrec n) <++> colon <++> go startPrec ty <+> comma <+> line <+> prettyBindings ns
           prettyBindings ((rig, p, n, (PImplicit _)) :: ns) = prettyRig rig <+> go startPrec n <+> comma <+> line <+> prettyBindings ns
           prettyBindings ((rig, p, n, ty) :: ns) = prettyRig rig <+> go startPrec n <++> colon <++> go startPrec ty <+> comma <+> line <+> prettyBindings ns
       go d (PLet _ rig n (PImplicit _) val sc alts) =

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -513,11 +513,11 @@ mutual
     showPrec d (PPi _ rig (DefImplicit t) (Just n) arg ret)
         = "{default " ++ showPrec App t ++ " " ++ showCount rig ++ showPrec d n ++ " : " ++ showPrec d arg ++ "} -> " ++ showPrec d ret
     showPrec d (PLam _ rig Implicit n (PImplicit _) sc)
-        = "\\{" ++ showCount rig ++ showPrec d n ++ "} => " ++ showPrec d sc
+        = "\\${" ++ showCount rig ++ showPrec d n ++ "} => " ++ showPrec d sc
     showPrec d (PLam _ rig _ n (PImplicit _) sc)
         = "\\" ++ showCount rig ++ showPrec d n ++ " => " ++ showPrec d sc
     showPrec d (PLam _ rig Implicit n ty sc)
-        = "\\{" ++ showCount rig ++ showPrec d n ++ " : " ++ showPrec d ty ++ "} => " ++ showPrec d sc
+        = "\\${" ++ showCount rig ++ showPrec d n ++ " : " ++ showPrec d ty ++ "} => " ++ showPrec d sc
     showPrec d (PLam _ rig _ n ty sc)
         = "\\" ++ showCount rig ++ showPrec d n ++ " : " ++ showPrec d ty ++ " => " ++ showPrec d sc
     showPrec d (PLet _ rig n (PImplicit _) val sc alts)

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -512,8 +512,12 @@ mutual
         = "{default " ++ showPrec App t ++ " " ++ showCount rig ++ "_ : " ++ showPrec d arg ++ "} -> " ++ showPrec d ret
     showPrec d (PPi _ rig (DefImplicit t) (Just n) arg ret)
         = "{default " ++ showPrec App t ++ " " ++ showCount rig ++ showPrec d n ++ " : " ++ showPrec d arg ++ "} -> " ++ showPrec d ret
+    showPrec d (PLam _ rig Implicit n (PImplicit _) sc)
+        = "\\{" ++ showCount rig ++ showPrec d n ++ "} => " ++ showPrec d sc
     showPrec d (PLam _ rig _ n (PImplicit _) sc)
         = "\\" ++ showCount rig ++ showPrec d n ++ " => " ++ showPrec d sc
+    showPrec d (PLam _ rig Implicit n ty sc)
+        = "\\{" ++ showCount rig ++ showPrec d n ++ " : " ++ showPrec d ty ++ "} => " ++ showPrec d sc
     showPrec d (PLam _ rig _ n ty sc)
         = "\\" ++ showCount rig ++ showPrec d n ++ " : " ++ showPrec d ty ++ " => " ++ showPrec d sc
     showPrec d (PLet _ rig n (PImplicit _) val sc alts)

--- a/src/Parser/Lexer/Source.idr
+++ b/src/Parser/Lexer/Source.idr
@@ -186,10 +186,11 @@ export
 symbols : List String
 symbols
     = [".(", -- for things such as Foo.Bar.(+)
-       "@{",
+       "@{", "${",
        "[|", "|]",
        "(", ")", "{", "}}", "}", "[", "]", ",", ";", "_",
-       "`(", "`{{", "`[", "`"]
+       "`(", "`{{", "`[", "`",
+       "\\"]
 
 export
 isOpChar : Char -> Bool
@@ -203,7 +204,7 @@ export
 reservedSymbols : List String
 reservedSymbols
     = symbols ++
-      ["%", "\\", ":", "=", ":=", "|", "|||", "<-", "->", "=>", "?", "!",
+      ["%", ":", "=", ":=", "|", "|||", "<-", "->", "=>", "?", "!",
        "&", "**", "..", "~"]
 
 fromBinLit : String -> Integer

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -45,7 +45,7 @@ idrisTests = MkTestPool []
        "basic036", "basic037", "basic038", "basic039", "basic040",
        "basic041", "basic042", "basic043", "basic044", "basic045",
        "basic046", "basic047", "basic048", "basic049", "basic050",
-       "basic051",
+       "basic051", "basic052",
        -- Coverage checking
        "coverage001", "coverage002", "coverage003", "coverage004",
        "coverage005", "coverage006", "coverage007", "coverage008",

--- a/tests/idris2/basic052/Test.idr
+++ b/tests/idris2/basic052/Test.idr
@@ -1,0 +1,17 @@
+import Data.Vect
+
+All : (a : i -> j -> Type) -> Type
+All a {i} {j} = {x : i} -> {y : j} -> a x y
+
+Matrix : Type -> Nat -> Nat -> Type
+Matrix a n m = Vect n (Vect m a)
+
+infixr 1 :->
+(:->) : (a, b : i -> j -> Type) -> (i -> j -> Type)
+(:->) a b i j = a i j -> b i j
+
+justShowAll : Maybe (All (Matrix Integer :-> Matrix String))
+justShowAll = Just (\{x, y} => ?justShowAll_rhs)
+
+justShowAllImpl : Maybe (All (Matrix Integer :-> Matrix String))
+justShowAllImpl = Just (\{x, y} => map (map show))

--- a/tests/idris2/basic052/Test.idr
+++ b/tests/idris2/basic052/Test.idr
@@ -11,7 +11,7 @@ infixr 1 :->
 (:->) a b i j = a i j -> b i j
 
 justShowAll : Maybe (All (Matrix Integer :-> Matrix String))
-justShowAll = Just (\{x, y} => ?justShowAll_rhs)
+justShowAll = Just (\${x, y} => ?justShowAll_rhs)
 
 justShowAllImpl : Maybe (All (Matrix Integer :-> Matrix String))
-justShowAllImpl = Just (\{x, y} => map (map show))
+justShowAllImpl = Just (\${x, y} => map (map show))

--- a/tests/idris2/basic052/expected
+++ b/tests/idris2/basic052/expected
@@ -3,7 +3,7 @@ Main> Main> Main>    x : Nat
    y : Nat
 ------------------------------
 justShowAll_rhs : Vect x (Vect y Integer) -> Vect x (Vect y String)
-Main> \x : Nat, {z : Nat} => x : Nat -> {_ : Nat} -> Nat
-Main> \x : Nat, {1 z} : Nat, {0 w : String} => z : Nat -> {1 _ : Nat} -> {0 _ : String} -> Nat
-Main> \1 b : Nat, {z} : ?_, {w} : ?_, y : ?_, {a : ?_} => b : (1 b : Nat) -> {z : ?_} -> {w : ?_} -> (y : ?_) -> {_ : ?_} -> Nat
+Main> \x : Nat, ${z : Nat} => x : Nat -> {_ : Nat} -> Nat
+Main> \x : Nat, ${1 z} : Nat, ${0 w : String} => z : Nat -> {1 _ : Nat} -> {0 _ : String} -> Nat
+Main> \1 b : Nat, ${z} : ?_, ${w} : ?_, y : ?_, ${a : ?_} => b : (1 b : Nat) -> {z : ?_} -> {w : ?_} -> (y : ?_) -> {_ : ?_} -> Nat
 Main> Bye for now!

--- a/tests/idris2/basic052/expected
+++ b/tests/idris2/basic052/expected
@@ -1,0 +1,9 @@
+1/1: Building Test (Test.idr)
+Main> Main> Main>    x : Nat
+   y : Nat
+------------------------------
+justShowAll_rhs : Vect x (Vect y Integer) -> Vect x (Vect y String)
+Main> \x : Nat, {z : Nat} => x : Nat -> {_ : Nat} -> Nat
+Main> \x : Nat, {1 z} : Nat, {0 w : String} => z : Nat -> {1 _ : Nat} -> {0 _ : String} -> Nat
+Main> \1 b : Nat, {z} : ?_, {w} : ?_, y : ?_, {a : ?_} => b : (1 b : Nat) -> {z : ?_} -> {w : ?_} -> (y : ?_) -> {_ : ?_} -> Nat
+Main> Bye for now!

--- a/tests/idris2/basic052/input
+++ b/tests/idris2/basic052/input
@@ -1,0 +1,7 @@
+:set showtypes
+:set showimplicits
+:t justShowAll_rhs
+\x : Nat, {z : Nat} => x
+\x : Nat, {1 z : Nat, 0 w : String} => z
+\1 b : Nat, {z, w}, y, {a} => b
+:q

--- a/tests/idris2/basic052/input
+++ b/tests/idris2/basic052/input
@@ -1,7 +1,7 @@
 :set showtypes
 :set showimplicits
 :t justShowAll_rhs
-\x : Nat, {z : Nat} => x
-\x : Nat, {1 z : Nat, 0 w : String} => z
-\1 b : Nat, {z, w}, y, {a} => b
+\x : Nat, ${z : Nat} => x
+\x : Nat, ${1 z : Nat, 0 w : String} => z
+\1 b : Nat, ${z, w}, y, ${a} => b
 :q

--- a/tests/idris2/basic052/run
+++ b/tests/idris2/basic052/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 --no-banner Test.idr < input
+
+rm -rf build


### PR DESCRIPTION
~~As proposed in this issue https://github.com/idris-lang/Idris2/issues/14,~~ I've added a new syntax for implicit arguments in lambda expressions. Implicit arguments can be freely interleaved with explicit arguments, and consecutive ones can be grouped withing a single pair of braces:
```
\x : Nat, {1 y : Int, 0 z, w}, y, {a, b} => ...
```
The syntax code is accompanied by a new test case and a new section describing the feature in the documentation.

EDIT: This PR has changed to just implementing positional implicit arguments and the surround bracket switched from `{x}` to `${x}`.