### PR TITLE
[base, contrib] Some cleanup

### DIFF
--- a/libs/base/Data/Fun.idr
+++ b/libs/base/Data/Fun.idr
@@ -22,4 +22,4 @@ public export
 ||| Returns the co-domain of a n-ary function.
 public export
 target : {ts : Vect n Type} -> {r: Type} -> Fun ts r -> Type
-target {r} _ = r
+target _ = r

--- a/libs/base/Data/List/Views.idr
+++ b/libs/base/Data/List/Views.idr
@@ -24,8 +24,8 @@ smallerLeft (z :: ys) y zs = LTESucc (smallerLeft ys _ _)
 
 smallerRight : (ys : List a) -> (zs : List a) ->
                LTE (S (S (length zs))) (S (length (ys ++ (y :: zs))))
-smallerRight {y} ys zs = rewrite lengthSuc ys y zs in
-                                 (LTESucc (LTESucc (lengthLT _ _)))
+smallerRight ys zs = rewrite lengthSuc ys y zs in
+                     (LTESucc (LTESucc (lengthLT _ _)))
 
 ||| View for splitting a list in half, non-recursively
 public export

--- a/libs/base/Data/Nat/Order.idr
+++ b/libs/base/Data/Nat/Order.idr
@@ -39,8 +39,8 @@ implementation Poset Nat LTE where
 
 public export
 total zeroNeverGreater : {n : Nat} -> LTE (S n) Z -> Void
-zeroNeverGreater {n} LTEZero     impossible
-zeroNeverGreater {n} (LTESucc _) impossible
+zeroNeverGreater LTEZero     impossible
+zeroNeverGreater (LTESucc _) impossible
 
 public export
 total zeroAlwaysSmaller : {n : Nat} -> LTE Z n
@@ -48,8 +48,8 @@ zeroAlwaysSmaller = LTEZero
 
 public export
 total ltesuccinjective : {0 n : Nat} -> {0 m : Nat} -> (LTE n m -> Void) -> LTE (S n) (S m) -> Void
-ltesuccinjective {n} {m} disprf (LTESucc nLTEm) = void (disprf nLTEm)
-ltesuccinjective {n} {m} disprf LTEZero         impossible
+ltesuccinjective disprf (LTESucc nLTEm) = void (disprf nLTEm)
+ltesuccinjective disprf LTEZero         impossible
 
 public export
 total decideLTE : (n : Nat) -> (m : Nat) -> Dec (LTE n m)

--- a/libs/base/Data/Stream.idr
+++ b/libs/base/Data/Stream.idr
@@ -69,8 +69,8 @@ scanl f acc (x :: xs) = acc :: scanl f (f acc x) xs
 ||| @ xs the sequence to repeat
 ||| @ ok proof that the list is non-empty
 export
-cycle : (xs : List a) -> {auto ok : NonEmpty xs} -> Stream a
-cycle {a} (x :: xs) {ok = IsNonEmpty} = x :: cycle' xs
+cycle : (xs : List a) -> {auto 0 ok : NonEmpty xs} -> Stream a
+cycle (x :: xs) = x :: cycle' xs
   where cycle' : List a -> Stream a
         cycle' []        = x :: cycle' xs
         cycle' (y :: ys) = y :: cycle' ys

