### PR TITLE
Don't add implicits after non-given explicits.

### DIFF
--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -496,26 +496,26 @@ findImplicits tm = []
 export
 implicitsAs : {auto c : Ref Ctxt Defs} ->
               Defs -> List Name -> RawImp -> Core RawImp
-implicitsAs defs ns tm = setAs (map Just (ns ++ map UN (findIBinds tm))) tm
+implicitsAs defs ns tm = setAs (map Just (ns ++ map UN (findIBinds tm))) [] tm
   where
-    setAs : List (Maybe Name) -> RawImp -> Core RawImp
-    setAs is (IApp loc f a)
-        = do f' <- setAs is f
+    setAs : List (Maybe Name) -> List (Maybe Name) -> RawImp -> Core RawImp
+    setAs is es (IApp loc f a)
+        = do f' <- setAs is (Nothing :: es) f
              pure $ IApp loc f' a
-    setAs is (IAutoApp loc f a)
-        = do f' <- setAs (Nothing :: is) f
+    setAs is es (IAutoApp loc f a)
+        = do f' <- setAs (Nothing :: is) es f
              pure $ IAutoApp loc f' a
-    setAs is (INamedApp loc f n a)
-        = do f' <- setAs (Just n :: is) f
+    setAs is es (INamedApp loc f n a)
+        = do f' <- setAs (Just n :: is) (Just n :: es) f
              pure $ INamedApp loc f' n a
-    setAs is (IWithApp loc f a)
-        = do f' <- setAs is f
+    setAs is es (IWithApp loc f a)
+        = do f' <- setAs is es f
              pure $ IWithApp loc f' a
-    setAs is (IVar loc n)
+    setAs is es (IVar loc n)
         = case !(lookupTyExact n (gamma defs)) of
                Nothing => pure $ IVar loc n
                Just ty => pure $ impAs loc
-                                    !(findImps is !(nf defs [] ty)) (IVar loc n)
+                                    !(findImps is es !(nf defs [] ty)) (IVar loc n)
       where
         -- If there's an @{c} in the list of given implicits, that's the next
         -- autoimplicit, so don't rewrite the LHS and update the list of given
@@ -529,20 +529,23 @@ implicitsAs defs ns tm = setAs (map Just (ns ++ map UN (findIBinds tm))) tm
                          pure (x :: ns')
         updateNs n [] = Nothing
 
-        findImps : List (Maybe Name) -> NF [] -> Core (List (Name, PiInfo RawImp))
-        findImps ns (NBind fc x (Pi _ _ Explicit _) sc)
-            = findImps ns !(sc defs (toClosure defaultOpts [] (Erased fc False)))
+        findImps : List (Maybe Name) -> List (Maybe Name) -> NF [] -> Core (List (Name, PiInfo RawImp))
+        -- don't add implicits coming after explicits that aren't given
+        findImps ns es (NBind fc x (Pi _ _ Explicit _) sc)
+            = case updateNs x es of
+                   Nothing => pure [] -- explicit wasn't given
+                   Just es' => findImps ns es' !(sc defs (toClosure defaultOpts [] (Erased fc False)))
         -- if the implicit was given, skip it
-        findImps ns (NBind fc x (Pi _ _ AutoImplicit _) sc)
+        findImps ns es (NBind fc x (Pi _ _ AutoImplicit _) sc)
             = case updateNs x ns of
                    Nothing => -- didn't find explicit call
-                      pure $ (x, AutoImplicit) :: !(findImps ns !(sc defs (toClosure defaultOpts [] (Erased fc False))))
-                   Just ns' => findImps ns' !(sc defs (toClosure defaultOpts [] (Erased fc False)))
-        findImps ns (NBind fc x (Pi _ _ p _) sc)
+                      pure $ (x, AutoImplicit) :: !(findImps ns es !(sc defs (toClosure defaultOpts [] (Erased fc False))))
+                   Just ns' => findImps ns' es !(sc defs (toClosure defaultOpts [] (Erased fc False)))
+        findImps ns es (NBind fc x (Pi _ _ p _) sc)
             = if Just x `elem` ns
-                 then findImps ns !(sc defs (toClosure defaultOpts [] (Erased fc False)))
-                 else pure $ (x, forgetDef p) :: !(findImps ns !(sc defs (toClosure defaultOpts [] (Erased fc False))))
-        findImps _ _ = pure []
+                 then findImps ns es !(sc defs (toClosure defaultOpts [] (Erased fc False)))
+                 else pure $ (x, forgetDef p) :: !(findImps ns es !(sc defs (toClosure defaultOpts [] (Erased fc False))))
+        findImps _ _ _ = pure []
 
         impAs : FC -> List (Name, PiInfo RawImp) -> RawImp -> RawImp
         impAs loc' [] tm = tm
@@ -558,7 +561,7 @@ implicitsAs defs ns tm = setAs (map Just (ns ++ map UN (findIBinds tm))) tm
                  INamedApp loc' tm n
                      (IAs loc' UseLeft n (Implicit loc' True))
         impAs loc' (_ :: ns) tm = impAs loc' ns tm
-    setAs is tm = pure tm
+    setAs is es tm = pure tm
 
 export
 definedInBlock : Namespace -> -- namespace to resolve names

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -532,9 +532,13 @@ implicitsAs defs ns tm = setAs (map Just (ns ++ map UN (findIBinds tm))) [] tm
         findImps : List (Maybe Name) -> List (Maybe Name) -> NF [] -> Core (List (Name, PiInfo RawImp))
         -- don't add implicits coming after explicits that aren't given
         findImps ns es (NBind fc x (Pi _ _ Explicit _) sc)
