### PR TITLE
[ contrib ] Some functions for lazy list + fix for `foldlM`

### DIFF
--- a/libs/contrib/Data/List/Lazy.idr
+++ b/libs/contrib/Data/List/Lazy.idr
@@ -31,6 +31,22 @@ public export
 bindLazy : (a -> LazyList b) -> LazyList a -> LazyList b
 bindLazy f = foldrLazy ((++) . f) []
 
+public export
+choice : Alternative f => LazyList (f a) -> f a
+choice = foldrLazy (<|>) empty
+
+public export
+choiceMap : Alternative f => (a -> f b) -> LazyList a -> f b
+choiceMap g = foldrLazy ((<|>) . g) empty
+
+public export
+any : (a -> Bool) -> LazyList a -> Bool
+any p = foldrLazy ((||) . p) False
+
+public export
+all : (a -> Bool) -> LazyList a -> Bool
+all p = foldrLazy ((&&) . p) True
+
 --- Interface implementations ---
 
 public export
@@ -44,7 +60,7 @@ Ord a => Ord (LazyList a) where
   compare [] [] = EQ
   compare [] (x :: xs) = LT
   compare (x :: xs) [] = GT
-  compare (x :: xs) (y ::ys)
+  compare (x :: xs) (y :: ys)
      = case compare x y of
             EQ => compare xs ys
             c => c
@@ -81,6 +97,10 @@ Foldable LazyList where
   null (_::_) = False
 
 public export
+foldlM : Monad m => (funcM : b -> a -> m b) -> (init : b) -> LazyList a -> m b
+foldlM fm init xs = foldrLazy (\x, k, z => fm z x >>= k) pure xs init
+
+public export
 Functor LazyList where
   map f [] = []
   map f (x :: xs) = f x :: map f xs
@@ -107,9 +127,30 @@ traverse : Applicative f => (a -> f b) -> LazyList a -> f (List b)
 traverse g [] = pure []
 traverse g (x :: xs) = [| g x :: traverse g xs |]
 
+public export %inline
+for : Applicative f => LazyList a -> (a -> f b) -> f (List b)
+for = flip traverse
+
 public export
 sequence : Applicative f => LazyList (f a) -> f (List a)
 sequence = traverse id
+
+public export
+Zippable LazyList where
+  zipWith _ [] _ = []
+  zipWith _ _ [] = []
+  zipWith f (x::xs) (y::ys) = f x y :: zipWith f xs ys
+
+  zipWith3 _ [] _ _ = []
+  zipWith3 _ _ [] _ = []
+  zipWith3 _ _ _ [] = []
+  zipWith3 f (x::xs) (y::ys) (z::zs) = f x y z :: zipWith3 f xs ys zs
+
+  unzip xs = (fst <$> xs, snd <$> xs)
+  unzipWith = unzip .: map
+
+  unzip3 xs = (fst <$> xs, fst . snd <$> xs, snd . snd <$> xs)
+  unzipWith3 = unzip3 .: map
 
 --- Lists creation ---
 
@@ -149,7 +190,7 @@ head' : LazyList a -> Maybe a
 head' []     = Nothing
 head' (x::_) = Just x
 
-export
+public export
 tail' : LazyList a -> Maybe (LazyList a)
 tail' []      = Nothing
 tail' (_::xs) = Just xs
@@ -209,3 +250,26 @@ namespace Colist1
   public export
   take : Fuel -> Colist1 a -> LazyList a
   take fuel as = take fuel (forget as)
+
+--- Functions for extending lists ---
+
+public export
+mergeReplicate : a -> LazyList a -> LazyList a
+mergeReplicate sep []      = []
+mergeReplicate sep (y::ys) = sep :: y :: mergeReplicate sep ys
+
+public export
+intersperse : a -> LazyList a -> LazyList a
+intersperse sep []      = []
+intersperse sep (x::xs) = x :: mergeReplicate sep xs
+
+public export
+intercalate : (sep : LazyList a) -> (xss : LazyList (LazyList a)) -> LazyList a
+intercalate sep xss = choice $ intersperse sep xss
+
+--- Functions converting lazy lists to something ---
+
+public export
+toColist : LazyList a -> Colist a
+toColist [] = []
+toColist (x::xs) = x :: toColist xs

