### PR TITLE
Do not super-lint .idr

### DIFF
--- a/.github/linters/.ecrc
+++ b/.github/linters/.ecrc
@@ -1,4 +1,7 @@
 {
+  "Exclude": [
+    "\\.idr$"
+  ],
   "Disable": {
     "IndentSize": true,
     "Indentation": true


### PR DESCRIPTION
This is a PR to disable editorconfig-checker of `*.idr` files.

I believe this **not** the right thing to do, we better abandon this PR:
* It's safer to run both `lint.py` and `editorconfig-checker` at least to validate `.editorconfig` is configured consistently
* Also `lint.py` performs fewer checks than `editorconfig-checker`

@gallais suggested to do this change, so I'm adding this PR for your consideration. Not a big deal either way.

Test run with spaces added to `.idr` file:
<img width="881" alt="Screenshot 2021-01-21 at 16 45 28" src="https://user-images.githubusercontent.com/28969/105382638-32ff0680-5c08-11eb-965e-e5bf561691f6.png">
