### PR TITLE
The blackbird operator (in the variant of `.:`) was added

### DIFF
--- a/libs/prelude/Prelude/Basics.idr
+++ b/libs/prelude/Prelude/Basics.idr
@@ -2,6 +2,8 @@ module Prelude.Basics
 
 import Builtin
 
+import Prelude.Ops
+
 %default total
 
 public export
@@ -38,6 +40,13 @@ const x = \value => x
 public export %inline
 (.) : (b -> c) -> (a -> b) -> a -> c
 (.) f g = \x => f (g x)
+
+||| Composition of a two-argument function with a single-argument one.
+||| `(.:)` is like `(.)` but the second argument and the result are two-argument functions.
+||| This operator is also known as "blackbird operator".
+public export %inline
+(.:) : (c -> d) -> (a -> b -> c) -> a -> b -> d
+(.:) = (.) . (.)
 
 ||| `on b u x y` runs the binary function b on the results of applying
 ||| unary function u to two arguments x and y. From the opposite perspective,

--- a/libs/prelude/Prelude/Ops.idr
+++ b/libs/prelude/Prelude/Ops.idr
@@ -21,7 +21,7 @@ infixr 4 <$>, $>, <$
 infixl 6 <+>
 
 -- Utility operators
-infixr 9 .
+infixr 9 ., .:
 infixr 0 $
 
 infixl 9 `div`, `mod`


### PR DESCRIPTION
After getting familiar with different kinds of function compositions, especially with the blackbird operator, I find myself using such things in almost every second module in my projects.

Blackbird operator is an operator similar to `(.)` but having a two-argument function on the right. It is convenient when combining a two-argument function and some post-processing. For example, instead of
```idris
f ls rs = unlines (zipWith (\l, r => map toUpper (trim (max l r))) ls rs)
-- or --
f ls rs = unlines $ zipWith (\l, r => map toUpper $ trim $ max l r) ls rs
```
you can write
```idris
f = unlines .: zipWith (map toUpper .: trim .: max)
```
which reads better, for those who are familiar with `(.:)` and its similarity to `(.)`.

This pattern of combining a two-argument and single-argument function is everywhere, that's why I think it is useful to have such an operator in `prelude` near to `(.)`.

---

By the way, in some places the operator with this meaning is denoted as `(...)`, but this clashes with an operator in the preoder reasoning syntax. Moreover, `(.:)` is used in a [haskell library](https://hackage.haskell.org/package/composition-1.0.2.1/docs/Data-Composition.html#v:.:) and is shorter.

By the way, in Idris 1 we could define a `(..)` operator (and I personally used it in this form back then), but lexer of Idris 2 does not allow this to be done easily, to alas.

---

I chose a priority of `(.:)` to be the same as for `(.)` for two reasons:
- we don't need early function fusion because both `(.)` and `(.:)` are inlined, i.e. we can always express `(f . g) .: h` as `f .: g .: h`;
- to have meaningful distinction between `f . g .: h` and `f .: g .: h`.