### PR TITLE
[ refactor ] generalise open union machinery

### DIFF
--- a/libs/contrib/Data/List/AtIndex.idr
+++ b/libs/contrib/Data/List/AtIndex.idr
@@ -56,7 +56,7 @@ public export
 interface Member (0 t : a) (0 ts : List a) where
   isMember' : Subset Nat (AtIndex t ts)
 
-public exportfindElement
+public export
 isMember : (0 t : a) -> (0 ts : List a) -> Member t ts =>
               Subset Nat (AtIndex t ts)
 isMember t ts @{p} = isMember' @{p}

--- a/libs/contrib/Data/List/AtIndex.idr
+++ b/libs/contrib/Data/List/AtIndex.idr
@@ -53,15 +53,22 @@ find x (y :: xs) with (decEq x y)
 
 ||| If the equality is not decidable, we may instead rely on interface resolution
 public export
-interface FindElement (0 t : a) (0 ts : List a) where
-  findElement : Subset Nat (AtIndex t ts)
+interface Member (0 t : a) (0 ts : List a) where
+  isMember' : Subset Nat (AtIndex t ts)
 
-FindElement t (t :: ts) where
-  findElement = Element 0 Z
+public exportfindElement
+isMember : (0 t : a) -> (0 ts : List a) -> Member t ts =>
+              Subset Nat (AtIndex t ts)
+isMember t ts @{p} = isMember' @{p}
 
-FindElement t ts => FindElement t (u :: ts) where
-  findElement = let (Element n prf) = findElement in
-                Element (S n) (S prf)
+public export
+Member t (t :: ts) where
+  isMember' = Element 0 Z
+
+public export
+Member t ts => Member t (u :: ts) where
+  isMember' = let (Element n prf) = isMember t ts in
+              Element (S n) (S prf)
 
 ||| Given an index, we can decide whether there is a value corresponding to it
 public export

--- a/libs/contrib/Data/OpenUnion.idr
+++ b/libs/contrib/Data/OpenUnion.idr
@@ -20,71 +20,77 @@ import Syntax.WithProof
 ||| An open union of families is an index picking a family out together with
 ||| a value in the family thus picked.
 public export
-data Union : (ts : List (a -> Type)) -> a -> Type where
-  Element : (k : Nat) -> (0 _ : AtIndex t ts k) -> t v -> Union ts v
+data Union : (elt : a -> Type) -> (ts : List a) -> Type where
+  Element : (k : Nat) -> (0 _ : AtIndex t ts k) -> elt t -> Union elt ts
 
 ||| An empty open union of families is empty
 public export
-Uninhabited (Union [] v) where uninhabited (Element _ p _) = void (uninhabited p)
-
+Uninhabited (Union elt []) where
+  uninhabited (Element _ p _) = void (uninhabited p)
 
 ||| Injecting a value into an open union, provided we know the index of
 ||| the appropriate type family.
-inj' : (k : Nat) -> (0 _ : AtIndex t ts k) -> t v -> Union ts v
+inj' : (k : Nat) -> (0 _ : AtIndex t ts k) -> elt t -> Union elt ts
 inj' = Element
 
 ||| Projecting out of an open union, provided we know the index of the
 ||| appropriate type family. This may obviously fail if the value stored
 ||| actually corresponds to another family.
-prj' : (k : Nat) -> (0 _ : AtIndex t ts k) -> Union ts v -> Maybe (t v)
+prj' : (k : Nat) -> (0 _ : AtIndex t ts k) -> Union elt ts -> Maybe (elt t)
 prj' k p (Element k' q t) with (decEq k  k')
   prj' k p (Element k q t) | Yes Refl = rewrite atIndexUnique p q in Just t
   prj' k p (Element k' q t) | No neq = Nothing
 
-||| Given that equality of type families is not decidable, we have to rely on
-||| the interface `FindElement` to automatically find the index of a given family.
+||| Given that equality of type families is not decidable, we have to
+||| rely on the interface `Member` to automatically find the index of a
+||| given family.
 public export
