### PR TITLE
Give App1 implementation of (>>)

### DIFF
--- a/libs/base/Control/App.idr
+++ b/libs/base/Control/App.idr
@@ -197,6 +197,11 @@ namespace App1
   (>>=) = bindApp1
 
   export
+  (>>) : {u : _} -> (1 _ : App1 e ()) ->
+         (1 _ : App1 {u} e b) -> App1 {u} e b
+  ma >> mb = ma >>= (\() => mb)
+
+  export
   pure : (x : a) -> App1 {u=Any} e a
   pure x =  MkApp1 $ \w => MkApp1ResW x w
 

--- a/libs/base/Control/App.idr
+++ b/libs/base/Control/App.idr
@@ -196,15 +196,15 @@ namespace App1
           (1 k : Cont1Type u a u' e b) -> App1 {u=u'} e b
   (>>=) = bindApp1
 
-  delay : {u_act : _} -> (1 _ : App1 {u=u_k} e b) -> Cont1Type u_act () u_k e b
-  delay mb = case u_act of
+  decideUsage : {u_act : _} -> (1 _ : App1 {u=u_k} e b) -> Cont1Type u_act () u_k e b
+  decideUsage mb = case u_act of
                   One => \ () => mb
                   Any => \ _ => mb
 
   export %inline
   (>>) : {u_act : _} -> (1 _ : App1 {u=u_act} e ()) ->
          (1 _ : App1 {u=u_k} e b) -> App1 {u=u_k} e b
-  ma >> mb = ma >>= delay mb
+  ma >> mb = ma >>= decideUsage mb
 
   export
   pure : (x : a) -> App1 {u=Any} e a

--- a/libs/base/Control/App.idr
+++ b/libs/base/Control/App.idr
@@ -198,7 +198,7 @@ namespace App1
 
   delay : {u_act : _} -> (1 _ : App1 {u=u_k} e b) -> Cont1Type u_act () u_k e b
   delay mb = case u_act of
-                  One => \ () => ?ars
+                  One => \ () => mb
                   Any => \ _ => mb
 
   export %inline

--- a/libs/base/Control/App.idr
+++ b/libs/base/Control/App.idr
@@ -196,10 +196,15 @@ namespace App1
           (1 k : Cont1Type u a u' e b) -> App1 {u=u'} e b
   (>>=) = bindApp1
 
-  export
-  (>>) : {u : _} -> (1 _ : App1 e ()) ->
-         (1 _ : App1 {u} e b) -> App1 {u} e b
-  ma >> mb = ma >>= (\() => mb)
+  delay : {u_act : _} -> (1 _ : App1 {u=u_k} e b) -> Cont1Type u_act () u_k e b
+  delay mb = case u_act of
+                  One => \ () => ?ars
+                  Any => \ _ => mb
+
+  export %inline
+  (>>) : {u_act : _} -> (1 _ : App1 {u=u_act} e ()) ->
+         (1 _ : App1 {u=u_k} e b) -> App1 {u=u_k} e b
+  ma >> mb = ma >>= delay mb
 
   export
   pure : (x : a) -> App1 {u=Any} e a

--- a/libs/base/Control/App.idr
+++ b/libs/base/Control/App.idr
@@ -196,15 +196,15 @@ namespace App1
           (1 k : Cont1Type u a u' e b) -> App1 {u=u'} e b
   (>>=) = bindApp1
 
-  decideUsage : {u_act : _} -> (1 _ : App1 {u=u_k} e b) -> Cont1Type u_act () u_k e b
-  decideUsage mb = case u_act of
+  delay : {u_act : _} -> (1 _ : App1 {u=u_k} e b) -> Cont1Type u_act () u_k e b
+  delay mb = case u_act of
                   One => \ () => mb
                   Any => \ _ => mb
 
   export %inline
   (>>) : {u_act : _} -> (1 _ : App1 {u=u_act} e ()) ->
          (1 _ : App1 {u=u_k} e b) -> App1 {u=u_k} e b
-  ma >> mb = ma >>= decideUsage mb
+  ma >> mb = ma >>= delay mb
 
   export
   pure : (x : a) -> App1 {u=Any} e a


### PR DESCRIPTION
App1 is not a monad, and was missed in the change to desugaring of non-binding sequences.

This fixes that.