### PR TITLE
deleted 'head' from Data.Stream

### DIFF
--- a/libs/base/Data/Stream.idr
+++ b/libs/base/Data/Stream.idr
@@ -4,11 +4,6 @@ import Data.List
 
 %default total
 
-||| The first element of an infinite stream
-public export
-head : Stream a -> a
-head (x::xs) = x
-
 ||| Drop the first n elements from the stream
 ||| @ n how many elements to drop
 public export


### PR DESCRIPTION
`head` for `Stream` is exported both from `Prelude.Types` and `Data.Stream`. This PR removes the export from `Data.Stream`.