### PR TITLE
Print warning `make test` does not invoke `make`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,9 @@ testbin:
 	@${MAKE} -C tests testbin
 
 test:
+	@echo
+	@echo "NOTE: \`${MAKE} test\` does not rebuild idris; to do that run \`${MAKE}\`"
+	@echo
 	@${MAKE} -C tests only=$(only) IDRIS2=../../../${TARGET}
 
 support:


### PR DESCRIPTION
Took some time for me to figure that out.