### PR TITLE
added MaybeT monad transformer to base

### DIFF
--- a/libs/base/Control/Monad/Either.idr
+++ b/libs/base/Control/Monad/Either.idr
@@ -78,9 +78,6 @@ catchE et f
 -- Interface Implementations
 -------------------------------------------------
 
-on : (b -> b -> c) -> (a -> b) -> a -> a -> c
-on f g x y = g x `f` g y
-
 public export
 Eq (m (Either e a)) => Eq (EitherT e m a) where
  (==) = (==) `on` runEitherT

--- a/libs/base/Control/Monad/Maybe.idr
+++ b/libs/base/Control/Monad/Maybe.idr
@@ -108,7 +108,7 @@ Functor m => Functor (MaybeT m) where
 public export
 Foldable m => Foldable (MaybeT m) where
   foldr f acc (MkMaybeT e)
-    = foldr (\x,xs => maybe acc (`f` xs) x) acc e
+    = foldr (\x,xs => maybe xs (`f` xs) x) acc e
 
   null (MkMaybeT e) = null e
 

--- a/libs/base/Control/Monad/Maybe.idr
+++ b/libs/base/Control/Monad/Maybe.idr
@@ -73,9 +73,6 @@ nothing = MkMaybeT $ pure Nothing
 -- Interface Implementations
 -------------------------------------------------
 
-on : (b -> b -> c) -> (a -> b) -> a -> a -> c
-on f g x y = g x `f` g y
-
 public export
 Eq (m (Maybe a)) => Eq (MaybeT m a) where
  (==) = (==) `on` runMaybeT
@@ -152,4 +149,3 @@ public export
 MonadState s m => MonadState s (MaybeT m) where
   get = lift get
   put = lift . put
-