-            = case updateNs x es of
-                   Nothing => pure [] -- explicit wasn't given
-                   Just es' => findImps ns es' !(sc defs (toClosure defaultOpts [] (Erased fc False)))
+            = case es of
+                   -- Explicits were skipped, therefore all explicits are given anyway
+                   Just (UN "_") :: _ => findImps ns es !(sc defs (toClosure defaultOpts [] (Erased fc False)))
+                   -- Explicits weren't skipped, so we need to check
+                   _ => case updateNs x es of
+                             Nothing => pure [] -- explicit wasn't given
+                             Just es' => findImps ns es' !(sc defs (toClosure defaultOpts [] (Erased fc False)))
         -- if the implicit was given, skip it
         findImps ns es (NBind fc x (Pi _ _ AutoImplicit _) sc)
             = case updateNs x ns of

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -111,7 +111,8 @@ idrisTestsRegression = MkTestPool []
        "reg008", "reg009", "reg010", "reg011", "reg012", "reg013", "reg014",
        "reg015", "reg016", "reg017", "reg018", "reg019", "reg020", "reg021",
        "reg022", "reg023", "reg024", "reg025", "reg026", "reg027", "reg028",
-       "reg029", "reg030", "reg031", "reg032", "reg033", "reg034", "reg035"]
+       "reg029", "reg030", "reg031", "reg032", "reg033", "reg034", "reg035",
+       "reg036"]
 
 idrisTests : TestPool
 idrisTests = MkTestPool []
@@ -144,6 +145,13 @@ idrisTests = MkTestPool []
        "reflection001", "reflection002", "reflection003", "reflection004",
        "reflection005", "reflection006", "reflection007", "reflection008",
        "reflection009",
+       -- Miscellaneous regressions
+       "reg001", "reg002", "reg003", "reg004", "reg005", "reg006", "reg007",
+       "reg008", "reg009", "reg010", "reg011", "reg012", "reg013", "reg014",
+       "reg015", "reg016", "reg017", "reg018", "reg019", "reg020", "reg021",
+       "reg022", "reg023", "reg024", "reg025", "reg026", "reg027", "reg028",
+       "reg029", "reg030", "reg031", "reg032", "reg033", "reg034", "reg035",
+       "reg036",
        -- Totality checking
        "total001", "total002", "total003", "total004", "total005",
        "total006", "total007", "total008", "total009", "total010",

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -145,13 +145,6 @@ idrisTests = MkTestPool []
        "reflection001", "reflection002", "reflection003", "reflection004",
        "reflection005", "reflection006", "reflection007", "reflection008",
        "reflection009",
-       -- Miscellaneous regressions
-       "reg001", "reg002", "reg003", "reg004", "reg005", "reg006", "reg007",
-       "reg008", "reg009", "reg010", "reg011", "reg012", "reg013", "reg014",
-       "reg015", "reg016", "reg017", "reg018", "reg019", "reg020", "reg021",
-       "reg022", "reg023", "reg024", "reg025", "reg026", "reg027", "reg028",
-       "reg029", "reg030", "reg031", "reg032", "reg033", "reg034", "reg035",
-       "reg036",
        -- Totality checking
        "total001", "total002", "total003", "total004", "total005",
        "total006", "total007", "total008", "total009", "total010",

--- a/tests/idris2/reg036/Test.idr
+++ b/tests/idris2/reg036/Test.idr
@@ -5,3 +5,6 @@ interface Foo a where
 
 foo : Void -> {auto ok: ()} -> Void
 foo = ?foo_hole
+
+baz : a -> b -> c -> {auto x : a} -> a
+baz {} = x

--- a/tests/idris2/reg036/Test.idr
+++ b/tests/idris2/reg036/Test.idr
@@ -1,0 +1,7 @@
+module Test
+
+interface Foo a where
+  bar : a -> {auto ok: ()} -> a
+
+foo : Void -> {auto ok: ()} -> Void
+foo = ?foo_hole

--- a/tests/idris2/reg036/expected
+++ b/tests/idris2/reg036/expected
@@ -1,0 +1,1 @@
+1/1: Building Test (Test.idr)

--- a/tests/idris2/reg036/run
+++ b/tests/idris2/reg036/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 Test.idr --check
+
+rm -rf build


### PR DESCRIPTION
The function `TTImp.TTImp.implicitsAs` is changed so that implicit
arguments that come after explicit ones that are not given are no longer
added. This fixes #67.

The reasoning behind this is that the former behaviour---of adding all
missing implicits---makes `implicitsAs` return malformed terms in
certain cases where the underlying function type has implicit arguments
that come after explicit ones. For example, the interface declaration

    interface Foo a where
      bar : a -> {auto ok : ()} -> a

and the function declaration

    foo : Void -> {auto ok : ()} -> Void
    foo = ?foo_hole

result in the errors

    ok is not a valid argument in bar

and

    ok is not a valid argument in foo

respectively, because the auto-implicit is added during elaboration. For
instance, in the second example the left hand side of the pattern
matching declaration

    foo = ?foo_hole

gets replaced by `foo {ok=ok}` (in `implicitsAs`), which is an invalid
function call (according to `TTImp.Elab.App.checkAppWith`).

The changes made are as follows.

The functions `TTImp.TTImp.setAs` and `TTImp.TTImp.findImps` now both
take a new argument `es` of type `List (Maybe Name)`.

In `setAs`, this variable is used to record the explicit arguments which
are explicitly given in the left hand side of the pattern matching
declaration.

This variable is then passed onto `findImps`, which uses it to determine
when it encounters an explicit variable not given and stop searching for
implicits.