### PR TITLE
Functions for converting between list-level universal quantification and elementwise one

### DIFF
--- a/libs/base/Data/DPair.idr
+++ b/libs/base/Data/DPair.idr
@@ -2,6 +2,16 @@ module Data.DPair
 
 %default total
 
+namespace DPair
+
+  public export
+  curry : {0 p : a -> Type} -> ((x : a ** p x) -> c) -> (x : a) -> p x -> c
+  curry f x y = f (x ** y)
+
+  public export
+  uncurry : {0 p : a -> Type} -> ((x : a) -> p x -> c) -> (x : a ** p x) -> c
+  uncurry f s = f s.fst s.snd
+
 namespace Exists
 
   ||| A dependent pair in which the first field (witness) should be
@@ -21,6 +31,14 @@ namespace Exists
     0 fst : type
     snd : this fst
 
+  public export
+  curry : {0 p : a -> Type} -> (Exists {type=a} p -> c) -> ({0 x : a} -> p x -> c)
+  curry f = f . Evidence _
+
+  public export
+  uncurry : {0 p : a -> Type} -> ({0 x : a} -> p x -> c) -> Exists {type=a} p -> c
+  uncurry f ex = f ex.snd
+
 namespace Subset
 
   ||| A dependent pair in which the second field (evidence) should not
@@ -37,3 +55,11 @@ namespace Subset
     constructor Element
     fst : type
     0 snd : pred fst
+
+  public export
+  curry : {0 p : a -> Type} -> (Subset a p -> c) -> (x : a) -> (0 _ : p x) -> c
+  curry f x y = f $ Element x y
+
+  public export
+  uncurry : {0 p : a -> Type} -> ((x : a) -> (0 _ : p x) -> c) -> Subset a p -> c
+  uncurry f s = f s.fst s.snd

--- a/libs/base/Data/List/Quantifiers.idr
+++ b/libs/base/Data/List/Quantifiers.idr
@@ -1,5 +1,7 @@
 module Data.List.Quantifiers
 
+import Data.DPair
+
 import Data.List
 import Data.List.Elem
 
@@ -86,3 +88,29 @@ export
 mapProperty : (f : {0 x : a} -> p x -> q x) -> All p l -> All q l
 mapProperty f [] = []
 mapProperty f (p::pl) = f p :: mapProperty f pl
+
+--- Relations between listwise `All` and elementwise `Subset` ---
+
+||| Push in the property from the list level with element level
+public export
+pushIn : (xs : List a) -> (0 _ : All p xs) -> List $ Subset a p
+pushIn []      []      = []
+pushIn (x::xs) (p::ps) = Element x p :: pushIn xs ps
+
+||| Pull the elementwise property out to the list level
+public export
+pullOut : (xs : List $ Subset a p) -> Subset (List a) (All p)
+pullOut [] = Element [] []
+pullOut (Element x p :: xs) = let Element ss ps = pullOut xs in Element (x::ss) (p::ps)
+
+export
+pushInOutInverse : (xs : List a) -> (0 prf : All p xs) -> pullOut (pushIn xs prf) = Element xs prf
+pushInOutInverse [] [] = Refl
+pushInOutInverse (x::xs) (p::ps) = rewrite pushInOutInverse xs ps in Refl
+
+export
+pushOutInInverse : (xs : List $ Subset a p) -> uncurry Quantifiers.pushIn (pullOut xs) = xs
+pushOutInInverse [] = Refl
+pushOutInInverse (Element x p :: xs) with (pushOutInInverse xs)
+  pushOutInInverse (Element x p :: xs) | subprf with (pullOut xs)
+    pushOutInInverse (Element x p :: xs) | subprf | Element ss ps = rewrite subprf in Refl


### PR DESCRIPTION
In some cases it's convenient to have a proof-carrying type of list elements. Suggested functions provide a way of converting between library way of expressing some property on the list level and a way of proof-carrying list elements (and vice-versa).

Technically, this PR depends on #928 and this PR's diff contains its diff too, so the only significant changes are in `Data.List.Quantifiers` module. However obviously it's possible to implement the suggested functions with similar but local definitions in case when general approach from #928 is undesired.