### PR TITLE
idris2 --help now prints env variables used by the compiler

### DIFF
--- a/idris2api.ipkg
+++ b/idris2api.ipkg
@@ -77,6 +77,7 @@ modules =
 
     Idris.CommandLine,
     Idris.Desugar,
+    Idris.Env,
     Idris.DocString,
     Idris.Driver,
     Idris.Error,

--- a/src/Compiler/ES/Node.idr
+++ b/src/Compiler/ES/Node.idr
@@ -1,5 +1,7 @@
 module Compiler.ES.Node
 
+import Idris.Env
+
 import Compiler.ES.ES
 
 import Compiler.Common
@@ -16,7 +18,7 @@ import Data.Maybe
 
 findNode : IO String
 findNode =
-  do env <- getEnv "NODE"
+  do env <- idrisGetEnv "NODE"
      pure $ fromMaybe "/usr/bin/env node" env
 
 ||| Compile a TT expression to Node

--- a/src/Compiler/RefC/RefC.idr
+++ b/src/Compiler/RefC/RefC.idr
@@ -24,15 +24,16 @@ import System
 import System.Info
 import System.File
 
+import Idris.Env
 import Idris.Version
 import Utils.Hex
 import Utils.Path
 
 findCC : IO String
 findCC
-    = do Nothing <- getEnv "IDRIS2_CC"
+    = do Nothing <- idrisGetEnv "IDRIS2_CC"
            | Just cc => pure cc
-         Nothing <- getEnv "CC"
+         Nothing <- idrisGetEnv "CC"
            | Just cc => pure cc
          pure "cc"
 

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -21,6 +21,8 @@ import Data.NameMap
 import Data.Strings
 import Data.Vect
 
+import Idris.Env
+
 import System
 import System.Directory
 import System.File
@@ -30,7 +32,7 @@ import System.Info
 
 pathLookup : IO String
 pathLookup
-    = do path <- getEnv "PATH"
+    = do path <- idrisGetEnv "PATH"
          let pathList = forget $ split (== pathSeparator) $ fromMaybe "/usr/bin:/usr/local/bin" path
          let candidates = [p ++ "/" ++ x | p <- pathList,
                                            x <- ["chez", "chezscheme9.5", "scheme", "scheme.exe"]]
@@ -39,7 +41,7 @@ pathLookup
 
 findChez : IO String
 findChez
-    = do Just chez <- getEnv "CHEZ" | Nothing => pathLookup
+    = do Just chez <- idrisGetEnv "CHEZ" | Nothing => pathLookup
          pure chez
 
 -- Given the chez compiler directives, return a list of pairs of:

--- a/src/Compiler/Scheme/Gambit.idr
+++ b/src/Compiler/Scheme/Gambit.idr
@@ -19,6 +19,8 @@ import Data.NameMap
 import Data.Strings
 import Data.Vect
 
+import Idris.Env
+
 import System
 import System.Directory
 import System.File
@@ -29,18 +31,18 @@ import System.Info
 -- TODO Look for gsi-script, then gsi
 findGSI : IO String
 findGSI =
-  do env <- getEnv "GAMBIT_GSI"
+  do env <- idrisGetEnv "GAMBIT_GSI"
      pure $ fromMaybe "/usr/bin/env gsi" env
 
 -- TODO Look for gsc-script, then gsc
 findGSC : IO String
 findGSC =
-  do env <- getEnv "GAMBIT_GSC"
+  do env <- idrisGetEnv "GAMBIT_GSC"
      pure $ fromMaybe "/usr/bin/env gsc" env
 
 findGSCBackend : IO String
 findGSCBackend =
-  do env <- getEnv "GAMBIT_GSC_BACKEND"
+  do env <- idrisGetEnv "GAMBIT_GSC_BACKEND"
      pure $ case env of
               Nothing => ""
               Just e => " -cc " ++ e

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -21,6 +21,8 @@ import Data.Nat
 import Data.Strings
 import Data.Vect
 
+import Idris.Env
+
 import System
 import System.Directory
 import System.File
@@ -30,12 +32,12 @@ import System.Info
 
 findRacket : IO String
 findRacket =
-  do env <- getEnv "RACKET"
+  do env <- idrisGetEnv "RACKET"
      pure $ fromMaybe "/usr/bin/env racket" env
 
 findRacoExe : IO String
 findRacoExe =
-  do env <- getEnv "RACKET_RACO"
+  do env <- idrisGetEnv "RACKET_RACO"
      pure $ (fromMaybe "/usr/bin/env raco" env) ++ " exe"
 
 schHeader : String -> String

--- a/src/Idris/Driver.idr
+++ b/src/Idris/Driver.idr
@@ -9,6 +9,7 @@ import Core.Metadata
 import Core.Unify
 
 import Idris.CommandLine
+import Idris.Env
 import Idris.IDEMode.REPL
 import Idris.ModTree
 import Idris.Package
