### PR TITLE
[ fix #1012 ] a more subtle criterion

### DIFF
--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -48,6 +48,10 @@ idrisTestsBasic = MkTestPool []
        "basic046", "basic047", "basic048", "basic049", "basic050",
        "basic051", "basic052", "basic053", "basic054", "basic055"]
 
+idrisTestsTypechecking : TestPool
+idrisTestsTypechecking = MkTestPool []
+      ["typechecking001"]
+
 idrisTestsCoverage : TestPool
 idrisTestsCoverage = MkTestPool []
        -- Coverage checking
@@ -221,6 +225,7 @@ main : IO ()
 main = runner
   [ testPaths "ttimp" ttimpTests
   , testPaths "idris2" idrisTestsBasic
+  , testPaths "idris2" idrisTestsTypechecking
   , testPaths "idris2" idrisTestsCoverage
   , testPaths "idris2" idrisTestsError
   , testPaths "idris2" idrisTestsInteractive

--- a/tests/idris2/basic003/expected
+++ b/tests/idris2/basic003/expected
@@ -2,8 +2,8 @@
 Main> Bye for now!
 1/1: Building Ambig2 (Ambig2.idr)
 Error: While processing right hand side of keepUnique. Ambiguous elaboration. Possible results:
-    Main.Set.toList ?arg
-    Main.Vect.toList ?arg
+    Main.Set.toList (Main.Set.fromList xs)
+    Main.Vect.toList (Main.Vect.fromList xs)
 
 Ambig2.idr:26:21--26:27
  22 |   export

--- a/tests/idris2/basic044/expected
+++ b/tests/idris2/basic044/expected
@@ -123,6 +123,14 @@ LOG elab.ambiguous:5: Ambiguous elaboration [($resolvedN 0), ($resolvedN 0)] at 
 With default. Target type : ?Vec.{a:N}_[]
 LOG elab.ambiguous:5: Ambiguous elaboration False [$resolvedN, $resolvedN] at Vec.idr:21:8--21:17
 Target type : ({arg:N} : (Data.Fin.Fin ?Vec.{n:N}_[])) -> ?Vec.{a:N}_[])
+LOG elab.ambiguous:5: Ambiguous elaboration False [(($resolvedN (fromInteger 0)) Nil), (($resolvedN (fromInteger 0)) Nil), (($resolvedN (fromInteger 0)) Nil)] at Vec.idr:21:13--21:16
+Target type : ?Vec.{a:N}_[]
+LOG elab.ambiguous:5: Ambiguous elaboration [($resolvedN 0), ($resolvedN 0)] at Vec.idr:21:14--21:15
+With default. Target type : ?Vec.{a:N}_[]
+LOG elab.ambiguous:5: Ambiguous elaboration False [$resolvedN, $resolvedN] at Vec.idr:21:13--21:16
+Target type : ({arg:N} : (Data.Fin.Fin ?Vec.{n:N}_[])) -> ?Vec.{a:N}_[])
+LOG elab.ambiguous:5: Ambiguous elaboration [($resolvedN 0), ($resolvedN 0)] at Vec.idr:21:14--21:15
+With default. Target type : ?Vec.{a:N}_[]
 LOG elab.ambiguous:5: Ambiguous elaboration True [(($resolvedN (fromInteger 0)) Nil)] at Vec.idr:21:13--21:16
 Target type : (Prelude.Types.List Prelude.Types.Nat)
 LOG elab.ambiguous:5: Ambiguous elaboration [($resolvedN 0), ($resolvedN 0)] at Vec.idr:21:14--21:15

--- a/tests/idris2/typechecking001/Issue1012.idr
+++ b/tests/idris2/typechecking001/Issue1012.idr
@@ -1,0 +1,30 @@
+module Issue1012
+
+namespace A
+
+  f : (x : Nat) -> {auto 0 p : Either (x=2) (x=3)} -> ()
+  f _ = ()
+
+  g : ()
+  g = f 3
+
+
+namespace B
+
+  fromInteger : Integer -> String
+
+  fw : (x : Nat) -> {auto 0 _ : Either (x=2) (x=3)} -> ()
+  fw _ = ()
+
+  gw : ()
+  gw = fw 3
+
+namespace C
+
+  fromInteger : Integer -> String
+
+  fw : (x : Nat) -> {auto 0 _ : Either (x=2) (x=3)} -> ()
+  fw _ = ()
+
+  gw : ()
+  gw = fw (the Nat 3)

--- a/tests/idris2/typechecking001/expected
+++ b/tests/idris2/typechecking001/expected
@@ -1,0 +1,1 @@
+1/1: Building Issue1012 (Issue1012.idr)

--- a/tests/idris2/typechecking001/run
+++ b/tests/idris2/typechecking001/run
@@ -1,0 +1,3 @@
+$1 --no-banner --no-color --console-width 0 Issue1012.idr --check
+
+rm -rf build

--- a/tests/ttimp/basic006/expected
+++ b/tests/ttimp/basic006/expected
@@ -2,5 +2,5 @@ Processing as TTImp
 Written TTC
 Yaffle> ((Main.Just [a = ((Main.Vect.Vect (Main.S Main.Z)) Integer)]) ((((Main.Vect.Cons [k = Main.Z]) [a = Integer]) 1) (Main.Vect.Nil [a = Integer])))
 Yaffle> ((Main.MkInfer [a = (Main.List.List Integer)]) (((Main.List.Cons [a = Integer]) 1) (Main.List.Nil [a = Integer])))
-Yaffle> (repl):1:9--1:12:Ambiguous elaboration [($resolved209 ?Main.{a:62}_[]), ($resolved189 ?Main.{a:62}_[])]
+Yaffle> (repl):1:9--1:12:Ambiguous elaboration [($resolved209 ?Main.{a:59}_[]), ($resolved189 ?Main.{a:59}_[])]
 Yaffle> Bye for now!


### PR DESCRIPTION
It's quite hard to find a new criterion that will be cheap, accept the example
in the issue report, and not break anything in the libs + test suite.
 
In the various examples, typechecking fails because things are not processed
in the right order for that specific example to succeed. I guess a more robust
solution would be to make it so that this ordering choice is largely irrelevant
by allowing problems to be postponed like we do in the unification part of the
system.