### PR TITLE
Support raw string

### DIFF
--- a/src/Idris/IDEMode/Parser.idr
+++ b/src/Idris/IDEMode/Parser.idr
@@ -28,7 +28,7 @@ ideTokens : TokenMap Token
 ideTokens =
     map (\x => (exact x, Symbol)) symbols ++
     [(digits, \x => IntegerLit (cast x)),
-     (stringLit, \x => StringLit (fromMaybe "" (escape (stripQuotes x)))),
+     (stringLit, \x => StringLit 0 (fromMaybe "" (escape 0 (stripQuotes x)))),
      (identAllowDashes, \x => Ident x),
      (space, Comment)]
 

--- a/src/Libraries/Utils/String.idr
+++ b/src/Libraries/Utils/String.idr
@@ -9,8 +9,12 @@ dotSep [x] = x
 dotSep (x :: xs) = x ++ concat ["." ++ y | y <- xs]
 
 export
-stripQuotes : (str : String) -> String
-stripQuotes str = substr 1 (length str `minus` 2) str
+stripSurrounds : (lead : Nat) -> (tail : Nat) -> String -> String
+stripSurrounds lead tail str = substr lead (length str `minus` (lead + tail)) str
+
+export
+stripQuotes : String -> String
+stripQuotes = stripSurrounds 1 1
 
 export
 lowerFirst : String -> Bool

--- a/src/Parser/Lexer/Source.idr
+++ b/src/Parser/Lexer/Source.idr
@@ -24,7 +24,7 @@ data Token
   = CharLit String
   | DoubleLit Double
   | IntegerLit Integer
-  | StringLit String
+  | StringLit Nat String
   -- Identifiers
   | HoleIdent String
   | Ident String
@@ -47,7 +47,7 @@ Show Token where
   show (CharLit x) = "character " ++ show x
   show (DoubleLit x) = "double " ++ show x
   show (IntegerLit x) = "literal " ++ show x
-  show (StringLit x) = "string " ++ show x
+  show (StringLit n x) = "string" ++ replicate n '#' ++ " " ++ show x
   -- Identifiers
   show (HoleIdent x) = "hole identifier " ++ x
   show (Ident x) = "identifier " ++ x
@@ -70,7 +70,7 @@ Pretty Token where
   pretty (CharLit x) = pretty "character" <++> squotes (pretty x)
   pretty (DoubleLit x) = pretty "double" <++> pretty x
   pretty (IntegerLit x) = pretty "literal" <++> pretty x
-  pretty (StringLit x) = pretty "string" <++> dquotes (pretty x)
+  pretty (StringLit n x) = pretty ("string" ++ String.Extra.replicate n '#') <++> dquotes (pretty x)
   -- Identifiers
   pretty (HoleIdent x) = reflow "hole identifier" <++> pretty x
   pretty (Ident x) = pretty "identifier" <++> pretty x
@@ -150,6 +150,15 @@ doubleLit : Lexer
 doubleLit
     = digits <+> is '.' <+> digits <+> opt
            (is 'e' <+> opt (is '-' <|> is '+') <+> digits)
+
+stringLit1 : Lexer
+stringLit1 = surround (exact "#\"") (exact "\"#") any
+
+stringLit2 : Lexer
+stringLit2 = surround (exact "##\"") (exact "\"##") any
+
+stringLit3 : Lexer
+stringLit3 = surround (exact "###\"") (exact "\"###") any
 
 -- Do this as an entire token, because the contents will be processed by
 -- a specific back end
@@ -251,7 +260,10 @@ rawTokens =
      (hexLit, \x => IntegerLit (fromHexLit x)),
      (octLit, \x => IntegerLit (fromOctLit x)),
      (digits, \x => IntegerLit (cast x)),
-     (stringLit, \x => StringLit (stripQuotes x)),
+     (stringLit, \x => StringLit 0 (stripQuotes x)),
+     (stringLit1, \x => StringLit 1 (stripSurrounds 2 2 x)),
+     (stringLit2, \x => StringLit 2 (stripSurrounds 3 3 x)),
+     (stringLit3, \x => StringLit 3 (stripSurrounds 4 4 x)),
      (charLit, \x => CharLit (stripQuotes x)),
      (dotIdent, \x => DotIdent (assert_total $ strTail x)),
      (namespacedIdent, parseNamespace),

--- a/src/Parser/Rule/Source.idr
+++ b/src/Parser/Rule/Source.idr
@@ -38,7 +38,7 @@ constant
                                              Just c' => Just (Ch c')
                            DoubleLit d  => Just (Db d)
                            IntegerLit i => Just (BI i)
-                           StringLit s => case escape s of
+                           StringLit n s => case escape n s of
                                                Nothing => Nothing
                                                Just s' => Just (Str s')
                            Ident "Char"    => Just CharType
