### PR TITLE
Add zip*/unzip* for List1

### DIFF
--- a/libs/base/Data/List.idr
+++ b/libs/base/Data/List.idr
@@ -341,7 +341,7 @@ zipWith f (x::xs) (y::ys) = f x y :: zipWith f xs ys
 ||| length of the shortest list.
 export
 zip : List a -> List b -> List (a, b)
-zip = zipWith \x, y => (x, y)
+zip = zipWith (,)
 
 export
 zipWith3 : (a -> b -> c -> d) -> List a -> List b -> List c -> List d
@@ -356,7 +356,7 @@ zipWith3 f (x::xs) (y::ys) (z::zs) = f x y z :: zipWith3 f xs ys zs
 ||| length of the shortest list.
 export
 zip3 : List a -> List b -> List c -> List (a, b, c)
-zip3 = zipWith3 \x, y, z => (x, y, z)
+zip3 = zipWith3 (,,)
 
 ||| Split a list by applying a function into two lists
 export

--- a/libs/base/Data/List1.idr
+++ b/libs/base/Data/List1.idr
@@ -10,6 +10,8 @@ record List1 a where
   head : a
   tail : List a
 
+%name List1 xs, ys, zs
+
 ------------------------------------------------------------------------
 -- Conversion
 
@@ -141,3 +143,65 @@ Ord a => Ord (List1 a) where
 export
 consInjective : the (List1 a) (x ::: xs) === (y ::: ys) -> (x === y, xs === ys)
 consInjective Refl = (Refl, Refl)
+
+------------------------------------------------------------------------
+-- Zip/Unzip
+
+export
+zipWith : (a -> b -> c) -> List1 a -> List1 b -> List1 c
+zipWith f (x ::: xs) (y ::: ys) = f x y ::: zipWith' xs ys
+  where
+    zipWith' : List a -> List b -> List c
+    zipWith' [] _ = []
+    zipWith' _ [] = []
+    zipWith' (x :: xs) (y :: ys) = f x y :: zipWith' xs ys
+
+export
+zip : List1 a -> List1 b -> List1 (a, b)
+zip = zipWith \x, y => (x, y)
+
+export
+zipWith3 : (a -> b -> c -> d) -> List1 a -> List1 b -> List1 c -> List1 d
+zipWith3 f (x ::: xs) (y ::: ys) (z ::: zs) = f x y z ::: zipWith3' xs ys zs
+  where
+    zipWith3' : List a -> List b -> List c -> List d
+    zipWith3' [] _ _ = []
+    zipWith3' _ [] _ = []
+    zipWith3' _ _ [] = []
+    zipWith3' (x :: xs) (y :: ys) (z :: zs) = f x y z :: zipWith3' xs ys zs
+
+export
+zip3 : List1 a -> List1 b -> List1 c -> List1 (a, b, c)
+zip3 = zipWith3 \x, y, z => (x, y, z)
+
+export
+unzipWith : (a -> (b, c)) -> List1 a -> (List1 b, List1 c)
+unzipWith f (x ::: xs) = let (b, c) = f x
+                             (bs, cs) = unzipWith' xs in
+                             (b ::: bs, c ::: cs)
+  where
+    unzipWith' : List a -> (List b, List c)
+    unzipWith' [] = ([], [])
+    unzipWith' (x :: xs) = let (b, c) = f x
+                               (bs, cs) = unzipWith' xs in
+                               (b :: bs, c :: cs)
+
+export
+unzip : List1 (a, b) -> (List1 a, List1 b)
+unzip = unzipWith id
+
+export
+unzipWith3 : (a -> (b, c, d)) -> List1 a -> (List1 b, List1 c, List1 d)
+unzipWith3 f (x ::: xs) = let (b, c, d) = f x
+                              (bs, cs, ds) = unzipWith3' xs in
+                              (b ::: bs, c ::: cs, d ::: ds)
+  where
+    unzipWith3' : List a -> (List b, List c, List d)
+    unzipWith3' [] = ([], [], [])
+    unzipWith3' (x :: xs) = let (b, c, d) = f x
+                                (bs, cs, ds) = unzipWith3' xs in
+                                (b :: bs, c :: cs, d :: ds)
+
+export
+unzip3 : List1 (a, b, c) -> (List1 a, List1 b, List1 c)
+unzip3 = unzipWith3 id

--- a/libs/base/Data/List1.idr
+++ b/libs/base/Data/List1.idr
@@ -158,7 +158,7 @@ zipWith f (x ::: xs) (y ::: ys) = f x y ::: zipWith' xs ys
 
 export
 zip : List1 a -> List1 b -> List1 (a, b)
-zip = zipWith \x, y => (x, y)
+zip = zipWith (,)
 
 export
 zipWith3 : (a -> b -> c -> d) -> List1 a -> List1 b -> List1 c -> List1 d
@@ -172,7 +172,7 @@ zipWith3 f (x ::: xs) (y ::: ys) (z ::: zs) = f x y z ::: zipWith3' xs ys zs
 
 export
 zip3 : List1 a -> List1 b -> List1 c -> List1 (a, b, c)
-zip3 = zipWith3 \x, y, z => (x, y, z)
+zip3 = zipWith3 (,,)
 
 export
 unzipWith : (a -> (b, c)) -> List1 a -> (List1 b, List1 c)

--- a/libs/base/Data/Stream.idr
+++ b/libs/base/Data/Stream.idr
@@ -45,7 +45,7 @@ zipWith f (x::xs) (y::ys) = f x y :: zipWith f xs ys
 ||| Create a stream of pairs from two streams
 export
 zip : Stream a -> Stream b -> Stream (a, b)
-zip = zipWith (\x,y => (x,y))
+zip = zipWith (,)
 
 ||| Combine three streams by applying a function element-wise
 export
@@ -55,7 +55,7 @@ zipWith3 f (x::xs) (y::ys) (z::zs) = f x y z :: zipWith3 f xs ys zs
 ||| Create a stream of triples from three streams
 export
 zip3 : Stream a -> Stream b -> Stream c -> Stream (a, b, c)
-zip3 = zipWith3 (\x,y,z => (x,y,z))
+zip3 = zipWith3 (,,)
 
 ||| Create a pair of streams from a stream of pairs
 export


### PR DESCRIPTION
Unfortunately, I wasn't just able to reuse `Data.List.zip*/unzip*` on `Data.List1`'s tail due to the circular
module dependency error as `Data.List` already depends on `Data.List1`