### PR TITLE
[ new ] Support overloaded floating point literals

### DIFF
--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -122,8 +122,8 @@ HasNames e => HasNames (TTCFile e) where
           = pure $ Just $ MkRewriteNs !(full gam e) !(full gam r)
 
       fullPrim : Context -> PrimNames -> Core PrimNames
-      fullPrim gam (MkPrimNs mi ms mc)
-          = pure $ MkPrimNs !(full gam mi) !(full gam ms) !(full gam mc)
+      fullPrim gam (MkPrimNs mi ms mc md)
+          = pure $ MkPrimNs !(full gam mi) !(full gam ms) !(full gam mc) !(full gam md)
 
 
   -- I don't think we ever actually want to call this, because after we read
@@ -160,8 +160,11 @@ HasNames e => HasNames (TTCFile e) where
           = pure $ Just $ MkRewriteNs !(resolved gam e) !(resolved gam r)
 
       resolvedPrim : Context -> PrimNames -> Core PrimNames
-      resolvedPrim gam (MkPrimNs mi ms mc)
-          = pure $ MkPrimNs !(resolved gam mi) !(resolved gam ms) !(resolved gam mc)
+      resolvedPrim gam (MkPrimNs mi ms mc md)
+          = pure $ MkPrimNs !(resolved gam mi)
+                            !(resolved gam ms)
+                            !(resolved gam mc)
+                            !(resolved gam md)
 
 -- NOTE: TTC files are only compatible if the version number is the same,
 -- *and* the 'annot/extra' type are the same, or there are no holes/constraints
@@ -337,7 +340,9 @@ updatePrimNames : PrimNames -> PrimNames -> PrimNames
 updatePrimNames p
     = record { fromIntegerName $= ((fromIntegerName p) <+>),
                fromStringName $= ((fromStringName p) <+>),
-               fromCharName $= ((fromCharName p) <+>) }
+               fromCharName $= ((fromCharName p) <+>),
+               fromDoubleName $= ((fromDoubleName p) <+>)
+             }
 
 export
 updatePrims : {auto c : Ref Ctxt Defs} ->

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -123,7 +123,7 @@ HasNames e => HasNames (TTCFile e) where
 
       fullPrim : Context -> PrimNames -> Core PrimNames
       fullPrim gam (MkPrimNs mi ms mc md)
-          = pure $ MkPrimNs !(full gam mi) !(full gam ms) !(full gam mc) !(full gam md)
+          = [| MkPrimNs (full gam mi) (full gam ms) (full gam mc) (full gam md) |]
 
 
   -- I don't think we ever actually want to call this, because after we read

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -31,7 +31,7 @@ import Data.Buffer
 -- TTC files can only be compatible if the version number is the same
 export
 ttcVersion : Int
-ttcVersion = 45
+ttcVersion = 46
 
 export
 checkTTCVersion : String -> Int -> Int -> Core ()

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -2241,6 +2241,13 @@ setFromChar n
          put Ctxt (record { options $= setFromChar n } defs)
 
 export
+setFromDouble : {auto c : Ref Ctxt Defs} ->
+              Name -> Core ()
+setFromDouble n
+    = do defs <- get Ctxt
+         put Ctxt (record { options $= setFromDouble n } defs)
+
+export
 addNameDirective : {auto c : Ref Ctxt Defs} ->
                    FC -> Name -> List String -> Core ()
 addNameDirective fc n ns
@@ -2311,8 +2318,19 @@ fromCharName
          pure $ fromCharName (primnames (options defs))
 
 export
+fromDoubleName : {auto c : Ref Ctxt Defs} ->
+               Core (Maybe Name)
+fromDoubleName
+    = do defs <- get Ctxt
+         pure $ fromDoubleName (primnames (options defs))
+
+export
 getPrimitiveNames : {auto c : Ref Ctxt Defs} -> Core (List Name)
-getPrimitiveNames = pure $ catMaybes [!fromIntegerName, !fromStringName, !fromCharName]
+getPrimitiveNames = pure $ catMaybes [ !fromIntegerName
+                                     , !fromStringName
+                                     , !fromCharName
+                                     , !fromDoubleName
+                                     ]
 
 export
 addLogLevel : {auto c : Ref Ctxt Defs} ->

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -2325,12 +2325,12 @@ fromDoubleName
          pure $ fromDoubleName (primnames (options defs))
 
 export
+getPrimNames : {auto c : Ref Ctxt Defs} -> Core PrimNames
+getPrimNames = [| MkPrimNs fromIntegerName fromStringName fromCharName fromDoubleName |]
+
+export
 getPrimitiveNames : {auto c : Ref Ctxt Defs} -> Core (List Name)