@@ -84,7 +84,7 @@ strLit : Rule String
 strLit
     = terminal "Expected string literal"
                (\x => case x.val of
-                           StringLit s => Just s
+                           StringLit 0 s => Just s
                            _ => Nothing)
 
 export

--- a/src/Parser/Support.idr
+++ b/src/Parser/Support.idr
@@ -138,64 +138,66 @@ getEsc "SP" = Just '\SP'
 getEsc "DEL" = Just '\DEL'
 getEsc str = Nothing
 
-escape' : List Char -> Maybe (List Char)
-escape' [] = pure []
-escape' ('\\' :: '\\' :: xs) = pure $ '\\' :: !(escape' xs)
-escape' ('\\' :: '&' :: xs) = pure !(escape' xs)
-escape' ('\\' :: 'a' :: xs) = pure $ '\a' :: !(escape' xs)
-escape' ('\\' :: 'b' :: xs) = pure $ '\b' :: !(escape' xs)
-escape' ('\\' :: 'f' :: xs) = pure $ '\f' :: !(escape' xs)
-escape' ('\\' :: 'n' :: xs) = pure $ '\n' :: !(escape' xs)
-escape' ('\\' :: 'r' :: xs) = pure $ '\r' :: !(escape' xs)
-escape' ('\\' :: 't' :: xs) = pure $ '\t' :: !(escape' xs)
-escape' ('\\' :: 'v' :: xs) = pure $ '\v' :: !(escape' xs)
-escape' ('\\' :: '\'' :: xs) = pure $ '\'' :: !(escape' xs)
-escape' ('\\' :: '\"' :: xs) = pure $ '\"' :: !(escape' xs)
-escape' ('\\' :: 'x' :: xs)
-    = case span isHexDigit xs of
-           ([], rest) => assert_total (escape' rest)
-           (ds, rest) => pure $ cast !(toHex 1 (reverse ds)) ::
-                                 !(assert_total (escape' rest))
+escape' : List Char -> List Char -> Maybe (List Char)
+escape' _ [] = pure []
+escape' escapeChars (x::xs)
+    = assert_total $ if escapeChars `isPrefixOf` (x::xs)
+         then case drop (length escapeChars) (x::xs) of
+                   ('\\' :: xs) => pure $ '\\' :: !(escape' escapeChars xs)
+                   ('\n' :: xs) => pure !(escape' escapeChars xs)
+                   ('&' :: xs) => pure !(escape' escapeChars xs)
+                   ('a' :: xs) => pure $ '\a' :: !(escape' escapeChars xs)
+                   ('b' :: xs) => pure $ '\b' :: !(escape' escapeChars xs)
+                   ('f' :: xs) => pure $ '\f' :: !(escape' escapeChars xs)
+                   ('n' :: xs) => pure $ '\n' :: !(escape' escapeChars xs)
+                   ('r' :: xs) => pure $ '\r' :: !(escape' escapeChars xs)
+                   ('t' :: xs) => pure $ '\t' :: !(escape' escapeChars xs)
+                   ('v' :: xs) => pure $ '\v' :: !(escape' escapeChars xs)
+                   ('\'' :: xs) => pure $ '\'' :: !(escape' escapeChars xs)
+                   ('"' :: xs) => pure $ '"' :: !(escape' escapeChars xs)
+                   ('x' :: xs) => case span isHexDigit xs of
+                                       ([], rest) => escape' escapeChars rest
+                                       (ds, rest) => pure $ cast !(toHex 1 (reverse ds)) ::
+                                                             !(escape' escapeChars rest)
+                   ('o' :: xs) => case span isOctDigit xs of
+                                       ([], rest) => escape' escapeChars rest
+                                       (ds, rest) => pure $ cast !(toOct 1 (reverse ds)) ::
+                                                             !(escape' escapeChars rest)
+                   xs => case span isDigit xs of
+                              ([], (a :: b :: c :: rest)) =>
+                                case getEsc (fastPack (the (List _) [a, b, c])) of
+                                     Just v => Just (v :: !(escape' escapeChars rest))
+                                     Nothing => case getEsc (fastPack (the (List _) [a, b])) of
+                                                     Just v => Just (v :: !(escape' escapeChars (c :: rest)))
+                                                     Nothing => escape' escapeChars xs
+                              ([], (a :: b :: [])) =>
+                                case getEsc (fastPack (the (List _) [a, b])) of
+                                     Just v => Just (v :: [])
+                                     Nothing => escape' escapeChars xs
+                              ([], rest) => escape' escapeChars rest
+                              (ds, rest) => Just $ cast (cast {to=Int} (fastPack ds)) ::
+                                              !(escape' escapeChars rest)
+         else Just $ x :: !(escape' escapeChars xs)
   where
     toHex : Int -> List Char -> Maybe Int
     toHex _ [] = Just 0
     toHex m (d :: ds)
         = pure $ !(hex (toLower d)) * m + !(toHex (m*16) ds)
-escape' ('\\' :: 'o' :: xs)
-    = case span isOctDigit xs of
-           ([], rest) => assert_total (escape' rest)
-           (ds, rest) => pure $ cast !(toOct 1 (reverse ds)) ::
-                                 !(assert_total (escape' rest))
-  where
+
     toOct : Int -> List Char -> Maybe Int
     toOct _ [] = Just 0
     toOct m (d :: ds)
         = pure $ !(oct (toLower d)) * m + !(toOct (m*8) ds)
-escape' ('\\' :: xs)
-    = case span isDigit xs of
-           ([], (a :: b :: c :: rest)) =>
-               case getEsc (fastPack (the (List _) [a, b, c])) of
-                   Just v => Just (v :: !(assert_total (escape' rest)))
-                   Nothing => case getEsc (fastPack (the (List _) [a, b])) of
-                                   Just v => Just (v :: !(assert_total (escape' (c :: rest))))
-                                   Nothing => escape' xs
-           ([], (a :: b :: [])) =>
-               case getEsc (fastPack (the (List _) [a, b])) of
-                   Just v => Just (v :: [])
-                   Nothing => escape' xs
-           ([], rest) => assert_total (escape' rest)
-           (ds, rest) => Just $ cast (cast {to=Int} (fastPack ds)) ::
-                                 !(assert_total (escape' rest))
-escape' (x :: xs) = Just $ x :: !(escape' xs)
 
 export
-escape : String -> Maybe String
-escape x = pure $ fastPack !(escape' (unpack x))
+escape : Nat -> String -> Maybe String
+escape hashtag x = let escapeChars = '\\' :: replicate hashtag '#' in
+                       fastPack <$> (escape' escapeChars (unpack x))
 
 export
 getCharLit : String -> Maybe Char
 getCharLit str
-   = do e <- escape str
+   = do e <- escape 0 str
         if length e == 1
            then Just (assert_total (prim__strHead e))
            else if length e == 0 -- parsed the NULL character that terminated the string!

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -45,7 +45,7 @@ idrisTestsBasic = MkTestPool []
        "basic036", "basic037", "basic038", "basic039", "basic040",
        "basic041", "basic042", "basic043", "basic044", "basic045",
        "basic046", "basic047", "basic048", "basic049", "basic050",
-       "basic051", "basic052"]
+       "basic051", "basic052", "basic053"]
 
 idrisTestsCoverage : TestPool
 idrisTestsCoverage = MkTestPool []

--- a/tests/idris2/basic053/RawString.idr
+++ b/tests/idris2/basic053/RawString.idr
@@ -1,0 +1,34 @@
+module RawString
+
+withWrap : String
+withWrap = "foo
+bar"
+
+withNoWrap : String
+withNoWrap = "foo \
+bar"
+
+withIndent : String
+withIndent = "foo
+  bar"
+
+withEscape : String
+withEscape = #""foo"\#n
+  \bar"#
+
+withEscapeNoWrap : String
+withEscapeNoWrap = #""foo" \#
+  \bar"#
+
+test : IO ()
+test =
+  do
+    putStrLn withWrap
+    putStrLn withNoWrap
+    putStrLn withIndent
+    putStrLn withEscape
+    putStrLn withEscapeNoWrap
+    putStrLn ##"
+name: #"foo"
+version: "bar"
+bzs: \#\'a\n\t\\'"##

--- a/tests/idris2/basic053/expected
+++ b/tests/idris2/basic053/expected
@@ -1,0 +1,13 @@
+foo
+bar
+foo bar
+foo
+  bar
+"foo"
+
+  \bar
+"foo"   \bar
+
+name: #"foo"
+version: "bar"
+bzs: \#\'a\n\t\\'

--- a/tests/idris2/basic053/run
+++ b/tests/idris2/basic053/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 --no-banner --exec test RawString.idr
+
+rm -rf build


### PR DESCRIPTION
This PR proposed a new simple syntax for raw string, aka, the string literal with no escape.

For example, a template string that contains lots of quotes can be written in:
```idris
template : String
template = #"[project]
name: "project"
version: "0.1.0"

[deps]
"semver" = 0.2
"#
```

before:

```idris
template : String
template =  "[project]\n"
         ++ "name: \"project\"\n"
         ++ "version: \"0.1.0\"\n"
         ++ "\n"
         ++ "[deps]\n"
         ++ "\"semver\" = 0.2\n"
```