### PR TITLE
Namespace checks for resugaring

### DIFF
--- a/tests/idris2/linear002/Door.idr
+++ b/tests/idris2/linear002/Door.idr
@@ -32,9 +32,9 @@ knock : (1 d : Door Closed) -> One m (Door Closed)
 openDoor : (1 d : Door Closed) -> One m (Either (Door Closed) (Door Open))
 closeDoor : (1 d : Door Open) -> One m (Door Closed)
 
-deleteDoor : (1 d : Door Closed) -> Any m ()
+deleteDoor : (1 d : Door Closed) -> Any m Unit
 
-doorProg : Any m ()
+doorProg : Any m Unit
 doorProg
     = do d <- newDoor
          Right d' <- openDoor d

--- a/tests/idris2/linear002/expected
+++ b/tests/idris2/linear002/expected
@@ -4,5 +4,5 @@ Main>  0 m : Type -> Type
  0 d : Door Closed
  1 d' : Door Open
 ------------------------------
-foo : Use Many m ()
+foo : Use Many m Unit
 Main> Bye for now!


### PR DESCRIPTION
Previously constructors which clashed with some builtin constructors
would get resugared incorrectly. `Nil` and `::` still get resugared
outside of the builtin namespace, allowing list syntax for different
types.

The linear002 test now expects and uses Unit explicitly, rather than
relying on this behaviour.

Fixes #634