### PR TITLE
[ new ] Lemmas: append preserves List membership.

### DIFF
--- a/libs/base/Data/List.idr
+++ b/libs/base/Data/List.idr
@@ -634,6 +634,12 @@ consInjective : forall x, xs, y, ys .
                 the (List a) (x :: xs) = the (List b) (y :: ys) -> (x = y, xs = ys)
 consInjective Refl = (Refl, Refl)
 
+||| The empty list is a left identity for append.
+public export
+appendNilLeftNeutral : (xs : List a) -> ([] ++ xs) = xs
+appendNilLeftNeutral xs = Refl
+
+
 ||| The empty list is a right identity for append.
 export
 appendNilRightNeutral : (l : List a) -> l ++ [] = l

--- a/libs/base/Data/List.idr
+++ b/libs/base/Data/List.idr
@@ -634,12 +634,6 @@ consInjective : forall x, xs, y, ys .
                 the (List a) (x :: xs) = the (List b) (y :: ys) -> (x = y, xs = ys)
 consInjective Refl = (Refl, Refl)
 
-||| The empty list is a left identity for append.
-public export
-appendNilLeftNeutral : (xs : List a) -> ([] ++ xs) = xs
-appendNilLeftNeutral xs = Refl
-
-
 ||| The empty list is a right identity for append.
 export
 appendNilRightNeutral : (l : List a) -> l ++ [] = l

--- a/libs/contrib/Data/Elem/Extra.idr
+++ b/libs/contrib/Data/Elem/Extra.idr
@@ -21,11 +21,11 @@ elemAppLeft (x :: xs) ys (There prf2) = There $ elemAppLeft xs ys prf2
 
 ||| Proof that an element is still inside a list if we prepend to it.
 public export
-elemAppRight :  (xs, ys : List a) -> (prf : Elem x xs) -> Elem x (ys ++ xs)
-elemAppRight (x :: xs) [] Here = Here
-elemAppRight (x :: xs) [] (There prf2) = There prf2
-elemAppRight xs [] prf = prf
-elemAppRight xs (y :: ys) prf = There $ elemAppRight xs ys prf
+elemAppRight :  (ys, xs : List a) -> (prf : Elem x xs) -> Elem x (ys ++ xs)
+elemAppRight [] (x :: xs) Here = Here
+elemAppRight [] (x :: xs) (There prf2) = There prf2
+elemAppRight [] xs prf = prf
+elemAppRight (y :: ys) xs prf = There $ elemAppRight ys xs prf
 
 ||| Proof that membership on append implies membership in left or right sublist.
 public export
@@ -55,7 +55,7 @@ notElemAppLeft xs ys prf val = prf $ elemAppLeft xs ys val
 
 ||| Proof that x is not in (xs ++ ys) implies proof that x is not in ys.
 public export
-notElemAppRight : (xs, ys : List a)
+notElemAppRight : (ys, xs : List a)
                -> (prf : Not (Elem x (xs ++ ys)))
                -> Not (Elem x ys)
-notElemAppRight xs ys prf val = prf $ elemAppRight ys xs val
+notElemAppRight ys xs prf val = prf $ elemAppRight xs ys val

--- a/libs/contrib/Data/Elem/Extra.idr
+++ b/libs/contrib/Data/Elem/Extra.idr
@@ -25,16 +25,10 @@ elemAppLorR : (xs, ys : List a)
            -> Either (Elem k xs) (Elem k ys)
 elemAppLorR [] [] prf = absurd prf
 elemAppLorR [] _ prf = Right prf
-elemAppLorR (x :: xs) [] prf =
-  let eq   : (xs ++ [] = xs)  = appendNilRightNeutral xs
-      prf' : Elem k (x :: xs) = replace {p = \g => Elem k (x :: g)} eq prf
-  in Left prf'
+elemAppLorR (x :: xs) [] prf = 
+  Left rewrite sym $ appendNilRightNeutral xs in prf
 elemAppLorR (x :: xs) _ Here = Left Here
