### PR TITLE
removed trailing whitespace

### DIFF
--- a/benchmark/benchmarks/mergeInt/mergeInt.idr
+++ b/benchmark/benchmarks/mergeInt/mergeInt.idr
@@ -24,4 +24,3 @@ doSort (S k) = do let xs = sort $ randishInts 12000 $ natToInteger k
 main : IO ()
 main = do max <- getLine
           doSort (integerToNat (cast max))
-

--- a/libs/base/Data/IORef.idr
+++ b/libs/base/Data/IORef.idr
@@ -38,4 +38,3 @@ modifyIORef : HasIO io => IORef a -> (a -> a) -> io ()
 modifyIORef ref f
     = do val <- readIORef ref
          writeIORef ref (f val)
-

--- a/libs/base/System/FFI.idr
+++ b/libs/base/System/FFI.idr
@@ -32,4 +32,3 @@ public export %inline
 setField : {s : _} -> Struct s fs -> (n : String) ->
            {auto fieldok : FieldType n ty fs} -> ty -> IO ()
 setField s n val = primIO (prim__setField s n fieldok val)
-

--- a/libs/base/System/REPL.idr
+++ b/libs/base/System/REPL.idr
@@ -33,5 +33,3 @@ repl : HasIO io =>
        (prompt : String) -> (onInput : String -> String) -> io ()
 repl prompt fn
    = replWith () prompt (\x, s => Just (fn s, ()))
-
-

--- a/libs/contrib/Control/Monad/Syntax.idr
+++ b/libs/contrib/Control/Monad/Syntax.idr
@@ -18,4 +18,3 @@ public export
 ||| Right-to-left monadic bind, flipped version of `>>=`.
 (=<<) : Monad m => (a -> m b) -> m a -> m b
 (=<<) = flip (>>=)
-

--- a/libs/contrib/Data/List/Views/Extra.idr
+++ b/libs/contrib/Data/List/Views/Extra.idr
@@ -170,4 +170,3 @@ lazyFilterRec pred (x :: xs) with (pred x)
         rewrite appendAssociative (reverse revSkipped) [y] (z :: zs) in
           rewrite sym (reverseOntoSpec [y] revSkipped) in
             filterHelper (y :: revSkipped) (z :: zs)
-

--- a/libs/contrib/Data/Nat/Division.idr
+++ b/libs/contrib/Data/Nat/Division.idr
@@ -380,4 +380,3 @@ DivisionTheoremUniqueness numer denom denom_nz q r x prf =
   rewrite sym $ sndDivmodNatNZeqMod numer denom denom_nz denom_nz in
   rewrite DivisionTheoremUniquenessDivMod numer denom denom_nz q r x prf in
   (Refl, Refl)
-

--- a/libs/contrib/Data/Nat/Properties.idr
+++ b/libs/contrib/Data/Nat/Properties.idr
@@ -14,4 +14,3 @@ multRightCancel (S a)  0    r@(S predr) r_nz ar_eq_br impossible
 multRightCancel (S a) (S b) r@(S predr) r_nz ar_eq_br =
   cong S $ multRightCancel a b r r_nz
          $ plusLeftCancel r (a*r) (b*r) ar_eq_br
-

