### PR TITLE
[ doc ] Documentation of package lookup was clarified a bit

### DIFF
--- a/docs/source/reference/overloadedlit.rst
+++ b/docs/source/reference/overloadedlit.rst
@@ -38,7 +38,7 @@ the literal is suitable for the ``Fin n`` type. The restricted behaviour can be
 observed in the REPL, where the failure to construct a valid proof is caught during
 the type-checking phase and not at runtime:
 
-.. code-block:: idris
+.. code-block::
 
     Main> the (Fin 3) 2
     FS (FS FZ)

--- a/docs/source/reference/packages.rst
+++ b/docs/source/reference/packages.rst
@@ -139,16 +139,20 @@ For example::
 Where does Idris look for packages?
 ===================================
 
-Packages can be installed globally (under ``$PREFIX/idris-<version>/`` as
+Compiled packages are directories with compiled TTC files (see :ref:`build-artefacts` section).
+Directory structure of the source `*.idr` files is preserved for TTC files.
+
+Compiled packages can be installed globally (under ``$PREFIX/idris-<version>/`` as
 described above) or locally (under a ``depends`` subdirectory in the top level
 working directory of a project).
 Packages specified using ``-p pkgname`` or with the ``depends`` field of a
 package will then be located as follows:
 
-* First, Idris looks in ``depends/pkgname-version``, for a package which
-  satsifies the version constraint.
+* First, Idris looks in ``depends/pkgname-<version>``, for a package which
+  satisfies the version constraint.
 * If no package is found locally, Idris looks in
-  ``$PREFIX/idris-<version>/pkgname-version``.
+  ``$PREFIX/idris-<version>/pkgname-<version>``.
 
 In each case, if more than one version satisfies the constraint, it will choose
 the one with the highest version number.
+If package versions are omitted in directory names, they are treated as the version ``0``.

--- a/docs/source/updates/updates.rst
+++ b/docs/source/updates/updates.rst
@@ -452,6 +452,8 @@ switching to ``%default partial`` (which is not recommended - use a ``partial``
 annotation instead to have the smallest possible place where functions are
 partial).
 
+.. _build-artefacts:
+
 Build artefacts
 ---------------
 


### PR DESCRIPTION
I tried to use the new (great) facility of `depends` subdirectory and found that it's not clear from the documentation that subdirectories in the `depends` folder should point to a directory with TTC files, not to one with an appropriate `ipkg`-file. I tried to clarify gthis in the documentation.