### PR TITLE
adds command for self-hosting when using racket

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -81,7 +81,7 @@ that everything has worked correctly. Assuming that `idris2` is in your
 `PATH`.
 
 - `make clean` -- to make sure you're building everything with the new version
-- `make all && make install`
+- `make all && make install` -- OR `make all IDRIS2_BOOT='idris2 --codegen racket' && make install` if using Racket.
 
 ### 5: Running tests
 


### PR DESCRIPTION
When trying to perform a self-hosting build, it will fail if you're not using `scheme`. This PR updates the docs with a command that succeeds when using `racket`.