### PR TITLE
[ fix #1193 ] Fine tune REPL's typesearch

### DIFF
--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -1379,6 +1379,7 @@ lookupDefTyExact = lookupExactBy (\g => (definition g, type g))
 -- private names are only visible in this namespace if their namespace
 -- is the current namespace (or an outer one)
 -- that is: the namespace of 'n' is a parent of nspace
+export
 visibleIn : Namespace -> Name -> Visibility -> Bool
 visibleIn nspace (NS ns n) Private = isParentOf ns nspace
 -- Public and Export names are always visible

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -1709,7 +1709,7 @@ setExternal fc tyn u
 
 export
 addHintFor : {auto c : Ref Ctxt Defs} ->
-					   FC -> Name -> Name -> Bool -> Bool -> Core ()
+             FC -> Name -> Name -> Bool -> Bool -> Core ()
 addHintFor fc tyn_in hintn_in direct loading
     = do defs <- get Ctxt
          tyn <- toFullNames tyn_in

--- a/src/Core/TT.idr
+++ b/src/Core/TT.idr
@@ -575,6 +575,11 @@ data Term : List Name -> Type where
      TType : FC -> Term vars
 
 export
+isErased : Term vars -> Bool
+isErased (Erased _ _) = True
+isErased _ = False
+
+export
 getLoc : Term vars -> FC
 getLoc (Local fc _ _ _) = fc
 getLoc (Ref fc _ _) = fc

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -816,6 +816,7 @@ process Help
     = pure RequestedHelp
 process (TypeSearch searchTerm)
     = do defs <- branch
+         let curr = currentNS defs
          let ctxt = gamma defs
          rawTy <- desugar AnyExpr [] searchTerm
          let bound = piBindNames replFC [] rawTy
@@ -826,7 +827,7 @@ process (TypeSearch searchTerm)
               defs    <- traverse (flip lookupCtxtExact ctxt) names
               let defs = flip mapMaybe defs $ \ md =>
                              do d <- md
-                                guard (Private < visibility d)
+                                guard (visibleIn curr (fullname d) (visibility d))
                                 pure d
               allDefs <- traverse (resolved ctxt) defs
               filterM (\def => equivTypes def.type ty') allDefs


### PR DESCRIPTION
* allow non-Pi types as search targets
* do not return defs whose type is `Erased`
* do not return private definitions