### PR TITLE
[ fix #762 ] Different case tree building strategy

### DIFF
--- a/libs/base/Language/Reflection/TTImp.idr
+++ b/libs/base/Language/Reflection/TTImp.idr
@@ -19,6 +19,7 @@ mutual
                  | ErasedArg
                  | UserDotted
                  | UnknownDot
+                 | UnderAppliedCon
 
   public export
   data TTImp : Type where

--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -37,6 +37,7 @@ data DotReason = NonLinearVar
                | ErasedArg
                | UserDotted
                | UnknownDot
+               | UnderAppliedCon
 
 export
 Show DotReason where
@@ -46,6 +47,7 @@ Show DotReason where
   show ErasedArg = "Erased argument"
   show UserDotted = "User dotted"
   show UnknownDot = "Unknown reason"
+  show UnderAppliedCon = "Under-applied constructor"
 
 export
 Pretty DotReason where
@@ -55,6 +57,7 @@ Pretty DotReason where
   pretty ErasedArg = reflow "Erased argument"
   pretty UserDotted = reflow "User dotted"
   pretty UnknownDot = reflow "Unknown reason"
+  pretty UnderAppliedCon = reflow "Under-applied constructor"
 
 -- All possible errors, carrying a location
 public export

--- a/src/Core/Coverage.idr
+++ b/src/Core/Coverage.idr
@@ -10,6 +10,7 @@ import Core.Value
 
 import Libraries.Data.Bool.Extra
 import Data.List
+import Data.Maybe
 import Data.Strings
 import Libraries.Data.NameMap
 
@@ -29,10 +30,10 @@ conflictMatch ((x, tm) :: ms) = conflictArgs x tm ms || conflictMatch ms
         = t /= t'
     clash (PrimVal _ c) (PrimVal _ c')
       = c /= c'
-    clash (Ref _ t _) (PrimVal _ _) = isCon t
-    clash (PrimVal _ _) (Ref _ t _) = isCon t
-    clash (Ref _ t _) (TType _) = isCon t
-    clash (TType _) (Ref _ t _) = isCon t
+    clash (Ref _ t _) (PrimVal _ _) = isJust (isCon t)
+    clash (PrimVal _ _) (Ref _ t _) = isJust (isCon t)
+    clash (Ref _ t _) (TType _) = isJust (isCon t)
+    clash (TType _) (Ref _ t _) = isJust (isCon t)
     clash (TType _) (PrimVal _ _) = True
     clash (PrimVal _ _) (TType _) = True
     clash _ _ = False

--- a/src/Core/TT.idr
+++ b/src/Core/TT.idr
@@ -24,10 +24,10 @@ data NameType : Type where
      TyCon   : (tag : Int) -> (arity : Nat) -> NameType
 
 export
-isCon : NameType -> Bool
-isCon (DataCon _ _) = True
-isCon (TyCon _ _) = True
-isCon _ = False
+isCon : NameType -> Maybe (Int, Nat)
+isCon (DataCon t a) = Just (t, a)
+isCon (TyCon t a) = Just (t, a)
+isCon _ = Nothing
 
 public export
 data Constant

--- a/src/TTImp/Elab/App.idr
+++ b/src/TTImp/Elab/App.idr
@@ -649,6 +649,9 @@ mutual
               then checkExp rig elabinfo env fc tm (glueBack defs env ty) expty
               else throw (InvalidArgs fc env (map (const (UN "<auto>")) autoargs ++ map fst namedargs) tm)
 
+  ||| Entrypoint for checkAppWith: run the elaboration first and, if we're
+  ||| on the LHS and the result is an under-applied constructor then insist
+  ||| that it ought to be forced by another pattern somewhere else in the LHS.
   checkAppWith : {vars : _} ->
                  {auto c : Ref Ctxt Defs} ->
                  {auto m : Ref MD Metadata} ->

--- a/src/TTImp/Elab/App.idr
+++ b/src/TTImp/Elab/App.idr
@@ -12,6 +12,7 @@ import Core.TT
 import Core.Value
 
 import TTImp.Elab.Check
+import TTImp.Elab.Dot
 import TTImp.TTImp
 
 import Data.List
@@ -485,7 +486,7 @@ mutual
   -- Check an application of 'fntm', with type 'fnty' to the given list
   -- of explicit and implicit arguments.
   -- Returns the checked term and its (weakly) normalised type
-  checkAppWith : {vars : _} ->
+  checkAppWith' : {vars : _} ->
                  {auto c : Ref Ctxt Defs} ->
                  {auto m : Ref MD Metadata} ->
                  {auto u : Ref UST UState} ->
@@ -505,20 +506,20 @@ mutual
                  (expected : Maybe (Glued vars)) ->
                  Core (Term vars, Glued vars)
    -- Explicit Pi, we use provided unnamed explicit argument
-  checkAppWith rig elabinfo nest env fc tm ty@(NBind tfc x (Pi _ rigb Explicit aty) sc)
+  checkAppWith' rig elabinfo nest env fc tm ty@(NBind tfc x (Pi _ rigb Explicit aty) sc)
                argdata (arg :: expargs') autoargs namedargs kr expty
      = do let argRig = rig |*| rigb
           checkRestApp rig argRig elabinfo nest env fc
                        tm x aty sc argdata arg expargs' autoargs namedargs kr expty
-  checkAppWith rig elabinfo nest env fc tm ty@(NBind tfc x (Pi _ rigb Explicit aty) sc)
+  checkAppWith' rig elabinfo nest env fc tm ty@(NBind tfc x (Pi _ rigb Explicit aty) sc)
                argdata [] autoargs namedargs kr expty with (findNamed x namedargs)
    -- We found a compatible named argument
-   checkAppWith rig elabinfo nest env fc tm ty@(NBind tfc x (Pi _ rigb Explicit aty) sc)
+   checkAppWith' rig elabinfo nest env fc tm ty@(NBind tfc x (Pi _ rigb Explicit aty) sc)
                 argdata [] autoargs namedargs kr expty | Just ((_, arg), namedargs')
     = do let argRig = rig |*| rigb
          checkRestApp rig argRig elabinfo nest env fc
                       tm x aty sc argdata arg [] autoargs namedargs' kr expty
-   checkAppWith rig elabinfo nest env fc tm ty@(NBind tfc x (Pi _ rigb Explicit aty) sc)
+   checkAppWith' rig elabinfo nest env fc tm ty@(NBind tfc x (Pi _ rigb Explicit aty) sc)
                 argdata [] autoargs namedargs kr expty | Nothing
     = case findBindAllExpPattern namedargs of
            Just arg => -- Bind-all-explicit pattern is present - implicitly bind
@@ -536,11 +537,11 @@ mutual
                    else -- Some user defined binding is present while we are out of explicit arguments, that's an error
                         throw (InvalidArgs fc env (map (const (UN "<auto>")) autoargs ++ map fst namedargs) tm)
   -- Function type is delayed, so force the term and continue
-  checkAppWith rig elabinfo nest env fc tm (NDelayed dfc r ty@(NBind _ _ (Pi _ _ _ _) sc)) argdata expargs autoargs namedargs kr expty
-      = checkAppWith rig elabinfo nest env fc (TForce dfc r tm) ty argdata expargs autoargs namedargs kr expty
+  checkAppWith' rig elabinfo nest env fc tm (NDelayed dfc r ty@(NBind _ _ (Pi _ _ _ _) sc)) argdata expargs autoargs namedargs kr expty
+      = checkAppWith' rig elabinfo nest env fc (TForce dfc r tm) ty argdata expargs autoargs namedargs kr expty
   -- If there's no more arguments given, and the plicities of the type and
   -- the expected type line up, stop
-  checkAppWith rig elabinfo nest env fc tm ty@(NBind tfc x (Pi _ rigb Implicit aty) sc)
+  checkAppWith' rig elabinfo nest env fc tm ty@(NBind tfc x (Pi _ rigb Implicit aty) sc)
                argdata [] [] [] kr (Just expty_in)
       = do let argRig = rig |*| rigb
            expty <- getNF expty_in
@@ -555,7 +556,7 @@ mutual
                         else handle (checkExp rig elabinfo env fc tm (glueBack defs env ty) (Just expty_in))
                                (\err => makeImplicit rig argRig elabinfo nest env fc tm x aty sc argdata [] [] [] kr (Just expty_in))
   -- Same for auto
-  checkAppWith rig elabinfo nest env fc tm ty@(NBind tfc x (Pi _ rigb AutoImplicit aty) sc)
+  checkAppWith' rig elabinfo nest env fc tm ty@(NBind tfc x (Pi _ rigb AutoImplicit aty) sc)
                argdata [] [] [] kr (Just expty_in)
       = do let argRig = rig |*| rigb
            expty <- getNF expty_in
@@ -565,7 +566,7 @@ mutual
                    => checkExp rig elabinfo env fc tm (glueBack defs env ty) (Just expty_in)
                 _ => makeAutoImplicit rig argRig elabinfo nest env fc tm x aty sc argdata [] [] [] kr (Just expty_in)
   -- Same for default
-  checkAppWith rig elabinfo nest env fc tm ty@(NBind tfc x (Pi _ rigb (DefImplicit aval) aty) sc)
+  checkAppWith' rig elabinfo nest env fc tm ty@(NBind tfc x (Pi _ rigb (DefImplicit aval) aty) sc)
                argdata [] [] [] kr (Just expty_in)
       = do let argRig = rigMult rig rigb
            expty <- getNF expty_in
@@ -578,12 +579,12 @@ mutual
                 _ => makeDefImplicit rig argRig elabinfo nest env fc tm x aval aty sc argdata [] [] [] kr (Just expty_in)
 
   -- Check next unnamed auto implicit argument
-  checkAppWith rig elabinfo nest env fc tm (NBind tfc x (Pi _ rigb AutoImplicit aty) sc)
+  checkAppWith' rig elabinfo nest env fc tm (NBind tfc x (Pi _ rigb AutoImplicit aty) sc)
                argdata expargs (arg :: autoargs') namedargs kr expty
       = checkRestApp rig (rig |*| rigb) elabinfo nest env fc
                          tm x aty sc argdata arg expargs autoargs' namedargs kr expty
   -- Check next named auto implicit argument
-  checkAppWith rig elabinfo nest env fc tm (NBind tfc x (Pi _ rigb AutoImplicit aty) sc)
+  checkAppWith' rig elabinfo nest env fc tm (NBind tfc x (Pi _ rigb AutoImplicit aty) sc)
                argdata expargs [] namedargs kr expty
       = let argRig = rig |*| rigb in
             case findNamed x namedargs of
@@ -594,7 +595,7 @@ mutual
                          makeAutoImplicit rig argRig elabinfo nest env fc tm
                                               x aty sc argdata expargs [] namedargs kr expty
   -- Check next implicit argument
-  checkAppWith rig elabinfo nest env fc tm (NBind tfc x (Pi _ rigb Implicit aty) sc)
+  checkAppWith' rig elabinfo nest env fc tm (NBind tfc x (Pi _ rigb Implicit aty) sc)
                argdata expargs autoargs namedargs kr expty
       = let argRig = rig |*| rigb in
             case findNamed x namedargs of
@@ -604,7 +605,7 @@ mutual
                      checkRestApp rig argRig elabinfo nest env fc
                                   tm x aty sc argdata arg expargs autoargs namedargs' kr expty
   -- Check next default argument
-  checkAppWith rig elabinfo nest env fc tm (NBind tfc x (Pi _ rigb (DefImplicit arg) aty) sc)
+  checkAppWith' rig elabinfo nest env fc tm (NBind tfc x (Pi _ rigb (DefImplicit arg) aty) sc)
                argdata expargs autoargs namedargs kr expty
       = let argRig = rigMult rig rigb in
             case findNamed x namedargs of
@@ -614,7 +615,7 @@ mutual
                      checkRestApp rig argRig elabinfo nest env fc
                                   tm x aty sc argdata arg expargs autoargs namedargs' kr expty
   -- Invent a function type if we have extra explicit arguments but type is further unknown
-  checkAppWith {vars} rig elabinfo nest env fc tm ty (n, argpos) (arg :: expargs) autoargs namedargs kr expty
+  checkAppWith' {vars} rig elabinfo nest env fc tm ty (n, argpos) (arg :: expargs) autoargs namedargs kr expty
       = -- Invent a function type,  and hope that we'll know enough to solve it
         -- later when we unify with expty
         do logNF "elab.with" 10 "Function type" env ty
@@ -634,7 +635,7 @@ mutual
            let expfnty = gnf env (Bind fc argn (Pi fc top Explicit argTy) (weaken retTy))
            logGlue "elab.with" 10 "Expected function type" env expfnty
            whenJust expty (logGlue "elab.with" 10 "Expected result type" env)
-           res <- checkAppWith rig elabinfo nest env fc fntm fnty (n, 1 + argpos) expargs autoargs namedargs kr expty
+           res <- checkAppWith' rig elabinfo nest env fc fntm fnty (n, 1 + argpos) expargs autoargs namedargs kr expty
            cres <- Check.convert fc elabinfo env (glueBack defs env ty) expfnty
            let [] = constraints cres
               | cs => do cty <- getTerm expfnty
@@ -642,12 +643,44 @@ mutual
                          pure (ctm, gnf env retTy)
            pure res
   -- Only non-user implicit `as` bindings are allowed to be present as arguments at this stage
-  checkAppWith rig elabinfo nest env fc tm ty argdata [] autoargs namedargs kr expty
+  checkAppWith' rig elabinfo nest env fc tm ty argdata [] autoargs namedargs kr expty
       = do defs <- get Ctxt
            if all isImplicitAs (autoargs ++ map snd (filter (not . isBindAllExpPattern . fst) namedargs))
               then checkExp rig elabinfo env fc tm (glueBack defs env ty) expty
               else throw (InvalidArgs fc env (map (const (UN "<auto>")) autoargs ++ map fst namedargs) tm)
 
+  checkAppWith : {vars : _} ->
+                 {auto c : Ref Ctxt Defs} ->
+                 {auto m : Ref MD Metadata} ->
+                 {auto u : Ref UST UState} ->
+                 {auto e : Ref EST (EState vars)} ->
+                 RigCount -> ElabInfo ->
+                 NestedNames vars -> Env Term vars ->
+                 FC -> (fntm : Term vars) -> (fnty : NF vars) ->
+                 (argdata : (Maybe Name, Nat)) ->
+                      -- function we're applying, and argument position, for
+                      -- checking if it's okay to erase against 'safeErase'
+                 (expargs : List RawImp) ->
+                 (autoargs : List RawImp) ->
+                 (namedargs : List (Name, RawImp)) ->
+                 (knownret : Bool) -> -- Do we know what the return type is yet?
+                              -- if we do, we might be able to use it to work
+                              -- out the types of arguments before elaborating them
+                 (expected : Maybe (Glued vars)) ->
+                 Core (Term vars, Glued vars)
+  checkAppWith rig info nest env fc tm ty
+    argdata expargs autoargs namedargs knownret expected
+    = do res <- checkAppWith' rig info nest env fc tm ty
+                   argdata expargs autoargs namedargs knownret expected
+         let Just _ = isLHS (elabMode info)
+               | Nothing => pure res
+         let (Ref _ t _, args) = getFnArgs (fst res)
+               | _ => pure res
+         let Just (_, a) = isCon t
+               | _ => pure res
+         if a == length args
+           then pure res
+           else registerDot rig env fc UnderAppliedCon (fst res) (snd res)
 
 export
 checkApp : {vars : _} ->

--- a/src/TTImp/Elab/Dot.idr
+++ b/src/TTImp/Elab/Dot.idr
@@ -18,6 +18,23 @@ import Libraries.Data.NameMap
 %default covering
 
 export
+registerDot : {vars : _} ->
+              {auto c : Ref Ctxt Defs} ->
+              {auto m : Ref MD Metadata} ->
+              {auto u : Ref UST UState} ->
+              {auto e : Ref EST (EState vars)} ->
+              RigCount -> Env Term vars ->
+              FC -> DotReason ->
+              Term vars -> Glued vars ->
+              Core (Term vars, Glued vars)
+registerDot rig env fc reason wantedTm gexpty
+    = do nm <- genName "dotTm"
+         expty <- getTerm gexpty
+         metaval <- metaVar fc rig env nm expty
+         addDot fc env nm wantedTm reason metaval
+         pure (metaval, gexpty)
+
+export
 checkDot : {vars : _} ->
            {auto c : Ref Ctxt Defs} ->
            {auto m : Ref MD Metadata} ->
@@ -38,10 +55,6 @@ checkDot rig elabinfo nest env fc reason tm (Just gexpty)
                                                   elabinfo)
                                               nest env
                                               tm (Just gexpty)
-             nm <- genName "dotTm"
-             expty <- getTerm gexpty
-             metaval <- metaVar fc rig env nm expty
-             addDot fc env nm wantedTm reason metaval
-             pure (metaval, gexpty)
+             registerDot rig env fc reason wantedTm gexpty
         _ => throw (GenericMsg fc ("Dot pattern not valid here (Not LHS) "
                                    ++ show tm))

--- a/src/TTImp/Reflect.idr
+++ b/src/TTImp/Reflect.idr
@@ -59,6 +59,7 @@ Reify DotReason where
              (NS _ (UN "ErasedArg"), _) => pure ErasedArg
              (NS _ (UN "UserDotted"), _) => pure UserDotted
              (NS _ (UN "UnknownDot"), _) => pure UnknownDot
+             (NS _ (UN "UnderAppliedCon"), _) => pure UnderAppliedCon
              _ => cantReify val "DotReason"
   reify defs val = cantReify val "DotReason"
 
@@ -76,6 +77,9 @@ Reflect DotReason where
       = getCon fc defs (reflectionttimp "UserDotted")
   reflect fc defs lhs env UnknownDot
       = getCon fc defs (reflectionttimp "UnknownDot")
+  reflect fc defs lhs env UnderAppliedCon
+      = getCon fc defs (reflectionttimp "UnderAppliedCon")
+
 
 mutual
   export

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -56,6 +56,11 @@ idrisTestsCoverage = MkTestPool []
        "coverage009", "coverage010", "coverage011", "coverage012",
        "coverage013", "coverage014"]
 
+idrisTestsCasetree : TestPool
+idrisTestsCasetree = MkTestPool []
+       -- Case tree building
+      ["casetree001"]
+
 idrisTestsError : TestPool
 idrisTestsError = MkTestPool []
        -- Error messages
@@ -234,6 +239,7 @@ main = runner
   [ testPaths "ttimp" ttimpTests
   , testPaths "idris2" idrisTestsBasic
   , testPaths "idris2" idrisTestsCoverage
+  , testPaths "idris2" idrisTestsCasetree
   , testPaths "idris2" idrisTestsError
   , testPaths "idris2" idrisTestsInteractive
   , testPaths "idris2" idrisTestsInterface

--- a/tests/idris2/casetree001/IsS.idr
+++ b/tests/idris2/casetree001/IsS.idr
@@ -1,5 +1,32 @@
 data IsS : (Nat -> Nat) -> Type where
-  Indeed : {s : Nat -> Nat} -> s === S -> IsS s
+  Indeed : (s : Nat -> Nat) -> s === S -> IsS s
 
-indeed : IsS S -> Nat
-indeed (Indeed _) = Z
+------------------------------------------------------------------------
+-- 1.
+-- the S pattern is forced by the fact the parameter is instantiated
+-- so everything is fine
+
+-- either left implicit
+indeed : IsS S -> S === S
+indeed (Indeed _ eq) = eq
+
+-- or made explicit
+indeed2 : IsS S -> S === S
+indeed2 (Indeed S eq) = eq
+
+------------------------------------------------------------------------
+-- 2. The S pattern is not forced by the parameter (a generic variable)
+
+-- either don't match on it
+indeed3 : IsS s -> s === S
+indeed3 (Indeed s eq) = eq
+
+-- or match on the proof that forces it
+indeed4 : IsS s -> s === S
+indeed4 (Indeed S Refl) = Refl
+--              ^ forced by Refl
+
+-- If you don't: too bad!
+fail : IsS s -> s === S
+fail (Indeed S eq) = eq
+--             ^ not Refl, S not forced! OUCH

--- a/tests/idris2/casetree001/IsS.idr
+++ b/tests/idris2/casetree001/IsS.idr
@@ -1,0 +1,5 @@
+data IsS : (Nat -> Nat) -> Type where
+  Indeed : {s : Nat -> Nat} -> s === S -> IsS s
+
+indeed : IsS S -> Nat
+indeed (Indeed _) = Z

--- a/tests/idris2/casetree001/Issue762.idr
+++ b/tests/idris2/casetree001/Issue762.idr
@@ -1,0 +1,12 @@
+%default total
+
+data Singleton : {a : Type} -> a -> Type where
+  Val : (x : a) -> Singleton x
+
+-- data constructors
+f : Singleton (MkPair True) -> Bool
+f (Val _) = True
+
+-- type constructors
+g : Singleton Maybe -> Bool
+g (Val _) = True

--- a/tests/idris2/casetree001/expected
+++ b/tests/idris2/casetree001/expected
@@ -1,0 +1,2 @@
+1/1: Building Issue762 (Issue762.idr)
+1/1: Building IsS (IsS.idr)

--- a/tests/idris2/casetree001/expected
+++ b/tests/idris2/casetree001/expected
@@ -1,2 +1,12 @@
 1/1: Building Issue762 (Issue762.idr)
 1/1: Building IsS (IsS.idr)
+Error: While processing left hand side of fail. Can't match on S (Under-applied constructor).
+
+IsS.idr:31:14--31:15
+ 27 | --              ^ forced by Refl
+ 28 | 
+ 29 | -- If you don't: too bad!
+ 30 | fail : IsS s -> s === S
+ 31 | fail (Indeed S eq) = eq
+                   ^
+

--- a/tests/idris2/casetree001/run
+++ b/tests/idris2/casetree001/run
@@ -1,0 +1,4 @@
+$1 --no-color --console-width 0 --no-banner --check Issue762.idr
+$1 --no-color --console-width 0 --no-banner --check IsS.idr
+
+rm -rf build/

--- a/tests/idris2/error014/expected
+++ b/tests/idris2/error014/expected
@@ -1,5 +1,5 @@
 1/1: Building Issue735 (Issue735.idr)
-Error: Constructor Prelude.Types.:: is not fully applied.
+Error: While processing left hand side of isCons. Can't match on :: (Under-applied constructor).
 
 Issue735.idr:5:8--5:12
  1 | module Issue735
@@ -9,7 +9,7 @@ Issue735.idr:5:8--5:12
  5 | isCons (::) = True
             ^^^^
 
-Error: Constructor Issue735.A is not fully applied.
+Error: While processing left hand side of test. Can't match on A (Under-applied constructor).
 
 Issue735.idr:12:6--12:7
  08 | interface A a where


### PR DESCRIPTION
Make sure that any under-applied constructor on the LHS is forced
by another pattern somewhere.

Do NOT split on a pattern just because it is constructor-headed:
start by making sure that the pattern is fully applied.

This is valid for both type and data constructors!