### PR TITLE
Hide countFrom function from prelude

### DIFF
--- a/libs/prelude/Prelude/Types.idr
+++ b/libs/prelude/Prelude/Types.idr
@@ -682,12 +682,15 @@ ceiling x = prim__doubleCeiling x
 -- RANGES --
 ------------
 
-public export
+-- These functions are here to support the range syntax:
+-- range expressions like `[a..b]` are desugared to `rangeFromXXX` calls.
+-- They are not exported, but similar functions are exported from
+-- `Data.Stream` instead.
+
+total
 countFrom : n -> (n -> n) -> Stream n
 countFrom start diff = start :: countFrom (diff start) diff
 
--- this and takeBefore are for range syntax, and not exported here since
--- they're partial. They are exported from Data.Stream instead.
 partial
 takeUntil : (n -> Bool) -> Stream n -> List n
 takeUntil p (x :: xs)


### PR DESCRIPTION
`countFrom` must be made public accidentally:
* it is defined in the ranges section of the file, not stream section
* it is used only in `Range` implementation
* the same function `iterate` is defined in `Data.Stream`

```
countFrom start next
```

is the same as

```
iterate next start
```