### PR TITLE
Better default permissions for created directories

### DIFF
--- a/support/c/idris_directory.c
+++ b/support/c/idris_directory.c
@@ -19,7 +19,7 @@ int idris2_createDir(char* dir) {
 #ifdef _WIN32
     return mkdir(dir);
 #else
-    return mkdir(dir, S_IRWXU | S_IRGRP | S_IROTH);
+    return mkdir(dir, S_IRWXU | S_IRWXG | S_IRWXO);
 #endif
 }
 


### PR DESCRIPTION
Change the support code for directory creation so that it sets all
permission bits (ugo=rwx). The process's currently active umask will be
subtracted from these permissions, which leads to the result that (for a
standard umask of "022") directories are created with a mode of "0755".

So by default, directories created with `prim__createDir` are now also
group-executable and other-executable by default.

Previous behaviour was to create the directories readable for group and
other, but not executable (mode "744"), and thus inaccessible to anyone
except the owner.