-getPrimitiveNames = pure $ catMaybes [ !fromIntegerName
-                                     , !fromStringName
-                                     , !fromCharName
-                                     , !fromDoubleName
-                                     ]
+getPrimitiveNames = primNamesToList <$> getPrimNames
 
 export
 addLogLevel : {auto c : Ref Ctxt Defs} ->

--- a/src/Core/Options.idr
+++ b/src/Core/Options.idr
@@ -102,6 +102,10 @@ record PrimNames where
   fromCharName : Maybe Name
   fromDoubleName : Maybe Name
 
+export
+primNamesToList : PrimNames -> List Name
+primNamesToList (MkPrimNs i s c d) = catMaybes [i,s,c,d]
+
 public export
 data LangExt
      = ElabReflection

--- a/src/Core/Options.idr
+++ b/src/Core/Options.idr
@@ -100,6 +100,7 @@ record PrimNames where
   fromIntegerName : Maybe Name
   fromStringName : Maybe Name
   fromCharName : Maybe Name
+  fromDoubleName : Maybe Name
 
 public export
 data LangExt
@@ -202,7 +203,7 @@ export
 defaults : Options
 defaults = MkOptions defaultDirs defaultPPrint defaultSession
                      defaultElab Nothing Nothing
-                     (MkPrimNs Nothing Nothing Nothing) []
+                     (MkPrimNs Nothing Nothing Nothing Nothing) []
                      []
 
 -- Reset the options which are set by source files
@@ -210,7 +211,7 @@ export
 clearNames : Options -> Options
 clearNames = record { pairnames = Nothing,
                       rewritenames = Nothing,
-                      primnames = MkPrimNs Nothing Nothing Nothing,
+                      primnames = MkPrimNs Nothing Nothing Nothing Nothing,
                       extensions = []
                     }
 
@@ -234,6 +235,10 @@ setFromString n = record { primnames->fromStringName = Just n }
 export
 setFromChar : Name -> Options -> Options
 setFromChar n = record { primnames->fromCharName = Just n }
+
+export
+setFromDouble : Name -> Options -> Options
+setFromDouble n = record { primnames->fromDoubleName = Just n }
 
 export
 setExtension : LangExt -> Options -> Options

--- a/src/Core/TTC.idr
+++ b/src/Core/TTC.idr
@@ -795,11 +795,13 @@ TTC PrimNames where
       = do toBuf b (fromIntegerName l)
            toBuf b (fromStringName l)
            toBuf b (fromCharName l)
+           toBuf b (fromDoubleName l)
   fromBuf b
       = do i <- fromBuf b
            str <- fromBuf b
            c <- fromBuf b
-           pure (MkPrimNs i str c)
+           d <- fromBuf b
+           pure (MkPrimNs i str c d)
 
 export
 TTC HoleInfo where

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -255,6 +255,12 @@ mutual
                 pure $ IPrimVal fc (Ch x)
              Just f => pure $ IApp fc (IVar fc f)
                                       (IPrimVal fc (Ch x))
+  desugarB side ps (PPrimVal fc (Db x))
+      = case !fromDoubleName of
+             Nothing =>
+                pure $ IPrimVal fc (Db x)
+             Just f => pure $ IApp fc (IVar fc f)
+                                      (IPrimVal fc (Db x))
   desugarB side ps (PPrimVal fc x) = pure $ IPrimVal fc x
   desugarB side ps (PQuote fc tm)
       = pure $ IQuote fc !(desugarB side ps tm)
@@ -971,6 +977,7 @@ mutual
              PrimInteger n => pure [IPragma [] (\nest, env => setFromInteger n)]
              PrimString n => pure [IPragma [] (\nest, env => setFromString n)]
              PrimChar n => pure [IPragma [] (\nest, env => setFromChar n)]
+             PrimDouble n => pure [IPragma [] (\nest, env => setFromDouble n)]
              CGAction cg dir => pure [IPragma [] (\nest, env => addDirective cg dir)]
              Names n ns => pure [IPragma [] (\nest, env => addNameDirective fc n ns)]
              StartExpr tm => pure [IPragma [] (\nest, env => throw (InternalError "%start not implemented"))] -- TODO!

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1077,6 +1077,10 @@ directive fname indents
          n <- name
          atEnd indents
          pure (PrimChar n)
+  <|> do pragma "doubleLit"
+         n <- name
+         atEnd indents
+         pure (PrimDouble n)
   <|> do pragma "name"
          n <- name
          ns <- sepBy1 (symbol ",") unqualifiedName

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -243,6 +243,7 @@ mutual
        PrimInteger : Name -> Directive
        PrimString : Name -> Directive
        PrimChar : Name -> Directive
