### PR TITLE
Fix package paths in for Nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   postInstall = let
     includedLibs = [ "base" "contrib" "network" "prelude" ];
     name = "${pname}-${version}";
-    packagePaths = builtins.map (l: "$out/${name}/" + l) includedLibs;
+    packagePaths = builtins.map (l: "$out/${name}/${l}-${version}") includedLibs;
     additionalIdris2Paths = builtins.concatStringsSep ":" packagePaths;
   in ''
     # Remove existing idris2 wrapper that sets incorrect LD_LIBRARY_PATH


### PR DESCRIPTION
Now that idris2 expects package version numbers, this tells nix to use them too.

It's assuming that `base`, `contrib`, `network`, and `prelude` version numbers follow the main version. Judging by `Release/CHECKLIST`, that's good enough for now.