### PR TITLE
Replace lint.py with super-linter

### DIFF
--- a/.ecrc
+++ b/.ecrc
@@ -1,0 +1,5 @@
+{
+  "Disable": {
+    "IndentSize": true,
+  }
+}

--- a/.github/workflows/ci-super-linter.yml
+++ b/.github/workflows/ci-super-linter.yml
@@ -1,0 +1,56 @@
+---
+###########################
+###########################
+## Linter GitHub Actions ##
+###########################
+###########################
+name: Lint Code Base
+
+#
+# Documentation:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+#
+
+#############################
+# Start the job on all push #
+#############################
+on:
+  push:
+    # branches-ignore: [master]
+    # Remove the line above to run when pushing to master
+  pull_request:
+    branches: [master]
+
+###############
+# Set the Job #
+###############
+jobs:
+  build:
+    # Name the Job
+    name: Lint Code Base
+    # Set the agent to run on
+    runs-on: ubuntu-latest
+
+    ##################
+    # Load all steps #
+    ##################
+    steps:
+      ##########################
+      # Checkout the code base #
+      ##########################
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      ################################
+      # Run Linter against code base #
+      ################################
+      - name: Lint Code Base
+        uses: github/super-linter@v3
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
Example run with error:
[here](https://github.com/stepancheg/Idris2/runs/1718861440?check_suite_focus=true)

The downside is super-linter runs for 3 minutes. But that's probably expected
since the linter is [provided by GitHub](https://github.com/github/super-linter).

Two days ago when I submitted #931 I did not know super-linter exists.