### PR TITLE
[ fix ] Change one implementation according to recent lib change

### DIFF
--- a/libs/contrib/Data/Validated.idr
+++ b/libs/contrib/Data/Validated.idr
@@ -62,7 +62,9 @@ Monoid e => Monoid (Validated e a) where
 public export
 Monoid e => Alternative (Validated e) where
   empty = neutral
-  (<|>) = (<+>)
+  l@(Valid _) <|> _           = l
+  _           <|> r@(Valid _) = r
+  Invalid e1  <|> Invalid e2  = Invalid $ e1 <+> e2
 
 public export
 Foldable (Validated e) where


### PR DESCRIPTION
A confusing thing: PR #1098 was checked as OK with CI some time ago, before the changes in the standard library. Then, the signature of the `Alternative` changed but CI wasn't rerun, thus this was merged and failing in the `master` now.

This fixes it.

I decided to repeat the implementation in order to get an advantage of the second lazy argument to be not evaluated when the first one is `Valid`