+       PrimDouble : Name -> Directive
        CGAction : String -> String -> Directive
        Names : Name -> List String -> Directive
        StartExpr : PTerm -> Directive

--- a/src/TTImp/Elab/Ambiguity.idr
+++ b/src/TTImp/Elab/Ambiguity.idr
@@ -49,7 +49,8 @@ expandAmbigName mode nest env orig args (IVar fc x) exp
                         fi <- fromIntegerName
                         si <- fromStringName
                         ci <- fromCharName
-                        let prims = mapMaybe id [fi, si, ci]
+                        di <- fromDoubleName
+                        let prims = mapMaybe id [fi, si, ci, di]
                         let primApp = isPrimName prims x
                         case lookupUN (userNameRoot x) (unambiguousNames est) of
                           Just xr => do
@@ -64,7 +65,7 @@ expandAmbigName mode nest env orig args (IVar fc x) exp
                                [nalt] =>
                                      do log "elab.ambiguous" 10 $ "Only one " ++ show (fst nalt)
                                         pure $ mkAlt primApp est nalt
-                               nalts => pure $ IAlternative fc (uniqType fi si ci x args)
+                               nalts => pure $ IAlternative fc (uniqType fi si ci di x args)
                                                       (map (mkAlt primApp est) nalts)
   where
     lookupUN : Maybe String -> StringMap a -> Maybe a
@@ -82,15 +83,17 @@ expandAmbigName mode nest env orig args (IVar fc x) exp
 
     -- If there's multiple alternatives and all else fails, resort to using
     -- the primitive directly
-    uniqType : Maybe Name -> Maybe Name -> Maybe Name -> Name ->
+    uniqType : Maybe Name -> Maybe Name -> Maybe Name -> Maybe Name -> Name ->
                List (FC, Maybe (Maybe Name), RawImp) -> AltType
-    uniqType (Just fi) _ _ n [(_, _, IPrimVal fc (BI x))]
+    uniqType (Just fi) _ _ _ n [(_, _, IPrimVal fc (BI x))]
         = UniqueDefault (IPrimVal fc (BI x))
-    uniqType _ (Just si) _ n [(_, _, IPrimVal fc (Str x))]
+    uniqType _ (Just si) _ _ n [(_, _, IPrimVal fc (Str x))]
         = UniqueDefault (IPrimVal fc (Str x))
-    uniqType _ _ (Just ci) n [(_, _, IPrimVal fc (Ch x))]
+    uniqType _ _ (Just ci) _ n [(_, _, IPrimVal fc (Ch x))]
         = UniqueDefault (IPrimVal fc (Ch x))
-    uniqType _ _ _ _ _ = Unique
+    uniqType _ _ _ (Just di) n [(_, _, IPrimVal fc (Db x))]
+        = UniqueDefault (IPrimVal fc (Db x))
+    uniqType _ _ _ _ _ _ = Unique
 
     buildAlt : RawImp -> List (FC, Maybe (Maybe Name), RawImp) ->
                RawImp

--- a/src/TTImp/Elab/Ambiguity.idr
+++ b/src/TTImp/Elab/Ambiguity.idr
@@ -6,6 +6,7 @@ import Core.Core
 import Core.Env
 import Core.Metadata
 import Core.Normalise
+import Core.Options
 import Core.Unify
 import Core.TT
 import Core.Value
@@ -46,11 +47,8 @@ expandAmbigName mode nest env orig args (IVar fc x) exp
                        else pure $ IMustUnify fc VarApplied orig
                   Nothing =>
                      do est <- get EST
-                        fi <- fromIntegerName
-                        si <- fromStringName
-                        ci <- fromCharName
-                        di <- fromDoubleName
-                        let prims = mapMaybe id [fi, si, ci, di]
+                        primNs <- getPrimNames
+                        let prims = primNamesToList primNs
                         let primApp = isPrimName prims x
                         case lookupUN (userNameRoot x) (unambiguousNames est) of
                           Just xr => do
@@ -65,7 +63,8 @@ expandAmbigName mode nest env orig args (IVar fc x) exp
                                [nalt] =>
                                      do log "elab.ambiguous" 10 $ "Only one " ++ show (fst nalt)
                                         pure $ mkAlt primApp est nalt
-                               nalts => pure $ IAlternative fc (uniqType fi si ci di x args)
+                               nalts => pure $ IAlternative fc
+                                                      (uniqType primNs x args)
                                                       (map (mkAlt primApp est) nalts)
   where
     lookupUN : Maybe String -> StringMap a -> Maybe a
