### PR TITLE
Make idris2_createDir default to mode 0755 on unix-like platforms

### DIFF
--- a/support/c/idris_directory.c
+++ b/support/c/idris_directory.c
@@ -19,7 +19,7 @@ int idris2_createDir(char* dir) {
 #ifdef _WIN32
     return mkdir(dir);
 #else
-    return mkdir(dir, S_IRWXU | S_IRGRP | S_IROTH);
+    return mkdir(dir, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
 #endif
 }
 


### PR DESCRIPTION
Without this change, Idris creates directories without an executable bit
set for group and others. This prevents others and group from accessing
entries within in this directory.

I noticed this while working on an Idris 2 package for the [Alpine Linux](https://alpinelinux.org)
distribution. The Idris 2 `--install` command uses this function for
creating directories containing the Idris 2 modules. If these
directories are owned by `root:root`, non-root users cannot load Idris
modules. For this reason, the Idris 2 REPL also fails to start with the
following error:

	Welcome to Idris 2.  Enjoy yourself!
	Uncaught error: (implicit):1:1--1:1:Prelude not found

Running `strace -f idris2` reveals the following:

    [pid  4717] open("/usr/idris2-0.3.0/prelude/Prelude.ttc", O_RDONLY|O_LARGEFILE) = -1 EACCES (Permission denied)
    [pid  4717] open("/usr/idris2-0.3.0/base/Prelude.ttc", O_RDONLY|O_LARGEFILE) = -1 EACCES (Permission denied)

While this can be fixed by changing the directory permissions from the
package recipe, I believe `0755` to be the more sensible default in general.
Furthermore, it allows installing Idris without manually changing directory
permissions.