### PR TITLE
rtassert and panic function

### DIFF
--- a/libs/base/Debug/Panic.idr
+++ b/libs/base/Debug/Panic.idr
@@ -1,0 +1,36 @@
+module Debug.Panic
+
+import System
+
+||| Print message and exit with error.
+export
+panic : HasIO io => (message : String) -> io Void
+panic message = do
+  -- TODO: print to stderr
+  putStrLn ("assertion failed: " ++ message)
+  exitFailure
+
+||| Print message and exit with error.
+||| This is an unsafe function, because it makes evaluation not pure.
+export
+unsafePanic : (message : String) -> Void
+unsafePanic message = unsafePerformIO im where
+  im : IO Void
+  im = do v <- panic message
+          pure v
+
+||| Perform runtime assertion: exit if condition is false.
+export
+rtassert : HasIO io => (cond : Bool) -> (message : Lazy String) -> io ()
+rtassert True message = pure ()
+rtassert False message = do v <- panic message
+                            pure (void v)
+
+||| Perform runtime assrtion in pure expressions.
+||| This is an unsafe function, because it makes evaluation not pure.
+export
+unsafeRtassert : (cond : Bool) -> (message : Lazy String) -> (result : a) -> a
+unsafeRtassert cond message result = unsafePerformIO im where
+  im : IO a
+  im = do rtassert cond message
+          pure result

--- a/libs/base/base.ipkg
+++ b/libs/base/base.ipkg
@@ -46,6 +46,7 @@ modules = Control.App,
           Data.Vect.Elem,
           Data.Vect.Quantifiers,
 
+          Debug.Panic,
           Debug.Trace,
 
           Decidable.Decidable,


### PR DESCRIPTION
Perform runtime assertion. Two version of the function:

* `rtassert` and `panic` which are `IO ()`
* `unsafeRtassert` and `unsafePanic` to be used in pure expressions

Sometimes it is hard or not possible to proove correctness, and
proper error propagation makes program clumsy.  `unsafeRtassert`
and `unsafePanic` are an escape hatch.

Have not found a way to write a test for this code (seems like libs
is not tested), so I tested manually with:

```
module A

import Debug.Panic

foo : ()
foo = unsafeRtassert False "rrr" ()

main : IO ()
main = do
    putStrLn "aaa"
    let () = foo
    putStrLn "bbb"
```

```
aaa
assertion failed: rrr
```