### PR TITLE
Restore the ability for data types to be operators

### DIFF
--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -979,7 +979,7 @@ dataDeclBody : FileName -> IndentInfo -> Rule PDataDecl
 dataDeclBody fname indents
     = do b <- bounds (do col <- column
                          keyword "data"
-                         n <- mustWork capitalisedName
+                         n <- mustWork dataTypeName
                          pure (col, n))
          (col, n) <- pure b.val
          simpleData fname b n indents <|> gadtData fname col b n indents
@@ -1378,7 +1378,7 @@ recordDecl fname indents
                          vis   <- visibility
                          col   <- column
                          keyword "record"
-                         n       <- mustWork capitalisedName
+                         n       <- mustWork dataTypeName
                          paramss <- many (recordParam fname indents)
                          let params = concat paramss
                          keyword "where"

--- a/src/Parser/Rule/Source.idr
+++ b/src/Parser/Rule/Source.idr
@@ -304,6 +304,10 @@ export
 dataConstructorName : Rule Name
 dataConstructorName = opNonNS <|> capitalisedName
 
+export %inline
+dataTypeName : Rule Name
+dataTypeName = dataConstructorName
+
 export
 IndentInfo : Type
 IndentInfo = Int

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -47,7 +47,7 @@ idrisTestsBasic = MkTestPool []
        "basic041", "basic042", "basic043", "basic044", "basic045",
        "basic046", "basic047", "basic048", "basic049", "basic050",
        "basic051", "basic052", "basic053", "basic054", "basic055",
-       "basic056", "basic057"]
+       "basic056", "basic057", "basic058"]
 
 idrisTestsCoverage : TestPool
 idrisTestsCoverage = MkTestPool []

--- a/tests/idris2/basic058/DataTypeOp.idr
+++ b/tests/idris2/basic058/DataTypeOp.idr
@@ -1,0 +1,30 @@
+--- Data declarations ---
+
+infix 0 =%=
+
+public export
+data (=%=) : (a -> b) -> (a -> b) -> Type where
+  ExtEq : {0 f, g : a -> b} -> ((x : a) -> f x = g x) -> f =%= g
+
+infix 0 %%
+
+public export
+data (%%) a b = Equs (a = b) (b = a)
+
+--- Records ---
+
+infix 0 =%%=
+
+public export
+record (=%%=) {a : Type} {b : Type} (f : a -> b) (g : a -> b) where
+  constructor ExtEqR
+  fa : (x : a) -> f x = g x
+
+--- Interfaces ---
+
+infix 0 =%%%=
+
+public export
+interface (=%%%=) (x : a) (y : a) (b : Type) (i : Type) where
+  idx : a -> i -> b
+  eq : (ix : i) -> idx x ix = idx y ix

--- a/tests/idris2/basic058/DataTypeProj.idr
+++ b/tests/idris2/basic058/DataTypeProj.idr
@@ -1,0 +1,26 @@
+--- Data declarations ---
+
+data (.ah) a = Ah (List a)
+
+g : Int .ah -> Int
+g (Ah xs) = sum xs
+
+--- Records ---
+
+record (.aah) a where
+  constructor Aah
+  unaah : List a
+
+h : Num a => a.aah -> a
+h = sum . unaah
+
+--- Interfaces ---
+
+interface (.defaultable) a where
+  defa : a
+
+(.defaultable) Int where
+  defa = 0
+
+f : Num a => a.defaultable => a -> a
+f x = x + defa

--- a/tests/idris2/basic058/expected
+++ b/tests/idris2/basic058/expected
@@ -1,0 +1,2 @@
+1/1: Building DataTypeOp (DataTypeOp.idr)
+1/1: Building DataTypeProj (DataTypeProj.idr)

--- a/tests/idris2/basic058/run
+++ b/tests/idris2/basic058/run
@@ -1,0 +1,4 @@
+$1 --no-banner --no-color --console-width 0 --check DataTypeOp.idr
+$1 --no-banner --no-color --console-width 0 --check DataTypeProj.idr
+
+rm -rf build


### PR DESCRIPTION
#1207 made less ambiguity but I think it was too restrictive. Previously, we were able to define our `data` named as operators and this was handy for custom type-level relations. #1207 restricted us to use only letter names for that. I suggest to relax this and to add an ability to define data types as operators, as it was possible before.

Originally, I invented and used analogue to `opNonNS` but without ability of projections, but later I found that the current interfaces are allowed to be named (besides all) as projections. Thus for consistency, I made data types to have the same rules as data constructors.

So, only `data` and `record`s are affected, but test were added for `interface`s too, just to fix the status quo.