### PR TITLE
[ performance ] add fastUnlines to base

### DIFF
--- a/libs/base/Data/String.idr
+++ b/libs/base/Data/String.idr
@@ -37,6 +37,11 @@ fastUnpack : String -> List Char
 export
 fastConcat : List String -> String
 
+-- This uses fastConcat internally so it won't compute at compile time.
+export
+fastUnlines : List String -> String
+fastUnlines = fastConcat . intersperse "\n"
+
 -- This is a deprecated alias for fastConcat for backwards compatibility
 -- (unfortunately, we don't have %deprecated yet).
 export


### PR DESCRIPTION
I am working on an algorithm, which generates several tens of thousands lines of Idris2 code. Replacing all occurences of `unlines` with `fastUnlines` as presented in this PR, brought the running time down by two orders of magnitude (from > 50 s to < 0.5 s on my system). I therefore thought this might be useful for others as well.