### PR TITLE
A tiny doc fix: heading line was not long enough.

### DIFF
--- a/docs/source/tutorial/starting.rst
+++ b/docs/source/tutorial/starting.rst
@@ -55,7 +55,7 @@ Installing from a Package Manager
 =================================
 
 Installing Using Homebrew
-----------------------
+-------------------------
 
 If you are Homebrew user you can install Idris 2 together with all the requirements
 by running following command::


### PR DESCRIPTION
Doc linter now shows this as a warning in each PR