### PR TITLE
[ fix #1224 ] moduleIdent must be capitalised 

### DIFF
--- a/src/Core/Directory.idr
+++ b/src/Core/Directory.idr
@@ -1,6 +1,7 @@
 module Core.Directory
 
 import Core.Context
+import Core.Context.Log
 import Core.Core
 import Core.FC
 import Core.Name
@@ -18,10 +19,12 @@ import System.Info
 %default total
 
 -- Return the name of the first file available in the list
-firstAvailable : List String -> Core (Maybe String)
+firstAvailable : {auto c : Ref Ctxt Defs} ->
+                 List String -> Core (Maybe String)
 firstAvailable [] = pure Nothing
 firstAvailable (f :: fs)
-    = do Right ok <- coreLift $ openFile f Read
+    = do log "import.file" 30 $ "Attempting to read " ++ f
+         Right ok <- coreLift $ openFile f Read
                | Left err => firstAvailable fs
          coreLift $ closeFile ok
          pure (Just f)

--- a/src/Idris/ModTree.idr
+++ b/src/Idris/ModTree.idr
@@ -60,6 +60,7 @@ Show BuildMod where
 data AllMods : Type where
 
 mkModTree : {auto c : Ref Ctxt Defs} ->
+            {auto o : Ref ROpts REPLOpts} ->
             {auto a : Ref AllMods (List (ModuleIdent, ModTree))} ->
             FC ->
             (done : List ModuleIdent) -> -- if 'mod' is here we have a cycle

--- a/src/Idris/ModTree.idr
+++ b/src/Idris/ModTree.idr
@@ -90,6 +90,7 @@ mkModTree loc done modFP mod
                 (\err =>
                     case err of
                          CyclicImports _ => throw err
+                         ParseFail _ _ => throw err
                          _ => pure (MkModTree mod Nothing []))
 
 data DoneMod : Type where

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1496,7 +1496,7 @@ import_ fname indents
     = do b <- bounds (do keyword "import"
                          reexp <- option False (do keyword "public"
                                                    pure True)
-                         ns <- moduleIdent
+                         ns <- mustWork moduleIdent
                          nsAs <- option (miAsNamespace ns)
                                         (do exactIdent "as"
                                             mustWork namespaceId)
@@ -1511,7 +1511,7 @@ prog fname
     = do b <- bounds (do doc    <- option "" documentation
                          nspace <- option (nsAsModuleIdent mainNS)
                                      (do keyword "module"
-                                         moduleIdent)
+                                         mustWork moduleIdent)
                          imports <- block (import_ fname)
                          pure (doc, nspace, imports))
          ds      <- block (topDecl fname)
@@ -1525,7 +1525,7 @@ progHdr fname
     = do b <- bounds (do doc    <- option "" documentation
                          nspace <- option (nsAsModuleIdent mainNS)
                                      (do keyword "module"
-                                         moduleIdent)
+                                         mustWork moduleIdent)
                          imports <- block (import_ fname)
                          pure (doc, nspace, imports))
          (doc, nspace, imports) <- pure b.val

--- a/src/Idris/ProcessIdr.idr
+++ b/src/Idris/ProcessIdr.idr
@@ -189,12 +189,14 @@ modTime fname
 
 export
 readHeader : {auto c : Ref Ctxt Defs} ->
+             {auto o : Ref ROpts REPLOpts} ->
              (path : String) -> Core Module
 readHeader path
     = do Right res <- coreLift (readFile path)
             | Left err => throw (FileErr path err)
          -- Stop at the first :, that's definitely not part of the header, to
          -- save lexing the whole file unnecessarily
+         setCurrentElabSource res -- for error printing purposes
          let Right mod = runParserTo path (isLitFile path) (is ':') res (progHdr path)
             | Left err => throw err
          pure mod

--- a/src/Parser/Rule/Source.idr
+++ b/src/Parser/Rule/Source.idr
@@ -234,12 +234,7 @@ namespaceId = do
 
 export
 moduleIdent : Rule ModuleIdent
-moduleIdent
-    = terminal "Expected module identifier"
-        (\x => case x of
-            DotSepIdent ns n => Just (mkModuleIdent (Just ns) n)
-            Ident i => Just (mkModuleIdent Nothing i)
-            _ => Nothing)
+moduleIdent = nsAsModuleIdent <$> namespaceId
 
 export
 unqualifiedName : Rule String

