### PR TITLE
Add Path@contrib & small changes

### DIFF
--- a/libs/base/Data/List/Quantifiers.idr
+++ b/libs/base/Data/List/Quantifiers.idr
@@ -122,7 +122,7 @@ allNegAny (np :: npxs) (Here p) = absurd (np p)
 allNegAny (np :: npxs) (There p) = allNegAny npxs p
 
 ||| Given a proof of membership for some element, extract the property proof for it
-export
+public export
 indexAll : Elem x xs -> All p xs -> p x
 indexAll  Here     (p::_  ) = p
 indexAll (There e) ( _::ps) = indexAll e ps

--- a/libs/base/Data/Stream.idr
+++ b/libs/base/Data/Stream.idr
@@ -32,7 +32,7 @@ unfoldr f c = let (a, n) = f c in a :: unfoldr f n
 ||| All of the natural numbers, in order
 public export
 nats : Stream Nat
-nats = unfoldr (\n => (n, S n)) Z
+nats = iterate S Z
 
 ||| Get the nth element of a stream
 public export

--- a/libs/contrib/Data/Path.idr
+++ b/libs/contrib/Data/Path.idr
@@ -43,5 +43,5 @@ export
 foldlPath : {0 gt : t -> t -> Type} -> {0 gu : u -> u -> Type} -> {0 f : t -> u}
         -> ({0 i, j, k : t} -> gu (f i) (f j) ->      gt j k -> gu (f i) (f k))
         ->  {0 i, j, k : t} -> gu (f i) (f j) -> Path gt j k -> gu (f i) (f k)
-foldlPath     gf ij []      = ij
-foldlPath {u} gf ij (e::jk) = foldlPath {gu} gf (gf ij e) jk
+foldlPath gf ij []      = ij
+foldlPath gf ij (e::jk) = foldlPath {gu} gf (gf ij e) jk

--- a/libs/contrib/Data/Path.idr
+++ b/libs/contrib/Data/Path.idr
@@ -1,0 +1,47 @@
+module Data.Path
+
+%default total
+
+||| Paths in a typed graph as a sequence of edges with source and target nodes matching up domino-style.
+||| AKA reflexive-transitive closure.
+public export
+data Path : (t -> t -> Type) -> t -> t -> Type where
+  Nil  : Path g i i
+  (::) : {0 i, j, k : t} ->
+         g i j -> Path g j k -> Path g i k
+
+export
+joinPath : Path g i j -> Path g j k -> Path g i k
+joinPath []      jk = jk
+joinPath (e::ij) jk = e :: joinPath ij jk
+
+export
+snocPath : Path g i j -> g j k -> Path g i k
+snocPath []      f = [f]
+snocPath (e::ij) f = e :: snocPath ij f
+
+export
+lengthPath : Path g i j -> Nat
+lengthPath []     = Z
+lengthPath (_::p) = S $ lengthPath p
+
+export
+mapPath : {0 gt : t -> t -> Type} -> {0 gu : u -> u -> Type} -> {0 f : t -> u}
+       -> ({0 i, j : t} ->      gt i j ->      gu (f i) (f j))
+       ->  {0 i, j : t} -> Path gt i j -> Path gu (f i) (f j)
+mapPath gf []     = []
+mapPath gf (e::p) = gf e :: mapPath gf p
+
+export
+foldPath : {0 gt : t -> t -> Type} -> {0 gu : u -> u -> Type} -> {0 f : t -> u}
+        -> ({0 i, j, k : t} ->      gt i j -> gu (f j) (f k) -> gu (f i) (f k))
+        ->  {0 i, j, k : t} -> Path gt i j -> gu (f j) (f k) -> gu (f i) (f k)
+foldPath gf []      jk = jk
+foldPath gf (e::ij) jk = gf e (foldPath {gu} gf ij jk)
+
+export
+foldlPath : {0 gt : t -> t -> Type} -> {0 gu : u -> u -> Type} -> {0 f : t -> u}
+        -> ({0 i, j, k : t} -> gu (f i) (f j) ->      gt j k -> gu (f i) (f k))
+        ->  {0 i, j, k : t} -> gu (f i) (f j) -> Path gt j k -> gu (f i) (f k)
+foldlPath     gf ij []      = ij
+foldlPath {u} gf ij (e::jk) = foldlPath {gu} gf (gf ij e) jk

--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -76,6 +76,8 @@ modules = Control.ANSI,
 
           Data.OpenUnion,
 
+          Data.Path,
+
           Data.Recursion.Free,
 
           Data.SortedMap,


### PR DESCRIPTION
I've added `Data.Path` because I keep copypasting it around and it seems generic enough, also Agda has it in the stdlib.

Also, exported publicly `List.Elem.indexElem` (I needed to access its structure in a logrel proof) and simplified `Stream.nats`.