### PR TITLE
Fix escaping in C backend

### DIFF
--- a/src/Compiler/RefC/RefC.idr
+++ b/src/Compiler/RefC/RefC.idr
@@ -64,15 +64,8 @@ showcCleanStringChar '%' = ("_percent" ++)
 showcCleanStringChar '~' = ("_tilde" ++)
 showcCleanStringChar c
    = if c < chr 32 || c > chr 126
-        then (("u" ++ pad (asHex (cast c))) ++)
+        then (("u" ++ leftPad '0' 4 (asHex (cast c))) ++)
         else strCons c
-  where
-    pad : String -> String
-    pad str
-        = let n = length str in
-          case isLTE n 4 of
-             Yes _ => fastPack (List.replicate (minus 4 n) '0') ++ str
-             No _ => str
 
 showcCleanString : List Char -> String -> String
 showcCleanString [] = id
@@ -140,17 +133,11 @@ where
     showCChar : Char -> String -> String
     showCChar '\\' = ("bkslash" ++)
     showCChar c
-       = if c < chr 32 || c > chr 126
-            then (("\\x" ++ (asHex (cast c))) ++)
-            else strCons c
-      where
-        pad : String -> String
-        pad str
-            = case isLTE (length str) 2 of
-                   --Yes _ => toString (List.replicate (natMinus 4 (length str)) '0') ++ str
-                   Yes _ => "0" ++ str
-                   No _ => str
-
+       = if c < chr 32
+            then (("\\x" ++ leftPad '0' 2 (asHex (cast c))) ++ "\"\"" ++)
+            else if c < chr 127 then strCons c
+            else if c < chr 65536 then (("\\u" ++ leftPad '0' 4 (asHex (cast c))) ++ "\"\"" ++)
+            else (("\\U" ++ leftPad '0' 8 (asHex (cast c))) ++ "\"\"" ++)
 
     showCString : List Char -> String -> String
     showCString [] = id


### PR DESCRIPTION
Use unicode escapes. Insert trailing doublequotes to terminate (otherwise hexchars will be considered part of escape)

What remains to do now is missing primitive functions.