--- a/src/Parser/Source.idr
+++ b/src/Parser/Source.idr
@@ -23,7 +23,8 @@ runParserTo fname lit reject str p
 
 export
 runParser : {e : _} ->
-            (fname : String) -> Maybe LiterateStyle -> String -> Grammar Token e ty -> Either Error ty
+            (fname : String) -> Maybe LiterateStyle -> String ->
+            Grammar Token e ty -> Either Error ty
 runParser fname lit = runParserTo fname lit (pred $ const False)
 
 export covering

--- a/src/Parser/Support.idr
+++ b/src/Parser/Support.idr
@@ -29,8 +29,10 @@ fromLexError fname (_, l, c, _)
     = LexFail (MkFC fname (l, c) (l, c + 1)) "Can't recognise token."
 
 export
-fromParsingError : (Show token, Pretty token) => String -> ParsingError token -> Error
-fromParsingError fname (Error msg Nothing) = ParseFail (MkFC fname (0, 0) (0, 0)) (msg +> '.')
+fromParsingError : (Show token, Pretty token) =>
+                   String -> ParsingError token -> Error
+fromParsingError fname (Error msg Nothing)
+    = ParseFail (MkFC fname (0, 0) (0, 0)) (msg +> '.')
 fromParsingError fname (Error msg (Just t))
     = let l = t.startLine
           c = t.startCol in

--- a/tests/chez/chez031/expected
+++ b/tests/chez/chez031/expected
@@ -11,6 +11,8 @@ Error: The given specifier was not accepted by any backend. Available backends:
 Some backends have additional specifier rules, refer to their documentation.
 
 Specifiers.idr:29:1--30:35
+ 29 | %foreign "scheme,racket:+"
+ 30 | plusRacketFail : Int -> Int -> Int
 
 Main> Loaded file Specifiers.idr
 Specifiers> Error: The given specifier was not accepted by any backend. Available backends:

--- a/tests/idris2/import004/expected
+++ b/tests/idris2/import004/expected
@@ -1,2 +1,2 @@
-Uncaught error: Module imports form a cycle: Cycle2 -> Cycle1 -> Cycle1
-Uncaught error: Module imports form a cycle: Loop -> Loop
+Uncaught error: Error: Module imports form a cycle: Cycle2 -> Cycle1 -> Cycle1
+Uncaught error: Error: Module imports form a cycle: Loop -> Loop

--- a/tests/idris2/perror008/Issue1224a.idr
+++ b/tests/idris2/perror008/Issue1224a.idr
@@ -1,0 +1,5 @@
+module ggg
+
+export
+yyy : Int
+yyy = 0

--- a/tests/idris2/perror008/Issue1224b.idr
+++ b/tests/idris2/perror008/Issue1224b.idr
@@ -1,0 +1,4 @@
+import ggg
+
+t : Int
+t = yyy

--- a/tests/idris2/perror008/expected
+++ b/tests/idris2/perror008/expected
@@ -52,3 +52,15 @@ Issue710f.idr:2:15--2:16
  2 |   constructor cons
                    ^
 
+Uncaught error: Error: Expected a capitalised identifier, got: ggg.
+
+Issue1224a.idr:1:8--1:9
+ 1 | module ggg
+            ^
+
+Uncaught error: Error: Expected a capitalised identifier, got: ggg.
+
+Issue1224b.idr:1:8--1:9
+ 1 | import ggg
+            ^
+

--- a/tests/idris2/perror008/run
+++ b/tests/idris2/perror008/run
@@ -5,4 +5,7 @@ $1 --no-color --console-width 0 --check Issue710d.idr || true
 $1 --no-color --console-width 0 --check Issue710e.idr || true
 $1 --no-color --console-width 0 --check Issue710f.idr || true
 
+$1 --no-color --console-width 0 --check Issue1224a.idr || true
+$1 --no-color --console-width 0 --check Issue1224b.idr || true
+
 rm -rf build


### PR DESCRIPTION
Had to do a bit of digging to get nice error messages.

I have decided to not reject files with a lowercase name and no
`module` declaration. They are implicitly declared as a `Main`
module and you simply won't be able to import them.