### PR TITLE
Ignore some REPL options in package commands

### DIFF
--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -664,7 +664,11 @@ filterPackageOpts acc (SetCG f       ::xs) = filterPackageOpts (record {oopts $=
 filterPackageOpts acc (BuildDir f    ::xs) = filterPackageOpts (record {oopts $= (BuildDir f::)}     acc) xs
 filterPackageOpts acc (OutputDir f   ::xs) = filterPackageOpts (record {oopts $= (OutputDir f::)}    acc) xs
 
-filterPackageOpts acc (x::xs) = pure (record {hasError = True} acc)
+filterPackageOpts acc (ConsoleWidth n::xs) = filterPackageOpts acc xs
+filterPackageOpts acc (Color b       ::xs) = filterPackageOpts acc xs
+filterPackageOpts acc (NoBanner      ::xs) = filterPackageOpts acc xs
+
+filterPackageOpts acc (x::xs) = filterPackageOpts (record {hasError = True} acc) xs
 
 -- If there's a package option, it must be the only option, so reject if
 -- it's not


### PR DESCRIPTION
Currently, `idris2 -p contrib --build mypkg.ipkg` enters the REPL, while ` --build mypkg.ipkg -p contrib` fails with an error. This PR makes both instances fail.

I also priveledged some REPL options to silently pass through package commands like `--build`, so users can alias idris2 with `--no-banner --no-colour`.
