### PR TITLE
Support prim__fork on javascript

### DIFF
--- a/libs/prelude/Prelude/IO.idr
+++ b/libs/prelude/Prelude/IO.idr
@@ -116,6 +116,7 @@ getChar : HasIO io => io Char
 getChar = primIO prim__getChar
 
 %foreign "scheme:blodwen-thread"
+         "javascript:lambda:x=>setTimeout(x,0)"
 export
 prim__fork : (1 prog : PrimIO ()) -> PrimIO ThreadID
 


### PR DESCRIPTION
When trying to use `PrimIO e => App e r` on javascript, the following error is thrown:
```
Uncaught error: INTERNAL ERROR: No node or javascript definition found for Prelude.IO.prim__fork in ["scheme:blodwen-thread"]
```
I worked around it with a separate PrimIO instance which I had to then use everywhere. Implementing fork is a better solution. 

In this PR, I added a javascript foreign implementation for `prim__fork` using `setTimeout`. Implementing `waitThread` on a timeout is not possible, but would be of arguably limited use in js (without `async`).

With this small change, it becomes possible to do `PrimIO` in `App` on javascript. 
