### PR TITLE
Make `zip` usable infix 

### DIFF
--- a/libs/base/Data/Zippable.idr
+++ b/libs/base/Data/Zippable.idr
@@ -21,6 +21,8 @@ interface Zippable z where
   zip : z a -> z b -> z (a, b)
   zip = zipWith (,)
 
+  infixr 6 `zip`
+
   ||| Combine three parameterised types by applying a function.
   ||| @ z the parameterised type
   ||| @ func the function to combine elements with


### PR DESCRIPTION
Since `(a, b, c)` is the same as `(a, (b, c))`, this allows for chaining `zip` in a nice-looking way:

```idris
zipFour : List a -> List b -> List c -> List d -> List (a,b,c,d)
zipFour x y z w = x `zip` y `zip` z `zip` w
```

I chose `infixr 6`, since that seemed reasonable enough to me, but I'm open to suggestions for a better precedence.