### PR TITLE
libs: mark Data.Nat.lteAddRight as public export

### DIFF
--- a/libs/base/Data/Nat.idr
+++ b/libs/base/Data/Nat.idr
@@ -115,7 +115,7 @@ lteTransitive : LTE n m -> LTE m p -> LTE n p
 lteTransitive LTEZero y = LTEZero
 lteTransitive (LTESucc x) (LTESucc y) = LTESucc (lteTransitive x y)
 
-export
+public export
 lteAddRight : (n : Nat) -> LTE n (n + m)
 lteAddRight Z = LTEZero
 lteAddRight (S k) {m} = LTESucc (lteAddRight {m} k)


### PR DESCRIPTION
I encountered a lack of this export in idris-lang/idris2#945

We might want to export more of these helpers as `public export`