### PR TITLE
Currying functions for dependent pairs were added

### DIFF
--- a/libs/base/Data/DPair.idr
+++ b/libs/base/Data/DPair.idr
@@ -2,6 +2,16 @@ module Data.DPair
 
 %default total
 
+namespace DPair
+
+  public export
+  curry : {0 p : a -> Type} -> ((x : a ** p x) -> c) -> (x : a) -> p x -> c
+  curry f x y = f (x ** y)
+
+  public export
+  uncurry : {0 p : a -> Type} -> ((x : a) -> p x -> c) -> (x : a ** p x) -> c
+  uncurry f s = f s.fst s.snd
+
 namespace Exists
 
   ||| A dependent pair in which the first field (witness) should be
@@ -21,6 +31,14 @@ namespace Exists
     0 fst : type
     snd : this fst
 
+  public export
+  curry : {0 p : a -> Type} -> (Exists {type=a} p -> c) -> ({0 x : a} -> p x -> c)
+  curry f = f . Evidence _
+
+  public export
+  uncurry : {0 p : a -> Type} -> ({0 x : a} -> p x -> c) -> Exists {type=a} p -> c
+  uncurry f ex = f ex.snd
+
 namespace Subset
 
   ||| A dependent pair in which the second field (evidence) should not
@@ -37,3 +55,11 @@ namespace Subset
     constructor Element
     fst : type
     0 snd : pred fst
+
+  public export
+  curry : {0 p : a -> Type} -> (Subset a p -> c) -> (x : a) -> (0 _ : p x) -> c
+  curry f x y = f $ Element x y
+
+  public export
+  uncurry : {0 p : a -> Type} -> ((x : a) -> (0 _ : p x) -> c) -> Subset a p -> c
+  uncurry f s = f s.fst s.snd


### PR DESCRIPTION
We have `curry` and `uncurry` for non-dependent pairs, however, similar functions for dependent pairs sometimes are useful. In particular, I run into a usefulness when defining an isomorphism between two-argument dependently typed function and a function that returns a dependent pair.

Technically, this PR depends on #922 ~and if you look to diff, you'll see a combined diff of #922 and of actual addition of currying functions. But if #922 is not accepted but we're okay with this PR, it can be rebased and slightly changed to work on `master`~.