### PR TITLE
Make isElem, DecEq public, not just export

### DIFF
--- a/libs/base/Data/List/Elem.idr
+++ b/libs/base/Data/List/Elem.idr
@@ -49,7 +49,7 @@ neitherHereNorThere xny _     Here        = xny Refl
 neitherHereNorThere _   xnxs  (There xxs) = xnxs xxs
 
 ||| Check whether the given element is a member of the given list.
-export
+public export
 isElem : DecEq a => (x : a) -> (xs : List a) -> Dec (Elem x xs)
 isElem x [] = No absurd
 isElem x (y :: xs) with (decEq x y)

--- a/libs/base/Decidable/Equality.idr
+++ b/libs/base/Decidable/Equality.idr
@@ -14,7 +14,7 @@ import public Decidable.Equality.Core as Decidable.Equality
 --- Unit
 --------------------------------------------------------------------------------
 
-export
+public export
 DecEq () where
   decEq () () = Yes Refl
 
@@ -22,7 +22,7 @@ DecEq () where
 -- Booleans
 --------------------------------------------------------------------------------
 
-export
+public export
 DecEq Bool where
   decEq True  True  = Yes Refl
   decEq False False = Yes Refl
@@ -33,7 +33,7 @@ DecEq Bool where
 -- Nat
 --------------------------------------------------------------------------------
 
-export
+public export
 DecEq Nat where
   decEq Z     Z     = Yes Refl
   decEq Z     (S _) = No absurd
@@ -46,7 +46,7 @@ DecEq Nat where
 -- Maybe
 --------------------------------------------------------------------------------
 
-export
+public export
 DecEq t => DecEq (Maybe t) where
   decEq Nothing Nothing = Yes Refl
   decEq Nothing (Just _) = No absurd
@@ -60,7 +60,7 @@ DecEq t => DecEq (Maybe t) where
 -- Either
 --------------------------------------------------------------------------------
 
-export
+public export
 (DecEq t, DecEq s) => DecEq (Either t s) where
   decEq (Left x) (Left y) with (decEq x y)
    decEq (Left x) (Left x) | Yes Refl = Yes Refl
@@ -78,7 +78,7 @@ export
 pairInjective : (a, b) = (c, d) -> (a = c, b = d)
 pairInjective Refl = (Refl, Refl)
 
-export
+public export
 (DecEq a, DecEq b) => DecEq (a, b) where
   decEq (a, b) (a', b') with (decEq a a')
     decEq (a, b) (a', b') | (No contra) =
@@ -92,7 +92,7 @@ export
 -- List
 --------------------------------------------------------------------------------
 
-export
+public export
 DecEq a => DecEq (List a) where
   decEq [] [] = Yes Refl
   decEq (x :: xs) [] = No absurd
@@ -110,7 +110,7 @@ DecEq a => DecEq (List a) where
 -- List1
 --------------------------------------------------------------------------------
 
-export
+public export
 DecEq a => DecEq (List1 a) where
 
   decEq (x ::: xs) (y ::: ys) with (decEq x y)
@@ -131,7 +131,7 @@ DecEq a => DecEq (List1 a) where
 --------------------------------------------------------------------------------
 -- Int
 --------------------------------------------------------------------------------
-export
+public export
 implementation DecEq Int where
     decEq x y = case x == y of -- Blocks if x or y not concrete
                      True => Yes primitiveEq
@@ -144,7 +144,7 @@ implementation DecEq Int where
 --------------------------------------------------------------------------------
 -- Char
 --------------------------------------------------------------------------------
-export
+public export
 implementation DecEq Char where
     decEq x y = case x == y of -- Blocks if x or y not concrete
                      True => Yes primitiveEq
@@ -157,7 +157,7 @@ implementation DecEq Char where
 --------------------------------------------------------------------------------
 -- Integer
 --------------------------------------------------------------------------------
-export
+public export
 implementation DecEq Integer where
     decEq x y = case x == y of -- Blocks if x or y not concrete
                      True => Yes primitiveEq
@@ -170,7 +170,7 @@ implementation DecEq Integer where
 --------------------------------------------------------------------------------
 -- String
 --------------------------------------------------------------------------------
-export
+public export
 implementation DecEq String where
     decEq x y = case x == y of -- Blocks if x or y not concrete
                      True => Yes primitiveEq


### PR DESCRIPTION
... so they could be used in proof search.

Follow-up to #942