### PR TITLE
editorconfig: trailing whitespaces in expected

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -40,3 +40,6 @@ indent_style = tab
 [*.nix]
 indent_style = space
 indent_size = 2
+
+[expected]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Do not trim trailing whitespaces in `expected` files.

Some on them have trailing whitespaces: `rg ' $' -g expected`
reports 26 files.