--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -186,8 +186,8 @@ replicate (S k) x = x :: replicate k x
 ||| ```
 export
 mergeBy : (elem -> elem -> Ordering) -> (xs : Vect n elem) -> (ys : Vect m elem) -> Vect (n + m) elem
-mergeBy     _ [] ys = ys
-mergeBy {n} _ xs [] = rewrite plusZeroRightNeutral n in xs
+mergeBy _ [] ys = ys
+mergeBy _ xs [] = rewrite plusZeroRightNeutral n in xs
 mergeBy {n = S k} {m = S k'} order (x :: xs) (y :: ys)
      = case order x y of
             LT => x :: mergeBy order xs (y :: ys)
@@ -247,7 +247,7 @@ toVect _ _ = Nothing
 public export
 fromList' : (xs : Vect len elem) -> (l : List elem) -> Vect (length l + len) elem
 fromList' ys [] = ys
-fromList' {len} ys (x::xs) =
+fromList' ys (x::xs) =
   rewrite (plusSuccRightSucc (length xs) len) in
   fromList' (x::ys) xs
 
@@ -831,9 +831,8 @@ exactLength {m} len xs with (decEq m len)
 export
 overLength : {m : Nat} -> -- expected at run-time
              (len : Nat) -> (xs : Vect m a) -> Maybe (p ** Vect (plus p len) a)
-overLength {m} n xs with (cmp m n)
-  overLength {m = m} (plus m (S y)) xs | (CmpLT y) = Nothing
-  overLength {m = m} m xs | CmpEQ
-         = Just (0 ** xs)
+overLength n xs with (cmp m n)
+  overLength {m}   (plus m (S y)) xs | (CmpLT y) = Nothing
+  overLength {m}                m xs | CmpEQ     = Just (0 ** xs)
   overLength {m = plus n (S x)} n xs | (CmpGT x)
          = Just (S x ** rewrite plusCommutative (S x) n in xs)

--- a/libs/base/Decidable/Equality/Core.idr
+++ b/libs/base/Decidable/Equality/Core.idr
@@ -18,15 +18,15 @@ interface DecEq t where
 
 ||| The negation of equality is symmetric (follows from symmetry of equality)
 export
-negEqSym : forall a, b . (a = b -> Void) -> (b = a -> Void)
+negEqSym : Not (a = b) -> Not (b = a)
 negEqSym p h = p (sym h)
 
 ||| Everything is decidably equal to itself
 export
 decEqSelfIsYes : DecEq a => {x : a} -> decEq x x = Yes Refl
-decEqSelfIsYes {x} with (decEq x x)
-  decEqSelfIsYes {x} | Yes Refl = Refl
-  decEqSelfIsYes {x} | No contra = absurd $ contra Refl
+decEqSelfIsYes with (decEq x x)
+  decEqSelfIsYes | Yes Refl = Refl
+  decEqSelfIsYes | No contra = absurd $ contra Refl
 
 ||| If you have a proof of inequality, you're sure that `decEq` would give a `No`.
 export

--- a/libs/contrib/Data/Nat/Factor.idr
+++ b/libs/contrib/Data/Nat/Factor.idr
@@ -194,20 +194,20 @@ multFactor p q = CofactorExists q Refl
 ||| If n > 0 then any factor of n must be less than or equal to n.
 export
 factorLteNumber : Factor p n -> {auto positN : LTE 1 n} -> LTE p n
-factorLteNumber (CofactorExists {n} {p} Z prf) {positN} =
+factorLteNumber (CofactorExists Z prf) =
         let nIsZero = replace {p = \x => n = x} (multZeroRightZero p) prf
             oneLteZero = replace {p = LTE 1} nIsZero positN
         in
         absurd $ succNotLTEzero oneLteZero
-factorLteNumber (CofactorExists {n} {p} (S k) prf) =
+factorLteNumber (CofactorExists (S k) prf) =
         rewrite prf in
         leftFactorLteProduct p k
 
 ||| If p is a factor of n, then it is also a factor of (n + p).
 export
 plusDivisorAlsoFactor : Factor p n -> Factor p (n + p)
-plusDivisorAlsoFactor (CofactorExists {n} {p} q prf) =
-        CofactorExists (S q) $
+plusDivisorAlsoFactor (CofactorExists q prf) =
+        CofactorExists (S q)
             rewrite plusCommutative n p in
             rewrite multRightSuccPlus p q in
             cong (plus p) prf
@@ -218,8 +218,8 @@ plusDivisorNeitherFactor : NotFactor p n -> NotFactor p (n + p)
 plusDivisorNeitherFactor (ZeroNotFactorS k) =
         rewrite plusZeroRightNeutral k in
         ZeroNotFactorS k
-plusDivisorNeitherFactor (ProperRemExists {n} {p} q r remPrf) =
-        ProperRemExists (S q) r $
+plusDivisorNeitherFactor (ProperRemExists q r remPrf) =
+        ProperRemExists (S q) r
             rewrite multRightSuccPlus p q in
             rewrite sym $ plusAssociative p (p * q) (S $ finToNat r) in
             rewrite plusCommutative p ((p * q) + S (finToNat r)) in
@@ -229,16 +229,16 @@ plusDivisorNeitherFactor (ProperRemExists {n} {p} q r remPrf) =
 ||| If p is a factor of n, then it is also a factor of any multiply of n.
 export
 multNAlsoFactor : Factor p n -> (a : Nat) -> {auto aok : LTE 1 a} -> Factor p (n * a)
-multNAlsoFactor _ Z {aok} = absurd $ succNotLTEzero aok
-multNAlsoFactor (CofactorExists {n} {p} q prf) (S a) =
-        CofactorExists (q * S a) $
+multNAlsoFactor _ Z = absurd $ succNotLTEzero aok
+multNAlsoFactor (CofactorExists q prf) (S a) =
+        CofactorExists (q * S a)
             rewrite prf in
             sym $ multAssociative p q (S a)
 
 ||| If p is a factor of both n and m, then it is also a factor of their sum.
 export
 plusFactor : Factor p n -> Factor p m -> Factor p (n + m)
-plusFactor {n} {p} (CofactorExists qn prfN) (CofactorExists qm prfM) =
+plusFactor (CofactorExists qn prfN) (CofactorExists qm prfM) =
         rewrite prfN in
         rewrite prfM in
         rewrite sym $ multDistributesOverPlusRight p qn qm in
@@ -250,12 +250,12 @@ plusFactor {n} {p} (CofactorExists qn prfN) (CofactorExists qm prfM) =
 ||| that one would expect from decent subtraction.
 export
 minusFactor : {a, b, p : Nat} -> Factor p (a + b) -> Factor p a -> Factor p b
-minusFactor {a} {b} (CofactorExists qab prfAB) (CofactorExists qa prfA) =
+minusFactor (CofactorExists qab prfAB) (CofactorExists qa prfA) =
         CofactorExists (minus qab qa) (
             rewrite multDistributesOverMinusRight p qab qa in
             rewrite sym prfA in
             rewrite sym prfAB in
-            replace {p = \x => b = minus (a + b) x} (plusZeroRightNeutral a) $
+            replace {p = \x => b = minus (a + b) x} (plusZeroRightNeutral a)
             rewrite plusMinusLeftCancel a b 0 in
             rewrite minusZeroRight b in
             Refl
@@ -287,11 +287,11 @@ decFactor n (S d) =
 ||| of (n + 1).
 export
 factNotSuccFact : {n, p : Nat} -> GT p 1 -> Factor p n -> NotFactor p (S n)
-factNotSuccFact {n} {p = Z} pGt1 (CofactorExists q prf) =
+factNotSuccFact {p = Z} pGt1 (CofactorExists q prf) =
         absurd $ succNotLTEzero pGt1
-factNotSuccFact {n} {p = S Z} pGt1 (CofactorExists q prf) =
+factNotSuccFact {p = S Z} pGt1 (CofactorExists q prf) =
         absurd . succNotLTEzero $ fromLteSucc pGt1
-factNotSuccFact {n} {p = S (S k)} pGt1 (CofactorExists q prf) =
+factNotSuccFact {p = S (S k)} pGt1 (CofactorExists q prf) =
         ProperRemExists q FZ (
             rewrite sym prf in
             rewrite plusCommutative n 1 in
@@ -319,7 +319,7 @@ gcdSym {a} {b = S b} (MkGCD {notBothZero = RightIsNotZero} cf greatest) =
 ||| This actually follows directly from the definition of GCD.
 export
 commonFactorAlsoFactorOfGCD : {p : Nat} -> Factor p a -> Factor p b -> GCD q a b -> Factor p q
-commonFactorAlsoFactorOfGCD {p} pfa pfb (MkGCD _ greatest) =
+commonFactorAlsoFactorOfGCD pfa pfb (MkGCD _ greatest) =
         greatest p (CommonFactorExists p pfa pfb)
 
 
@@ -333,7 +333,7 @@ oneCommonFactor a b = CommonFactorExists 1
 ||| Any natural number is a common factor of itself and itself.
 export
 selfIsCommonFactor : (a : Nat) -> {auto ok : LTE 1 a} -> CommonFactor a a a
-selfIsCommonFactor Z {ok} = absurd $ succNotLTEzero ok
+selfIsCommonFactor Z = absurd $ succNotLTEzero ok
 selfIsCommonFactor (S k) = CommonFactorExists (S k) (factorReflexive $ S k) (factorReflexive $ S k)
 
 
@@ -362,7 +362,7 @@ gcd_step (SearchArgs Z _ bLteA {bNonZero}) _ = absurd . succNotLTEzero $ lteTran
 gcd_step (SearchArgs _ Z _ {bNonZero}) _ = absurd $ succNotLTEzero bNonZero
 gcd_step (SearchArgs (S a) (S b) bLteA {bNonZero}) rec = case divMod (S a) (S b) of
     Fraction (S a) (S b) q FZ prf =>
-        let sbIsFactor = the (S a = plus q (mult b q)) $
+        let sbIsFactor = the (S a = plus q (mult b q))
                 rewrite multCommutative b q in
                 rewrite sym $ multRightSuccPlus q b in
                 replace {p = \x => S a = x} (plusZeroRightNeutral (q * S b)) $ sym prf
@@ -452,25 +452,25 @@ divByGcdHelper : (a, b, c : Nat) -> GCD (S a) (S a * S b) (S a * c) -> GCD 1 (S 
 divByGcdHelper a b c (MkGCD _ greatest) =
     MkGCD (CommonFactorExists 1 (oneIsFactor (S b)) (oneIsFactor c)) $
     \q, (CommonFactorExists q (CofactorExists qb prfQB) (CofactorExists qc prfQC)) =>
-        let qFab = CofactorExists {n = S a * S b} {p = q * S a} qb $
+        let qFab = CofactorExists {n = S a * S b} {p = q * S a} qb
                 rewrite multCommutative q (S a) in
                 rewrite sym $ multAssociative (S a) q qb in
                 rewrite sym $ prfQB in
                 Refl
-            qFac = CofactorExists {n = S a * c} {p = q * S a} qc $
+            qFac = CofactorExists {n = S a * c} {p = q * S a} qc
                 rewrite multCommutative q (S a) in
                 rewrite sym $ multAssociative (S a) q qc in
                 rewrite sym $ prfQC in
                 Refl
             CofactorExists f prfQAfA =
                 greatest (q * S a) (CommonFactorExists (q * S a) qFab qFac)
-            qf1 = multOneSoleNeutral a (f * q) $
+            qf1 = multOneSoleNeutral a (f * q)
                 rewrite multCommutative f q in
                 rewrite multAssociative (S a) q f in
                 rewrite sym $ multCommutative q (S a) in
                 prfQAfA
         in
-        CofactorExists f $
+        CofactorExists f
             rewrite multCommutative q f in
             sym qf1
 

--- a/libs/contrib/Data/Telescope/Segment.idr
+++ b/libs/contrib/Data/Telescope/Segment.idr
@@ -30,7 +30,7 @@ data Segment : (n : Nat) -> Left.Telescope k -> Type where
 public export
 tabulate : (n : Nat) -> (Left.Environment gamma -> Left.Telescope n) -> Segment n gamma
 tabulate Z tel = []
-tabulate {gamma} (S n) tel = (sigma :: tabulate n (uncurry delta)) where
+tabulate (S n) tel = (sigma :: tabulate n (uncurry delta)) where
 
   sigma : TypeIn gamma
   sigma env = fst (uncons (tel env))
@@ -86,9 +86,9 @@ keep Refl = Refl
 ||| Segments act on telescope from the right.
 public export
 (|++) : (gamma : Left.Telescope k) -> {n : Nat} -> (delta : Segment n gamma) -> Left.Telescope (n + k)
-(|++)     gamma {n = 0} delta  = gamma
-(|++) {k} gamma {n=S n} (ty :: delta) = rewrite sym $ succLemma n k in
-                                          gamma -. ty |++ delta
+(|++)  gamma {n = 0} delta  = gamma
+(|++)  gamma {n=S n} (ty :: delta) = rewrite sym $ succLemma n k in
+                                       gamma -. ty |++ delta
 
 ||| Segments form a kind of an indexed monoid w.r.t. the action `(|++)`
 public export
@@ -97,9 +97,9 @@ public export
     -> (lft : Segment n  gamma         )
     -> (rgt : Segment m (gamma |++ lft))
     -> Segment (n + m) gamma
-(++) {n = 0  }     delta       rgt = rgt
-(++) {n = S n} {m} (ty :: lft) rgt = ty :: lft ++ rewrite succLemma n k in
-                                                  rgt
+(++) {n = 0  } delta       rgt = rgt
+(++) {n = S n} (ty :: lft) rgt = ty :: lft ++ rewrite succLemma n k in
+                                              rgt
 -- This monoid does act on telescopes:
 export
 actSegmentAssociative : (gamma : Left.Telescope k)
@@ -169,7 +169,7 @@ break : {0 k : Nat} -> (gamma : Telescope k') -> (pos : Position gamma)
      -> {auto 0 ford : k' = cast pos + k } -> Telescope k
 break gamma          FZ      {ford = Refl} = gamma
 break []            (FS pos) {ford = _   } impossible
-break {k} {k' = S k'} (gamma -. ty) (FS pos) {ford} = break gamma pos
+break {k' = S k'} (gamma -. ty) (FS pos) {ford} = break gamma pos
   {ford = Calc $
    |~ k'
    ~~ cast pos + k ...(succInjective _ _ ford)}

--- a/libs/contrib/Data/Vect/Sort.idr
+++ b/libs/contrib/Data/Vect/Sort.idr
@@ -21,7 +21,7 @@ mutual
 ||| Merge sort implementation for Vect n a
 export total
 sortBy : {n : Nat} -> (cmp : a -> a -> Ordering) -> (xs : Vect n a) -> Vect n a
-sortBy {n} cmp xs = sortBySplit n cmp xs
+sortBy cmp xs = sortBySplit n cmp xs
 
 export total
 sort : Ord a => {n : Nat} -> Vect n a -> Vect n a

--- a/libs/contrib/Decidable/Decidable/Extra.idr
+++ b/libs/contrib/Decidable/Decidable/Extra.idr
@@ -10,7 +10,6 @@ import Decidable.Decidable
 
 %default total
 
-
 public export
 NotNot : {n : Nat} -> {ts : Vect n Type} -> (r : Rel ts) -> Rel ts
 NotNot r = map @{Nary} (Not . Not) r
@@ -23,9 +22,9 @@ doubleNegationElimination : {n : Nat} -> {0 ts : Vect n Type} -> {r : Rel ts} ->
   (witness : HVect ts) ->
   uncurry (NotNot {ts} r) witness ->
   uncurry              r  witness
-doubleNegationElimination {ts = []     } @{dec} [] prfnn =
+doubleNegationElimination {ts = []} @{dec} [] prfnn =
   case decide @{dec} of
-    Yes prf   => prf
+    Yes prf  => prf
     No  prfn => absurd $ prfnn prfn
 doubleNegationElimination {ts = t :: ts} @{dec} (w :: witness) prfnn =
   doubleNegationElimination {ts} {r = r w} @{ DecidablePartialApplication @{dec} } witness prfnn
@@ -43,7 +42,7 @@ public export
 doubleNegationExists : {n : Nat} -> {0 ts : Vect n Type} -> {r : Rel ts} -> Decidable n ts r =>
   Ex ts (NotNot {ts} r) ->
   Ex ts r
-doubleNegationExists {ts} {r} @{dec} nnxs =
+doubleNegationExists @{dec} nnxs =
   let witness : HVect ts
       witness = extractWitness nnxs
       witnessingnn : uncurry (NotNot {ts} r) witness
@@ -63,8 +62,8 @@ decideTransform :
   -> (tDec : {a : Type} -> Dec a -> Dec (t a))
   -> (posDec : IsDecidable n ts r)
   -> IsDecidable n ts (chain {ts} t r)
-decideTransform {t = t} tDec posDec =
-  curryAll $ \xs =>
+decideTransform tDec posDec =
+  curryAll \xs =>
     replace {p = id} (chainUncurry (chain t r) Dec xs) $
       replace {p = Dec} (chainUncurry r t xs) $
         tDec $ replace {p = id} (sym $ chainUncurry r Dec xs) $
@@ -86,8 +85,8 @@ notExistsNotForall :
   -> Dec ((x : a) -> p x)
 notExistsNotForall dec decEx =
   case decEx of
-    Yes (x ** nx) => No $ \ f => nx $ f x
-    No notNot => Yes $ \x => case (dec x) of
+    Yes (x ** nx) => No \f => nx $ f x
+    No notNot => Yes \x => case (dec x) of
       Yes px => px
       No nx => void $ notNot $ (x ** nx)
 

--- a/libs/contrib/Decidable/Order/Strict.idr
+++ b/libs/contrib/Decidable/Order/Strict.idr
@@ -39,7 +39,7 @@ public export
 %hint
 public export
 InferPoset : {t : Type} -> {spo : t -> t -> Type} -> StrictPreorder t spo => Poset t (EqOr spo)
-InferPoset {t} {spo} = MkPoset @{MkPreorder} {antisym = antisym}
+InferPoset = MkPoset @{MkPreorder} {antisym}
   where
     antisym : (a,b : t) -> EqOr spo a b -> EqOr spo b a -> a = b
     antisym a a (Left  Refl) (Left  Refl) = Refl
@@ -63,7 +63,7 @@ interface StrictPreorder t spo => StrictOrdered t spo where
 %hint
 public export
 InferOrder : {t : Type} -> {spo : t -> t -> Type} -> StrictOrdered t spo => Ordered t (EqOr spo)
-InferOrder {t} {spo} @{so} = MkOrdered @{InferPoset} {ord = ord}
+InferOrder @{so} = MkOrdered @{InferPoset} {ord}
   where
     ord : (a,b : t) -> Either (EqOr spo a b) (EqOr spo b a)
     ord  a b with (Strict.order @{so} a b)

--- a/libs/contrib/System/Random.idr
+++ b/libs/contrib/System/Random.idr
@@ -69,9 +69,9 @@ rndFin (S k) = do
 ||| Select a random element from a vector
 public export
 rndSelect' : {k : Nat} -> Vect (S k) a -> IO a
-rndSelect' {k} xs = pure $ Vect.index !(rndFin k) xs
+rndSelect' xs = pure $ Vect.index !(rndFin k) xs
 
 ||| Select a random element from a non-empty list
 public export
-rndSelect : (elems : List a) -> {auto prf : NonEmpty elems} -> IO a
-rndSelect (x :: xs) {prf = IsNonEmpty} = rndSelect' $ fromList (x :: xs)
+rndSelect : (elems : List a) -> (0 _ : NonEmpty elems) => IO a
+rndSelect (x :: xs) = rndSelect' $ fromList (x :: xs)

--- a/libs/contrib/Text/Lexer.idr
+++ b/libs/contrib/Text/Lexer.idr
@@ -37,9 +37,9 @@ non l = reject l <+> any
 export
 choiceMap : {c : Bool} ->
             Foldable t => (a -> Recognise c) -> t a -> Recognise c
-choiceMap {c} f xs = foldr (\x, acc => rewrite sym (andSameNeutral c) in
-                                               f x <|> acc)
-                           fail xs
+choiceMap f xs = foldr (\x, acc => rewrite sym (andSameNeutral c) in
+                                           f x <|> acc)
+                       fail xs
 
 ||| Recognise the first matching recogniser in a container. Consumes input if
 ||| recognisers in the list consume. Fails if the container is empty.

--- a/libs/contrib/Text/Lexer/Core.idr
+++ b/libs/contrib/Text/Lexer/Core.idr
@@ -78,8 +78,8 @@ reject = Lookahead False
 export
 concatMap : (a -> Recognise c) -> (xs : List a) ->
             Recognise (c && (isCons xs))
-concatMap {c} _ [] = rewrite andFalseFalse c in Empty
-concatMap {c} f (x :: xs)
+concatMap _ [] = rewrite andFalseFalse c in Empty
+concatMap f (x :: xs)
    = rewrite andTrueNeutral c in
      rewrite sym (orSameAndRightNeutral c (isCons xs)) in
              SeqEmpty (f x) (Core.concatMap f xs)

--- a/libs/contrib/Text/Parser.idr
+++ b/libs/contrib/Text/Parser.idr
@@ -54,9 +54,9 @@ choiceMap : {c : Bool} ->
             (a -> Grammar tok c b) ->
             Foldable t => t a ->
             Grammar tok c b
-choiceMap {c} f xs = foldr (\x, acc => rewrite sym (andSameNeutral c) in
-                                               f x <|> acc)
-                           (fail "No more options") xs
+choiceMap f xs = foldr (\x, acc => rewrite sym (andSameNeutral c) in
+                                           f x <|> acc)
+                       (fail "No more options") xs
 
 %hide Prelude.(>>=)
 
@@ -125,9 +125,9 @@ mutual
              (end : Grammar tok c e) ->
              (p : Grammar tok True a) ->
              Grammar tok True (List a)
-  someTill {c} end p = do x <- p
-                          seq (manyTill end p)
-                              (\xs => pure (x :: xs))
+  someTill end p = do x <- p
+                      seq (manyTill end p)
+                          (\xs => pure (x :: xs))
 
   ||| Parse zero or more instances of `p` until `end` succeeds, returning the
   ||| list of values from `p`. Guaranteed to consume input if `end` consumes.
@@ -136,8 +136,8 @@ mutual
              (end : Grammar tok c e) ->
              (p : Grammar tok True a) ->
              Grammar tok c (List a)
-  manyTill {c} end p = rewrite sym (andTrueNeutral c) in
-                               map (const []) end <|> someTill end p
+  manyTill end p = rewrite sym (andTrueNeutral c) in
+                           map (const []) end <|> someTill end p
 
 ||| Parse one or more instances of `p` until `end` succeeds, returning the
 ||| list of values from `p`, along with a proof that the resulting list is
@@ -170,8 +170,8 @@ mutual
               (skip : Grammar tok True s) ->
               (p : Grammar tok c a) ->
               Grammar tok c a
-  afterMany {c} skip p = rewrite sym (andTrueNeutral c) in
-                                 p <|> afterSome skip p
+  afterMany skip p = rewrite sym (andTrueNeutral c) in
+                             p <|> afterSome skip p
 
 ||| Parse one or more things, each separated by another thing.
 export
@@ -179,8 +179,8 @@ sepBy1 : {c : Bool} ->
          (sep : Grammar tok True s) ->
          (p : Grammar tok c a) ->
          Grammar tok c (List a)
-sepBy1 {c} sep p = rewrite sym (orFalseNeutral c) in
-                           [| p :: many (sep *> p) |]
+sepBy1 sep p = rewrite sym (orFalseNeutral c) in
+                       [| p :: many (sep *> p) |]
 
 ||| Parse zero or more things, each separated by another thing. May
 ||| match the empty input.
@@ -198,7 +198,7 @@ sepBy1' : {c : Bool} ->
          (sep : Grammar tok True s) ->
          (p : Grammar tok c a) ->
          Grammar tok c (xs : List a ** NonEmpty xs)
-sepBy1' {c} sep p
+sepBy1' sep p
   = rewrite sym (orFalseNeutral c) in
             seq p (\x => do xs <- many (sep *> p)
                             pure (x :: xs ** IsNonEmpty))
@@ -210,8 +210,8 @@ sepEndBy1 : {c : Bool} ->
             (sep : Grammar tok True s) ->
             (p : Grammar tok c a) ->
             Grammar tok c (List a)
-sepEndBy1 {c} sep p = rewrite sym (orFalseNeutral c) in
-                              sepBy1 sep p <* optional sep
+sepEndBy1 sep p = rewrite sym (orFalseNeutral c) in
+                          sepBy1 sep p <* optional sep
 
 ||| Parse zero or more instances of `p`, separated by and optionally terminated
 ||| by `sep`. Will not match a separator by itself.
@@ -230,8 +230,8 @@ sepEndBy1' : {c : Bool} ->
              (sep : Grammar tok True s) ->
              (p : Grammar tok c a) ->
              Grammar tok c (xs : List a ** NonEmpty xs)
-sepEndBy1' {c} sep p = rewrite sym (orFalseNeutral c) in
-                               sepBy1' sep p <* optional sep
+sepEndBy1' sep p = rewrite sym (orFalseNeutral c) in
+                           sepBy1' sep p <* optional sep
 
 ||| Parse one or more instances of `p`, separated and terminated by `sep`.
 export
@@ -239,8 +239,8 @@ endBy1 : {c : Bool} ->
          (sep : Grammar tok True s) ->
          (p : Grammar tok c a) ->
          Grammar tok True (List a)
-endBy1 {c} sep p = some $ rewrite sym (orTrueTrue c) in
-                                  p <* sep
+endBy1 sep p = some $ rewrite sym (orTrueTrue c) in
+                              p <* sep
 
 export
 endBy : {c : _} ->
@@ -256,8 +256,8 @@ endBy1' : {c : Bool} ->
           (sep : Grammar tok True s) ->
           (p : Grammar tok c a) ->
           Grammar tok True (xs : List a ** NonEmpty xs)
-endBy1' {c} sep p = some' $ rewrite sym (orTrueTrue c) in
-                                    p <* sep
+endBy1' sep p = some' $ rewrite sym (orTrueTrue c) in
+                                p <* sep
 
 ||| Parse an instance of `p` that is between `left` and `right`.
 export


### PR DESCRIPTION
Some useless matches of implicit arguments were removed (seemingly, left after porting from Idris 1). Useless `$`'s were removed where (arguably) they didn't give anything to readability. Identation was nicened in couple of places (while leaving it as it was in all the other places).

Changed code is mosly equivalent to the former except for two added `0`'s to `NonEmpty` auto arguments.