--- a/libs/contrib/Data/List/Lazy.idr
+++ b/libs/contrib/Data/List/Lazy.idr
@@ -93,12 +93,10 @@ Foldable LazyList where
   foldl op acc [] = acc
   foldl op acc (x :: xs) = foldl op (acc `op` x) xs
 
+  foldlM fm init xs = foldrLazy (\x, k, z => fm z x >>= k) pure xs init
+
   null []     = True
   null (_::_) = False
-
-public export
-foldlM : Monad m => (funcM : b -> a -> m b) -> (init : b) -> LazyList a -> m b
-foldlM fm init xs = foldrLazy (\x, k, z => fm z x >>= k) pure xs init
 
 public export
 Functor LazyList where

--- a/libs/prelude/Prelude/Interfaces.idr
+++ b/libs/prelude/Prelude/Interfaces.idr
@@ -243,11 +243,11 @@ interface Foldable t where
   null : t elem -> Lazy Bool
   null = foldr {acc = Lazy Bool} (\ _,_ => False) True
 
-||| Similar to `foldl`, but uses a function wrapping its result in a `Monad`.
-||| Consequently, the final value is wrapped in the same `Monad`.
-public export
-foldlM : (Foldable t, Monad m) => (funcM: a -> b -> m a) -> (init: a) -> (input: t b) -> m a
-foldlM fm a0 = foldl (\ma,b => ma >>= flip fm b) (pure a0)
+  ||| Similar to `foldl`, but uses a function wrapping its result in a `Monad`.
+  ||| Consequently, the final value is wrapped in the same `Monad`.
+  public export
+  foldlM : Monad m => (funcM : acc -> elem -> m acc) -> (init : acc) -> (input : t elem) -> m acc
+  foldlM fm a0 = foldl (\ma, b => ma >>= flip fm b) (pure a0)
 
 ||| Maps each element to a value and combine them
 public export

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -139,7 +139,7 @@ idrisTests = MkTestPool []
        "interpreter001", "interpreter002", "interpreter003", "interpreter004",
        "interpreter005", "interpreter006", "interpreter007",
        -- Implicit laziness, lazy evaluation
-       "lazy001",
+       "lazy001", "lazy002",
        -- Namespace blocks
        "namespace001",
        -- Parameters blocks

--- a/tests/idris2/lazy002/LazyFoldlM.idr
+++ b/tests/idris2/lazy002/LazyFoldlM.idr
@@ -1,0 +1,19 @@
+module LazyFoldlM
+
+import Data.List.Lazy
+
+import Debug.Trace
+
+foldlM' : Monad m => (fm : b -> a -> m b) -> (init : b) -> LazyList a -> m b
+foldlM' fm init xs = foldrLazy (\x, k, z => fm z x >>= k) pure xs init
+
+l : LazyList Nat
+l = (\n => trace "gen \{show n}" n) <$> iterateN 10000 (+1) 0
+
+-- Both should be actually short-cutting (i.e., not many `gen *` should be printed)
+
+x : Maybe Nat
+x = foldlM' (\m, n => if m <= 1 then Just n else Nothing) 0 l
+
+y : Maybe Nat
+y = foldlM (\m, n => if m <= 1 then Just n else Nothing) 0 l

--- a/tests/idris2/lazy002/expected
+++ b/tests/idris2/lazy002/expected
@@ -1,0 +1,15 @@
+gen 0
+gen 1
+gen 2
+gen 3
+gen 4
+Nothing
+gen 0
+gen 1
+gen 2
+gen 3
+gen 4
+Nothing
+1/1: Building LazyFoldlM (LazyFoldlM.idr)
+LazyFoldlM> LazyFoldlM> LazyFoldlM> 
+Bye for now!

--- a/tests/idris2/lazy002/input
+++ b/tests/idris2/lazy002/input
@@ -1,0 +1,2 @@
+:exec putStrLn $ show x
+:exec putStrLn $ show y

--- a/tests/idris2/lazy002/run
+++ b/tests/idris2/lazy002/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 --no-banner -p contrib LazyFoldlM.idr < input
+
+rm -rf build


### PR DESCRIPTION
Sometimes I find myself wanting to switch from usual to lazy lists and missing some functions.

Also, the usual implementation of `foldlM` through `foldl` is very bad for shortcutting monads used with the lazy list. That's why I suggest to move `foldlM` inside the `Foldable` interface to make an effective specialised implementation to be definable. A test for that is included.