### PR TITLE
[new] Additional Eq and Show implementations for SortedMap and Set

### DIFF
--- a/libs/contrib/Data/SortedMap.idr
+++ b/libs/contrib/Data/SortedMap.idr
@@ -318,6 +318,10 @@ export
 (Show k, Show v) => Show (SortedMap k v) where
    show m = "fromList " ++ (show $ toList m)
 
+export
+(Eq k, Eq v) => Eq (SortedMap k v) where
+  (==) = (==) `on` toList
+
 -- TODO: is this the right variant of merge to use for this? I think it is, but
 -- I could also see the advantages of using `mergeLeft`. The current approach is
 -- strictly more powerful I believe, because `mergeLeft` can be emulated with

--- a/libs/contrib/Data/SortedSet.idr
+++ b/libs/contrib/Data/SortedSet.idr
@@ -65,6 +65,14 @@ Ord k => Monoid (SortedSet k) where
   neutral = empty
 
 export
+Eq k => Eq (SortedSet k) where
+  SetWrapper x == SetWrapper y = x == y
+
+export
+Show k => Show (SortedSet k) where
+   show m = "fromList " ++ (show $ toList m)
+
+export
 keySet : SortedMap k v -> SortedSet k
 keySet = SetWrapper . map (const ())
 


### PR DESCRIPTION
This just adds some missing implementations. In case of `Eq` instances, this goes via `toList`, so two sorted maps with different `Ord` implementations might still be considered equal if they return their key-value-pairs in the same order.