### PR TITLE
[ base ] DecEq implementations of Fin and Vect were exported publicly

### DIFF
--- a/libs/base/Data/Fin.idr
+++ b/libs/base/Data/Fin.idr
@@ -167,7 +167,7 @@ restrict n val = let val' = assert_total (abs (mod val (cast (S n)))) in
 -- DecEq
 --------------------------------------------------------------------------------
 
-export
+public export
 DecEq (Fin n) where
   decEq FZ FZ = Yes Refl
   decEq FZ (FS f) = No absurd

--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -273,7 +273,7 @@ Eq a => Eq (Vect n a) where
   (==) []      []      = True
   (==) (x::xs) (y::ys) = x == y && xs == ys
 
-export
+public export
 DecEq a => DecEq (Vect n a) where
   decEq []      []      = Yes Refl
   decEq (x::xs) (y::ys) with (decEq x y, decEq xs ys)


### PR DESCRIPTION
All the other `DecEq` implementations already are `public export` and this gives us an ability to use `decEq` in type-level expressions and those expressions to be reduced when needed. We lack this now for `Fin`s and `Vect`s.