### PR TITLE
[ makefile ] Build idris2 with local libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,8 @@ all: support ${TARGET} libs
 
 idris2-exec: ${TARGET}
 
-${TARGET}: src/IdrisPaths.idr
-	${IDRIS2_BOOT} --build ${IDRIS2_APP_IPKG}
+${TARGET}: src/IdrisPaths.idr libs
+	IDRIS2_PATH=${IDRIS2_BOOT_PATH} ${IDRIS2_BOOT} --build ${IDRIS2_APP_IPKG}
 
 # We use FORCE to always rebuild IdrisPath so that the git SHA1 info is always up to date
 src/IdrisPaths.idr: FORCE


### PR DESCRIPTION
Signed-off-by: Andy Lok <andylokandy@hotmail.com>

Build the libraries first and then the compiler, and use the local libraries instead of the global ones. 

This help:

1. build compiler by more versions of globally installed bootstrap, as long as the bootstrap compiler accept the grammar that the new compiler is using; 
2. not to break the compiler by changes on libraries. Without this PR, we can never accept #1091;
3. move some common things in `Libraries` to `contrib` with less concern.
4. unify the behavior with `make bootstrap` which has been using the local libraries. 

### Drawback

- `make` takes more time because it always checks and tries to rebuild the local libraries in case any new changes.