### PR TITLE
[ contrib ] support for C backend

### DIFF
--- a/libs/contrib/Test/Golden.idr
+++ b/libs/contrib/Test/Golden.idr
@@ -225,13 +225,14 @@ pathLookup names = do
 ||| Some test may involve Idris' backends and have requirements.
 ||| We define here the ones supported by Idris
 public export
-data Requirement = Chez | Node | Racket
+data Requirement = Chez | Node | Racket | C
 
 export
 Show Requirement where
   show Chez = "Chez"
   show Node = "node"
   show Racket = "racket"
+  show C = "C"
 
 export
 checkRequirement : Requirement -> IO (Maybe String)
@@ -245,6 +246,7 @@ checkRequirement req
     requirement Chez = ("CHEZ", ["chez", "chezscheme9.5", "scheme", "scheme.exe"])
     requirement Node = ("NODE", ["node"])
     requirement Racket = ("RACKET", ["racket"])
+    requirement C = ("CC", ["cc"])
 
 export
 findCG : IO (Maybe String)
@@ -253,6 +255,7 @@ findCG
        Nothing <- checkRequirement Chez    | p => pure (Just "chez")
        Nothing <- checkRequirement Node    | p => pure (Just "node")
        Nothing <- checkRequirement Racket  | p => pure (Just "racket")
+       Nothing <- checkRequirement C       | p => pure (Just "cc")
        pure Nothing
 
 ||| A test pool is characterised by

--- a/libs/contrib/Test/Golden.idr
+++ b/libs/contrib/Test/Golden.idr
@@ -255,7 +255,7 @@ findCG
        Nothing <- checkRequirement Chez    | p => pure (Just "chez")
        Nothing <- checkRequirement Node    | p => pure (Just "node")
        Nothing <- checkRequirement Racket  | p => pure (Just "racket")
-       Nothing <- checkRequirement C       | p => pure (Just "cc")
+       Nothing <- checkRequirement C       | p => pure (Just "refc")
        pure Nothing
 
 ||| A test pool is characterised by

--- a/tests/Lib.idr
+++ b/tests/Lib.idr
@@ -255,6 +255,7 @@ findCG
        Nothing <- checkRequirement Chez    | p => pure (Just "chez")
        Nothing <- checkRequirement Node    | p => pure (Just "node")
        Nothing <- checkRequirement Racket  | p => pure (Just "racket")
+       Nothing <- checkRequirement C       | p => pure (Just "refc")
        pure Nothing
 
 ||| A test pool is characterised by


### PR DESCRIPTION
Adding support for C backend requirement in the test suite just like I
did when adding a test in #848.