### PR TITLE
Restore an ability for data constructors to start with a lower-case char

### DIFF
--- a/src/Parser/Rule/Source.idr
+++ b/src/Parser/Rule/Source.idr
@@ -297,11 +297,11 @@ capitalisedName = do
 
 export
 dataConstructorName : Rule Name
-dataConstructorName = opNonNS <|> capitalisedName
+dataConstructorName = name
 
-export %inline
+export
 dataTypeName : Rule Name
-dataTypeName = dataConstructorName
+dataTypeName = opNonNS <|> capitalisedName
 
 export
 IndentInfo : Type

--- a/tests/idris2/perror008/expected
+++ b/tests/idris2/perror008/expected
@@ -17,24 +17,7 @@ Issue710b.idr:3:6--3:7
           ^
 
 1/1: Building Issue710c (Issue710c.idr)
-Error: Expected a capitalised identifier, got: leaf.
-
-Issue710c.idr:5:3--5:4
- 1 | infix 3 #
- 2 | 
- 3 | data T : Type where
- 4 |   (#) : T -> T -> T
- 5 |   leaf : T
-       ^
-
 1/1: Building Issue710d (Issue710d.idr)
-Error: Expected a capitalised identifier, got: mkT.
-
-Issue710d.idr:2:15--2:16
- 1 | record T where
- 2 |   constructor mkT
-                   ^
-
 1/1: Building Issue710e (Issue710e.idr)
 Error: Expected a capitalised identifier, got: a.
 
@@ -45,13 +28,6 @@ Issue710e.idr:3:11--3:12
                ^
 
 1/1: Building Issue710f (Issue710f.idr)
-Error: Expected a capitalised identifier, got: cons.
-
-Issue710f.idr:2:15--2:16
- 1 | interface Lalala where
- 2 |   constructor cons
-                   ^
-
 Uncaught error: Error: Expected a capitalised identifier, got: ggg.
 
 Issue1224a.idr:1:8--1:9


### PR DESCRIPTION
Following the discussion at #1207, _data constructors_ (like `c1` in the example below, unlike _type constructors_) do not define and are not going to define a namespace. Thus they still could start with an upper-case letter with no ambiguity.

```idris
data D : Type -> Type where
  c1 : D Int
```