### PR TITLE
Use file extensions when looking for exes on windows

### DIFF
--- a/libs/test/Test/Golden.idr
+++ b/libs/test/Test/Golden.idr
@@ -240,9 +240,11 @@ export
 pathLookup : List String -> IO (Maybe String)
 pathLookup names = do
   path <- getEnv "PATH"
+  let extensions = if isWindows then [".exe", ".cmd", ".bat", ""] else [""]
   let pathList = forget $ split (== pathSeparator) $ fromMaybe "/usr/bin:/usr/local/bin" path
-  let candidates = [p ++ "/" ++ x | p <- pathList,
-                                    x <- names]
+  let candidates = [p ++ "/" ++ x ++ y | p <- pathList,
+                                         x <- names,
+                                         y <- extensions]
   firstExists candidates
 
 
@@ -269,7 +271,7 @@ checkRequirement req
   where
     requirement : Requirement -> (String, List String)
     requirement C = ("CC", ["cc"])
-    requirement Chez = ("CHEZ", ["chez", "chezscheme9.5", "scheme", "scheme.exe"])
+    requirement Chez = ("CHEZ", ["chez", "chezscheme9.5", "scheme"])
     requirement Node = ("NODE", ["node"])
     requirement Racket = ("RACKET", ["racket"])
     requirement Gambit = ("GAMBIT", ["gsc"])

--- a/src/Compiler/Common.idr
+++ b/src/Compiler/Common.idr
@@ -20,7 +20,7 @@ import Data.IOArray
 import Data.List
 import Data.List1
 import Libraries.Data.NameMap
-import Data.Strings
+import Data.Strings as String
 
 import Idris.Env
 

--- a/src/Compiler/ES/Node.idr
+++ b/src/Compiler/ES/Node.idr
@@ -17,9 +17,12 @@ import System.File
 import Data.Maybe
 
 findNode : IO String
-findNode =
-  do env <- idrisGetEnv "NODE"
-     pure $ fromMaybe "/usr/bin/env node" env
+findNode = do
+   Just node <- idrisGetEnv "NODE"
+      | Nothing => do
+         path <- pathLookup ["node"]
+         pure $ fromMaybe "/usr/bin/env node" path
+   pure node
 
 ||| Compile a TT expression to Node
 compileToNode : Ref Ctxt Defs ->

--- a/src/Compiler/ES/Node.idr
+++ b/src/Compiler/ES/Node.idr
@@ -18,11 +18,10 @@ import Data.Maybe
 
 findNode : IO String
 findNode = do
-   Just node <- idrisGetEnv "NODE"
-      | Nothing => do
-         path <- pathLookup ["node"]
-         pure $ fromMaybe "/usr/bin/env node" path
-   pure node
+   Nothing <- idrisGetEnv "NODE"
+      | Just node => pure node
+   path <- pathLookup ["node"]
+   pure $ fromMaybe "/usr/bin/env node" path
 
 ||| Compile a TT expression to Node
 compileToNode : Ref Ctxt Defs ->

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -32,10 +32,10 @@ import System.Info
 
 findChez : IO String
 findChez
-    = do Just chez <- idrisGetEnv "CHEZ"
-            | Nothing =>
-                pure $ fromMaybe "/usr/bin/env scheme" !(pathLookup ["chez", "chezscheme9.5", "scheme"])
-         pure chez
+    = do Nothing <- idrisGetEnv "CHEZ"
+            | Just chez => pure chez
+         path <- pathLookup ["chez", "chezscheme9.5", "scheme"]
+         pure $ fromMaybe "/usr/bin/env scheme" path
 
 -- Given the chez compiler directives, return a list of pairs of:
 --   - the library file name

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -30,18 +30,11 @@ import System.Info
 
 %default covering
 
-pathLookup : IO String
-pathLookup
-    = do path <- idrisGetEnv "PATH"
-         let pathList = forget $ split (== pathSeparator) $ fromMaybe "/usr/bin:/usr/local/bin" path
-         let candidates = [p ++ "/" ++ x | p <- pathList,
-                                           x <- ["chez", "chezscheme9.5", "scheme", "scheme.exe"]]
-         e <- firstExists candidates
-         pure $ fromMaybe "/usr/bin/env scheme" e
-
 findChez : IO String
 findChez
-    = do Just chez <- idrisGetEnv "CHEZ" | Nothing => pathLookup
+    = do Just chez <- idrisGetEnv "CHEZ"
+            | Nothing =>
+                pure $ fromMaybe "/usr/bin/env scheme" !(pathLookup ["chez", "chezscheme9.5", "scheme"])
          pure chez
 
 -- Given the chez compiler directives, return a list of pairs of:


### PR DESCRIPTION
Move pathLookup to Compiler.Common and use it on Node.