### PR TITLE
[ new ] support record projections in refc backend

### DIFF
--- a/src/Compiler/RefC/RefC.idr
+++ b/src/Compiler/RefC/RefC.idr
@@ -86,6 +86,7 @@ cName (UN n) = cCleanString n
 cName (MN n i) = cCleanString n ++ "_" ++ cCleanString (show i)
 cName (PV n d) = "pat__" ++ cName n
 cName (DN _ n) = cName n
+cName (RF n) = "rec__" ++ cCleanString n
 cName (Nested i n) = "n__" ++ cCleanString (show i) ++ "_" ++ cName n
 cName (CaseBlock x y) = "case__" ++ cCleanString (show x) ++ "_" ++ cCleanString (show y)
 cName (WithBlock x y) = "with__" ++ cCleanString (show x) ++ "_" ++ cCleanString (show y)

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -180,7 +180,7 @@ chezTests = MkTestPool [Chez]
 
 refcTests : TestPool
 refcTests = MkTestPool [C]
-  [ "refc001" ]
+  [ "refc001" , "refc002" ]
 
 racketTests : TestPool
 racketTests = MkTestPool [Racket]

--- a/tests/refc/refc002/RecordProjection.idr
+++ b/tests/refc/refc002/RecordProjection.idr
@@ -1,0 +1,21 @@
+module RecordProjection
+
+record Name where
+  constructor MkName
+  firstName : String
+  lastName : String
+
+(.fullName) : Name -> String
+name.fullName = name.firstName ++ " " ++ name.lastName
+
+johnSmith : Name
+johnSmith = MkName
+  { firstName = "John"
+  , lastName = "Smith"
+  }
+
+main : IO ()
+main = assert_total $ do
+  putStrLn johnSmith.firstName
+  putStrLn johnSmith.lastName
+  putStrLn johnSmith.fullName

--- a/tests/refc/refc002/expected
+++ b/tests/refc/refc002/expected
@@ -1,0 +1,3 @@
+John
+Smith
+John Smith

--- a/tests/refc/refc002/run
+++ b/tests/refc/refc002/run
@@ -1,0 +1,4 @@
+$1 --no-banner --no-color --console-width 0 --cg refc -o refc002 RecordProjection.idr > /dev/null
+./build/exec/refc002
+
+rm -rf build


### PR DESCRIPTION
Fixes records (specifically '.' syntax) being unsupported with refc backend. 