### PR TITLE
Introduce IDE Protocol Versioning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changes since Idris 2 v0.3.0
 
 REPL/IDE mode changes:
 
+* Extended the IDE Protocol to introduce IDE protocol versions.
+  This will allow IDE Clients to differentiate between versions of the protocol used by Idris1 and Idris2.
+  A reasonable way to support compatibility between clients and versions of Idris.
+  By default Idris1 will have protocol version 0 and Idris2 protocol version 1.
 * Added `:search` command, which searches for functions by type
 * `:load`/`:l` and `:cd` commands now only accept paths surrounded by double quotes
 

--- a/src/Idris/IDEMode/Commands.idr
+++ b/src/Idris/IDEMode/Commands.idr
@@ -9,6 +9,10 @@ import System.File
 
 %default total
 
+export
+versionIDEProtocol : Int
+versionIDEProtocol = 1
+
 public export
 data SExp = SExpList (List SExp)
           | StringAtom String
@@ -52,6 +56,7 @@ data IDECommand
      | EnableSyntax Bool
      | Version
      | GetOptions
+     | VersionIDEProtocol
 
 readHints : List SExp -> Maybe (List String)
 readHints [] = Just []
@@ -146,6 +151,7 @@ getIDECommand (SExpList [SymbolAtom "enable-syntax", BoolAtom b])
     = Just $ EnableSyntax b
 getIDECommand (SymbolAtom "version") = Just Version
 getIDECommand (SExpList [SymbolAtom "get-options"]) = Just GetOptions
+getIDECommand (SymbolAtom "version-ide-protocol") = Just VersionIDEProtocol
 getIDECommand _ = Nothing
 
 export
@@ -191,6 +197,8 @@ putIDECommand (Directive n)             = (SExpList [SymbolAtom "directive", Str
 putIDECommand (EnableSyntax b)                = (SExpList [SymbolAtom "enable-syntax", BoolAtom b])
 putIDECommand GetOptions                      = (SExpList [SymbolAtom "get-options"])
 putIDECommand Version                         = SymbolAtom "version"
+putIDECommand VersionIDEProtocol              = SymbolAtom "version-ide-protocol"
+
 
 export
 getMsg : SExp -> Maybe (IDECommand, Integer)
@@ -275,6 +283,10 @@ sym = UN
 export
 version : Int -> Int -> SExp
 version maj min = toSExp (SymbolAtom "protocol-version", maj, min)
+
+export
+versionProtocol : SExp
+versionProtocol = toSExp (SymbolAtom "version-ide-protocol", versionIDEProtocol)
 
 sendStr : File -> String -> IO ()
 sendStr f st =

--- a/src/Idris/IDEMode/REPL.idr
+++ b/src/Idris/IDEMode/REPL.idr
@@ -238,6 +238,8 @@ process (Metavariables _)
     = replWrap $ Idris.REPL.process Metavars
 process GetOptions
     = replWrap $ Idris.REPL.process GetOpts
+process VersionIDEProtocol
+    = replWrap $ Idris.REPL.process ShowVersionIDEProtocol
 
 processCatch : {auto c : Ref Ctxt Defs} ->
                {auto u : Ref UST UState} ->

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1855,6 +1855,7 @@ parserCommandsForHelp =
   , onOffArgCmd (ParseREPLCmd ["color", "colour"]) SetColor "Whether to use color for the console output (enabled by default)"
   , noArgCmd (ParseREPLCmd ["m", "metavars"]) Metavars "Show remaining proof obligations (metavariables or holes)"
   , noArgCmd (ParseREPLCmd ["version"]) ShowVersion "Display the Idris version"
+  , noArgCmd (ParseREPLCmd ["versionIDEProtocol"]) ShowVersionIDEProtocol "Display the IDE Protocol Version"
   , noArgCmd (ParseREPLCmd ["?", "h", "help"]) Help "Display this help text"
   , declsArgCmd (ParseKeywordCmd "let") NewDefn "Define a new value"
   ]

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -548,6 +548,7 @@ data REPLResult : Type where
   ConsoleWidthSet : Maybe Nat -> REPLResult
   ColorSet : Bool -> REPLResult
   VersionIs : Version -> REPLResult
+  VersionIDEProtocolIs : Int -> REPLResult
   DefDeclared : REPLResult
   Exited : REPLResult
   Edited : EditResult -> REPLResult
@@ -910,6 +911,8 @@ process NOP
     = pure Done
 process ShowVersion
     = pure $ VersionIs  version
+process ShowVersionIDEProtocol
+    = pure $ VersionIDEProtocolIs versionIDEProtocol
 
 processCatch : {auto c : Ref Ctxt Defs} ->
                {auto u : Ref UST UState} ->
@@ -1060,6 +1063,7 @@ mutual
   displayResult (ConsoleWidthSet Nothing) = printResult (reflow "Set consolewidth to auto")
   displayResult (ColorSet b) = printResult (reflow (if b then "Set color on" else "Set color off"))
   displayResult (VersionIs x) = printResult (pretty (showVersion True x))
+  displayResult (VersionIDEProtocolIs x) = printResult (pretty x)
   displayResult (RequestedHelp) = printResult (pretty displayHelp)
   displayResult (Edited (DisplayEdit Empty)) = pure ()
   displayResult (Edited (DisplayEdit xs)) = printResult xs

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -458,6 +458,7 @@ data REPLCmd : Type where
      ShowVersion : REPLCmd
      Quit : REPLCmd
      NOP : REPLCmd
+     ShowVersionIDEProtocol : REPLCmd
 
 public export
 record Import where


### PR DESCRIPTION
Before, the IDE Protocol allowed clients to query the version of Idris being used.
When there was a single version of Idris this was the same as querying the version of the IDE Protocol being used.
Various clients (Emacs) uses this to keep track of the version of the IDE Protocol it is using.

With Idris2, and now different protocol implementations and extensions, such querying is not useful.

We introduce a notion of IDE Protocol versioning separate from the compiler version number.
This will allow IDE Clients to differentiate between versions of the protocol used by different versions of Idris.

This is a reasonable first step in supporting compatibility between clients, versions of Idris, and versions of the IDE Protocol.

By default Idris1 will have protocol version 0 and Idris2 protocol version 1.