### PR TITLE
Add missing Bits64->Int cast

### DIFF
--- a/src/Compiler/Scheme/Common.idr
+++ b/src/Compiler/Scheme/Common.idr
@@ -155,6 +155,7 @@ schOp (Cast IntegerType IntType) [x] = x
 schOp (Cast Bits8Type IntType) [x] = x
 schOp (Cast Bits16Type IntType) [x] = x
 schOp (Cast Bits32Type IntType) [x] = x
+schOp (Cast Bits64Type IntType) [x] = x
 schOp (Cast DoubleType IntType) [x] = op "exact-floor" [x]
 schOp (Cast StringType IntType) [x] = op "cast-string-int" [x]
 schOp (Cast CharType IntType) [x] = op "char->integer" [x]


### PR DESCRIPTION
Looks like it was just missing. The Int->Bits64 and Integer->Bits64
cases are identical, so casting back can also be identical.

I ran into this in some binary parsing code.