### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*.idr]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+trim_trailing_whitespace = true


### PR DESCRIPTION
Add .editorconfig to the repository to trim trailing whitespaces
and insert trailing newlines in many editors.

See also #931