### PR TITLE
More reliable exception handling in Control.App

### DIFF
--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -286,7 +286,8 @@ templateTests = MkTestPool "Test templates" [] Nothing
 -- available.
 baseLibraryTests : TestPool
 baseLibraryTests = MkTestPool "Base library" [Chez, Node] Nothing
-  [ "system_file001"
+  [ "control_app001"
+  , "system_file001"
   , "system_info_os001"
   , "data_bits001"
   , "system_info001"

--- a/tests/base/control_app001/TestException.idr
+++ b/tests/base/control_app001/TestException.idr
@@ -1,0 +1,8 @@
+module TestException
+
+import Control.App
+
+throwBoth : Has [Exception String, Exception Int] es => App es ()
+
+throwOne : Has [Exception Int] es => App es Int
+throwOne {es} = handle {err = String} {e = es} throwBoth (\r => pure 1) (\e => pure 3)

--- a/tests/base/control_app001/expected
+++ b/tests/base/control_app001/expected
@@ -1,0 +1,3 @@
+1/1: Building TestException (TestException.idr)
+TestException> 
+Bye for now!

--- a/tests/base/control_app001/run
+++ b/tests/base/control_app001/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 --no-banner TestException.idr < input
+
+rm -rf build


### PR DESCRIPTION
Convert `App.Control.Exception` interface to an alias to `HasErr`.

Probably `Exception` interface need to be deprecated or removed.

Note similar problem exists with `PrimIO` calling `PrimIO, Exception`,
also need to be fixed.

Fix this scenario:

```
throwBoth : Has [Exception String, Exception Int] es => App es ()

throwOne : Has [Exception Int] es => App es Int
throwOne {es} = handle {err = String} {e = es} throwBoth (\r => pure 1) (\e => pure 3)
```

With this commit it works, before this commit it failed with:

```
Error: While processing right hand side of throwOne. Can't find an implementation for Exception Int (String :: es).

TestException.idr:8:48--8:57
   |
 8 | throwOne {es} = handle {err = String} {e = es} throwBoth (\r => pure 1) (\e => pure 3)
   |                                                ^^^^^^^^^
```