### PR TITLE
[ base ] A property of interaction between `zipWith` and `index`

### DIFF
--- a/libs/base/Data/List.idr
+++ b/libs/base/Data/List.idr
@@ -330,7 +330,7 @@ intersectAll = intersectAllBy (==)
 -- Zippable --
 ---------------------------
 
-export
+public export
 Zippable List where
   zipWith _ [] _ = []
   zipWith _ _ [] = []

--- a/libs/base/Data/List1.idr
+++ b/libs/base/Data/List1.idr
@@ -149,7 +149,7 @@ consInjective Refl = (Refl, Refl)
 ------------------------------------------------------------------------
 -- Zippable
 
-export
+public export
 Zippable List1 where
   zipWith f (x ::: xs) (y ::: ys) = f x y ::: zipWith' xs ys
   where

--- a/libs/base/Data/Stream.idr
+++ b/libs/base/Data/Stream.idr
@@ -38,7 +38,7 @@ index (S k) (x::xs) = index k xs
 -- Zippable --
 ---------------------------
 
-export
+public export
 Zippable Stream where
   zipWith f (x :: xs) (y :: ys) = f x y :: zipWith f xs ys
 

--- a/libs/base/Data/Stream.idr
+++ b/libs/base/Data/Stream.idr
@@ -52,6 +52,16 @@ Zippable Stream where
 
   unzip3 xs = (map (\(x, _, _) => x) xs, map (\(_, x, _) => x) xs, map (\(_, _, x) => x) xs)
 
+export
+zipWithIndexLinear : (0 f : _) -> (xs, ys : Stream a) -> (i : Nat) -> index i (zipWith f xs ys) = f (index i xs) (index i ys)
+zipWithIndexLinear f (_::xs) (_::ys) Z     = Refl
+zipWithIndexLinear f (_::xs) (_::ys) (S k) = zipWithIndexLinear f xs ys k
+
+export
+zipWith3IndexLinear : (0 f : _) -> (xs, ys, zs : Stream a) -> (i : Nat) -> index i (zipWith3 f xs ys zs) = f (index i xs) (index i ys) (index i zs)
+zipWith3IndexLinear f (_::xs) (_::ys) (_::zs) Z     = Refl
+zipWith3IndexLinear f (_::xs) (_::ys) (_::zs) (S k) = zipWith3IndexLinear f xs ys zs k
+
 ||| Return the diagonal elements of a stream of streams
 export
 diag : Stream (Stream a) -> Stream a

--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -750,7 +750,7 @@ range {len=S _} = FZ :: map FS range
 -- Zippable
 --------------------------------------------------------------------------------
 
-export
+public export
 Zippable (Vect k) where
   zipWith _ [] [] = []
   zipWith f (x :: xs) (y :: ys) = f x y :: zipWith f xs ys

--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -768,6 +768,16 @@ Zippable (Vect k) where
                                (bs, cs, ds) = unzipWith3 f xs in
                                (b :: bs, c :: cs, d :: ds)
 
+export
+zipWithIndexLinear : (0 f : _) -> (xs, ys : Vect n a) -> (i : Fin n) -> index i (zipWith f xs ys) = f (index i xs) (index i ys)
+zipWithIndexLinear _ (_::xs) (_::ys) FZ     = Refl
+zipWithIndexLinear f (_::xs) (_::ys) (FS i) = zipWithIndexLinear f xs ys i
+
+export
+zipWith3IndexLinear : (0 f : _) -> (xs, ys, zs : Vect n a) -> (i : Fin n) -> index i (zipWith3 f xs ys zs) = f (index i xs) (index i ys) (index i zs)
+zipWith3IndexLinear _ (_::xs) (_::ys) (_::zs) FZ     = Refl
+zipWith3IndexLinear f (_::xs) (_::ys) (_::zs) (FS i) = zipWith3IndexLinear f xs ys zs i
+
 --------------------------------------------------------------------------------
 -- Matrix transposition
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Rewriting rules for `index i (zipWith ...)` were added for `Vect` and `Stream`.

Also, implementations of `Zippable` were made to be publicly exported (actually, some of them were originally `public export` and were dispublished when introducing `Zippable`).