### PR TITLE
Exclude "expected" files from linting

### DIFF
--- a/.github/linters/.ecrc
+++ b/.github/linters/.ecrc
@@ -1,4 +1,5 @@
 {
+  "Exclude" : ["expected"],
   "Disable": {
     "IndentSize": true,
     "Indentation": true


### PR DESCRIPTION
Those files are part of tests and hold what should be the output of the
compiler. If they are included in the linting, warnings will be emitted
when one of the tests in which the compiler outputs a line with trailing
whitespace is edited, which is not desirable.

I ran into this in (#998): The output of the test interpreter/003 changed,
and I updated the "expected" file accordingly, but the linter issued a
warning due to a space character that the REPL outputs in that
sequence of interactions, while the character can't be removed without
breaking the test.