--- a/libs/contrib/Text/Lexer/Core.idr
+++ b/libs/contrib/Text/Lexer/Core.idr
@@ -208,4 +208,3 @@ lexTo : (TokenData a -> Bool) ->
 lexTo pred tmap str
     = let (ts, (l, c, str')) = tokenise pred 0 0 [] tmap (fastUnpack str) in
           (ts, (l, c, pack str'))
-

--- a/libs/prelude/Prelude/EqOrd.idr
+++ b/libs/prelude/Prelude/EqOrd.idr
@@ -211,5 +211,3 @@ Ord a => Ord b => Ord (a, b) where
   compare (x1, y1) (x2, y2)
       = if x1 /= x2 then compare x1 x2
                     else compare y1 y2
-
-

--- a/libs/prelude/Prelude/Ops.idr
+++ b/libs/prelude/Prelude/Ops.idr
@@ -25,4 +25,3 @@ infixr 9 .
 infixr 0 $
 
 infixl 9 `div`, `mod`
-

--- a/libs/prelude/Prelude/Uninhabited.idr
+++ b/libs/prelude/Prelude/Uninhabited.idr
@@ -36,4 +36,3 @@ Uninhabited (True = False) where
 public export
 Uninhabited (False = True) where
   uninhabited Refl impossible
-

--- a/samples/Interp.idr
+++ b/samples/Interp.idr
@@ -52,6 +52,3 @@ main : IO ()
 main = do putStr "Enter a number: "
           x <- getLine
           printLn (interp [] fact (cast x))
-
-
-

--- a/samples/Vect.idr
+++ b/samples/Vect.idr
@@ -37,4 +37,3 @@ Show a => Show (Vect n a) where
         show' Nil        = ""
         show' (x :: Nil) = show x
         show' (x :: xs)  = show x ++ ", " ++ show' xs
-

--- a/samples/With.idr
+++ b/samples/With.idr
@@ -44,4 +44,3 @@ natToBin Z = Nil
 natToBin k with (parity k)
    natToBin (j + j)     | Even = False :: natToBin j
    natToBin (S (j + j)) | Odd  = True  :: natToBin j
-

--- a/samples/proofs/induction.idr
+++ b/samples/proofs/induction.idr
@@ -14,4 +14,3 @@ plus_ind n m
                    (\k, k_rec => S k_rec) -- Inductive step plus_ind (S k) m
                                           -- where k_rec = plus_ind k m
                    n
-

--- a/samples/proofs/plusprops.idr
+++ b/samples/proofs/plusprops.idr
@@ -1,4 +1,2 @@
 plus_commutes : (n, m : Nat) -> plus n m = plus m n
 plus_assoc : (n, m, p : Nat) -> plus n (plus m p) = plus (plus n m) p
-
-

--- a/src/TTImp/BindImplicits.idr
+++ b/src/TTImp/BindImplicits.idr
@@ -188,4 +188,3 @@ piBindNames loc env tm
     piBind [] ty = ty
     piBind (n :: ns) ty
        = IPi loc erased Implicit (Just (UN n)) (Implicit loc False) (piBind ns ty)
-

--- a/src/TTImp/Elab/Dot.idr
+++ b/src/TTImp/Elab/Dot.idr
@@ -45,4 +45,3 @@ checkDot rig elabinfo nest env fc reason tm (Just gexpty)
              pure (metaval, gexpty)
         _ => throw (GenericMsg fc ("Dot pattern not valid here (Not LHS) "
                                    ++ show tm))
-

--- a/src/TTImp/Elab/Prim.idr
+++ b/src/TTImp/Elab/Prim.idr
@@ -27,4 +27,3 @@ checkPrim fc StringType = (PrimVal fc StringType, TType fc)
 checkPrim fc CharType = (PrimVal fc CharType, TType fc)
 checkPrim fc DoubleType = (PrimVal fc DoubleType, TType fc)
 checkPrim fc WorldType = (PrimVal fc WorldType, TType fc)
-

--- a/src/Utils/Octal.idr
+++ b/src/Utils/Octal.idr
@@ -49,4 +49,3 @@ fromOctChars = fromOctChars' 1
 export
 fromOct : String -> Maybe Int
 fromOct = fromOctChars . unpack
-

--- a/src/Utils/Path.idr
+++ b/src/Utils/Path.idr
@@ -1,541 +1,1081 @@
 module Utils.Path
 
+
+
 import Data.List
+
 import Data.Maybe
+
 import Data.Nat
+
 import Data.Strings
+
 import Data.String.Extra
 
+
+
 import Text.Token
+
 import Text.Lexer
+
 import Text.Parser
+
 import Text.Quantity
+
+
 
 import System.Info
 
+
+
 infixr 5 </>
+
 infixr 7 <.>
 
 
+
+
+
 ||| The character that separates directories in the path.
+
 export
+
 dirSeparator : Char
+
 dirSeparator = if isWindows then '\\' else '/'
 
+
+
 ||| The character that separates multiple paths.
+
 export
+
 pathSeparator : Char
+
 pathSeparator = if isWindows then ';' else ':'
 
+
+
 ||| Windows path prefix.
+
 public export
+
 data Volume
+
   =
+
   ||| Windows Uniform Naming Convention, consisting of server name and share
+
   ||| directory.
+
   |||
+
   ||| Example: `\\localhost\share`
+
   UNC String String |
+
   ||| The drive.
+
   |||
+
   ||| Example: `C:`
+
   Disk Char
 
+
+
 ||| A single body in path.
+
 public export
+
 data Body
+
   =
+
   ||| Represents ".".
+
   CurDir |
+
   ||| Represents "..".
+
   ParentDir |
+
   ||| Directory or file.
+
   Normal String
 
+
+
 ||| A parsed cross-platform file system path.
+
 |||
+
 ||| Use the function `parse` to constructs a Path from String, and use the
+
 ||| function `show` to convert in reverse.
+
 |||
+
 ||| Trailing separator is only used for display and is ignored when comparing
+
 ||| paths.
+
 public export
+
 record Path where
+
     constructor MkPath
+
     ||| Windows path prefix (only for Windows).
+
     volume : Maybe Volume
+
     ||| Whether the path contains root.
+
     hasRoot : Bool
+
     ||| Path bodies.
+
     body : List Body
+
     ||| Whether the path terminates with a separator.
+
     hasTrailSep : Bool
 
+
+
 export
+
 Eq Volume where
+
   (==) (UNC l1 l2) (UNC r1 r2) = l1 == r1 && r1 == r2
+
   (==) (Disk l) (Disk r) = l == r
+
   (==) _ _ = False
 
+
+
 export
+
 Eq Body where
+
   (==) CurDir CurDir = True
+
   (==) ParentDir ParentDir = True
+
   (==) (Normal l) (Normal r) = l == r
+
   (==) _ _ = False
 
+
+
 export
+
 Eq Path where
+
   (==) (MkPath l1 l2 l3 _) (MkPath r1 r2 r3 _) =
+
     l1 == r1 && l2 == r2 && l3 == r3
 
+
+
 ||| An empty path, which represents "".
+
 public export
+
 emptyPath : Path
+
 emptyPath = MkPath Nothing False [] False
 
---------------------------------------------------------------------------------
--- Show
+
+
 --------------------------------------------------------------------------------
 
+-- Show
+
+--------------------------------------------------------------------------------
+
+
+
 export
+
 Show Body where
+
   show CurDir = "."
+
   show ParentDir = ".."
+
   show (Normal normal) = normal
 
+
+
 export
+
 Show Volume where
+
   show (UNC server share) = "\\\\" ++ server ++ "\\" ++ share
+
   show (Disk disk) = Strings.singleton disk ++ ":"
 
+
+
 ||| Displays the path in the format of this platform.
+
 export
+
 Show Path where
+
   show path =
+
     let
+
       sep = Strings.singleton dirSeparator
+
       showVol = maybe "" show path.volume
+
       showRoot = if path.hasRoot then sep else ""
+
       showBody = join sep $ map show path.body
+
       showTrail = if path.hasTrailSep then sep else ""
+
     in
+
       showVol ++ showRoot ++ showBody ++ showTrail
 
+
+
 --------------------------------------------------------------------------------
+
 -- Parser
+
 --------------------------------------------------------------------------------
+
+
 
 data PathTokenKind = PTText | PTPunct Char
 
+
+
 Eq PathTokenKind where
+
   (==) PTText PTText = True
+
   (==) (PTPunct c1) (PTPunct c2) = c1 == c2
+
   (==) _ _ = False
 
+
+
 PathToken : Type
+
 PathToken = Token PathTokenKind
 
+
+
 TokenKind PathTokenKind where
+
   TokType PTText = String
+
   TokType (PTPunct _) = ()
 
+
+
   tokValue PTText x = x
+
   tokValue (PTPunct _) _ = ()
 
+
+
 pathTokenMap : TokenMap PathToken
+
 pathTokenMap = toTokenMap $
+
   [ (is '/', PTPunct '/')
+
   , (is '\\', PTPunct '\\')
+
   , (is ':', PTPunct ':')
+
   , (is '?', PTPunct '?')
+
   , (some $ non $ oneOf "/\\:?", PTText)
+
   ]
 
+
+
 lexPath : String -> List (WithBounds PathToken)
+
 lexPath str = let (tokens, _, _, _) = lex pathTokenMap str in tokens
 
+
+
 -- match both '/' and '\\' regardless of the platform.
+
 bodySeparator : Grammar PathToken True ()
+
 bodySeparator = (match $ PTPunct '\\') <|> (match $ PTPunct '/')
 
+
+
 -- Windows will automatically translate '/' to '\\'. And the verbatim prefix,
+
 -- i.e., `\\?\`, can be used to disable the translation.
+
 -- However, we just parse it and ignore it.
+
 --
+
 -- Example: \\?\
+
 verbatim : Grammar PathToken True ()
+
 verbatim =
+
   do
+
     count (exactly 2) $ match $ PTPunct '\\'
+
     match $ PTPunct '?'
+
     match $ PTPunct '\\'
+
     pure ()
 
+
+
 -- Example: \\server\share
+
 unc : Grammar PathToken True Volume
+
 unc =
+
   do
+
     count (exactly 2) $ match $ PTPunct '\\'
+
     server <- match PTText
+
     bodySeparator
+
     share <- match PTText
+
     pure $ UNC server share
+
+
 
 -- Example: \\?\server\share
+
 verbatimUnc : Grammar PathToken True Volume
+
 verbatimUnc =
+
   do
+
     verbatim
+
     server <- match PTText
+
     bodySeparator
+
     share <- match PTText
+
     pure $ UNC server share
 
+
+
 -- Example: C:
+
 disk : Grammar PathToken True Volume
+
 disk =
+
   do
+
     text <- match PTText
+
     disk <- case unpack text of
+
               (disk :: xs) => pure disk
+
               [] => fail "Expects disk"
+
     match $ PTPunct ':'
+
     pure $ Disk (toUpper disk)
 
+
+
 -- Example: \\?\C:
+
 verbatimDisk : Grammar PathToken True Volume
+
 verbatimDisk =
+
   do
+
     verbatim
+
     disk <- disk
+
     pure disk
 
+
+
 parseVolume : Grammar PathToken True Volume
+
 parseVolume =
+
       verbatimUnc
+
   <|> verbatimDisk
+
   <|> unc
+
   <|> disk
 
+
+
 parseBody : Grammar PathToken True Body
+
 parseBody =
+
   do
+
     text <- match PTText
+
     the (Grammar _ False _) $
+
       case text of
+
         ".." => pure ParentDir
+
         "." => pure CurDir
+
         normal => pure (Normal normal)
 
+
+
 parsePath : Grammar PathToken False Path
+
 parsePath =
+
   do
+
     vol <- optional parseVolume
+
     root <- optional (some bodySeparator)
+
     body <- sepBy (some bodySeparator) parseBody
+
     trailSep <- optional (some bodySeparator)
+
     let body = filter (\case Normal s => ltrim s /= ""; _ => True) body
+
     let body = case body of
+
                 [] => []
+
                 (x::xs) => x :: delete CurDir xs
+
     pure $ MkPath vol (isJust root) body (isJust trailSep)
 
+
+
 ||| Parses a String into Path.
+
 |||
+
 ||| The string is parsed as much as possible from left to right, and the invalid
+
 ||| parts on the right is ignored.
+
 |||
+
 ||| Some kind of invalid paths are accepted. The relax rules:
+
 |||
+
 ||| - Both slash('/') and backslash('\\') are parsed as valid directory separator,
+
 |||   regardless of the platform;
+
 ||| - Any characters in the body in allowed, e.g., glob like "/root/*";
+
 ||| - Verbatim prefix(`\\?\`) that disables the forward slash is ignored (for
+
 |||   Windows only).
+
 ||| - Repeated separators are ignored, therefore, "a/b" and "a//b" both have "a"
+
 |||   and "b" as bodies.
+
 ||| - "." in the body are removed, unless they are at the beginning of the path.
+
 |||   For example, "a/./b", "a/b/", "a/b/." and "a/b" will have "a" and "b" as
+
 |||   bodies, and "./a/b" will starts with `CurDir`.
+
 |||
+
 ||| ```idris example
+
 ||| parse "C:\\Windows/System32"
+
 ||| parse "/usr/local/etc/*"
+
 ||| ```
+
 export
+
 parse : String -> Path
+
 parse str =
+
   case parse parsePath (lexPath str) of
+
     Right (path, _) => path
+
     _ => emptyPath
 
+
+
 --------------------------------------------------------------------------------
+
 -- Utils
+
 --------------------------------------------------------------------------------
+
+
 
 isAbsolute' : Path -> Bool
+
 isAbsolute' path =
+
   if isWindows then
+
     case path.volume of
+
       Just (UNC _ _) => True
+
       Just (Disk _) => path.hasRoot
+
       Nothing => False
+
   else
+
     path.hasRoot
 
+
+
 append' : (left : Path) -> (right : Path) -> Path
+
 append' left right =
+
   if isAbsolute' right || isJust right.volume then
+
     right
+
   else if hasRoot right then
+
     record { volume = left.volume } right
+
   else
+
     record { body = left.body ++ right.body, hasTrailSep = right.hasTrailSep } left
 
+
+
 splitPath' : Path -> List Path
+
 splitPath' path =
+
   case splitRoot path of
+
     (Just root, other) => root :: iterateBody (path.body) (path.hasTrailSep)
+
     (Nothing, other) => iterateBody (path.body) (path.hasTrailSep)
+
   where
+
     splitRoot : Path -> (Maybe Path, Path)
+
     splitRoot path@(MkPath Nothing False _ _) = (Nothing, path)
+
     splitRoot (MkPath vol root xs trailSep) =
+
       (Just $ MkPath vol root [] False, MkPath Nothing False xs trailSep)
 
+
+
     iterateBody : List Body -> (trailSep : Bool) -> List Path
+
     iterateBody [] _ = []
+
     iterateBody [x] trailSep = [MkPath Nothing False [x] trailSep]
+
     iterateBody (x::y::xs) trailSep =
+
       (MkPath Nothing False [x] False) :: iterateBody (y::xs) trailSep
 
+
+
 splitParent' : Path -> Maybe (Path, Path)
+
 splitParent' path =
+
   case path.body of
+
     [] => Nothing
+
     (x::xs) =>
+
       let
+
         parent = record { body = init (x::xs), hasTrailSep = False } path
+
         child = MkPath Nothing False [last (x::xs)] path.hasTrailSep
+
       in
+
         Just (parent, child)
 
+
+
 parent' : Path -> Maybe Path
+
 parent' = map fst . splitParent'
 
+
+
 fileName' : Path -> Maybe String
+
 fileName' path =
+
   findNormal $ reverse path.body
+
 where
+
   findNormal : List Body -> Maybe String
+
   findNormal ((Normal normal)::xs) = Just normal
+
   findNormal (CurDir::xs) = findNormal xs
+
   findNormal _ = Nothing
 
+
+
 setFileName' : (name : String) -> Path -> Path
+
 setFileName' name path =
+
   if isJust (fileName' path) then
+
     append' (fromMaybe emptyPath $ parent' path) (parse name)
+
   else
+
     append' path (parse name)
 
+
+
 splitFileName : String -> (String, String)
+
 splitFileName name =
+
   case break (== '.') $ reverse $ unpack name of
+
     (_, []) => (name, "")
+
     (_, ['.']) => (name, "")
+
     (revExt, (dot :: revStem)) =>
+
       ((pack $ reverse revStem), (pack $ reverse revExt))
 
+
+
 --------------------------------------------------------------------------------
+
 -- Methods
+
 --------------------------------------------------------------------------------
+
+
 
 ||| Returns true if the path is absolute.
+
 |||
+
 ||| - On Unix, a path is absolute if it starts with the root, so `isAbsolute` and
+
 |||   `hasRoot` are equivalent.
+
 |||
+
 ||| - On Windows, a path is absolute if it starts with a disk and has root or
+
 |||   starts with UNC. For example, `c:\\windows` is absolute, while `c:temp`
+
 |||   and `\temp` are not.
+
 export
+
 isAbsolute : String -> Bool
+
 isAbsolute = isAbsolute' . parse
 
+
+
 ||| Returns true if the path is relative.
+
 export
+
 isRelative : String -> Bool
+
 isRelative = not . isAbsolute
 
+
+
 ||| Appends the right path to the left path.
+
 |||
+
 ||| If the path on the right is absolute, it replaces the left path.
+
 |||
+
 ||| On Windows:
+
 |||
+
 ||| - If the right path has a root but no volume (e.g., `\windows`), it replaces
+
 |||   everything except for the volume (if any) of left.
+
 ||| - If the right path has a volume but no root, it replaces left.
+
 |||
+
 ||| ```idris example
+
 ||| "/usr" </> "local/etc" == "/usr/local/etc"
+
 ||| ```
+
 export
+
 (</>) : (left : String) -> (right : String) -> String
+
 (</>) left right = show $ append' (parse left) (parse right)
 
+
+
 ||| Joins path components into one.
+
 |||
+
 ||| ```idris example
+
 ||| joinPath ["/usr", "local/etc"] == "/usr/local/etc"
+
 ||| ```
+
 export
+
 joinPath : List String -> String
+
 joinPath xs = foldl (</>) "" xs
 
+
+
 ||| Splits path into components.
+
 |||
+
 ||| ```idris example
+
 ||| splitPath "/usr/local/etc" == ["/", "usr", "local", "etc"]
+
 ||| splitPath "tmp/Foo.idr" == ["tmp", "Foo.idr"]
+
 ||| ```
+
 export
+
 splitPath : String -> List String
+
 splitPath = map show . splitPath' . parse
 
+
+
 ||| Splits the path into parent and child.
+
 |||
+
 ||| ```idris example
+
 ||| splitParent "/usr/local/etc" == Just ("/usr/local", "etc")
+
 ||| ```
+
 export
+
 splitParent : String -> Maybe (String, String)
+
 splitParent path =
+
   do
+
     (parent, child) <- splitParent' (parse path)
+
     pure (show parent, show child)
 
+
+
 ||| Returns the path without its final component, if there is one.
+
 |||
+
 ||| Returns Nothing if the path terminates by a root or volume.
+
 export
+
 parent : String -> Maybe String
+
 parent = map show . parent' . parse
 
+
+
 ||| Returns the list of all parents of the path, longest first, self included.
+
 |||
+
 ||| ```idris example
+
 ||| parents "/etc/kernel" == ["/etc/kernel", "/etc", "/"]
+
 ||| ```
+
 export
+
 parents : String -> List String
+
 parents = map show . List.iterate parent' . parse
 
+
+
 ||| Determines whether the base is one of the parents of target.
+
 |||
+
 ||| Trailing separator is ignored.
+
 |||
+
 ||| ```idris example
+
 ||| "/etc" `isBaseOf` "/etc/kernel"
+
 ||| ```
+
 export
+
 isBaseOf : (base : String) -> (target : String) -> Bool
+
 isBaseOf base target =
+
   let
+
     MkPath baseVol baseRoot baseBody _ = parse base
+
     MkPath targetVol targetRoot targetBody _ = parse target
+
   in
+
        baseVol == targetVol
+
     && baseRoot == targetRoot
+
     && (baseBody `isPrefixOf` targetBody)
 
+
+
 ||| Returns a path that, when appended to base, yields target.
+
 |||
+
 ||| Returns Nothing if the base is not a prefix of the target.
+
 export
+
 dropBase : (base : String) -> (target : String) -> Maybe String
+
 dropBase base target =
+
   do
+
     let MkPath baseVol baseRoot baseBody _ = parse base
+
     let MkPath targetVol targetRoot targetBody targetTrialSep = parse target
+
     if baseVol == targetVol && baseRoot == targetRoot then Just () else Nothing
+
     body <- dropBody baseBody targetBody
+
     pure $ show $ MkPath Nothing False body targetTrialSep
+
   where
+
     dropBody : (base : List Body) -> (target : List Body) -> Maybe (List Body)
+
     dropBody [] ys = Just ys
+
     dropBody xs [] = Nothing
+
     dropBody (x::xs) (y::ys) = if x == y then dropBody xs ys else Nothing
 
+
+
 ||| Returns the last body of the path.
+
 |||
+
 ||| If the last body is a file, this is the file name;
+
 ||| if it's a directory, this is the directory name;
+
 ||| if it's ".", it recurses on the previous body;
+
 ||| if it's "..", returns Nothing.
+
 export
+
 fileName : String -> Maybe String
+
 fileName  = fileName' . parse
 
+
+
 ||| Extracts the file name in the path without extension.
+
 |||
+
 ||| The stem is:
+
 |||
+
 ||| - Nothing, if there is no file name;
+
 ||| - The entire file name if there is no embedded ".";
+
 ||| - The entire file name if the file name begins with a "." and has no other ".";
+
 ||| - Otherwise, the portion of the file name before the last ".".
+
 export
+
 fileStem : String -> Maybe String
+
 fileStem path = pure $ fst $ splitFileName !(fileName path)
 
+
+
 ||| Extracts the extension of the file name in the path.
+
 |||
+
 ||| The extension is:
+
 |||
+
 ||| - Nothing, if there is no file name;
+
 ||| - Nothing, if there is no embedded ".";
+
 ||| - Nothing, if the file name begins with a "." and has no other ".";
+
 ||| - Otherwise, the portion of the file name after the last ".".
+
 export
+
 extension : String -> Maybe String
+
 extension path = pure $ snd $ splitFileName !(fileName path)
 
+
+
 ||| Updates the file name in the path.
+
 |||
+
 ||| If there is no file name, it appends the name to the path;
+
 ||| otherwise, it appends the name to the parent of the path.
+
 export
+
 setFileName : (name : String) -> String -> String
+
 setFileName name path = show $ setFileName' name (parse path)
 
+
+
 ||| Appends a extension to the path.
+
 |||
+
 ||| If there is no file name, the path will not change;
+
 ||| if the path has no extension, the extension will be appended;
+
 ||| if the given extension is empty, the extension of the path will be dropped;
+
 ||| otherwise, the extension will be replaced.
+
 |||
+
 ||| ```idris example
+
 ||| "/tmp/Foo" <.> "idr" == "/tmp/Foo.idr"
+
 ||| ```
+
 export
+
 (<.>) : String -> (extension : String) -> String
+
 (<.>) path ext =
+
   let
+
     path' = parse path
+
     ext = pack $ dropWhile (\char => char == '.' || isSpace char) (unpack ext)
+
     ext = if ext == "" then "" else "." ++ ext
+
   in
+
     case fileName' path' of
+
       Just name =>
+
         let (stem, _) = splitFileName name in
+
           show $ setFileName' (stem ++ ext) path'
+
       Nothing => path
 
+
+
 ||| Drops the extension of the path.
+
 export
+
 dropExtension : String -> String
+
 dropExtension path = path <.> ""

--- a/src/Utils/Path.idr
+++ b/src/Utils/Path.idr
@@ -1,1081 +1,541 @@
 module Utils.Path
 
-
-
 import Data.List
-
 import Data.Maybe
-
 import Data.Nat
-
 import Data.Strings
-
 import Data.String.Extra
 
-
-
 import Text.Token
-
 import Text.Lexer
-
 import Text.Parser
-
 import Text.Quantity
-
-
 
 import System.Info
 
-
-
 infixr 5 </>
-
 infixr 7 <.>
 
 
-
-
-
 ||| The character that separates directories in the path.
-
 export
-
 dirSeparator : Char
-
 dirSeparator = if isWindows then '\\' else '/'
 
-
-
 ||| The character that separates multiple paths.
-
 export
-
 pathSeparator : Char
-
 pathSeparator = if isWindows then ';' else ':'
 
-
-
 ||| Windows path prefix.
-
 public export
-
 data Volume
-
   =
-
   ||| Windows Uniform Naming Convention, consisting of server name and share
-
   ||| directory.
-
   |||
-
   ||| Example: `\\localhost\share`
-
   UNC String String |
-
   ||| The drive.
-
   |||
-
   ||| Example: `C:`
-
   Disk Char
 
-
-
 ||| A single body in path.
-
 public export
-
 data Body
-
   =
-
   ||| Represents ".".
-
   CurDir |
-
   ||| Represents "..".
-
   ParentDir |
-
   ||| Directory or file.
-
   Normal String
 
-
-
 ||| A parsed cross-platform file system path.
-
 |||
-
 ||| Use the function `parse` to constructs a Path from String, and use the
-
 ||| function `show` to convert in reverse.
-
 |||
-
 ||| Trailing separator is only used for display and is ignored when comparing
-
 ||| paths.
-
 public export
-
 record Path where
-
     constructor MkPath
-
     ||| Windows path prefix (only for Windows).
-
     volume : Maybe Volume
-
     ||| Whether the path contains root.
-
     hasRoot : Bool
-
     ||| Path bodies.
-
     body : List Body
-
     ||| Whether the path terminates with a separator.
-
     hasTrailSep : Bool
 
-
-
 export
-
 Eq Volume where
-
   (==) (UNC l1 l2) (UNC r1 r2) = l1 == r1 && r1 == r2
-
   (==) (Disk l) (Disk r) = l == r
-
   (==) _ _ = False
 
-
-
 export
-
 Eq Body where
-
   (==) CurDir CurDir = True
-
   (==) ParentDir ParentDir = True
-
   (==) (Normal l) (Normal r) = l == r
-
   (==) _ _ = False
 
-
-
 export
-
 Eq Path where
-
   (==) (MkPath l1 l2 l3 _) (MkPath r1 r2 r3 _) =
-
     l1 == r1 && l2 == r2 && l3 == r3
 
-
-
 ||| An empty path, which represents "".
-
 public export
-
 emptyPath : Path
-
 emptyPath = MkPath Nothing False [] False
 
-
-
 --------------------------------------------------------------------------------
-
 -- Show
-
 --------------------------------------------------------------------------------
-
-
 
 export
-
 Show Body where
-
   show CurDir = "."
-
   show ParentDir = ".."
-
   show (Normal normal) = normal
 
-
-
 export
-
 Show Volume where
-
   show (UNC server share) = "\\\\" ++ server ++ "\\" ++ share
-
   show (Disk disk) = Strings.singleton disk ++ ":"
 
-
-
 ||| Displays the path in the format of this platform.
-
 export
-
 Show Path where
-
   show path =
-
     let
-
       sep = Strings.singleton dirSeparator
-
       showVol = maybe "" show path.volume
-
       showRoot = if path.hasRoot then sep else ""
-
       showBody = join sep $ map show path.body
-
       showTrail = if path.hasTrailSep then sep else ""
-
     in
-
       showVol ++ showRoot ++ showBody ++ showTrail
 
-
-
 --------------------------------------------------------------------------------
-
 -- Parser
-
 --------------------------------------------------------------------------------
-
-
 
 data PathTokenKind = PTText | PTPunct Char
 
-
-
 Eq PathTokenKind where
-
   (==) PTText PTText = True
-
   (==) (PTPunct c1) (PTPunct c2) = c1 == c2
-
   (==) _ _ = False
 
-
-
 PathToken : Type
-
 PathToken = Token PathTokenKind
 
-
-
 TokenKind PathTokenKind where
-
   TokType PTText = String
-
   TokType (PTPunct _) = ()
 
-
-
   tokValue PTText x = x
-
   tokValue (PTPunct _) _ = ()
 
-
-
 pathTokenMap : TokenMap PathToken
-
 pathTokenMap = toTokenMap $
-
   [ (is '/', PTPunct '/')
-
   , (is '\\', PTPunct '\\')
-
   , (is ':', PTPunct ':')
-
   , (is '?', PTPunct '?')
-
   , (some $ non $ oneOf "/\\:?", PTText)
-
   ]
 
-
-
 lexPath : String -> List (WithBounds PathToken)
-
 lexPath str = let (tokens, _, _, _) = lex pathTokenMap str in tokens
 
-
-
 -- match both '/' and '\\' regardless of the platform.
-
 bodySeparator : Grammar PathToken True ()
-
 bodySeparator = (match $ PTPunct '\\') <|> (match $ PTPunct '/')
 
-
-
 -- Windows will automatically translate '/' to '\\'. And the verbatim prefix,
-
 -- i.e., `\\?\`, can be used to disable the translation.
-
 -- However, we just parse it and ignore it.
-
 --
-
 -- Example: \\?\
-
 verbatim : Grammar PathToken True ()
-
 verbatim =
-
   do
-
     count (exactly 2) $ match $ PTPunct '\\'
-
     match $ PTPunct '?'
-
     match $ PTPunct '\\'
-
     pure ()
 
-
-
 -- Example: \\server\share
-
 unc : Grammar PathToken True Volume
-
 unc =
-
   do
-
     count (exactly 2) $ match $ PTPunct '\\'
-
     server <- match PTText
-
     bodySeparator
-
     share <- match PTText
-
     pure $ UNC server share
-
-
 
 -- Example: \\?\server\share
-
 verbatimUnc : Grammar PathToken True Volume
-
 verbatimUnc =
-
   do
-
     verbatim
-
     server <- match PTText
-
     bodySeparator
-
     share <- match PTText
-
     pure $ UNC server share
 
-
-
 -- Example: C:
-
 disk : Grammar PathToken True Volume
-
 disk =
-
   do
-
     text <- match PTText
-
     disk <- case unpack text of
-
               (disk :: xs) => pure disk
-
               [] => fail "Expects disk"
-
     match $ PTPunct ':'
-
     pure $ Disk (toUpper disk)
 
-
-
 -- Example: \\?\C:
-
 verbatimDisk : Grammar PathToken True Volume
-
 verbatimDisk =
-
   do
-
     verbatim
-
     disk <- disk
-
     pure disk
 
-
-
 parseVolume : Grammar PathToken True Volume
-
 parseVolume =
-
       verbatimUnc
-
   <|> verbatimDisk
-
   <|> unc
-
   <|> disk
 
-
-
 parseBody : Grammar PathToken True Body
-
 parseBody =
-
   do
-
     text <- match PTText
-
     the (Grammar _ False _) $
-
       case text of
-
         ".." => pure ParentDir
-
         "." => pure CurDir
-
         normal => pure (Normal normal)
 
-
-
 parsePath : Grammar PathToken False Path
-
 parsePath =
-
   do
-
     vol <- optional parseVolume
-
     root <- optional (some bodySeparator)
-
     body <- sepBy (some bodySeparator) parseBody
-
     trailSep <- optional (some bodySeparator)
-
     let body = filter (\case Normal s => ltrim s /= ""; _ => True) body
-
     let body = case body of
-
                 [] => []
-
                 (x::xs) => x :: delete CurDir xs
-
     pure $ MkPath vol (isJust root) body (isJust trailSep)
 
-
-
 ||| Parses a String into Path.
-
 |||
-
 ||| The string is parsed as much as possible from left to right, and the invalid
-
 ||| parts on the right is ignored.
-
 |||
-
 ||| Some kind of invalid paths are accepted. The relax rules:
-
 |||
-
 ||| - Both slash('/') and backslash('\\') are parsed as valid directory separator,
-
 |||   regardless of the platform;
-
 ||| - Any characters in the body in allowed, e.g., glob like "/root/*";
-
 ||| - Verbatim prefix(`\\?\`) that disables the forward slash is ignored (for
-
 |||   Windows only).
-
 ||| - Repeated separators are ignored, therefore, "a/b" and "a//b" both have "a"
-
 |||   and "b" as bodies.
-
 ||| - "." in the body are removed, unless they are at the beginning of the path.
-
 |||   For example, "a/./b", "a/b/", "a/b/." and "a/b" will have "a" and "b" as
-
 |||   bodies, and "./a/b" will starts with `CurDir`.
-
 |||
-
 ||| ```idris example
-
 ||| parse "C:\\Windows/System32"
-
 ||| parse "/usr/local/etc/*"
-
 ||| ```
-
 export
-
 parse : String -> Path
-
 parse str =
-
   case parse parsePath (lexPath str) of
-
     Right (path, _) => path
-
     _ => emptyPath
 
-
-
 --------------------------------------------------------------------------------
-
 -- Utils
-
 --------------------------------------------------------------------------------
-
-
 
 isAbsolute' : Path -> Bool
-
 isAbsolute' path =
-
   if isWindows then
-
     case path.volume of
-
       Just (UNC _ _) => True
-
       Just (Disk _) => path.hasRoot
-
       Nothing => False
-
   else
-
     path.hasRoot
 
-
-
 append' : (left : Path) -> (right : Path) -> Path
-
 append' left right =
-
   if isAbsolute' right || isJust right.volume then
-
     right
-
   else if hasRoot right then
-
     record { volume = left.volume } right
-
   else
-
     record { body = left.body ++ right.body, hasTrailSep = right.hasTrailSep } left
 
-
-
 splitPath' : Path -> List Path
-
 splitPath' path =
-
   case splitRoot path of
-
     (Just root, other) => root :: iterateBody (path.body) (path.hasTrailSep)
-
     (Nothing, other) => iterateBody (path.body) (path.hasTrailSep)
-
   where
-
     splitRoot : Path -> (Maybe Path, Path)
-
     splitRoot path@(MkPath Nothing False _ _) = (Nothing, path)
-
     splitRoot (MkPath vol root xs trailSep) =
-
       (Just $ MkPath vol root [] False, MkPath Nothing False xs trailSep)
 
-
-
     iterateBody : List Body -> (trailSep : Bool) -> List Path
-
     iterateBody [] _ = []
-
     iterateBody [x] trailSep = [MkPath Nothing False [x] trailSep]
-
     iterateBody (x::y::xs) trailSep =
-
       (MkPath Nothing False [x] False) :: iterateBody (y::xs) trailSep
 
-
-
 splitParent' : Path -> Maybe (Path, Path)
-
 splitParent' path =
-
   case path.body of
-
     [] => Nothing
-
     (x::xs) =>
-
       let
-
         parent = record { body = init (x::xs), hasTrailSep = False } path
-
         child = MkPath Nothing False [last (x::xs)] path.hasTrailSep
-
       in
-
         Just (parent, child)
 
-
-
 parent' : Path -> Maybe Path
-
 parent' = map fst . splitParent'
 
-
-
 fileName' : Path -> Maybe String
-
 fileName' path =
-
   findNormal $ reverse path.body
-
 where
-
   findNormal : List Body -> Maybe String
-
   findNormal ((Normal normal)::xs) = Just normal
-
   findNormal (CurDir::xs) = findNormal xs
-
   findNormal _ = Nothing
 
-
-
 setFileName' : (name : String) -> Path -> Path
-
 setFileName' name path =
-
   if isJust (fileName' path) then
-
     append' (fromMaybe emptyPath $ parent' path) (parse name)
-
   else
-
     append' path (parse name)
 
-
-
 splitFileName : String -> (String, String)
-
 splitFileName name =
-
   case break (== '.') $ reverse $ unpack name of
-
     (_, []) => (name, "")
-
     (_, ['.']) => (name, "")
-
     (revExt, (dot :: revStem)) =>
-
       ((pack $ reverse revStem), (pack $ reverse revExt))
 
-
-
 --------------------------------------------------------------------------------
-
 -- Methods
-
 --------------------------------------------------------------------------------
-
-
 
 ||| Returns true if the path is absolute.
-
 |||
-
 ||| - On Unix, a path is absolute if it starts with the root, so `isAbsolute` and
-
 |||   `hasRoot` are equivalent.
-
 |||
-
 ||| - On Windows, a path is absolute if it starts with a disk and has root or
-
 |||   starts with UNC. For example, `c:\\windows` is absolute, while `c:temp`
-
 |||   and `\temp` are not.
-
 export
-
 isAbsolute : String -> Bool
-
 isAbsolute = isAbsolute' . parse
 
-
-
 ||| Returns true if the path is relative.
-
 export
-
 isRelative : String -> Bool
-
 isRelative = not . isAbsolute
 
-
-
 ||| Appends the right path to the left path.
-
 |||
-
 ||| If the path on the right is absolute, it replaces the left path.
-
 |||
-
 ||| On Windows:
-
 |||
-
 ||| - If the right path has a root but no volume (e.g., `\windows`), it replaces
-
 |||   everything except for the volume (if any) of left.
-
 ||| - If the right path has a volume but no root, it replaces left.
-
 |||
-
 ||| ```idris example
-
 ||| "/usr" </> "local/etc" == "/usr/local/etc"
-
 ||| ```
-
 export
-
 (</>) : (left : String) -> (right : String) -> String
-
 (</>) left right = show $ append' (parse left) (parse right)
 
-
-
 ||| Joins path components into one.
-
 |||
-
 ||| ```idris example
-
 ||| joinPath ["/usr", "local/etc"] == "/usr/local/etc"
-
 ||| ```
-
 export
-
 joinPath : List String -> String
-
 joinPath xs = foldl (</>) "" xs
 
-
-
 ||| Splits path into components.
-
 |||
-
 ||| ```idris example
-
 ||| splitPath "/usr/local/etc" == ["/", "usr", "local", "etc"]
-
 ||| splitPath "tmp/Foo.idr" == ["tmp", "Foo.idr"]
-
 ||| ```
-
 export
-
 splitPath : String -> List String
-
 splitPath = map show . splitPath' . parse
 
-
-
 ||| Splits the path into parent and child.
-
 |||
-
 ||| ```idris example
-
 ||| splitParent "/usr/local/etc" == Just ("/usr/local", "etc")
-
 ||| ```
-
 export
-
 splitParent : String -> Maybe (String, String)
-
 splitParent path =
-
   do
-
     (parent, child) <- splitParent' (parse path)
-
     pure (show parent, show child)
 
-
-
 ||| Returns the path without its final component, if there is one.
-
 |||
-
 ||| Returns Nothing if the path terminates by a root or volume.
-
 export
-
 parent : String -> Maybe String
-
 parent = map show . parent' . parse
 
-
-
 ||| Returns the list of all parents of the path, longest first, self included.
-
 |||
-
 ||| ```idris example
-
 ||| parents "/etc/kernel" == ["/etc/kernel", "/etc", "/"]
-
 ||| ```
-
 export
-
 parents : String -> List String
-
 parents = map show . List.iterate parent' . parse
 
-
-
 ||| Determines whether the base is one of the parents of target.
-
 |||
-
 ||| Trailing separator is ignored.
-
 |||
-
 ||| ```idris example
-
 ||| "/etc" `isBaseOf` "/etc/kernel"
-
 ||| ```
-
 export
-
 isBaseOf : (base : String) -> (target : String) -> Bool
-
 isBaseOf base target =
-
   let
-
     MkPath baseVol baseRoot baseBody _ = parse base
-
     MkPath targetVol targetRoot targetBody _ = parse target
-
   in
-
        baseVol == targetVol
-
     && baseRoot == targetRoot
-
     && (baseBody `isPrefixOf` targetBody)
 
-
-
 ||| Returns a path that, when appended to base, yields target.
-
 |||
-
 ||| Returns Nothing if the base is not a prefix of the target.
-
 export
-
 dropBase : (base : String) -> (target : String) -> Maybe String
-
 dropBase base target =
-
   do
-
     let MkPath baseVol baseRoot baseBody _ = parse base
-
     let MkPath targetVol targetRoot targetBody targetTrialSep = parse target
-
     if baseVol == targetVol && baseRoot == targetRoot then Just () else Nothing
-
     body <- dropBody baseBody targetBody
-
     pure $ show $ MkPath Nothing False body targetTrialSep
-
   where
-
     dropBody : (base : List Body) -> (target : List Body) -> Maybe (List Body)
-
     dropBody [] ys = Just ys
-
     dropBody xs [] = Nothing
-
     dropBody (x::xs) (y::ys) = if x == y then dropBody xs ys else Nothing
 
-
-
 ||| Returns the last body of the path.
-
 |||
-
 ||| If the last body is a file, this is the file name;
-
 ||| if it's a directory, this is the directory name;
-
 ||| if it's ".", it recurses on the previous body;
-
 ||| if it's "..", returns Nothing.
-
 export
-
 fileName : String -> Maybe String
-
 fileName  = fileName' . parse
 
-
-
 ||| Extracts the file name in the path without extension.
-
 |||
-
 ||| The stem is:
-
 |||
-
 ||| - Nothing, if there is no file name;
-
 ||| - The entire file name if there is no embedded ".";
-
 ||| - The entire file name if the file name begins with a "." and has no other ".";
-
 ||| - Otherwise, the portion of the file name before the last ".".
-
 export
-
 fileStem : String -> Maybe String
-
 fileStem path = pure $ fst $ splitFileName !(fileName path)
 
-
-
 ||| Extracts the extension of the file name in the path.
-
 |||
-
 ||| The extension is:
-
 |||
-
 ||| - Nothing, if there is no file name;
-
 ||| - Nothing, if there is no embedded ".";
-
 ||| - Nothing, if the file name begins with a "." and has no other ".";
-
 ||| - Otherwise, the portion of the file name after the last ".".
-
 export
-
 extension : String -> Maybe String
-
 extension path = pure $ snd $ splitFileName !(fileName path)
 
-
-
 ||| Updates the file name in the path.
-
 |||
-
 ||| If there is no file name, it appends the name to the path;
-
 ||| otherwise, it appends the name to the parent of the path.
-
 export
-
 setFileName : (name : String) -> String -> String
-
 setFileName name path = show $ setFileName' name (parse path)
 
-
-
 ||| Appends a extension to the path.
-
 |||
-
 ||| If there is no file name, the path will not change;
-
 ||| if the path has no extension, the extension will be appended;
-
 ||| if the given extension is empty, the extension of the path will be dropped;
-
 ||| otherwise, the extension will be replaced.
-
 |||
-
 ||| ```idris example
-
 ||| "/tmp/Foo" <.> "idr" == "/tmp/Foo.idr"
-
 ||| ```
-
 export
-
 (<.>) : String -> (extension : String) -> String
-
 (<.>) path ext =
-
   let
-
     path' = parse path
-
     ext = pack $ dropWhile (\char => char == '.' || isSpace char) (unpack ext)
-
     ext = if ext == "" then "" else "." ++ ext
-
   in
-
     case fileName' path' of
-
       Just name =>
-
         let (stem, _) = splitFileName name in
-
           show $ setFileName' (stem ++ ext) path'
-
       Nothing => path
 
-
-
 ||| Drops the extension of the path.
-
 export
-
 dropExtension : String -> String
-
 dropExtension path = path <.> ""

--- a/tests/chez/chez004/Buffer.idr
+++ b/tests/chez/chez004/Buffer.idr
@@ -61,4 +61,3 @@ main
 --              | Left err => do putStrLn "Buffer read fail"
 --                               closeFile f
 --          closeFile f
-

--- a/tests/chez/chez006/TypeCase.idr
+++ b/tests/chez/chez006/TypeCase.idr
@@ -29,4 +29,3 @@ main = do printLn (foo Nat)
           printLn (foo (List Int))
           printLn (strangeId 42)
           printLn (strangeId (the Int 42))
-

--- a/tests/chez/chez017/dir.idr
+++ b/tests/chez/chez017/dir.idr
@@ -12,4 +12,3 @@ main = do Right () <- createDir "testdir"
           printLn ok
           writeFile "test.txt" "hello\n"
           printLn !currentDir
-

--- a/tests/chez/chez021/Bits.idr
+++ b/tests/chez/chez021/Bits.idr
@@ -40,4 +40,3 @@ main
          printLn (the Bits16 (fromInteger (-1)))
          printLn (the Bits32 (fromInteger (-1)))
          printLn (the Bits64 (fromInteger (-1)))
-

--- a/tests/idris2/basic002/Do.idr
+++ b/tests/idris2/basic002/Do.idr
@@ -46,4 +46,3 @@ mLetBind x y
     = do let Just res = maybeAdd x y
                   | Nothing => Just Z
          Just res
-

--- a/tests/idris2/basic003/Ambig2.idr
+++ b/tests/idris2/basic003/Ambig2.idr
@@ -24,4 +24,3 @@ namespace Set
 
 keepUnique : List b -> List b
 keepUnique {b} xs = toList (fromList xs)
-

--- a/tests/idris2/basic009/Stuff.idr
+++ b/tests/idris2/basic009/Stuff.idr
@@ -100,4 +100,3 @@ public export
 data Dec : Type -> Type where
      Yes : a -> Dec a
      No : (a -> Void) -> Dec a
-

--- a/tests/idris2/basic011/Dots2.idr
+++ b/tests/idris2/basic011/Dots2.idr
@@ -1,3 +1,2 @@
 foo : Int -> Int -> Int
 foo x x = x + x
-

--- a/tests/idris2/basic018/Fin.idr
+++ b/tests/idris2/basic018/Fin.idr
@@ -32,4 +32,3 @@ foo = 3
 
 bar : Fin 5
 bar = 8
-

--- a/tests/idris2/basic019/CaseBlock.idr
+++ b/tests/idris2/basic019/CaseBlock.idr
@@ -1,4 +1,3 @@
 foo : (x : Nat) -> case x of
                         Z => Nat -> Nat
                         S k => Nat
-

--- a/tests/idris2/basic028/Do.idr
+++ b/tests/idris2/basic028/Do.idr
@@ -46,4 +46,3 @@ mLetBind x y
     = do let Just res = maybeAdd x y
                   | Nothing => Just Z
          Just res
-

--- a/tests/idris2/basic033/unboundimps.idr
+++ b/tests/idris2/basic033/unboundimps.idr
@@ -17,4 +17,3 @@ len : forall xs . Env xs -> Nat
 -- neither of these are fine
 len': Env xs -> Nat
 append' : Vect n a -> Vect m a -> Vect (n + m) a
-

--- a/tests/idris2/basic036/defimp.idr
+++ b/tests/idris2/basic036/defimp.idr
@@ -2,4 +2,3 @@ import Data.Vect
 
 dvec : (n : Nat) -> {default (replicate n 1) xs : Vect n Nat} -> Nat
 dvec n = foldr (+) Z xs
-

--- a/tests/idris2/coverage001/Vect.idr
+++ b/tests/idris2/coverage001/Vect.idr
@@ -19,4 +19,3 @@ lookup (FS k) (x :: xs) = lookup k xs
 zip : Vect n a -> Vect n b -> Vect n (a, b)
 zip [] [] = []
 zip (x :: xs) (y :: ys) = (x, y) :: zip xs ys
-

--- a/tests/idris2/error006/IfErr.idr
+++ b/tests/idris2/error006/IfErr.idr
@@ -21,4 +21,3 @@ Eq Foo where
 
 test2 : String
 test2 = showIfEq MkFoo MkBar
-

--- a/tests/idris2/error013/Issue361.idr
+++ b/tests/idris2/error013/Issue361.idr
@@ -8,5 +8,3 @@ main : IO ()
 main = printLn $ T == T
 
 %default covering
-
-

--- a/tests/idris2/import001/Nat.idr
+++ b/tests/idris2/import001/Nat.idr
@@ -7,4 +7,3 @@ public export
 plus : Nat -> Nat -> Nat
 plus Z y = y
 plus (S k) y = S (plus k y)
-

--- a/tests/idris2/import001/Test.idr
+++ b/tests/idris2/import001/Test.idr
@@ -4,4 +4,3 @@ import Mult
 
 thing : Nat -> Nat
 thing x = mult x (plus x x)
-

--- a/tests/idris2/import002/Nat.idr
+++ b/tests/idris2/import002/Nat.idr
@@ -7,4 +7,3 @@ public export
 plus : Nat -> Nat -> Nat
 plus Z y = y
 plus (S k) y = S (plus k y)
-

--- a/tests/idris2/import002/Test.idr
+++ b/tests/idris2/import002/Test.idr
@@ -4,4 +4,3 @@ import Mult
 
 thing : Nat -> Nat
 thing x = mult x (plus x x)
-

--- a/tests/idris2/import003/A.idr
+++ b/tests/idris2/import003/A.idr
@@ -2,4 +2,3 @@ module A
 
 public export
 defA : Int -> Int
-

--- a/tests/idris2/import003/B.idr
+++ b/tests/idris2/import003/B.idr
@@ -1,4 +1,3 @@
 module B
 
 import A
-

--- a/tests/idris2/interactive002/IEdit.idr
+++ b/tests/idris2/interactive002/IEdit.idr
@@ -16,4 +16,3 @@ suc x y prf = ?quux
 
 suc' : x = y -> S x = S y
 suc' {x} {y} prf = ?quuz
-

--- a/tests/idris2/interactive003/IEdit2.idr
+++ b/tests/idris2/interactive003/IEdit2.idr
@@ -9,4 +9,3 @@ append xs ys
     = case xs of
            [] => ?bar_3
            (x :: zs) => ?bar_4
-

--- a/tests/idris2/interactive010/IEdit.idr
+++ b/tests/idris2/interactive010/IEdit.idr
@@ -8,4 +8,3 @@ dupAll : Vect n a -> Vect n (a, a)
 dupAll xs = zipHere xs xs
   where
     zipHere : forall n . Vect n a -> Vect n b -> Vect n (a, b)
-

--- a/tests/idris2/interface001/Stuff.idr
+++ b/tests/idris2/interface001/Stuff.idr
@@ -110,4 +110,3 @@ public export
 data Dec : Type -> Type where
      Yes : a -> Dec a
      No : (a -> Void) -> Dec a
-

--- a/tests/idris2/interface002/Functor.idr
+++ b/tests/idris2/interface002/Functor.idr
@@ -18,4 +18,3 @@ Functor (Test c d) where
 -- renamed)
 Functor (Test a b) where
   map = ?bar
-

--- a/tests/idris2/interface008/Deps.idr
+++ b/tests/idris2/interface008/Deps.idr
@@ -17,4 +17,3 @@ interface BadFinite t where
 implementation BadFinite (Fin k) where
   badcard = k
   badto = id
-

--- a/tests/idris2/interface009/Odd.idr
+++ b/tests/idris2/interface009/Odd.idr
@@ -6,4 +6,3 @@ interface Foo m where
 -- clash, so one has to be renamed.
 Eq k => Foo (\s, t => List (s, t)) where
   bar x y z = ?bang
-

--- a/tests/idris2/interface010/Dep.idr
+++ b/tests/idris2/interface010/Dep.idr
@@ -4,4 +4,3 @@ interface Monad m => FooBar m where
   Foo : {0 a : Type} -> a -> m a -> Type
   Bar : {0 A : Type} -> m A -> Type
   foo : {0 A : Type} -> (x : A) -> (ma : m A) -> Foo x ma -> Bar ma
-

--- a/tests/idris2/interface011/FuncImpl.idr
+++ b/tests/idris2/interface011/FuncImpl.idr
@@ -5,4 +5,3 @@ interface Monad m => FooBar m where
   Foo    : {A : Type} -> A -> m A -> Type
   bar    : {A : Type} -> (ma : m A) -> m (DPair A (\ a => Foo a ma))
   foobar : {A : Type} -> (ma : m A) -> map DPair.fst (bar ma) = ma
-

--- a/tests/idris2/lazy001/Lazy.idr
+++ b/tests/idris2/lazy001/Lazy.idr
@@ -19,4 +19,3 @@ data Nat = Z | S Nat
 take : Nat -> Stream a -> List a
 take Z xs = Nil
 take (S k) (x :: xs) = List.(::) x (take k xs)
-

--- a/tests/idris2/linear001/Door.idr
+++ b/tests/idris2/linear001/Door.idr
@@ -41,4 +41,3 @@ doorProg
             | Left d => deleteDoor d
          d <- closeDoor d
          deleteDoor d
-

--- a/tests/idris2/linear002/Door.idr
+++ b/tests/idris2/linear002/Door.idr
@@ -40,4 +40,3 @@ doorProg
          Right d' <- openDoor d
             | Left d => deleteDoor d
          ?foo
-

--- a/tests/idris2/linear003/Linear.idr
+++ b/tests/idris2/linear003/Linear.idr
@@ -45,4 +45,3 @@ holetest1 x y = plus ?this y
 
 holetest2 : (1 x : Nat) -> (1 y : Nat) -> Nat
 holetest2 x y = plus x ?that
-

--- a/tests/idris2/linear006/ZFun.idr
+++ b/tests/idris2/linear006/ZFun.idr
@@ -11,4 +11,3 @@ baz = test foo -- fine!
 
 bar : Nat
 bar = test foo -- bad!
-

--- a/tests/idris2/perf001/Big.idr
+++ b/tests/idris2/perf001/Big.idr
@@ -15,4 +15,3 @@ test bytes_list = do
   let int9 = (index 12 bytes_list * 8) + (index 13 bytes_list * 4) + (index 14 bytes_list * 2) + (index 15 bytes_list)
   let int10 = (index 12 bytes_list * 8) + (index 13 bytes_list * 4) + (index 14 bytes_list * 2) + (index 15 bytes_list)
   pure int1
-

--- a/tests/idris2/perf004/bigdpair.idr
+++ b/tests/idris2/perf004/bigdpair.idr
@@ -28,4 +28,3 @@ eqBigs = Refl
 
 eqBigs' : bigEx' 800000 = bigEx' 800000
 eqBigs' = Refl
-

--- a/tests/idris2/record001/Record.idr
+++ b/tests/idris2/record001/Record.idr
@@ -27,4 +27,3 @@ testDVect = MkDVect 94 [1,2,3,4,5]
 
 testPerson : Person
 testPerson = MkPerson "Wowbagger" 1337 10 (\x => S x)
-

--- a/tests/idris2/record003/Record.idr
+++ b/tests/idris2/record003/Record.idr
@@ -30,4 +30,3 @@ c = MkFlexiString "hello"
 
 d : FlexiString {k = ASCII}
 d = MkFlexiString ['h', 'i']
-

--- a/tests/idris2/reg001/D.idr
+++ b/tests/idris2/reg001/D.idr
@@ -14,4 +14,3 @@ mfunc fn g (ma, mb)
 
 func2 : (a -> c) -> (b -> d) -> a -> b -> (c, d)
 func2 f g a b = MkPair (f a) (g b)
-

--- a/tests/idris2/reg018/cycle.idr
+++ b/tests/idris2/reg018/cycle.idr
@@ -25,4 +25,3 @@ segfaults = Fix (Lam (Var (count 0)))
 cycleDetected : {len : _} -> {ctx : Vect len Typ} ->
                 Term (TLam TNat TNat) ctx
 cycleDetected = Fix (Var (count 0))
-

--- a/tests/idris2/with001/Temp.idr
+++ b/tests/idris2/with001/Temp.idr
@@ -26,4 +26,3 @@ safeStrHead4 : (s : String) -> {pr : NonEmpty (unpack s)} -> Char
 safeStrHead4 {pr=foo} s with (unpack s)
   safeStrHead4 {pr=bar} s | [] = absurd bar
   safeStrHead4 s | (c::_) = c
-

--- a/tests/node/node006/TypeCase.idr
+++ b/tests/node/node006/TypeCase.idr
@@ -29,4 +29,3 @@ main = do printLn (foo Nat)
           printLn (foo (List Int))
           printLn (strangeId 42)
           printLn (strangeId (the Int 42))
-

--- a/tests/node/node017/dir.idr
+++ b/tests/node/node017/dir.idr
@@ -12,4 +12,3 @@ main = do Right () <- createDir "testdir"
           printLn ok
           writeFile "test.txt" "hello\n"
           printLn !currentDir
-

--- a/tests/node/node021/Bits.idr
+++ b/tests/node/node021/Bits.idr
@@ -40,4 +40,3 @@ main
          printLn (the Bits16 (fromInteger (-1)))
          printLn (the Bits32 (fromInteger (-1)))
          printLn (the Bits64 (fromInteger (-1)))
-

--- a/tests/typedd-book/chapter01/HelloHole.idr
+++ b/tests/typedd-book/chapter01/HelloHole.idr
@@ -2,5 +2,3 @@ module Main
 
 main : IO ()
 main = putStrLn ?greeting
-
-

--- a/tests/typedd-book/chapter02/All.idr
+++ b/tests/typedd-book/chapter02/All.idr
@@ -5,4 +5,3 @@ import Partial
 import Reverse
 import AveMain
 import Let_Where
-

--- a/tests/typedd-book/chapter03/All.idr
+++ b/tests/typedd-book/chapter03/All.idr
@@ -5,4 +5,3 @@ import Vectors
 import WordLength
 import WordLength_vec
 import XOR
-

--- a/tests/typedd-book/chapter05/PrintLength.idr
+++ b/tests/typedd-book/chapter05/PrintLength.idr
@@ -3,4 +3,3 @@ printLength = putStr "Input string: " >>= \_ =>
               getLine >>= \input =>
               let len = length input in
               putStrLn (show len)
-

--- a/tests/typedd-book/chapter08/EqNat.idr
+++ b/tests/typedd-book/chapter08/EqNat.idr
@@ -11,5 +11,3 @@ checkEqNat (S k) Z = Nothing
 checkEqNat (S k) (S j) = case checkEqNat k j of
                               Nothing => Nothing
                               Just eq => Just (sameS _ _ eq)
-
-

--- a/tests/typedd-book/chapter10/Shape.idr
+++ b/tests/typedd-book/chapter10/Shape.idr
@@ -14,5 +14,3 @@ area : Shape -> Double
 area (Triangle base height) = 0.5 * rectangle_area base height
 area (Rectangle length height) = rectangle_area length height
 area (Circle radius) = pi * radius * radius
-
-

--- a/tests/typedd-book/chapter10/Shape_abs.idr
+++ b/tests/typedd-book/chapter10/Shape_abs.idr
@@ -26,5 +26,3 @@ area : Shape -> Double
 area (Triangle base height) = 0.5 * rectangle_area base height
 area (Rectangle length height) = rectangle_area length height
 area (Circle radius) = pi * radius * radius
-
-

--- a/tests/typedd-book/chapter10/TestStore.idr
+++ b/tests/typedd-book/chapter10/TestStore.idr
@@ -21,4 +21,3 @@ filterKeys test input with (storeView input)
        = if test value
             then key :: filterKeys test store | rec
             else filterKeys test store | rec
-

--- a/tests/typedd-book/chapter12/DataStore.idr
+++ b/tests/typedd-book/chapter12/DataStore.idr
@@ -24,5 +24,3 @@ data Command : Schema -> Type where
      Add : SchemaType schema -> Command schema
      Get : Integer -> Command schema
      Quit : Command schema
-
-

--- a/tests/typedd-book/chapter12/Record.idr
+++ b/tests/typedd-book/chapter12/Record.idr
@@ -7,4 +7,3 @@ record Album where
        constructor MkAlbum
        title : String
        tracks : List String
-

--- a/tests/typedd-book/chapter12/State.idr
+++ b/tests/typedd-book/chapter12/State.idr
@@ -3,4 +3,3 @@ import Control.Monad.State
 increment : Nat -> State Nat ()
 increment inc = do current <- get
                    put (current + inc)
-

--- a/tests/typedd-book/chapter12/TreeLabel.idr
+++ b/tests/typedd-book/chapter12/TreeLabel.idr
@@ -21,4 +21,3 @@ treeLabelWith lbls (Node left val right)
 
 treeLabel : Tree a -> Tree (Integer, a)
 treeLabel tree = snd (treeLabelWith [1..] tree)
-

--- a/tests/typedd-book/chapter12/TreeLabelState.idr
+++ b/tests/typedd-book/chapter12/TreeLabelState.idr
@@ -23,4 +23,3 @@ treeLabelWith (Node left val right)
 
 treeLabel : Tree a -> Tree (Integer, a)
 treeLabel tree = evalState [1..] (treeLabelWith tree)
-

--- a/tests/typedd-book/chapter12/TreeLabelType.idr
+++ b/tests/typedd-book/chapter12/TreeLabelType.idr
@@ -57,4 +57,3 @@ treeLabelWith (Node left val right)
 
 treeLabel : Tree a -> Tree (Integer, a)
 treeLabel tree = fst (runState (treeLabelWith tree) [1..])
-


### PR DESCRIPTION
This removed all trailing whitespace and newline characters from all .idr files by running [fix_whitespace -f](https://github.com/stefan-hoeck/idris-fix-whitespace) from the root directory (see also #935).

However, there are many more files with whitespace issues in the repo (see attached log file). If this is desired, I could fix (a subset of) those as well.

[List of other files](https://github.com/idris-lang/Idris2/files/5837427/log.txt).
