### PR TITLE
Added exponentation operator for numerical types.

### DIFF
--- a/libs/base/Data/Nat/Views.idr
+++ b/libs/base/Data/Nat/Views.idr
@@ -37,3 +37,14 @@ halfRec n with (sizeAccessible n)
           in HalfRecEven _ (halfRec (S k) | acc (S k) (LTESucc (LTESucc (lteAddRight _))))
     halfRec (S (k + k)) | Access acc | HalfEven k
       = HalfRecOdd _ (halfRec k | acc k (LTESucc (lteAddRight _)))
+
+public export
+||| Raises a number to a power which is a natural number.
+(^) : Num ty => ty -> Nat -> ty
+(^) x k = fastPow k x 1 where
+  ||| Raises a number to a natural-number-power using repeated squaring.
+  fastPow : Nat -> ty -> ty -> ty
+  fastPow k x res with (halfRec k)
+    fastPow Z x res | HalfRecZ = res
+    fastPow (m + m) x res | (HalfRecEven m rec) = fastPow m (x * x) res | rec
+    fastPow (S (m + m)) x res | (HalfRecOdd m rec) = fastPow m (x * x) (res * x) | rec

--- a/libs/prelude/Prelude/Ops.idr
+++ b/libs/prelude/Prelude/Ops.idr
@@ -5,6 +5,7 @@ infix 6 ==, /=, <, <=, >, >=
 infixl 7 <<, >> -- unused
 infixl 8 +, -
 infixl 9 *, /
+infixr 10 ^
 
 -- Boolean operators
 infixr 5 &&


### PR DESCRIPTION
An exponentation operation `x ^ n` is added for all types implementing `Num` and natural numbers `n`. In particular, this fixes issue #592.

## Remarks regarding the implementation

The operator `(^)` is right-associative, following mathematical
conventions, with precedence level `10`.

It is implemented using repeating squaring. This is reasonably fast, e.g. computing `2 ^ 2 ^ 2 ^ 2 ^ 2` takes under 10 seconds.

## Justification for the draft PR

Currently, there is no exponentation operator defined (for any of the numerical types), even though there is a power function for natural numbers. This power function is very slow however.

## Problems with this draft

Even though this operator makes sense for any numerical type, it is defined in the module `Data.Nat.Views`, which seems a rather odd place. However, I couldn't place it in `Prelude.Num` because it uses the recursive half-view for natural numbers, and even if it wasn't, it would still result in a circular module dependency as `Prelude.Num` is imported in `Prelude.Types` (where `Nat` is defined).

I therefore welcome any suggestions for a better placement.