### PR TITLE
Name quotes are suggested to use single brace instead of double

### DIFF
--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -398,7 +398,7 @@ mutual
            pure (PDotted (boundToFC fname b) b.val)
     <|> do b <- bounds (symbol "`(" *> expr pdef fname indents <* symbol ")")
            pure (PQuote (boundToFC fname b) b.val)
-    <|> do b <- bounds (symbol "`{{" *> name <* symbol "}}")
+    <|> do b <- bounds (symbol "`{" *> name <* symbol "}")
            pure (PQuoteName (boundToFC fname b) b.val)
     <|> do b <- bounds (symbol "`[" *> nonEmptyBlock (topDecl fname) <* symbol "]")
            pure (PQuoteDecl (boundToFC fname b) (collectDefs (concat b.val)))

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -570,7 +570,7 @@ mutual
         = showPrec d f ++ " {" ++ showPrec d n ++ " = " ++ showPrec d a ++ "}"
     showPrec _ (PSearch _ _) = "%search"
     showPrec d (PQuote _ tm) = "`(" ++ showPrec d tm ++ ")"
-    showPrec d (PQuoteName _ n) = "`{{" ++ showPrec d n ++ "}}"
+    showPrec d (PQuoteName _ n) = "`{" ++ showPrec d n ++ "}"
     showPrec d (PQuoteDecl _ tm) = "`[ <<declaration>> ]"
     showPrec d (PUnquote _ tm) = "~(" ++ showPrec d tm ++ ")"
     showPrec d (PRunElab _ tm) = "%runElab " ++ showPrec d tm

--- a/src/Parser/Lexer/Source.idr
+++ b/src/Parser/Lexer/Source.idr
@@ -210,7 +210,7 @@ symbols = [",", ";", "_", "`"]
 export
 groupSymbols : List String
 groupSymbols = [".(", -- for things such as Foo.Bar.(+)
-    "@{", "[|", "(", "{", "[", "`(", "`{{", "`["]
+    "@{", "[|", "(", "{", "[", "`(", "`{", "`["]
 
 export
 groupClose : String -> String
@@ -221,7 +221,7 @@ groupClose "(" = ")"
 groupClose "[" = "]"
 groupClose "{" = "}"
 groupClose "`(" = ")"
-groupClose "`{{" = "}}"
+groupClose "`{" = "}"
 groupClose "`[" = "]"
 groupClose _ = ""
 

--- a/tests/idris2/reflection001/quote.idr
+++ b/tests/idris2/reflection001/quote.idr
@@ -25,7 +25,7 @@ bad val
             xfn ~(val))
 
 names : List Name
-names = [ `{{ names }}, `{{ Prelude.(+) }} ]
+names = [ `{ names }, `{ Prelude.(+) } ]
 
 noExtension : Elab ()
 noExtension = fail "Should not print this message"

--- a/tests/idris2/reflection003/refprims.idr
+++ b/tests/idris2/reflection003/refprims.idr
@@ -4,7 +4,7 @@ import Language.Reflection
 
 logPrims : Elab a
 logPrims
-    = do ns <- getType `{{ (++) }}
+    = do ns <- getType `{ (++) }
          traverse (\ (n, ty) =>
                         do logMsg "" 0 ("Name: " ++ show n)
                            logTerm "" 0 "Type" ty) ns
@@ -12,7 +12,7 @@ logPrims
 
 logDataCons : Elab a
 logDataCons
-    = do [(n, _)] <- getType `{{ Nat }}
+    = do [(n, _)] <- getType `{ Nat }
              | _ => fail "Ambiguous name"
          logMsg "" 0 ("Resolved name: " ++ show n)
          logMsg "" 0 ("Constructors: " ++ show !(getCons n))
@@ -20,7 +20,7 @@ logDataCons
 
 logBad : Elab a
 logBad
-    = do [(n, _)] <- getType `{{ DoesntExist }}
+    = do [(n, _)] <- getType `{ DoesntExist }
              | [] => fail "Undefined name"
              | _ => fail "Ambiguous name"
          logMsg "" 0 ("Resolved name: " ++ show n)

--- a/tests/idris2/reflection004/refdecl.idr
+++ b/tests/idris2/reflection004/refdecl.idr
@@ -21,7 +21,7 @@ mkPoint n
 logDecls : TTImp -> Elab (Int -> Int)
 logDecls v
     = do declare [IClaim EmptyFC MW Public []
-                 (MkTy EmptyFC EmptyFC `{{ Main.foo }}
+                 (MkTy EmptyFC EmptyFC `{ Main.foo }
                                `(Int -> Int -> Int) )]
 
          declare `[ foo x y = x + y ]

--- a/tests/idris2/reg033/DerivingEq.idr
+++ b/tests/idris2/reg033/DerivingEq.idr
@@ -48,4 +48,4 @@ data TreeOne a = BranchOne (TreeOne a) a (TreeOne a)
                | Leaf
 
 Eq a => Eq (TreeOne a) where
-  (==) = %runElab genEq `{{ TreeOne }}
+  (==) = %runElab genEq `{ TreeOne }

--- a/tests/idris2/reg033/test.idr
+++ b/tests/idris2/reg033/test.idr
@@ -9,4 +9,4 @@ data TreeTwo a = BranchTwo (TreeTwo a) a (TreeTwo a)
                | Leaf
 
 Eq a => Eq (TreeTwo a) where
-  (==) = %runElab genEq `{{ TreeTwo }}
+  (==) = %runElab genEq `{ TreeTwo }


### PR DESCRIPTION
An extremist's solution of problems mentioned in #838 (actually, this is a further continuation of #838).

Well, I'm sure there was a reason to make name quotes to have double braces (when the other quotes have single-character syntax). But I don't see this reason since only names are allowed between those braces.

But this double-brace syntax clashes with implicit and named parameters syntax in case when actual parameter's expression ends with an implicit or named parameter or auto-parameter bind (i.e. `@{..}`). I showed in #838 an example like
```idris
h : Nat -> Nat
h c = g {b = f {a=c}}
```

So what are the arguments to not doing this?