### PR TITLE
withFile & writeFile cleanup

### DIFF
--- a/libs/base/System/File.idr
+++ b/libs/base/System/File.idr
@@ -374,7 +374,7 @@ export
 writeFile : HasIO io =>
             (filepath : String) -> (contents : String) ->
             io (Either FileError ())
-writeFile file contents 
+writeFile file contents
   = withFile file WriteTruncate pure $
       (flip fPutStr contents)
 


### PR DESCRIPTION
As a fast follow to my previous PR that merged today:

I went to use `withFile` in `writeFile` and realized `withFile` could be made more ergonomic. More often than not (really, just about always), the thing you want to do with a successfully opened file can itself fail so I updated the signature of the `onOpen` function to allow for errors and things got a whole lot nicer.

Note that `withFile` was totally new as of today, so I don't feel bad about breaking it immediately. I do feel a bit embarrassed though 😊.