### PR TITLE
[ fix #893 ] `proof` gadget for `with` clauses

### DIFF
--- a/libs/contrib/Data/Fun/Graph.idr
+++ b/libs/contrib/Data/Fun/Graph.idr
@@ -5,7 +5,7 @@ public export
 record Graph {0 a : Type} {0 b : a -> Type}
              (f : (x : a) -> b x) (x : a) (y : b x) where
   constructor MkGraph
-  proof : f x === y
+  equality : f x === y
 
 ||| An alternative for 'Syntax.WithProof' that allows to keep the
 ||| proof certificate in non-reduced form after nested matching.

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -31,7 +31,7 @@ import Data.Buffer
 -- TTC files can only be compatible if the version number is the same
 export
 ttcVersion : Int
-ttcVersion = 46
+ttcVersion = 47
 
 export
 checkTTCVersion : String -> Int -> Int -> Core ()

--- a/src/Core/TT.idr
+++ b/src/Core/TT.idr
@@ -365,12 +365,12 @@ setMultiplicity (PLet fc _ val ty) c = PLet fc c val ty
 setMultiplicity (PVTy fc _ ty) c = PVTy fc c ty
 
 Show ty => Show (Binder ty) where
-	show (Lam _ c _ t) = "\\" ++ showCount c ++ show t
-	show (Pi _ c _ t) = "Pi " ++ showCount c ++ show t
-	show (Let _ c v t) = "let " ++ showCount c ++ show v ++ " : " ++ show t
-	show (PVar _ c _ t) = "pat " ++ showCount c ++ show t
-	show (PLet _ c v t) = "plet " ++ showCount c ++ show v ++ " : " ++ show t
-	show (PVTy _ c t) = "pty " ++ showCount c ++ show t
+  show (Lam _ c _ t) = "\\" ++ showCount c ++ show t
+  show (Pi _ c _ t) = "Pi " ++ showCount c ++ show t
+  show (Let _ c v t) = "let " ++ showCount c ++ show v ++ " : " ++ show t
+  show (PVar _ c _ t) = "pat " ++ showCount c ++ show t
+  show (PLet _ c v t) = "plet " ++ showCount c ++ show v ++ " : " ++ show t
+  show (PVTy _ c t) = "pty " ++ showCount c ++ show t
 
 export
 setType : Binder tm -> tm -> Binder tm

--- a/src/Core/Unify.idr
+++ b/src/Core/Unify.idr
@@ -1142,23 +1142,23 @@ mutual
                        (NDCon xfc x tagx ax xs)
                        (NDCon yfc y tagy ay ys)
   unifyNoEta mode loc env (NTCon xfc x tagx ax xs) (NTCon yfc y tagy ay ys)
-      = if x == y
-           then do ust <- get UST
-                   -- see above
-                   {-
-                   when (logging ust) $
-                      do log "" 0 $ "Constructor " ++ show !(toFullNames x) ++ " " ++ show loc
-                         log "" 0 "ARGUMENTS:"
-                         defs <- get Ctxt
-                         traverse_ (dumpArg env) xs
-                         log "" 0 "WITH:"
-                         traverse_ (dumpArg env) ys
-                   -}
-                   unifyArgs mode loc env (map snd xs) (map snd ys)
+   = do x <- toFullNames x
+        y <- toFullNames y
+        log "unify" 20 $ "Comparing type constructors " ++ show x ++ " and " ++ show y
+        if x == y
+           then do let xs = map snd xs
+                   let ys = map snd ys
+
+                   logC "unify" 20 $
+                     pure $ "Constructor " ++ show x
+                   logC "unify" 20 $ map (const "") $ traverse_ (dumpArg env) xs
+                   logC "unify" 20 $ map (const "") $ traverse_ (dumpArg env) ys
+                   unifyArgs mode loc env xs ys
              -- TODO: Type constructors are not necessarily injective.
              -- If we don't know it's injective, need to postpone the
              -- constraint. But before then, we need some way to decide
              -- what's injective...
+             -- gallais: really? We don't mind being anticlassical do we?
 --                then postpone True loc mode env (quote empty env (NTCon x tagx ax xs))
 --                                           (quote empty env (NTCon y tagy ay ys))
            else convertError loc env

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -650,11 +650,11 @@ mutual
 
            pure (nm, PatClause fc lhs' rhs')
 
-  desugarClause ps arg (MkWithClause fc lhs wval flags cs)
+  desugarClause ps arg (MkWithClause fc lhs wval prf flags cs)
       = do cs' <- traverse (map snd . desugarClause ps arg) cs
            (nm, bound, lhs') <- desugarLHS ps arg lhs
            wval' <- desugar AnyExpr (bound ++ ps) wval
-           pure (nm, WithClause fc lhs' wval' flags cs')
+           pure (nm, WithClause fc lhs' wval' prf flags cs')
 
   desugarClause ps arg (MkImpossible fc lhs)
       = do (nm, _, lhs') <- desugarLHS ps arg lhs
@@ -774,8 +774,8 @@ mutual
       toIDef : Name -> ImpClause -> Core ImpDecl
       toIDef nm (PatClause fc lhs rhs)
           = pure $ IDef fc nm [PatClause fc lhs rhs]
-      toIDef nm (WithClause fc lhs rhs flags cs)
-          = pure $ IDef fc nm [WithClause fc lhs rhs flags cs]
+      toIDef nm (WithClause fc lhs rhs prf flags cs)
+          = pure $ IDef fc nm [WithClause fc lhs rhs prf flags cs]
       toIDef nm (ImpossibleClause fc lhs)
           = pure $ IDef fc nm [ImpossibleClause fc lhs]
 

--- a/src/Idris/Elab/Implementation.idr
+++ b/src/Idris/Elab/Implementation.idr
@@ -477,10 +477,10 @@ elabImplementation {vars} fc vis opts_in pass env nest is cons iname ps named im
     updateClause ns (PatClause fc lhs rhs)
         = do lhs' <- updateApp ns lhs
              pure (PatClause fc lhs' rhs)
-    updateClause ns (WithClause fc lhs wval flags cs)
+    updateClause ns (WithClause fc lhs wval prf flags cs)
         = do lhs' <- updateApp ns lhs
              cs' <- traverse (updateClause ns) cs
-             pure (WithClause fc lhs' wval flags cs')
+             pure (WithClause fc lhs' wval prf flags cs')
     updateClause ns (ImpossibleClause fc lhs)
         = do lhs' <- updateApp ns lhs
              pure (ImpossibleClause fc lhs')

--- a/src/Idris/Elab/Interface.idr
+++ b/src/Idris/Elab/Interface.idr
@@ -483,9 +483,9 @@ elabInterface {vars} fc vis env nest constraints iname params dets mcon body
         changeName : Name -> ImpClause -> ImpClause
         changeName dn (PatClause fc lhs rhs)
             = PatClause fc (changeNameTerm dn lhs) rhs
-        changeName dn (WithClause fc lhs wval flags cs)
+        changeName dn (WithClause fc lhs wval prf flags cs)
             = WithClause fc (changeNameTerm dn lhs) wval
-                         flags (map (changeName dn) cs)
+                         prf flags (map (changeName dn) cs)
         changeName dn (ImpossibleClause fc lhs)
             = ImpossibleClause fc (changeNameTerm dn lhs)
 

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -866,6 +866,7 @@ mutual
             let fc = boundToFC fname (mergeBounds start b)
             pure (MkPatClause fc lhs rhs ws)
      <|> do b <- bounds (do keyword "with"
+                            commit
                             flags <- bounds (withFlags)
                             symbol "("
                             wval <- bracketedExpr fname flags indents
@@ -889,7 +890,9 @@ mutual
            -- Can't have the dependent 'if' here since we won't be able
            -- to infer the termination status of the rule
            ifThenElse (withArgs /= length extra)
-              (fatalError "Wrong number of 'with' arguments")
+              (fatalError $ "Wrong number of 'with' arguments:"
+                         ++ " expected " ++ show withArgs
+                         ++ " but got " ++ show (length extra))
               (parseRHS withArgs fname b col indents (applyArgs lhs extra))
     where
       applyArgs : PTerm -> List (FC, PTerm) -> PTerm

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -869,11 +869,12 @@ mutual
                             flags <- bounds (withFlags)
                             symbol "("
                             wval <- bracketedExpr fname flags indents
+                            prf <- optional (keyword "proof" *> name)
                             ws <- mustWork $ nonEmptyBlockAfter col (clause (S withArgs) fname)
-                            pure (flags, wval, forget ws))
-            (flags, wval, ws) <- pure b.val
+                            pure (prf, flags, wval, forget ws))
+            (prf, flags, wval, ws) <- pure b.val
             let fc = boundToFC fname (mergeBounds start b)
-            pure (MkWithClause fc lhs wval flags.val ws)
+            pure (MkWithClause fc lhs wval prf flags.val ws)
      <|> do end <- bounds (keyword "impossible")
             atEnd indents
             pure (MkImpossible (boundToFC fname (mergeBounds start end)) lhs)

--- a/src/Idris/Pretty.idr
+++ b/src/Idris/Pretty.idr
@@ -108,7 +108,7 @@ mutual
   prettyAlt : PClause -> Doc IdrisAnn
   prettyAlt (MkPatClause _ lhs rhs _) =
     space <+> pipe <++> prettyTerm lhs <++> pretty "=>" <++> prettyTerm rhs <+> semi
-  prettyAlt (MkWithClause _ lhs wval flags cs) =
+  prettyAlt (MkWithClause _ lhs wval prf flags cs) =
     space <+> pipe <++> angles (angles (reflow "with alts not possible")) <+> semi
   prettyAlt (MkImpossible _ lhs) =
     space <+> pipe <++> prettyTerm lhs <++> impossible_ <+> semi
@@ -116,7 +116,7 @@ mutual
   prettyCase : PClause -> Doc IdrisAnn
   prettyCase (MkPatClause _ lhs rhs _) =
     prettyTerm lhs <++> pretty "=>" <++> prettyTerm rhs
-  prettyCase (MkWithClause _ lhs rhs flags _) =
+  prettyCase (MkWithClause _ lhs rhs prf flags _) =
     space <+> pipe <++> angles (angles (reflow "with alts not possible"))
   prettyCase (MkImpossible _ lhs) =
     prettyTerm lhs <++> impossible_

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -217,12 +217,16 @@ printClause l i (PatClause _ lhsraw rhsraw)
     = do lhs <- pterm lhsraw
          rhs <- pterm rhsraw
          pure (relit l (pack (replicate i ' ') ++ show lhs ++ " = " ++ show rhs))
-printClause l i (WithClause _ lhsraw wvraw flags csraw)
+printClause l i (WithClause _ lhsraw wvraw prf flags csraw)
     = do lhs <- pterm lhsraw
          wval <- pterm wvraw
          cs <- traverse (printClause l (i + 2)) csraw
-         pure ((relit l ((pack (replicate i ' ') ++ show lhs ++ " with (" ++ show wval ++ ")\n")) ++
-                 showSep "\n" cs))
+         pure (relit l ((pack (replicate i ' ')
+                ++ show lhs
+                ++ " with (" ++ show wval ++ ")"
+                ++ maybe "" (\ nm => " proof " ++ show nm) prf
+                ++ "\n"))
+               ++ showSep "\n" cs)
 printClause l i (ImpossibleClause _ lhsraw)
     = do lhs <- pterm lhsraw
          pure (relit l (pack (replicate i ' ') ++ show lhs ++ " impossible"))

--- a/src/Idris/Resugar.idr
+++ b/src/Idris/Resugar.idr
@@ -352,9 +352,10 @@ mutual
       = pure (MkPatClause fc !(toPTerm startPrec lhs)
                              !(toPTerm startPrec rhs)
                              [])
-  toPClause (WithClause fc lhs rhs flags cs)
+  toPClause (WithClause fc lhs rhs prf flags cs)
       = pure (MkWithClause fc !(toPTerm startPrec lhs)
                               !(toPTerm startPrec rhs)
+                              prf
                               flags
                               !(traverse toPClause cs))
   toPClause (ImpossibleClause fc lhs)

--- a/src/Parser/Lexer/Source.idr
+++ b/src/Parser/Lexer/Source.idr
@@ -201,7 +201,7 @@ mkDirective str = CGDirective (trim (substr 3 (length str) str))
 keywords : List String
 keywords = ["data", "module", "where", "let", "in", "do", "record",
             "auto", "default", "implicit", "mutual", "namespace",
-            "parameters", "with", "impossible", "case", "of",
+            "parameters", "with", "proof", "impossible", "case", "of",
             "if", "then", "else", "forall", "rewrite",
             "using", "interface", "implementation", "open", "import",
             "public", "export", "private",

--- a/src/TTImp/Elab/Case.idr
+++ b/src/TTImp/Elab/Case.idr
@@ -336,11 +336,11 @@ caseBlock {vars} rigc elabinfo fc nest env scr scrtm scrty caseRig alts expected
                         (bindCaseLocals loc' (map getNestData (names nest))
                                         ns rhs)
     -- With isn't allowed in a case block but include for completeness
-    updateClause casen splitOn nest env (WithClause loc' lhs wval flags cs)
+    updateClause casen splitOn nest env (WithClause loc' lhs wval prf flags cs)
         = let (_, args) = addEnv 0 env (usedIn lhs)
               args' = mkSplit splitOn lhs args
               lhs' = apply (IVar loc' casen) args' in
-              WithClause loc' (applyNested nest lhs') wval flags cs
+              WithClause loc' (applyNested nest lhs') wval prf flags cs
     updateClause casen splitOn nest env (ImpossibleClause loc' lhs)
         = let (_, args) = addEnv 0 env (usedIn lhs)
               args' = mkSplit splitOn lhs args

--- a/src/TTImp/Elab/Quote.idr
+++ b/src/TTImp/Elab/Quote.idr
@@ -82,9 +82,14 @@ mutual
                      Core ImpClause
   getUnquoteClause (PatClause fc l r)
       = pure $ PatClause fc !(getUnquote l) !(getUnquote r)
-  getUnquoteClause (WithClause fc l w flags cs)
-      = pure $ WithClause fc !(getUnquote l) !(getUnquote w)
-                          flags !(traverse getUnquoteClause cs)
+  getUnquoteClause (WithClause fc l w prf flags cs)
+      = pure $ WithClause
+                 fc
+                 !(getUnquote l)
+                 !(getUnquote w)
+                 prf
+                 flags
+                 !(traverse getUnquoteClause cs)
   getUnquoteClause (ImpossibleClause fc l)
       = pure $ ImpossibleClause fc !(getUnquote l)
 

--- a/src/TTImp/Interactive/GenerateDef.idr
+++ b/src/TTImp/Interactive/GenerateDef.idr
@@ -78,7 +78,8 @@ expandClause loc opts n c
     updateRHS : ImpClause -> RawImp -> ImpClause
     updateRHS (PatClause fc lhs _) rhs = PatClause fc lhs rhs
     -- 'with' won't happen, include for completeness
-    updateRHS (WithClause fc lhs wval flags cs) rhs = WithClause fc lhs wval flags cs
+    updateRHS (WithClause fc lhs wval prf flags cs) rhs
+      = WithClause fc lhs wval prf flags cs
     updateRHS (ImpossibleClause fc lhs) _ = ImpossibleClause fc lhs
 
     dropLams : Nat -> RawImp -> RawImp
@@ -141,7 +142,7 @@ generateSplits : {auto m : Ref MD Metadata} ->
                  FC -> SearchOpts -> Int -> ImpClause ->
                  Core (List (Name, List ImpClause))
 generateSplits loc opts fn (ImpossibleClause fc lhs) = pure []
-generateSplits loc opts fn (WithClause fc lhs wval flags cs) = pure []
+generateSplits loc opts fn (WithClause fc lhs wval prf flags cs) = pure []
 generateSplits loc opts fn (PatClause fc lhs rhs)
     = do (lhstm, _) <-
                 elabTerm fn (InLHS linear) [] (MkNested []) []

--- a/src/TTImp/Parser.idr
+++ b/src/TTImp/Parser.idr
@@ -510,10 +510,11 @@ mutual
            symbol "("
            wval <- expr fname indents
            symbol ")"
+           prf <- optional (keyword "proof" *> name)
            ws <- nonEmptyBlock (clause (S withArgs) fname)
            end <- location
            let fc = MkFC fname start end
-           pure (!(getFn lhs), WithClause fc lhs wval [] (forget $ map snd ws))
+           pure (!(getFn lhs), WithClause fc lhs wval prf [] (forget $ map snd ws))
 
     <|> do keyword "impossible"
            atEnd indents

--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -569,7 +569,7 @@ checkClause {vars} mult vis totreq hashit n opts nest env
             , Term (ext ++ xs)
             , (Term (ext ++ xs) -> Term xs)
             ))
-    bindWithArgs wvalTy Nothing wvalEnv =
+    bindWithArgs {xs} wvalTy Nothing wvalEnv =
       let wargn : Name
           wargn = MN "warg" 0
           wargs : List Name
@@ -586,7 +586,7 @@ checkClause {vars} mult vis totreq hashit n opts nest env
 
       in pure (wargs ** (scenv, var, binder))
 
-    bindWithArgs wvalTy (Just (name, wval)) wvalEnv = do
+    bindWithArgs {xs} wvalTy (Just (name, wval)) wvalEnv = do
       defs <- get Ctxt
 
       let eqName = NS builtinNS (UN "Equal")

--- a/src/TTImp/Reflect.idr
+++ b/src/TTImp/Reflect.idr
@@ -378,12 +378,13 @@ mutual
                           y' <- reify defs !(evalClosure defs y)
                           z' <- reify defs !(evalClosure defs z)
                           pure (PatClause x' y' z')
-               (NS _ (UN "WithClause"), [w,x,y,z])
-                    => do w' <- reify defs !(evalClosure defs w)
+               (NS _ (UN "WithClause"), [v,w,x,y,z])
+                    => do v' <- reify defs !(evalClosure defs v)
+                          w' <- reify defs !(evalClosure defs w)
                           x' <- reify defs !(evalClosure defs x)
                           y' <- reify defs !(evalClosure defs y)
                           z' <- reify defs !(evalClosure defs z)
-                          pure (WithClause w' x' y' [] z')
+                          pure (WithClause v' w' x' y' [] z')
                (NS _ (UN "ImpossibleClause"), [x,y])
                     => do x' <- reify defs !(evalClosure defs x)
                           y' <- reify defs !(evalClosure defs y)
@@ -705,12 +706,13 @@ mutual
              y' <- reflect fc defs lhs env y
              z' <- reflect fc defs lhs env z
              appCon fc defs (reflectionttimp "PatClause") [x', y', z']
-    reflect fc defs lhs env (WithClause v w x y z)
-        = do v' <- reflect fc defs lhs env v
+    reflect fc defs lhs env (WithClause u v w x y z)
+        = do u' <- reflect fc defs lhs env u
+             v' <- reflect fc defs lhs env v
              w' <- reflect fc defs lhs env w
              x' <- reflect fc defs lhs env x
              z' <- reflect fc defs lhs env z
-             appCon fc defs (reflectionttimp "WithClause") [v', w', x', z']
+             appCon fc defs (reflectionttimp "WithClause") [u', v', w', x', z']
     reflect fc defs lhs env (ImpossibleClause x y)
         = do x' <- reflect fc defs lhs env x
              y' <- reflect fc defs lhs env y

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -719,6 +719,16 @@ apply f [] = f
 apply f (x :: xs) = apply (IApp (getFC f) f x) xs
 
 export
+gapply : RawImp -> List (Maybe Name, RawImp) -> RawImp
+gapply f [] = f
+gapply f (x :: xs) = gapply (uncurry (app f) x) xs where
+
+  app : RawImp -> Maybe Name -> RawImp -> RawImp
+  app f Nothing x =  IApp (getFC f) f x
+  app f (Just nm) x = INamedApp (getFC f) f nm x
+
+
+export
 getFn : RawImp -> RawImp
 getFn (IApp _ f _) = getFn f
 getFn (IWithApp _ f _) = getFn f

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -317,7 +317,8 @@ mutual
   public export
   data ImpClause : Type where
        PatClause : FC -> (lhs : RawImp) -> (rhs : RawImp) -> ImpClause
-       WithClause : FC -> (lhs : RawImp) -> (wval : RawImp) ->
+       WithClause : FC -> (lhs : RawImp) ->
+                    (wval : RawImp) -> (prf : Maybe Name) ->
                     (flags : List WithFlag) ->
                     List ImpClause -> ImpClause
        ImpossibleClause : FC -> (lhs : RawImp) -> ImpClause
@@ -326,8 +327,11 @@ mutual
   Show ImpClause where
     show (PatClause fc lhs rhs)
        = show lhs ++ " = " ++ show rhs
-    show (WithClause fc lhs wval flags block)
-       = show lhs ++ " with " ++ show wval ++ "\n\t" ++ show block
+    show (WithClause fc lhs wval prf flags block)
+       = show lhs
+       ++ " with " ++ show wval
+       ++ maybe "" (\ nm => " proof " ++ show nm) prf
+       ++ "\n\t" ++ show block
     show (ImpossibleClause fc lhs)
        = show lhs ++ " impossible"
 
@@ -958,8 +962,13 @@ mutual
         = do tag 0; toBuf b fc; toBuf b lhs; toBuf b rhs
     toBuf b (ImpossibleClause fc lhs)
         = do tag 1; toBuf b fc; toBuf b lhs
-    toBuf b (WithClause fc lhs wval flags cs)
-        = do tag 2; toBuf b fc; toBuf b lhs; toBuf b wval; toBuf b cs
+    toBuf b (WithClause fc lhs wval prf flags cs)
+        = do tag 2
+             toBuf b fc
+             toBuf b lhs
+             toBuf b wval
+             toBuf b prf
+             toBuf b cs
 
     fromBuf b
         = case !getTag of
@@ -969,8 +978,9 @@ mutual
                1 => do fc <- fromBuf b; lhs <- fromBuf b;
                        pure (ImpossibleClause fc lhs)
                2 => do fc <- fromBuf b; lhs <- fromBuf b;
-                       wval <- fromBuf b; cs <- fromBuf b
-                       pure (WithClause fc lhs wval [] cs)
+                       wval <- fromBuf b; prf <- fromBuf b;
+                       cs <- fromBuf b
+                       pure (WithClause fc lhs wval prf [] cs)
                _ => corrupt "ImpClause"
 
   export

--- a/src/TTImp/Utils.idr
+++ b/src/TTImp/Utils.idr
@@ -206,12 +206,12 @@ mutual
                      ++ bound in
             PatClause fc (substNames' bvar [] [] lhs)
                          (substNames' bvar bound' ps rhs)
-  substNamesClause' bvar bound ps (WithClause fc lhs wval flags cs)
+  substNamesClause' bvar bound ps (WithClause fc lhs wval prf flags cs)
       = let bound' = map UN (map snd (findBindableNames True bound [] lhs))
                      ++ findIBindVars lhs
                      ++ bound in
             WithClause fc (substNames' bvar [] [] lhs)
-                          (substNames' bvar bound' ps wval) flags cs
+                          (substNames' bvar bound' ps wval) prf flags cs
   substNamesClause' bvar bound ps (ImpossibleClause fc lhs)
       = ImpossibleClause fc (substNames' bvar bound [] lhs)
 
@@ -304,9 +304,10 @@ mutual
   substLocClause fc' (PatClause fc lhs rhs)
       = PatClause fc' (substLoc fc' lhs)
                       (substLoc fc' rhs)
-  substLocClause fc' (WithClause fc lhs wval flags cs)
+  substLocClause fc' (WithClause fc lhs wval prf flags cs)
       = WithClause fc' (substLoc fc' lhs)
                        (substLoc fc' wval)
+                       prf
                        flags
                        (map (substLocClause fc') cs)
   substLocClause fc' (ImpossibleClause fc lhs)

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -162,7 +162,7 @@ idrisTests = MkTestPool []
        "total001", "total002", "total003", "total004", "total005",
        "total006", "total007", "total008", "total009", "total010",
        -- The 'with' rule
-       "with001", "with002", "with004",
+       "with001", "with002", "with004", "with005",
        -- with-disambiguation
        "with003"]
 

--- a/tests/idris2/perror004/expected
+++ b/tests/idris2/perror004/expected
@@ -1,5 +1,5 @@
 1/1: Building PError (PError.idr)
-Error: Wrong number of 'with' arguments.
+Error: Wrong number of 'with' arguments: expected 2 but got 3.
 
 PError.idr:4:33--4:34
  1 | foo : Nat -> Nat -> Bool

--- a/tests/idris2/with005/Issue893.idr
+++ b/tests/idris2/with005/Issue893.idr
@@ -1,0 +1,25 @@
+module Issue893
+
+%default total
+
+foo : (a, b : Nat) -> Bool
+foo  Z    b = False
+foo (S _) b = False
+
+notFoo : (a, b : Nat) -> Not (foo a b = True)
+notFoo  Z    _ = uninhabited
+notFoo (S _) _ = uninhabited
+
+bar : (a, b : Nat) -> (foo a b) && c = foo a b
+bar a b with (foo a b) proof ab
+  bar a b | True  = absurd $ notFoo a b ab
+  bar a b | False = Refl
+
+goo : (a, b : Nat) -> Bool -> Bool
+goo a b True = True
+goo a b False = foo a b || foo a b
+
+bar2 : (a, b : Nat) -> goo a b (foo a b) = foo a b
+bar2 a b with (foo a b) proof ab
+  bar2 a b | True = Refl
+  bar2 a b | False = rewrite ab in Refl

--- a/tests/idris2/with005/WithProof.idr
+++ b/tests/idris2/with005/WithProof.idr
@@ -1,0 +1,26 @@
+module WithProof
+
+%default total
+
+filter : (p : a -> Bool) -> (xs : List a) -> List a
+filter p [] = []
+filter p (x :: xs) with (p x)
+  filter p (x :: xs) | False = filter p xs
+  filter p (x :: xs) | True = x :: filter p xs
+
+
+filterSquared : (p : a -> Bool) -> (xs : List a) ->
+                filter p (filter p xs) === filter p xs
+filterSquared p [] = Refl
+{-
+filterSquared p (x :: xs) with (p x)
+  filterSquared p (x :: xs) | False = filterSquared p xs -- easy
+  filterSquared p (x :: xs) | True = ?a
+     -- argh! stuck on another with-block casing on (p x)!
+     -- we could check (p x) again but how do we prove it
+     -- can only ever be `True`?!
+-}
+filterSquared p (x :: xs) with (p x) proof eq
+  filterSquared p (x :: xs) | False = filterSquared p xs -- easy
+  filterSquared p (x :: xs) | True
+    = rewrite eq in cong (x ::) (filterSquared p xs)

--- a/tests/idris2/with005/expected
+++ b/tests/idris2/with005/expected
@@ -1,0 +1,2 @@
+1/1: Building WithProof (WithProof.idr)
+1/1: Building Issue893 (Issue893.idr)

--- a/tests/idris2/with005/run
+++ b/tests/idris2/with005/run
@@ -1,0 +1,4 @@
+$1 --no-color --console-width 0 --no-banner --check WithProof.idr
+$1 --no-color --console-width 0 --no-banner --check Issue893.idr
+
+rm -rf build


### PR DESCRIPTION
All the scoping-related work is isolated in `bindWithArgs` so hopefully
it won't be too much work to extend this to multiwith.

Had to fix an unrelated bug in `Core.Unify` to get this through!