-elemAppLorR (x :: xs) ys (There prf) =
-  let iH : Either (Elem k xs) (Elem k ys) = elemAppLorR xs ys prf
-  in case iH of
-      (Left l) => Left $ There l
-      (Right r) => Right r
+elemAppLorR (x :: xs) ys (There prf) = mapFst There $ elemAppLorR xs ys prf
 
 
 ||| Proof that x is not in (xs ++ ys) implies proof that x is not in xs.

--- a/libs/contrib/Data/Elem/Extra.idr
+++ b/libs/contrib/Data/Elem/Extra.idr
@@ -25,7 +25,7 @@ elemAppLorR : (xs, ys : List a)
            -> Either (Elem k xs) (Elem k ys)
 elemAppLorR [] [] prf = absurd prf
 elemAppLorR [] _ prf = Right prf
-elemAppLorR (x :: xs) [] prf = 
+elemAppLorR (x :: xs) [] prf =
   Left rewrite sym $ appendNilRightNeutral xs in prf
 elemAppLorR (x :: xs) _ Here = Left Here
 elemAppLorR (x :: xs) ys (There prf) = mapFst There $ elemAppLorR xs ys prf

--- a/libs/contrib/Data/Elem/Extra.idr
+++ b/libs/contrib/Data/Elem/Extra.idr
@@ -29,12 +29,12 @@ elemAppRight xs (y :: ys) prf = There $ elemAppRight xs ys prf
 
 ||| Proof that membership on append implies membership in left or right sublist.
 public export
-elemAppLorR : (xs, ys : List a) 
-           -> (prf : Elem k (xs ++ ys)) 
+elemAppLorR : (xs, ys : List a)
+           -> (prf : Elem k (xs ++ ys))
            -> Either (Elem k xs) (Elem k ys)
 elemAppLorR [] [] prf = absurd prf
 elemAppLorR [] _ prf = Right prf
-elemAppLorR (x :: xs) [] prf = 
+elemAppLorR (x :: xs) [] prf =
   let eq   : (xs ++ [] = xs)  = appendNilRightNeutral xs
       prf' : Elem k (x :: xs) = replace {p = \g => Elem k (x :: g)} eq prf
   in Left prf'
@@ -48,14 +48,14 @@ elemAppLorR (x :: xs) ys (There prf) =
 
 ||| Proof that x is not in (xs ++ ys) implies proof that x is not in xs.
 public export
-notElemAppLeft : (xs, ys : List a) 
-              -> (prf : Not (Elem x (xs ++ ys))) 
+notElemAppLeft : (xs, ys : List a)
+              -> (prf : Not (Elem x (xs ++ ys)))
               -> Not (Elem x xs)
 notElemAppLeft xs ys prf val = prf $ elemAppLeft xs ys val
 
 ||| Proof that x is not in (xs ++ ys) implies proof that x is not in ys.
 public export
-notElemAppRight : (xs, ys : List a) 
-               -> (prf : Not (Elem x (xs ++ ys))) 
+notElemAppRight : (xs, ys : List a)
+               -> (prf : Not (Elem x (xs ++ ys)))
                -> Not (Elem x ys)
 notElemAppRight xs ys prf val = prf $ elemAppRight ys xs val

--- a/libs/contrib/Data/Elem/Extra.idr
+++ b/libs/contrib/Data/Elem/Extra.idr
@@ -15,8 +15,6 @@ elemAppLeft (x :: xs) ys (There prf2) = There $ elemAppLeft xs ys prf2
 ||| Proof that an element is still inside a list if we prepend to it.
 public export
 elemAppRight :  (ys, xs : List a) -> (prf : Elem x xs) -> Elem x (ys ++ xs)
-elemAppRight [] (x :: xs) Here = Here
-elemAppRight [] (x :: xs) (There prf2) = There prf2
 elemAppRight [] xs prf = prf
 elemAppRight (y :: ys) xs prf = There $ elemAppRight ys xs prf
 