--- a/libs/base/Control/Monad/Maybe.idr
+++ b/libs/base/Control/Monad/Maybe.idr
@@ -1,0 +1,154 @@
+module Control.Monad.Maybe
+
+-------------------------------------------------
+-- The monad transformer `MaybeT m a` equips a monad with the ability to
+-- return no value at all.
+
+-- Sequenced actions of `MaybeT m a` produce a value `a` only if all of the
+-- actions in the sequence returned a value.
+
+-- This is isomorphic to `EitherT ()` and therefore less powerful than `EitherT e a`
+-- ability to not return a result.
+-------------------------------------------------
+
+import Control.Monad.Trans
+import Control.Monad.Reader
+import Control.Monad.State
+import Data.Maybe
+
+public export
+data MaybeT : (m : Type -> Type) -> (a : Type) -> Type where
+  MkMaybeT : (1 _ : m (Maybe a)) -> MaybeT m a
+
+export
+%inline
+runMaybeT : MaybeT m a -> m (Maybe a)
+runMaybeT (MkMaybeT x) = x
+
+export
+%inline
+isNothingT : Functor m => MaybeT m a -> m Bool
+isNothingT = map isNothing . runMaybeT
+
+export
+%inline
+isJustT : Functor m => MaybeT m a -> m Bool
+isJustT = map isJust . runMaybeT
+
+export
+%inline
+maybeT : Monad m => m b -> (a -> m b) -> MaybeT m a -> m b
+maybeT v g x = runMaybeT x >>= maybe v g
+
+export
+%inline
+fromMaybeT : Monad m => m a -> MaybeT m a -> m a
+fromMaybeT v x = runMaybeT x >>= maybe v pure
+
+export
+%inline
+toMaybeT : Functor m => Bool -> m a -> MaybeT m a
+toMaybeT b m = MkMaybeT $ map (\a => toMaybe b a) m
+
+||| map the underlying computation
+||| The basic 'unwrap, apply, rewrap' of this transformer.
+export
+%inline
+mapMaybeT : (m (Maybe a) -> n (Maybe a')) -> MaybeT m a -> MaybeT n a'
+mapMaybeT f = MkMaybeT . f . runMaybeT
+
+||| Analogous to Just, aka pure for MaybeT
+export
+%inline
+just : Applicative m => a -> MaybeT m a
+just = MkMaybeT . pure . Just
+
+||| Analogous to Nothing, aka empty for MaybeT
+export
+%inline
+nothing : Applicative m => MaybeT m a
+nothing = MkMaybeT $ pure Nothing
+
+-------------------------------------------------
+-- Interface Implementations
+-------------------------------------------------
+
+on : (b -> b -> c) -> (a -> b) -> a -> a -> c
+on f g x y = g x `f` g y
+
+public export
+Eq (m (Maybe a)) => Eq (MaybeT m a) where
+ (==) = (==) `on` runMaybeT
+
+public export
+Ord (m (Maybe a)) => Ord (MaybeT m a) where
+ compare = compare `on` runMaybeT
+
+public export
+Show (m (Maybe a)) => Show (MaybeT m a) where
+  showPrec d (MkMaybeT x) = showCon d "MkMaybeT" $ showArg x
+
+-- Corresponds to the Semigroup instance of Maybe
+--
+-- Note: This could also be implemented with only an Applicative
+-- prerequisite: MkMaybeT x <+> MkMaybeT y = MkMaybeT $ [| x <+> y |]
+--
+-- However, the monadic version only runs the second argument
+-- if the first fails, whish seems to be more efficient.
+public export
+Monad m => Semigroup (MaybeT m a) where
+  MkMaybeT x <+> MkMaybeT y = MkMaybeT $ [| x <+> y |]
+
+public export
+Monad m => Monoid (MaybeT m a) where
+  neutral = nothing
+
+public export
+Functor m => Functor (MaybeT m) where
+  map f m = MkMaybeT $ map f <$> runMaybeT m
+
+public export
+Foldable m => Foldable (MaybeT m) where
+  foldr f acc (MkMaybeT e)
+    = foldr (\x,xs => maybe acc (`f` xs) x) acc e
+
+  null (MkMaybeT e) = null e
+
+public export
+Traversable m => Traversable (MaybeT m) where
+  traverse f (MkMaybeT x)
+    = MkMaybeT <$> traverse (maybe (pure Nothing) (map Just . f)) x
+
+public export
+Applicative m => Applicative (MaybeT m) where
+  pure = just
+  MkMaybeT f <*> MkMaybeT x = MkMaybeT [| f <*> x |]
+
+public export
+Monad m => Monad (MaybeT m) where
+  MkMaybeT x >>= k = MkMaybeT $ x >>= maybe (pure Nothing) (runMaybeT . k)
+
+-- See note about Monad prerequisite on Semigroup instance.
+public export
+Monad m => Alternative (MaybeT m) where
+  empty = nothing
+  (<|>) = (<+>)
+
+public export
+MonadTrans MaybeT where
+  lift = MkMaybeT . map Just
+
+public export
+HasIO m => HasIO (MaybeT m) where
+  liftIO act = MkMaybeT $ liftIO (io_bind act (pure . Just))
+
+public export
+MonadReader r m => MonadReader r (MaybeT m) where
+  ask = lift ask
+  local f (MkMaybeT x) = MkMaybeT (local f x)
+
+public export
+MonadState s m => MonadState s (MaybeT m) where
+  get = lift get
+  put = lift . put
+

--- a/libs/base/Control/Monad/Maybe.idr
+++ b/libs/base/Control/Monad/Maybe.idr
@@ -18,7 +18,7 @@ import Data.Maybe
 
 public export
 data MaybeT : (m : Type -> Type) -> (a : Type) -> Type where
-  MkMaybeT : (1 _ : m (Maybe a)) -> MaybeT m a
+  MkMaybeT : m (Maybe a) -> MaybeT m a
 
 export
 %inline

--- a/libs/base/base.ipkg
+++ b/libs/base/base.ipkg
@@ -6,6 +6,7 @@ modules = Control.App,
 
           Control.Monad.Either,
           Control.Monad.Identity,
+          Control.Monad.Maybe,
           Control.Monad.Reader,
           Control.Monad.ST,
           Control.Monad.State,

--- a/libs/prelude/Prelude/Basics.idr
+++ b/libs/prelude/Prelude/Basics.idr
@@ -40,6 +40,24 @@ public export %inline
 (.) : (b -> c) -> (a -> b) -> a -> c
 (.) f g = \x => f (g x)
 
+||| Binary function composition. This can be useful for instance
+||| when implementing interfaces for wrapper types:
+|||
+||| ```idris example
+||| record Id a where
+|||   constructor MkId
+|||   runId : a
+||| 
+||| Eq a => Eq (Id a) where
+|||   (==) = (==) `on` runId
+||| 
+||| Ord a => Ord (Id a) where
+|||   compare = compare `on` runId
+||| ```
+public export
+on : (b -> b -> c) -> (a -> b) -> a -> a -> c
+on f g x y = g x `f` g y
+
 ||| Takes in the first two arguments in reverse order.
 ||| @ f the function to flip
 public export

--- a/libs/prelude/Prelude/Basics.idr
+++ b/libs/prelude/Prelude/Basics.idr
@@ -40,23 +40,24 @@ public export %inline
 (.) : (b -> c) -> (a -> b) -> a -> c
 (.) f g = \x => f (g x)
 
-||| Binary function composition. This can be useful for instance
-||| when implementing interfaces for wrapper types:
+||| `on b u x y` runs the binary function b on the results of applying
+||| unary function u to two arguments x and y. From the opposite perspective,
+||| it transforms two inputs and combines the outputs.
+||| 
+||| ```idris example
+||| ((+) `on` f) x y = f x + f y
+||| ```
+||| 
+||| Typical usage:
 |||
 ||| ```idris example
-||| record Id a where
-|||   constructor MkId
-|||   runId : a
-||| 
-||| Eq a => Eq (Id a) where
-|||   (==) = (==) `on` runId
-||| 
-||| Ord a => Ord (Id a) where
-|||   compare = compare `on` runId
+||| sortBy (compare `on` fst).
 ||| ```
 public export
 on : (b -> b -> c) -> (a -> b) -> a -> a -> c
 on f g x y = g x `f` g y
+
+infixl 0 `on`
 
 ||| Takes in the first two arguments in reverse order.
 ||| @ f the function to flip


### PR DESCRIPTION
This adds MaybeT to base. The implementation was based on the one of EitherT. Note: As far as I can see, this was not in Idris1 but neither was EitherT, so I thought it should be fine if I put this in base.