### PR TITLE
Run super-linter in all branches

### DIFF
--- a/.github/workflows/ci-super-linter.yml
+++ b/.github/workflows/ci-super-linter.yml
@@ -11,15 +11,15 @@ name: Lint Code Base
 # https://help.github.com/en/articles/workflow-syntax-for-github-actions
 #
 
-#############################
-# Start the job on all push #
-#############################
 on:
   push:
-    # branches-ignore: [master]
-    # Remove the line above to run when pushing to master
+    branches:
+      - '*'
+    tags:
+      - '*'
   pull_request:
-    branches: [master]
+    branches:
+      - master
 
 ###############
 # Set the Job #


### PR DESCRIPTION
Use the same trigger as in the rest of jobs.

Before submitting a PR, commit is pushed to a private branch where
the jobs are executed. Super-linter should be executed in these
jobs as well to get signal about linting issue before submitting a
PR, to reduce noise to PR reviewers.