-interface FindElement t ts => Member (0 t : a -> Type) (0 ts : List (a -> Type)) where
+inj : Member t ts => elt t -> Union elt ts
+inj = let (Element n p) = isMember t ts in inj' n p
 
-  inj : t v -> Union ts v
-  inj = let (Element n p) = findElement in inj' n p
-
-  prj : Union ts v -> Maybe (t v)
-  prj = let (Element n p) = findElement in prj' n p
-
-||| By doing a bit of arithmetic we can figure out whether the union's value came from
-||| the left or the right list used in the index.
+||| Given that equality of type families is not decidable, we have to
+||| rely on the interface `Member` to automatically find the index of a
+||| given family.
 public export
-split : Subset Nat (HasLength ss) -> Union (ss ++ ts) v -> Either (Union ss v) (Union ts v)
+prj : Member t ts => Union elt ts -> Maybe (elt t)
+prj = let (Element n p) = isMember t ts in prj' n p
+
+||| By doing a bit of arithmetic we can figure out whether the union's value
+||| came from the left or the right list used in the index.
+public export
+split : Subset Nat (HasLength ss) ->
+        Union elt (ss ++ ts) -> Either (Union elt ss) (Union elt ts)
 split m (Element n p t) with (@@ lt n (fst m))
-  split m (Element n p t) | (True ** lt) = Left (Element n (strengthenL m lt p) t)
-  split m (Element n p t) | (False ** notlt) =
-     let 0 lte : lte (fst m) n === True = LteIslte (fst m) n (notltIsGTE n (fst m) notlt)
-     in Right (Element (minus n (fst m)) (strengthenR m lte p) t)
+  split m (Element n p t) | (True ** lt)
+    = Left (Element n (strengthenL m lt p) t)
+  split m (Element n p t) | (False ** notlt)
+    = let 0 lte : lte (fst m) n === True
+                = LteIslte (fst m) n (notltIsGTE n (fst m) notlt)
+      in Right (Element (minus n (fst m)) (strengthenR m lte p) t)
 
 ||| We can inspect an open union over a non-empty list of families to check
 ||| whether the value it contains belongs either to the first family or any
 ||| other in the tail.
 public export
-decomp : Union (t :: ts) v -> Either (Union ts v) (t v)
+decomp : Union elt (t :: ts) -> Either (Union elt ts) (elt t)
 decomp (Element 0     (Z)   t) = Right t
 decomp (Element (S n) (S p) t) = Left (Element n p t)
 
-||| An open union over a singleton list is just a wrapper over values of that family
+||| An open union over a singleton list is just a wrapper
 public export
-decomp0 : Union [t] v -> t v
+decomp0 : Union elt [t] -> elt t
 decomp0 elt = case decomp elt of
   Left t => absurd t
   Right t => t
 
-||| Inserting new families at the end of the list leaves the index unchanged.
+||| Inserting new union members on the right leaves the index unchanged.
 public export
-weakenR : Union ts v -> Union (ts ++ us) v
+weakenR : Union elt ts -> Union elt (ts ++ us)
 weakenR (Element n p t) = Element n (weakenR p) t
 
-||| If we introduce them at the beginning however, we need to shift the index by
-||| the number of families we have introduced. Note that this number is the only
+||| Inserting new union members on the left, requires shifting the index by
+||| the number of members introduced. Note that this number is the only
 ||| thing we need to keep around at runtime.
 public export
-weakenL : Subset Nat (HasLength ss) -> Union ts v -> Union (ss ++ ts) v
+weakenL : Subset Nat (HasLength ss) -> Union elt ts -> Union elt (ss ++ ts)
 weakenL m (Element n p t) = Element (fst m + n) (weakenL m p) t


### PR DESCRIPTION
The previous approach could only work with type families. This
should be fully generic. Potential users of the previous scheme
can change `Union ts v` to `Union ($ v) ts`.