### PR TITLE
fix Golden so that prompt is run after both paths where expected and actual outputs don't match.

### DIFF
--- a/libs/contrib/Test/Golden.idr
+++ b/libs/contrib/Test/Golden.idr
@@ -202,10 +202,10 @@ runTest opts testPath = forkIO $ do
             ["Golden value differs from actual value."] ++
             (if (code < 0) then expVsOut exp out else []) ++
             ["Accept actual value as new golden value? [yn]"]
-          b <- getAnswer
-          when b $ do Right _ <- writeFile (testPath ++ "/expected") out
-                        | Left err => print err
-                      pure ()
+      b <- getAnswer
+      when b $ do Right _ <- writeFile (testPath ++ "/expected") out
+                    | Left err => print err
+                  pure ()
 
     printTiming : Bool -> Clock type -> String -> IO ()
     printTiming True  clock msg = putStrLn (unwords [msg, show clock])

--- a/tests/Lib.idr
+++ b/tests/Lib.idr
@@ -202,10 +202,10 @@ runTest opts testPath = forkIO $ do
             ["Golden value differs from actual value."] ++
             (if (code < 0) then expVsOut exp out else []) ++
             ["Accept actual value as new golden value? [yn]"]
-          b <- getAnswer
-          when b $ do Right _ <- writeFile (testPath ++ "/expected") out
-                        | Left err => print err
-                      pure ()
+      b <- getAnswer
+      when b $ do Right _ <- writeFile (testPath ++ "/expected") out
+                    | Left err => print err
+                  pure ()
 
     printTiming : Bool -> Clock type -> String -> IO ()
     printTiming True  clock msg = putStrLn (unwords [msg, show clock])


### PR DESCRIPTION
I discovered that the prompt for updating expected values did not work when the expected file was not found -- it just asked for "y/n" and then immediately exited without an opportunity to choose!

It turned out is was just an indentation bug causing the required code for reading in a response to only get run under one of the two paths.