### PR TITLE
DESTDIR support for make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ else
 	SEP := :
 endif
 
+IDRIS2_DESTDIR := ${DESTDIR}${IDRIS2_PREFIX}
+
 # Library and data paths for bootstrap-test
 IDRIS2_BOOT_TEST_LIBS := ${IDRIS2_CURDIR}/bootstrap/${NAME}-${IDRIS2_VERSION}/lib
 IDRIS2_BOOT_TEST_DATA := ${IDRIS2_CURDIR}/bootstrap/${NAME}-${IDRIS2_VERSION}/support
@@ -115,25 +117,25 @@ install-api: src/IdrisPaths.idr
 	${IDRIS2_BOOT} --install ${IDRIS2_LIB_IPKG}
 
 install-idris2:
-	mkdir -p ${PREFIX}/bin/
-	install ${TARGET} ${PREFIX}/bin
+	mkdir -p ${IDRIS2_DESTDIR}/bin/
+	install ${TARGET} ${IDRIS2_DESTDIR}/bin
 ifeq ($(OS), windows)
-	-install ${TARGET}.cmd ${PREFIX}/bin
+	-install ${TARGET}.cmd ${IDRIS2_DESTDIR}/bin
 endif
-	mkdir -p ${PREFIX}/lib/
-	install support/c/${IDRIS2_SUPPORT} ${PREFIX}/lib
-	mkdir -p ${PREFIX}/bin/${NAME}_app
-	install ${TARGETDIR}/${NAME}_app/* ${PREFIX}/bin/${NAME}_app
+	mkdir -p ${IDRIS2_DESTDIR}/lib/
+	install support/c/${IDRIS2_SUPPORT} ${IDRIS2_DESTDIR}/lib
+	mkdir -p ${IDRIS2_DESTDIR}/bin/${NAME}_app
+	install ${TARGETDIR}/${NAME}_app/* ${IDRIS2_DESTDIR}/bin/${NAME}_app
 
 install-support:
-	mkdir -p ${PREFIX}/idris2-${IDRIS2_VERSION}/support/chez
-	mkdir -p ${PREFIX}/idris2-${IDRIS2_VERSION}/support/racket
-	mkdir -p ${PREFIX}/idris2-${IDRIS2_VERSION}/support/gambit
-	mkdir -p ${PREFIX}/idris2-${IDRIS2_VERSION}/support/js
-	install support/chez/* ${PREFIX}/idris2-${IDRIS2_VERSION}/support/chez
-	install support/racket/* ${PREFIX}/idris2-${IDRIS2_VERSION}/support/racket
-	install support/gambit/* ${PREFIX}/idris2-${IDRIS2_VERSION}/support/gambit
-	install support/js/* ${PREFIX}/idris2-${IDRIS2_VERSION}/support/js
+	mkdir -p ${IDRIS2_DESTDIR}/idris2-${IDRIS2_VERSION}/support/chez
+	mkdir -p ${IDRIS2_DESTDIR}/idris2-${IDRIS2_VERSION}/support/racket
+	mkdir -p ${IDRIS2_DESTDIR}/idris2-${IDRIS2_VERSION}/support/gambit
+	mkdir -p ${IDRIS2_DESTDIR}/idris2-${IDRIS2_VERSION}/support/js
+	install support/chez/* ${IDRIS2_DESTDIR}/idris2-${IDRIS2_VERSION}/support/chez
+	install support/racket/* ${IDRIS2_DESTDIR}/idris2-${IDRIS2_VERSION}/support/racket
+	install support/gambit/* ${IDRIS2_DESTDIR}/idris2-${IDRIS2_VERSION}/support/gambit
+	install support/js/* ${IDRIS2_DESTDIR}/idris2-${IDRIS2_VERSION}/support/js
 	@${MAKE} -C support/c install
 	@${MAKE} -C support/refc install
 

--- a/Makefile
+++ b/Makefile
@@ -140,10 +140,10 @@ install-support:
 	@${MAKE} -C support/refc install
 
 install-libs:
-	${MAKE} -C libs/prelude install IDRIS2?=../../${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
-	${MAKE} -C libs/base install IDRIS2?=../../${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
-	${MAKE} -C libs/contrib install IDRIS2?=../../${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
-	${MAKE} -C libs/network install IDRIS2?=../../${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
+	${MAKE} -C libs/prelude install IDRIS2?=../../${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH} DESTDIR=${DESTDIR}
+	${MAKE} -C libs/base install IDRIS2?=../../${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH} DESTDIR=${DESTDIR}
+	${MAKE} -C libs/contrib install IDRIS2?=../../${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH} DESTDIR=${DESTDIR}
+	${MAKE} -C libs/network install IDRIS2?=../../${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH} DESTDIR=${DESTDIR}
 
 
 .PHONY: bootstrap bootstrap-build bootstrap-racket bootstrap-racket-build bootstrap-test bootstrap-clean

--- a/src/Idris/Env.idr
+++ b/src/Idris/Env.idr
@@ -33,7 +33,8 @@ envs = [
          MkEnvDesc "IDRIS2_CC"     "C compiler executable used in RefC codegen",
          MkEnvDesc "CC"            "C compiler executable used in RefC codegen",
          MkEnvDesc "NODE"          "node executable used in Node codegen",
-         MkEnvDesc "PATH"          "PATH variable is used to search for executables in certain codegens"
+         MkEnvDesc "PATH"          "PATH variable is used to search for executables in certain codegens",
+         MkEnvDesc "DESTDIR"       "variable prepended to each installed target file for install comand"
        ]
 
 --- `public export` only for `auto` to work in `idrisGetEnv`

--- a/support/c/Makefile
+++ b/support/c/Makefile
@@ -4,6 +4,7 @@ TARGET = libidris2_support
 
 LIBTARGET = $(TARGET).a
 DYLIBTARGET = $(TARGET)$(SHLIB_SUFFIX)
+IDRIS2_DESTDIR := ${DESTDIR}${PREFIX}
 
 CFLAGS += -O2
 
@@ -51,8 +52,8 @@ cleandep: clean
 .PHONY: install
 
 install: build
-	mkdir -p ${DESTDIR}${PREFIX}/idris2-${IDRIS2_VERSION}/lib
-	mkdir -p ${DESTDIR}${PREFIX}/idris2-${IDRIS2_VERSION}/include
-	install -m 755 $(DYLIBTARGET) ${DESTDIR}${PREFIX}/idris2-${IDRIS2_VERSION}/lib
-	install -m 644 $(LIBTARGET)   ${DESTDIR}${PREFIX}/idris2-${IDRIS2_VERSION}/lib
-	install -m 644 *.h            ${DESTDIR}${PREFIX}/idris2-${IDRIS2_VERSION}/include
+	mkdir -p ${IDRIS2_DESTDIR}/idris2-${IDRIS2_VERSION}/lib
+	mkdir -p ${IDRIS2_DESTDIR}/idris2-${IDRIS2_VERSION}/include
+	install -m 755 $(DYLIBTARGET) ${IDRIS2_DESTDIR}/idris2-${IDRIS2_VERSION}/lib
+	install -m 644 $(LIBTARGET)   ${IDRIS2_DESTDIR}/idris2-${IDRIS2_VERSION}/lib
+	install -m 644 *.h            ${IDRIS2_DESTDIR}/idris2-${IDRIS2_VERSION}/include

--- a/support/c/Makefile
+++ b/support/c/Makefile
@@ -51,8 +51,8 @@ cleandep: clean
 .PHONY: install
 
 install: build
-	mkdir -p ${PREFIX}/idris2-${IDRIS2_VERSION}/lib
-	mkdir -p ${PREFIX}/idris2-${IDRIS2_VERSION}/include
-	install -m 755 $(DYLIBTARGET) ${PREFIX}/idris2-${IDRIS2_VERSION}/lib
-	install -m 644 $(LIBTARGET)   ${PREFIX}/idris2-${IDRIS2_VERSION}/lib
-	install -m 644 *.h            ${PREFIX}/idris2-${IDRIS2_VERSION}/include
+	mkdir -p ${DESTDIR}${PREFIX}/idris2-${IDRIS2_VERSION}/lib
+	mkdir -p ${DESTDIR}${PREFIX}/idris2-${IDRIS2_VERSION}/include
+	install -m 755 $(DYLIBTARGET) ${DESTDIR}${PREFIX}/idris2-${IDRIS2_VERSION}/lib
+	install -m 644 $(LIBTARGET)   ${DESTDIR}${PREFIX}/idris2-${IDRIS2_VERSION}/lib
+	install -m 644 *.h            ${DESTDIR}${PREFIX}/idris2-${IDRIS2_VERSION}/include

--- a/support/refc/Makefile
+++ b/support/refc/Makefile
@@ -45,5 +45,5 @@ cleandep: clean
 .PHONY: install
 
 install: build
-	mkdir -p ${PREFIX}/idris2-${IDRIS2_VERSION}/refc
-	install $(LIBTARGET) *.h ${PREFIX}/idris2-${IDRIS2_VERSION}/refc
+	mkdir -p ${DESTDIR}${PREFIX}/idris2-${IDRIS2_VERSION}/refc
+	install $(LIBTARGET) *.h ${DESTDIR}${PREFIX}/idris2-${IDRIS2_VERSION}/refc

--- a/support/refc/Makefile
+++ b/support/refc/Makefile
@@ -3,6 +3,7 @@ include ../../config.mk
 TARGET = libidris2_refc
 
 LIBTARGET = $(TARGET).a
+IDRIS2_DESTDIR := ${DESTDIR}${PREFIX}
 
 CFLAGS += -O2
 
@@ -45,5 +46,5 @@ cleandep: clean
 .PHONY: install
 
 install: build
-	mkdir -p ${DESTDIR}${PREFIX}/idris2-${IDRIS2_VERSION}/refc
-	install $(LIBTARGET) *.h ${DESTDIR}${PREFIX}/idris2-${IDRIS2_VERSION}/refc
+	mkdir -p ${IDRIS2_DESTDIR}/idris2-${IDRIS2_VERSION}/refc
+	install $(LIBTARGET) *.h ${IDRIS2_DESTDIR}/idris2-${IDRIS2_VERSION}/refc


### PR DESCRIPTION
This pull request adds support for `${DESTDIR}` environment variable to Makefile files.
It is useful to have to be able to move files after installing, to automate system wide installs.
it is documented here https://www.gnu.org/prep/standards/html_node/DESTDIR.html
it's optional and should not break install if not used.

But ideally I want to have some kind of DESTDIR support on `idris2 --install` too
Here: https://github.com/idris-lang/Idris2/blob/master/Makefile#L140-L144

I expect that it should be used somewhere here: https://github.com/idris-lang/Idris2/blob/master/src/Idris/Package.idr#L366-L367
I think adding ability to pass it as `--install --destdir=` option or checking environment variable could be great.

Thank you.