### PR TITLE
Local hints shouldn't be accessible globally

### DIFF
--- a/tests/idris2/interface019/expected
+++ b/tests/idris2/interface019/expected
@@ -1,1 +1,8 @@
 1/1: Building LocalHints (LocalHints.idr)
+Error: While processing right hand side of bug. Can't find an implementation for Gnu.
+
+LocalHints.idr:48:17--48:22
+    |
+ 48 |             in (findB ** Refl)
+    |                 ^^^^^
+


### PR DESCRIPTION
We can't just assume that a hint added in an empty environment is a global hint, because a top level definition might still have no local variables.