### PR TITLE
[ prelude ] Strange definition of different priorities for a single operator was removed

### DIFF
--- a/libs/prelude/Prelude/Ops.idr
+++ b/libs/prelude/Prelude/Ops.idr
@@ -2,7 +2,6 @@ module Prelude.Ops
 
 -- Numerical operators
 infix 6 ==, /=, <, <=, >, >=
-infixl 7 <<, >> -- unused
 infixl 8 +, -
 infixl 9 *, /
 


### PR DESCRIPTION
After `>>` started to be widely used for monads, is was added as `infixl 1`, but the older (and unused) definition as `infixl 7` left in the same file. Let's remove unused and immidiately overridden definition of `infixl 7` (also with undefined elsewhere `<<` operator).