### PR TITLE
Add Data.Monoid.Exponentiation to contrib.ipkg

### DIFF
--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -61,6 +61,8 @@ modules = Control.ANSI,
 
           Data.Logic.Propositional,
 
+          Data.Monoid.Exponentiation,
+
           Data.Morphisms.Algebra,
 
           Data.Nat.Algebra,


### PR DESCRIPTION
Add a missing module to `contrib.ipkg`.