### PR TITLE
Disable indents check (properly this time)

### DIFF
--- a/.github/linters/.ecrc
+++ b/.github/linters/.ecrc
@@ -1,5 +1,6 @@
 {
   "Disable": {
     "IndentSize": true,
+    "Indentation": true
   }
 }


### PR DESCRIPTION
* `.ecrc` was in incorrect directory
* add another option for extra precaution

Tested on [this job](https://github.com/stepancheg/Idris2/runs/1742739559?check_suite_focus=true).