### PR TITLE
Tune precedence of (===), (~=~) and (<+>)

### DIFF
--- a/libs/prelude/Builtin.idr
+++ b/libs/prelude/Builtin.idr
@@ -114,7 +114,7 @@ data Equal : forall a, b . a -> b -> Type where
 
 %name Equal prf
 
-infix 9 ===, ~=~
+infix 6 ===, ~=~
 
 -- An equality type for when you want to assert that each side of the
 -- equality has the same type, but there's not other evidence available

--- a/libs/prelude/Prelude/Ops.idr
+++ b/libs/prelude/Prelude/Ops.idr
@@ -17,7 +17,7 @@ infixl 1 >>=, =<<, >>, >=>, <=<
 infixr 2 <|>
 infixl 3 <*>, *>, <*
 infixr 4 <$>, $>, <$
-infixl 6 <+>
+infixl 8 <+>
 
 -- Utility operators
 infixr 9 ., .:


### PR DESCRIPTION
Lower the precedence of `(===)` and `(~=~)` to match that of `==` (6). 
With the tuned precedence, arithmetic operators `(+)`, `(*)`, etc. behave as one would expect when combined with propositional equality. Examples of impacted expressions:
- `2 + 2 === 4` now parses as `(2 + 2) === 4`
- `2 :: Nil === [2]` now parses as `(2 :: Nil) === [2]`
- `[1, 2] ++ [3, 4] === [1, 2, 3, 4]` now parses as `([1, 2] ++ [3, 4]) === [1, 2, 3, 4]`


Also `(<+>)` is made to bind as tight as `(+)` (precedence 8).

None of the builtin operators seem to be negatively impacted by the change.