--- a/libs/contrib/Data/Elem/Extra.idr
+++ b/libs/contrib/Data/Elem/Extra.idr
@@ -1,0 +1,61 @@
+module Data.Elem.Extra
+
+import Data.List
+import Data.List.Elem
+
+%default total
+
+||| Convenience lemma showing that prepending nil to xs is just xs.
+public export
+appendNilLeftNeutral : (xs : List a) -> ([] ++ xs) = xs
+appendNilLeftNeutral [] = Refl
+appendNilLeftNeutral (x :: xs) = Refl
+
+
+||| Proof that an element is still inside a list if we append to it.
+public export
+elemAppLeft : (xs, ys : List a) -> (prf : Elem x xs) -> Elem x (xs ++ ys)
+elemAppLeft (x :: xs) ys Here = Here
+elemAppLeft (x :: xs) ys (There prf2) = There $ elemAppLeft xs ys prf2
+
+
+||| Proof that an element is still inside a list if we prepend to it.
+public export
+elemAppRight :  (xs, ys : List a) -> (prf : Elem x xs) -> Elem x (ys ++ xs)
+elemAppRight (x :: xs) [] Here = Here
+elemAppRight (x :: xs) [] (There prf2) = There prf2
+elemAppRight xs [] prf = prf
+elemAppRight xs (y :: ys) prf = There $ elemAppRight xs ys prf
+
+||| Proof that membership on append implies membership in left or right sublist.
+public export
+elemAppLorR : (xs, ys : List a) 
+           -> (prf : Elem k (xs ++ ys)) 
+           -> Either (Elem k xs) (Elem k ys)
+elemAppLorR [] [] prf = absurd prf
+elemAppLorR [] _ prf = Right prf
+elemAppLorR (x :: xs) [] prf = 
+  let eq   : (xs ++ [] = xs)  = appendNilRightNeutral xs
+      prf' : Elem k (x :: xs) = replace {p = \g => Elem k (x :: g)} eq prf
+  in Left prf'
+elemAppLorR (x :: xs) _ Here = Left Here
+elemAppLorR (x :: xs) ys (There prf) =
+  let iH : Either (Elem k xs) (Elem k ys) = elemAppLorR xs ys prf
+  in case iH of
+      (Left l) => Left $ There l
+      (Right r) => Right r
+
+
+||| Proof that x is not in (xs ++ ys) implies proof that x is not in xs.
+public export
+notElemAppLeft : (xs, ys : List a) 
+              -> (prf : Not (Elem x (xs ++ ys))) 
+              -> Not (Elem x xs)
+notElemAppLeft xs ys prf val = prf $ elemAppLeft xs ys val
+
+||| Proof that x is not in (xs ++ ys) implies proof that x is not in ys.
+public export
+notElemAppRight : (xs, ys : List a) 
+               -> (prf : Not (Elem x (xs ++ ys))) 
+               -> Not (Elem x ys)
+notElemAppRight xs ys prf val = prf $ elemAppRight ys xs val

--- a/libs/contrib/Data/Elem/Extra.idr
+++ b/libs/contrib/Data/Elem/Extra.idr
@@ -5,13 +5,6 @@ import Data.List.Elem
 
 %default total
 
-||| Convenience lemma showing that prepending nil to xs is just xs.
-public export
-appendNilLeftNeutral : (xs : List a) -> ([] ++ xs) = xs
-appendNilLeftNeutral [] = Refl
-appendNilLeftNeutral (x :: xs) = Refl
-
-
 ||| Proof that an element is still inside a list if we append to it.
 public export
 elemAppLeft : (xs, ys : List a) -> (prf : Elem x xs) -> Elem x (xs ++ ys)


### PR DESCRIPTION
Some lemmas that show appending doesn't impact on a proof that
an element is a member of a List.