### PR TITLE
Add a total way of reading files in.

### DIFF
--- a/.github/linters/.ecrc
+++ b/.github/linters/.ecrc
@@ -1,5 +1,5 @@
 {
-  "Exclude" : ["expected"],
+  "Exclude" : ["expected", "*.js"],
   "Disable": {
     "IndentSize": true,
     "Indentation": true

--- a/.github/workflows/ci-super-linter.yml
+++ b/.github/workflows/ci-super-linter.yml
@@ -52,6 +52,7 @@ jobs:
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_JSCPD: false  # erroneously complains about docs/requirements.txt
+          VALIDATE_JAVASCRIPT_STANDARD: false #requires camel-casing
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/libs/base/System/File.idr
+++ b/libs/base/System/File.idr
@@ -320,7 +320,7 @@ withFile filename mode onError onOpen =
      closeFile h
      pure $ Right res
 
-try : (Monad m) => m (Either FileError a) -> (a -> m (Either FileError b)) -> m (Either FileError b)
+try : Monad m => m (Either FileError a) -> (a -> m (Either FileError b)) -> m (Either FileError b)
 try a f = a >>= either (pure . Left) f
 
 readOnto : HasIO io => (acc : List String) ->
@@ -364,7 +364,7 @@ readFilePage offset fuel file
 export
 partial
 readFile : HasIO io => String -> io (Either FileError String)
-readFile = (map $ map (fastAppend . snd)) . readFilePage 0 forever
+readFile = (map $ map (fastConcat . snd)) . readFilePage 0 forever
 
 ||| Write a string to a file
 export

--- a/libs/base/System/File.idr
+++ b/libs/base/System/File.idr
@@ -1,8 +1,9 @@
 module System.File
 
+import public Data.Fuel
+
 import Data.List
 import Data.Strings
-import Data.Fuel
 import System.Info
 
 %default total

--- a/libs/base/System/File.idr
+++ b/libs/base/System/File.idr
@@ -359,7 +359,7 @@ export
 readFilePage : HasIO io => (offset : Nat) -> (until : Fuel) -> String -> io (Either FileError (Bool, List String))
 readFilePage offset fuel file
   = join <$> (withFile file Read pure $
-                readOnto [] offset fuel) 
+                readOnto [] offset fuel)
 
 export
 partial

--- a/libs/base/System/File.idr
+++ b/libs/base/System/File.idr
@@ -330,10 +330,13 @@ withFile filename mode onError onOpen =
 ||| fuel to read exactly a given number of lines.
 |||
 ||| On success, returns a tuple of whether the end of
-||| the file was reached or not and the String read in
+||| the file was reached or not and the lines read in
 ||| from the file.
 |||
-||| Note that because we are chunking by lines, this
+||| Note that each line will still have a newline
+||| character at the end.
+|||
+||| Important: because we are chunking by lines, this
 ||| function's totality depends on the assumption that
 ||| no single line in the input file is infinite.
 export

--- a/libs/base/System/File.idr
+++ b/libs/base/System/File.idr
@@ -333,8 +333,8 @@ readOnto acc offset (More fuel) h
   = do False <- fEOF h
          | True => pure $ Right (True, reverse acc)
        case offset of
-            (S offset') => fSeekLine h >> readOnto acc offset' (More fuel) h
-            0           => try (fGetLine h) (\str => readOnto (str :: acc) 0 fuel h)
+            (S offset') => try (fSeekLine h) (const $ readOnto acc offset' (More fuel) h)
+            0           => try (fGetLine h)  (\str => readOnto (str :: acc) 0 fuel h)
 
 ||| Read a chunk of a file in a line-delimited fashion.
 ||| You can use this function to read an entire file

--- a/libs/base/System/File.idr
+++ b/libs/base/System/File.idr
@@ -323,8 +323,8 @@ lineCount (S k) = More (lineCount k)
 ||| The @lineCount@ function can provide you with enough
 ||| fuel to read exactly a given number of lines.
 |||
-||| On success, returns a tuple of whether the end of 
-||| the file was reached or not and the String read in 
+||| On success, returns a tuple of whether the end of
+||| the file was reached or not and the String read in
 ||| from the file.
 |||
 ||| Note that because we are chunking by lines, this
@@ -343,14 +343,14 @@ readFilePage offset fuel file
   where
     read : (offset : Nat) -> (fuel : Fuel) -> List String -> File -> io (Either FileError (Bool, List String))
     read 0 Dry acc h = pure (Right (False, reverse acc))
-    read (S offset) fuel acc h 
+    read (S offset) fuel acc h
       = do eof <- fEOF h
            if eof
               then pure (Right (True, reverse acc))
               else do Right () <- fSeekLine h
                         | Left err => returnError
                       read offset fuel acc h
-    read 0 (More fuel) acc h 
+    read 0 (More fuel) acc h
       = do eof <- fEOF h
            if eof
               then pure (Right (True, reverse acc))

--- a/support/c/idris_file.c
+++ b/support/c/idris_file.c
@@ -96,6 +96,25 @@ void idris2_pclose(void *stream) {
 #endif
 }
 
+// seek through the next newline, consuming and
+// throwing away anything until then.
+int idris2_seekLine(FILE *f)
+{
+    while (1) {
+        int c = fgetc(f);
+        if (c == -1) {
+            if (feof(f)) {
+                return 0;
+            } else {
+                return -1;
+            }
+        }
+        if (c == '\n') {
+            return 0;
+        }
+    }
+}
+
 char* idris2_readLine(FILE* f) {
     char *buffer = NULL;
     size_t n = 0;

--- a/support/c/idris_file.h
+++ b/support/c/idris_file.h
@@ -16,6 +16,10 @@ int idris2_fileSize(FILE* h);
 
 int idris2_fpoll(FILE* f);
 
+// Seek through the next newline without
+// saving anything along the way
+int idris2_seekLine(FILE* f);
+
 // Treat as a Ptr String (might be NULL)
 char* idris2_readLine(FILE* f);
 char* idris2_readChars(int num, FILE* f);

--- a/support/js/support_system_file.js
+++ b/support/js/support_system_file.js
@@ -11,13 +11,13 @@ function support_system_file_seekLine(file_ptr){
     if (bytesRead === 0) {
       file_ptr.eof = true;
       file_ptr.buffer = Buffer.alloc(0);
-      return 0;
+      return 0n;
     }
     file_ptr.buffer = Buffer.concat([file_ptr.buffer, readBuf.slice(0, bytesRead)]);
     lineEnd = file_ptr.buffer.indexOf(LF);
   }
   file_ptr.buffer = file_ptr.buffer.slice(lineEnd + 1);
-  return 0;
+  return 0n;
 }
 
 function support_system_file_readLine(file_ptr){

--- a/support/js/support_system_file.js
+++ b/support/js/support_system_file.js
@@ -1,6 +1,6 @@
 const support_system_file_fs = require('fs')
 
-// like `readLine` without the overhaead of copying characters.
+// like `readLine` without the overhead of copying characters.
 // returns int (success 0, failure -1) to align with the C counterpart.
 function support_system_file_seekLine (file_ptr) {
   const LF = 0x0a

--- a/support/js/support_system_file.js
+++ b/support/js/support_system_file.js
@@ -2,65 +2,64 @@ const support_system_file_fs = require("fs")
 
 // like `readLine` without the overhaead of copying characters.
 // returns int (success 0, failure -1) to align with the C counterpart.
-function support_system_file_seekLine(file_ptr){
-  const LF = 0x0a;
-  const readBuf = Buffer.alloc(1);
-  let lineEnd = file_ptr.buffer.indexOf(LF);
+function support_system_file_seekLine(file_ptr) {
+  const LF = 0x0a
+  const readBuf = Buffer.alloc(1)
+  let lineEnd = file_ptr.buffer.indexOf(LF)
   while (lineEnd === -1) {
-    const bytesRead = support_system_file_fs.readSync(file_ptr.fd, readBuf,0,1,null);
+    const bytesRead = support_system_file_fs.readSync(file_ptr.fd, readBuf, 0, 1, null)
     if (bytesRead === 0) {
-      file_ptr.eof = true;
-      file_ptr.buffer = Buffer.alloc(0);
-      return 0n;
+      file_ptr.eof = true
+      file_ptr.buffer = Buffer.alloc(0)
+      return 0n
     }
-    file_ptr.buffer = Buffer.concat([file_ptr.buffer, readBuf.slice(0, bytesRead)]);
-    lineEnd = file_ptr.buffer.indexOf(LF);
+    file_ptr.buffer = Buffer.concat([file_ptr.buffer, readBuf.slice(0, bytesRead)])
+    lineEnd = file_ptr.buffer.indexOf(LF)
   }
-  file_ptr.buffer = file_ptr.buffer.slice(lineEnd + 1);
-  return 0n;
+  file_ptr.buffer = file_ptr.buffer.slice(lineEnd + 1)
+  return 0n
 }
 
-function support_system_file_readLine(file_ptr){
-  const LF = 0x0a;
-  const readBuf = Buffer.alloc(1);
-  let lineEnd = file_ptr.buffer.indexOf(LF);
+function support_system_file_readLine(file_ptr) {
+  const LF = 0x0a
+  const readBuf = Buffer.alloc(1)
+  let lineEnd = file_ptr.buffer.indexOf(LF)
   while (lineEnd === -1) {
-    const bytesRead = support_system_file_fs.readSync(file_ptr.fd, readBuf,0,1,null);
+    const bytesRead = support_system_file_fs.readSync(file_ptr.fd, readBuf, 0, 1, null)
     if (bytesRead === 0) {
-      file_ptr.eof = true;
-      const line = file_ptr.buffer.toString('utf-8');
+      file_ptr.eof = true
+      const line = file_ptr.buffer.toString('utf-8')
       file_ptr.buffer = Buffer.alloc(0)
       return line
     }
-    file_ptr.buffer = Buffer.concat([file_ptr.buffer, readBuf.slice(0, bytesRead)]);
-    lineEnd = file_ptr.buffer.indexOf(LF);
+    file_ptr.buffer = Buffer.concat([file_ptr.buffer, readBuf.slice(0, bytesRead)])
+    lineEnd = file_ptr.buffer.indexOf(LF)
   }
-  const line = file_ptr.buffer.slice(0, lineEnd + 1).toString('utf-8');
-  file_ptr.buffer = file_ptr.buffer.slice(lineEnd + 1);
-  return line;
+  const line = file_ptr.buffer.slice(0, lineEnd + 1).toString('utf-8')
+  file_ptr.buffer = file_ptr.buffer.slice(lineEnd + 1)
+  return line
 }
 
-
-function support_system_file_getStr(){
+function support_system_file_getStr() {
   return support_system_file_readLine({fd:0, buffer: Buffer.alloc(0), name:'<stdin>', eof: false})
 }
 
-function support_system_file_openFile(n,m){
+function support_system_file_openFile(n,m) {
   try{
     const fd = support_system_file_fs.openSync(n, m)
     return {fd: fd, buffer: Buffer.alloc(0), name:n, eof: false}
-  }catch(e){
-    process.__lasterr = e; return null
+  } catch(e) {
+    process.__lasterr = e
+    return null
   }
 }
 
-
-function support_system_file_chmod(filename, mode){
-  try{
+function support_system_file_chmod(filename, mode) {
+  try {
     support_system_file_fs.chmodSync(filename, Number(mode))
     return 0n
-  }catch(e){
-    process.__lasterr = e;
+  } catch(e) {
+    process.__lasterr = e
     return 1n
   }
 }

--- a/support/js/support_system_file.js
+++ b/support/js/support_system_file.js
@@ -1,5 +1,25 @@
 const support_system_file_fs = require("fs")
 
+// like `readLine` without the overhaead of copying characters.
+// returns int (success 0, failure -1) to align with the C counterpart.
+function support_system_file_seekLine(file_ptr){
+  const LF = 0x0a;
+  const readBuf = Buffer.alloc(1);
+  let lineEnd = file_ptr.buffer.indexOf(LF);
+  while (lineEnd === -1) {
+    const bytesRead = support_system_file_fs.readSync(file_ptr.fd, readBuf,0,1,null);
+    if (bytesRead === 0) {
+      file_ptr.eof = true;
+      file_ptr.buffer = Buffer.alloc(0);
+      return 0;
+    }
+    file_ptr.buffer = Buffer.concat([file_ptr.buffer, readBuf.slice(0, bytesRead)]);
+    lineEnd = file_ptr.buffer.indexOf(LF);
+  }
+  file_ptr.buffer = file_ptr.buffer.slice(lineEnd + 1);
+  return 0;
+}
+
 function support_system_file_readLine(file_ptr){
   const LF = 0x0a;
   const readBuf = Buffer.alloc(1);

--- a/support/js/support_system_file.js
+++ b/support/js/support_system_file.js
@@ -1,8 +1,8 @@
-const support_system_file_fs = require("fs")
+const support_system_file_fs = require('fs')
 
 // like `readLine` without the overhaead of copying characters.
 // returns int (success 0, failure -1) to align with the C counterpart.
-function support_system_file_seekLine(file_ptr) {
+function support_system_file_seekLine (file_ptr) {
   const LF = 0x0a
   const readBuf = Buffer.alloc(1)
   let lineEnd = file_ptr.buffer.indexOf(LF)
@@ -20,7 +20,7 @@ function support_system_file_seekLine(file_ptr) {
   return 0n
 }
 
-function support_system_file_readLine(file_ptr) {
+function support_system_file_readLine (file_ptr) {
   const LF = 0x0a
   const readBuf = Buffer.alloc(1)
   let lineEnd = file_ptr.buffer.indexOf(LF)
@@ -40,25 +40,25 @@ function support_system_file_readLine(file_ptr) {
   return line
 }
 
-function support_system_file_getStr() {
-  return support_system_file_readLine({fd:0, buffer: Buffer.alloc(0), name:'<stdin>', eof: false})
+function support_system_file_getStr () {
+  return support_system_file_readLine({ fd: 0, buffer: Buffer.alloc(0), name: '<stdin>', eof: false })
 }
 
-function support_system_file_openFile(n,m) {
-  try{
+function support_system_file_openFile (n, m) {
+  try {
     const fd = support_system_file_fs.openSync(n, m)
-    return {fd: fd, buffer: Buffer.alloc(0), name:n, eof: false}
-  } catch(e) {
+    return { fd: fd, buffer: Buffer.alloc(0), name: n, eof: false }
+  } catch (e) {
     process.__lasterr = e
     return null
   }
 }
 
-function support_system_file_chmod(filename, mode) {
+function support_system_file_chmod (filename, mode) {
   try {
     support_system_file_fs.chmodSync(filename, Number(mode))
     return 0n
-  } catch(e) {
+  } catch (e) {
     process.__lasterr = e
     return 1n
   }

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -217,7 +217,7 @@ templateTests = MkTestPool []
   [ "simple-test", "ttimp", "with-ipkg"
   ]
 
--- base library tests are run against 
+-- base library tests are run against
 -- each codegen supported and to keep
 -- things simple it's all one test group
 -- that only runs if all backends are

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -217,12 +217,13 @@ templateTests = MkTestPool []
   [ "simple-test", "ttimp", "with-ipkg"
   ]
 
--- tests are run against both the default
--- codegen and also any codegens that have
--- special behavior defined for the tests
--- in this pool.
+-- base library tests are run against 
+-- each codegen supported and to keep
+-- things simple it's all one test group
+-- that only runs if all backends are
+-- available.
 baseLibraryTests : TestPool
-baseLibraryTests = MkTestPool [Node]
+baseLibraryTests = MkTestPool [Chez, Node]
   [ "system_file001"
   ]
 

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -217,6 +217,11 @@ templateTests = MkTestPool []
   [ "simple-test", "ttimp", "with-ipkg"
   ]
 
+baseLibraryTests : TestPool
+baseLibraryTests = MkTestPool []
+  [ "system_file001"
+  ]
+
 main : IO ()
 main = runner
   [ testPaths "ttimp" ttimpTests
@@ -233,6 +238,7 @@ main = runner
   , testPaths "typedd-book" typeddTests
   , testPaths "ideMode" ideModeTests
   , testPaths "prelude" preludeTests
+  , testPaths "base" baseLibraryTests
   , testPaths "chez" chezTests
   , testPaths "refc" refcTests
   , testPaths "racket" racketTests

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -217,8 +217,12 @@ templateTests = MkTestPool []
   [ "simple-test", "ttimp", "with-ipkg"
   ]
 
+-- tests are run against both the default
+-- codegen and also any codegens that have
+-- special behavior defined for the tests
+-- in this pool.
 baseLibraryTests : TestPool
-baseLibraryTests = MkTestPool []
+baseLibraryTests = MkTestPool [Node]
   [ "system_file001"
   ]
 

--- a/tests/base/system_file001/ReadFilePage.idr
+++ b/tests/base/system_file001/ReadFilePage.idr
@@ -35,3 +35,7 @@ main = do totalChecks
             | Right (False, _) => putStrLn "Failed EOF check"
             | Left err => putStrLn $ show err
           putStrLn $ "empty: " ++ (show l7)
+          Right l8 <- readFile "test.txt"
+            | Left err => putStrLn $ show err
+          putStrLn l8
+

--- a/tests/base/system_file001/ReadFilePage.idr
+++ b/tests/base/system_file001/ReadFilePage.idr
@@ -1,8 +1,37 @@
--- import System.File
+import System.File
 
+total
+totalChecks : IO ()
+totalChecks =
+  do Right (False, l1) <- readFilePage 0 (lineCount 0) "test.txt"
+       | Right (True, _) => putStrLn "Failed EOF check"
+       | Left err => putStrLn $ show err
+     putStrLn $ "empty: " ++ (show l1)
+     Right (False, l2) <- readFilePage 0 (lineCount 1) "test.txt"
+       | Right (True, _) => putStrLn "Failed EOF check"
+       | Left err => putStrLn $ show err
+     putStrLn l2
+     Right (False, l3) <- readFilePage 1 (lineCount 2) "test.txt"
+       | Right (True, _) => putStrLn "Failed EOF check"
+       | Left err => putStrLn $ show err
+     putStrLn l3
+     Right (True, l4) <- readFilePage 0 (lineCount 100) "test.txt"
+       | Right (False, _) => putStrLn "Failed EOF check"
+       | Left err => putStrLn $ show err
+     putStrLn l4
+
+partial
 main : IO ()
-main = do -- l1 <- readFilePage 0 0 "test.txt"
-          let l1 = "hello world"
-          putStrLn $ "emty: " ++ (show l1)
---           l2 <- readFilePage 0 1 "test.txt"
---           putStrLn l2
+main = do totalChecks
+          Right (True, l5) <- readFilePage 0 forever "test.txt"
+            | Right (False, _) => putStrLn "Failed EOF check"
+            | Left err => putStrLn $ show err
+          putStrLn l5
+          Right (True, l6) <- readFilePage 2 forever "test.txt"
+            | Right (False, _) => putStrLn "Failed EOF check"
+            | Left err => putStrLn $ show err
+          putStrLn l6
+          Right (True, l7) <- readFilePage 100 forever "test.txt"
+            | Right (False, _) => putStrLn "Failed EOF check"
+            | Left err => putStrLn $ show err
+          putStrLn $ "empty: " ++ (show l7)

--- a/tests/base/system_file001/ReadFilePage.idr
+++ b/tests/base/system_file001/ReadFilePage.idr
@@ -1,24 +1,28 @@
 import System.File
+import Data.Strings
+
+putLines : List String -> IO ()
+putLines = putStrLn . fastAppend
 
 total
 totalChecks : IO ()
 totalChecks =
-  do Right (False, l1) <- readFilePage 0 (lineCount 0) "test.txt"
+  do Right (False, l1) <- readFilePage 0 (limit 0) "test.txt"
        | Right (True, _) => putStrLn "Failed EOF check"
        | Left err => putStrLn $ show err
      putStrLn $ "empty: " ++ (show l1)
-     Right (False, l2) <- readFilePage 0 (lineCount 1) "test.txt"
+     Right (False, l2) <- readFilePage 0 (limit 1) "test.txt"
        | Right (True, _) => putStrLn "Failed EOF check"
        | Left err => putStrLn $ show err
-     putStrLn l2
-     Right (False, l3) <- readFilePage 1 (lineCount 2) "test.txt"
+     putLines l2
+     Right (False, l3) <- readFilePage 1 (limit 2) "test.txt"
        | Right (True, _) => putStrLn "Failed EOF check"
        | Left err => putStrLn $ show err
-     putStrLn l3
-     Right (True, l4) <- readFilePage 0 (lineCount 100) "test.txt"
+     putLines l3
+     Right (True, l4) <- readFilePage 0 (limit 100) "test.txt"
        | Right (False, _) => putStrLn "Failed EOF check"
        | Left err => putStrLn $ show err
-     putStrLn l4
+     putLines l4
 
 partial
 main : IO ()
@@ -26,11 +30,11 @@ main = do totalChecks
           Right (True, l5) <- readFilePage 0 forever "test.txt"
             | Right (False, _) => putStrLn "Failed EOF check"
             | Left err => putStrLn $ show err
-          putStrLn l5
+          putLines l5
           Right (True, l6) <- readFilePage 2 forever "test.txt"
             | Right (False, _) => putStrLn "Failed EOF check"
             | Left err => putStrLn $ show err
-          putStrLn l6
+          putLines l6
           Right (True, l7) <- readFilePage 100 forever "test.txt"
             | Right (False, _) => putStrLn "Failed EOF check"
             | Left err => putStrLn $ show err

--- a/tests/base/system_file001/ReadFilePage.idr
+++ b/tests/base/system_file001/ReadFilePage.idr
@@ -1,0 +1,8 @@
+-- import System.File
+
+main : IO ()
+main = do -- l1 <- readFilePage 0 0 "test.txt"
+          let l1 = "hello world"
+          putStrLn $ "emty: " ++ (show l1)
+--           l2 <- readFilePage 0 1 "test.txt"
+--           putStrLn l2

--- a/tests/base/system_file001/expected
+++ b/tests/base/system_file001/expected
@@ -21,6 +21,12 @@ four
 five lines total
 
 empty: ""
+one
+two
+three lines in
+four
+five lines total
+
 1/1: Building ReadFilePage (ReadFilePage.idr)
 Main> Main> Bye for now!
 empty: ""
@@ -46,4 +52,10 @@ four
 five lines total
 
 empty: ""
+one
+two
+three lines in
+four
+five lines total
+
 Main> Main> Bye for now!

--- a/tests/base/system_file001/expected
+++ b/tests/base/system_file001/expected
@@ -1,4 +1,4 @@
-empty: ""
+empty: []
 one
 
 two
@@ -20,7 +20,7 @@ three lines in
 four
 five lines total
 
-empty: ""
+empty: []
 one
 two
 three lines in
@@ -29,7 +29,7 @@ five lines total
 
 1/1: Building ReadFilePage (ReadFilePage.idr)
 Main> Main> Bye for now!
-empty: ""
+empty: []
 one
 
 two
@@ -51,7 +51,7 @@ three lines in
 four
 five lines total
 
-empty: ""
+empty: []
 one
 two
 three lines in

--- a/tests/base/system_file001/expected
+++ b/tests/base/system_file001/expected
@@ -23,3 +23,27 @@ five lines total
 empty: ""
 1/1: Building ReadFilePage (ReadFilePage.idr)
 Main> Main> Bye for now!
+empty: ""
+one
+
+two
+three lines in
+
+one
+two
+three lines in
+four
+five lines total
+
+one
+two
+three lines in
+four
+five lines total
+
+three lines in
+four
+five lines total
+
+empty: ""
+Main> Main> Bye for now!

--- a/tests/base/system_file001/expected
+++ b/tests/base/system_file001/expected
@@ -1,0 +1,2 @@
+1/1: Building Test (ReadFileLines.idr)
+Main> Bye for now!

--- a/tests/base/system_file001/expected
+++ b/tests/base/system_file001/expected
@@ -1,2 +1,25 @@
-1/1: Building Test (ReadFileLines.idr)
-Main> Bye for now!
+empty: ""
+one
+
+two
+three lines in
+
+one
+two
+three lines in
+four
+five lines total
+
+one
+two
+three lines in
+four
+five lines total
+
+three lines in
+four
+five lines total
+
+empty: ""
+1/1: Building ReadFilePage (ReadFilePage.idr)
+Main> Main> Bye for now!

--- a/tests/base/system_file001/input
+++ b/tests/base/system_file001/input
@@ -1,0 +1,2 @@
+:exec main
+:q

--- a/tests/base/system_file001/run
+++ b/tests/base/system_file001/run
@@ -3,7 +3,7 @@
 $1 --cg chez --no-color --console-width 0 --no-banner ReadFilePage.idr < input
 $1 --cg node --no-color --console-width 0 --no-banner ReadFilePage.idr < input
 
-# The following backends failed for reasons unrealted to this test. They can be
+# The following backends failed for reasons unrelated to this test. They can be
 # uncommented at a future date.
 # RACKET failed to find the builtin idris support library
 # $1 --cg racket --no-color --console-width 0 --no-banner ReadFilePage.idr < input

--- a/tests/base/system_file001/run
+++ b/tests/base/system_file001/run
@@ -1,6 +1,15 @@
 # @readFilePage@ uses primitive functions with definitions for both
 # C (supported by most backends) and Node.
-$1 --no-color --console-width 0 --no-banner ReadFilePage.idr < input
+$1 --cg chez --no-color --console-width 0 --no-banner ReadFilePage.idr < input
 $1 --cg node --no-color --console-width 0 --no-banner ReadFilePage.idr < input
+
+# The following backends failed for reasons unrealted to this test. They can be
+# uncommented at a future date.
+# RACKET failed to find the builtin idris support library
+# $1 --cg racket --no-color --console-width 0 --no-banner ReadFilePage.idr < input
+# REFC doesn't support :exec yet
+# $1 --cg refc --no-color --console-width 0 --no-banner ReadFilePage.idr < input
+# GAMBIT hung seemingly indefinitely
+# $1 --cg gambit --no-color --console-width 0 --no-banner ReadFilePage.idr < input
 
 rm -rf build

--- a/tests/base/system_file001/run
+++ b/tests/base/system_file001/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 --no-banner ReadFilePage.idr < input
+
+rm -rf build

--- a/tests/base/system_file001/run
+++ b/tests/base/system_file001/run
@@ -1,3 +1,6 @@
+# @readFilePage@ uses primitive functions with definitions for both
+# C (supported by most backends) and Node.
 $1 --no-color --console-width 0 --no-banner ReadFilePage.idr < input
+$1 --cg node --no-color --console-width 0 --no-banner ReadFilePage.idr < input
 
 rm -rf build

--- a/tests/base/system_file001/test.txt
+++ b/tests/base/system_file001/test.txt
@@ -1,5 +1,5 @@
-Hello
-world
-with just
-a few
-lines
+one
+two
+three lines in
+four
+five lines total

--- a/tests/base/system_file001/test.txt
+++ b/tests/base/system_file001/test.txt
@@ -1,0 +1,5 @@
+Hello
+world
+with just
+a few
+lines


### PR DESCRIPTION
It's useful to be able to read files in within total code. I figured if I was adding a concept of fuel, I may as well add an efficient way to offset the start of the read operation.

I added tests (and caught a bug in my initial pass at the JS helper implementation so I am glad I did). As far as I could tell, this was the first base library test added.