### PR TITLE
Change PreorderReasoning arguments to 0

### DIFF
--- a/libs/contrib/Syntax/PreorderReasoning.idr
+++ b/libs/contrib/Syntax/PreorderReasoning.idr
@@ -22,7 +22,7 @@ data FastDerivation : (x : a) -> (y : b) -> Type where
   (~~) : FastDerivation x y -> (step : Step y z) -> FastDerivation x z
 
 public export
-Calc : {x : a} -> {y : b} -> FastDerivation x y -> x ~=~ y
+Calc : {0 x : a} -> {0 y : b} -> FastDerivation x y -> x ~=~ y
 Calc (|~ x) = Refl
 Calc ((~~) der (_ ...(Refl))) = Calc der
 

--- a/libs/contrib/Syntax/PreorderReasoning/Generic.idr
+++ b/libs/contrib/Syntax/PreorderReasoning/Generic.idr
@@ -18,12 +18,12 @@ data FastDerivation : (leq : a -> a -> Type) -> (x : a) -> (y : a) -> Type where
          -> FastDerivation leq x z
 
 public export
-CalcWith : Preorder dom leq => {x,y : dom} -> FastDerivation leq x y -> x `leq` y
+CalcWith : Preorder dom leq => {0 x : dom} -> {0 y : dom} -> FastDerivation leq x y -> x `leq` y
 CalcWith (|~ x) = reflexive x
 CalcWith ((<~) der (z ... step)) = transitive {po = leq} _ _ _ (CalcWith der) step
 
 public export
-(~~) : {x,y : dom}
+(~~) : {0 x : dom} -> {0 y : dom}
          -> FastDerivation leq x y -> {z : dom} -> (step : Step Equal y z)
          -> FastDerivation leq x z
 (~~) der (z ... Refl) = der


### PR DESCRIPTION
Small change to the multiplicity of the PreorderReasoning syntax. The implicit arguments were declared with omega multiplicity instead of zero leading to errors like this one:
```idris
foo : {0 a : Nat} -> a = a
foo = Calc $
  |~ a
  ~~ a ...(Refl)
```
Which produced the following error:
```Error: While processing right hand side of foo. a is not accessible in this context.```

This change should align PreorderReasoning with the rewrite syntax which allows the use of zero arguments.