### PR TITLE
[ re #1087 ] Better error messages in the REPL

### DIFF
--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -74,7 +74,7 @@ idrisTestsInteractive = MkTestPool []
        "interactive013", "interactive014", "interactive015", "interactive016",
        "interactive017", "interactive018", "interactive019", "interactive020",
        "interactive021", "interactive022", "interactive023", "interactive024",
-       "interactive025", "interactive026", "interactive027"]
+       "interactive025", "interactive026", "interactive027", "interactive028"]
 
 idrisTestsInterface : TestPool
 idrisTestsInterface = MkTestPool []

--- a/tests/idris2/basic044/Term.idr
+++ b/tests/idris2/basic044/Term.idr
@@ -3,7 +3,7 @@ module Term
 import Data.Fin
 
 %logging 1
-%logging declare.def 3
+%logging "declare.def" 3
 
 mutual
 

--- a/tests/idris2/basic044/Vec.idr
+++ b/tests/idris2/basic044/Vec.idr
@@ -5,7 +5,7 @@ import Data.Fin
 %default total
 
 %logging 1
-%logging declare.def 2
+%logging "declare.def" 2
 
 Vec : Type -> Nat -> Type
 Vec a n = Fin n -> a

--- a/tests/idris2/interactive028/expected
+++ b/tests/idris2/interactive028/expected
@@ -1,0 +1,20 @@
+Main> Expected 'case', 'if', 'do', application or operator expression.
+
+(interactive):1:4--1:5
+ 1 | :t (3 : Nat)
+        ^
+
+Main> Expected string begin.
+
+(interactive):1:5--1:6
+ 1 | :cd ..
+         ^
+
+Main> Expected string begin.
+
+(interactive):1:7--1:8
+ 1 | :load expected
+           ^
+
+Main> 
+Bye for now!

--- a/tests/idris2/interactive028/input
+++ b/tests/idris2/interactive028/input
@@ -1,0 +1,4 @@
+:t (3 : Nat)
+:cd ..
+:load expected
+:log with

--- a/tests/idris2/interactive028/run
+++ b/tests/idris2/interactive028/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 --no-banner < input
+
+rm -rf build

--- a/tests/idris2/positivity002/Issue660.idr
+++ b/tests/idris2/positivity002/Issue660.idr
@@ -2,7 +2,7 @@ module Issue660
 
 %default total
 
-%logging declare.data.parameters 20
+%logging "declare.data.parameters" 20
 
 data C : Type -> Type where
   MkC : List a -> C a

--- a/tests/idris2/positivity003/Issue660.idr
+++ b/tests/idris2/positivity003/Issue660.idr
@@ -2,8 +2,8 @@ module Main
 
 %default total
 
-%logging declare.data.parameters 20
-%logging eval.eta 10
+%logging "declare.data.parameters" 20
+%logging "eval.eta" 10
 
 
 -- explicit

--- a/tests/idris2/with003/expected
+++ b/tests/idris2/with003/expected
@@ -62,10 +62,10 @@ Mismatch between: Vect 0 ?elem and List ?a.
                                       ^^^^^^^
 
 Main> the (Maybe Integer) (pure 4) : Maybe Integer
-Main> Unrecognised command.
+Main> Expected 'case', 'if', 'do', application or operator expression.
 
-(interactive):1:2--1:3
+(interactive):1:4--1:5
  1 | :t with [] 4
-      ^
+        ^
 
 Main> Bye for now!


### PR DESCRIPTION
(as well as in type signatures now that I know how to do that)

Also taking this opportunity to fix the historical mistake of parsing
`logging` arguments as qualified names (which meant you couldn't use
reserved keywords like `"with"` as logging topics...)