@@ -83,17 +82,16 @@ expandAmbigName mode nest env orig args (IVar fc x) exp
 
     -- If there's multiple alternatives and all else fails, resort to using
     -- the primitive directly
-    uniqType : Maybe Name -> Maybe Name -> Maybe Name -> Maybe Name -> Name ->
-               List (FC, Maybe (Maybe Name), RawImp) -> AltType
-    uniqType (Just fi) _ _ _ n [(_, _, IPrimVal fc (BI x))]
+    uniqType : PrimNames -> Name -> List (FC, Maybe (Maybe Name), RawImp) -> AltType
+    uniqType (MkPrimNs (Just fi) _ _ _) n [(_, _, IPrimVal fc (BI x))]
         = UniqueDefault (IPrimVal fc (BI x))
-    uniqType _ (Just si) _ _ n [(_, _, IPrimVal fc (Str x))]
+    uniqType (MkPrimNs _ (Just si) _ _) n [(_, _, IPrimVal fc (Str x))]
         = UniqueDefault (IPrimVal fc (Str x))
-    uniqType _ _ (Just ci) _ n [(_, _, IPrimVal fc (Ch x))]
+    uniqType (MkPrimNs _ _ (Just ci) _) n [(_, _, IPrimVal fc (Ch x))]
         = UniqueDefault (IPrimVal fc (Ch x))
-    uniqType _ _ _ (Just di) n [(_, _, IPrimVal fc (Db x))]
+    uniqType (MkPrimNs _ _ _ (Just di)) n [(_, _, IPrimVal fc (Db x))]
         = UniqueDefault (IPrimVal fc (Db x))
-    uniqType _ _ _ _ _ _ = Unique
+    uniqType _ _ _ = Unique
 
     buildAlt : RawImp -> List (FC, Maybe (Maybe Name), RawImp) ->
                RawImp

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -46,7 +46,8 @@ idrisTestsBasic = MkTestPool []
        "basic036", "basic037", "basic038", "basic039", "basic040",
        "basic041", "basic042", "basic043", "basic044", "basic045",
        "basic046", "basic047", "basic048", "basic049", "basic050",
-       "basic051", "basic052", "basic053", "basic054", "basic055"]
+       "basic051", "basic052", "basic053", "basic054", "basic055",
+       "basic056"]
 
 idrisTestsCoverage : TestPool
 idrisTestsCoverage = MkTestPool []

--- a/tests/idris2/basic056/DoubleLit.idr
+++ b/tests/idris2/basic056/DoubleLit.idr
@@ -1,0 +1,42 @@
+import Data.So
+
+%doubleLit fromDouble
+
+public export
+interface FromDouble ty where
+  fromDouble : Double -> ty
+
+%allow_overloads fromDouble
+
+
+record Newtype where
+  constructor
+  MkNewtype
+  wrapped : Double
+
+FromDouble Newtype where
+  fromDouble = MkNewtype
+
+Show Newtype where
+  showPrec p (MkNewtype v) = showCon p "MkNewtype" $ showArg v
+
+
+record InUnit where
+  constructor MkInUnit
+  value      : Double
+  0 inBounds : So (0 <= value && value <= 1)
+
+Show InUnit where
+  showPrec p (MkInUnit v _) = showCon p "MkInUnit" $ showArg v ++ " _"
+
+namespace InUnit
+  public export
+  fromDouble :  (v : Double)
+             -> {auto 0 prf : So (0 <= v && v <= 1)}
+             -> InUnit
+  fromDouble v = MkInUnit v prf
+
+
+main : IO ()
+main = do printLn $ the InUnit 0.25
+          printLn $ the Newtype 123.456

--- a/tests/idris2/basic056/expected
+++ b/tests/idris2/basic056/expected
@@ -1,0 +1,4 @@
+MkInUnit 0.25 _
+MkNewtype 123.456
+1/1: Building DoubleLit (DoubleLit.idr)
+Main> Main> Bye for now!

--- a/tests/idris2/basic056/input
+++ b/tests/idris2/basic056/input
@@ -1,0 +1,2 @@
+:exec main
+:q

--- a/tests/idris2/basic056/run
+++ b/tests/idris2/basic056/run
@@ -1,0 +1,3 @@
+$1 --no-banner --no-color --console-width 0 DoubleLit.idr < input
+
+rm -rf build


### PR DESCRIPTION
So far, there seems to be no way to overload floating point literals. I thought they might be useful, so this PR adds a new `%doubleLit` pragma. I added a test case and it seems to work OK, but I still might have overlooked something, so please review carefully.