@@ -45,23 +46,23 @@ updateEnv : {auto c : Ref Ctxt Defs} ->
             Core ()
 updateEnv
     = do defs <- get Ctxt
-         bprefix <- coreLift $ getEnv "IDRIS2_PREFIX"
+         bprefix <- coreLift $ idrisGetEnv "IDRIS2_PREFIX"
          the (Core ()) $ case bprefix of
               Just p => setPrefix p
               Nothing => setPrefix yprefix
-         bpath <- coreLift $ getEnv "IDRIS2_PATH"
+         bpath <- coreLift $ idrisGetEnv "IDRIS2_PATH"
          the (Core ()) $ case bpath of
               Just path => do traverseList1_ addExtraDir (map trim (split (==pathSeparator) path))
               Nothing => pure ()
-         bdata <- coreLift $ getEnv "IDRIS2_DATA"
+         bdata <- coreLift $ idrisGetEnv "IDRIS2_DATA"
          the (Core ()) $ case bdata of
               Just path => do traverseList1_ addDataDir (map trim (split (==pathSeparator) path))
               Nothing => pure ()
-         blibs <- coreLift $ getEnv "IDRIS2_LIBS"
+         blibs <- coreLift $ idrisGetEnv "IDRIS2_LIBS"
          the (Core ()) $ case blibs of
               Just path => do traverseList1_ addLibDir (map trim (split (==pathSeparator) path))
               Nothing => pure ()
-         cg <- coreLift $ getEnv "IDRIS2_CG"
+         cg <- coreLift $ idrisGetEnv "IDRIS2_CG"
          the (Core ()) $ case cg of
               Just e => case getCG (options defs) e of
                              Just cg => setCG cg
@@ -87,7 +88,7 @@ updateREPLOpts : {auto o : Ref ROpts REPLOpts} ->
                  Core ()
 updateREPLOpts
     = do opts <- get ROpts
-         ed <- coreLift $ getEnv "EDITOR"
+         ed <- coreLift $ idrisGetEnv "EDITOR"
          the (Core ()) $ case ed of
               Just e => put ROpts (record { editor = e } opts)
               Nothing => pure ()

--- a/src/Idris/Env.idr
+++ b/src/Idris/Env.idr
@@ -1,0 +1,49 @@
+module Idris.Env
+
+--- All environment variables accessed by the compiler are enumerated in this module.
+
+import public Data.List
+import public Data.Maybe
+
+import System
+
+||| Environment variable used by Idris2 compiler
+public export
+record EnvDesc where
+  constructor MkEnvDesc
+  name : String
+  help : String
+
+||| All environment variables used by Idris2 compiler
+public export
+envs : List EnvDesc
+envs = [
+         MkEnvDesc "EDITOR"        "Editor used in REPL :e command",
+         MkEnvDesc "IDRIS2_PREFIX" "Idris2 installation prefix",
+         MkEnvDesc "IDRIS2_PATH"   "Places Idris2 looks for import files",
+         MkEnvDesc "IDRIS2_DATA"   "Places Idris2 looks for data files",
+         MkEnvDesc "IDRIS2_LIBS"   "Places Idris2 looks for libraries (for code generation)",
+         MkEnvDesc "IDRIS2_CG"     "Codegen backend",
+         MkEnvDesc "CHEZ"          "chez executable used in Chez codegen",
+         MkEnvDesc "RACKET"        "racket executable used in Racket codegen",
+         MkEnvDesc "RACKET_RACO"   "raco executable used in Racket codegen",
+         MkEnvDesc "GAMBIT_GSI"    "gsi executable used in Gambit codegen",
+         MkEnvDesc "GAMBIT_GSC"    "gsc executable used in Gambit codegen",
+         MkEnvDesc "GAMBIT_GSC_BACKEND" "gsc executable backend argument",
+         MkEnvDesc "IDRIS2_CC"     "C compiler executable used in RefC codegen",
+         MkEnvDesc "CC"            "C compiler executable used in RefC codegen",
+         MkEnvDesc "NODE"          "node executable used in Node codegen",
+         MkEnvDesc "PATH"          "PATH variable is used to search for executables in certain codegens"
+       ]
+
+--- `public export` only for `auto` to work in `idrisGetEnv`
+public export
+envNames : List String
+envNames = map (.name) envs
+
+||| Query documented environment variable
+public export
+idrisGetEnv : HasIO io => (name : String) ->
+  {auto known : IsJust (find (name ==) Env.envNames)}
+  -> io (Maybe String)
+idrisGetEnv name = getEnv name


### PR DESCRIPTION
Until yesterday I did not know Idris2 accesses environment variables.
Mentioning them in `--help` would educate other users.

Not all descriptions make sense, I tried my best to guess them.

Output is: [link](https://gist.github.com/stepancheg/7d1dff344a0dd35b9d07fb4a417ecb32).