### PR TITLE
[ fix ] bootstrap-stage2: IDRIS2_CG not set correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,8 +157,8 @@ bootstrap: support
 	sed 's/libidris2_support.so/${IDRIS2_SUPPORT}/g; s|__PREFIX__|${IDRIS2_CURDIR}/bootstrap|g' \
 		bootstrap/idris2_app/idris2.ss \
 		> bootstrap/idris2_app/idris2-boot.ss
-	sh ./bootstrap-stage1-chez.sh
-	sh ./bootstrap-stage2.sh IDRIS2_CG="chez"
+	$(SHELL) ./bootstrap-stage1-chez.sh
+	IDRIS2_CG="chez" $(SHELL) ./bootstrap-stage2.sh
 
 # Bootstrapping using racket
 bootstrap-racket: support
@@ -166,8 +166,8 @@ bootstrap-racket: support
 	sed 's|__PREFIX__|${IDRIS2_CURDIR}/bootstrap|g' \
 		bootstrap/idris2_app/idris2.rkt \
 		> bootstrap/idris2_app/idris2-boot.rkt
-	sh ./bootstrap-stage1-racket.sh
-	sh ./bootstrap-stage2.sh IDRIS2_CG="racket"
+	$(SHELL) ./bootstrap-stage1-racket.sh
+	IDRIS2_CG="racket" $(SHELL) ./bootstrap-stage2.sh
 
 bootstrap-test:
 	$(MAKE) test INTERACTIVE='' IDRIS2_PATH=${IDRIS2_BOOT_PATH} IDRIS2_DATA=${IDRIS2_BOOT_TEST_DATA} IDRIS2_LIBS=${IDRIS2_BOOT_TEST_LIBS}


### PR DESCRIPTION
1. Fixes an error in stage2 of `make bootstrap-racket`. Reproducible if Chez is not available as 'scheme' and IDRIS2_CG is not exported in environment / not passed to make.
2. Use the same shell as Make, allowing it to be be overridden.