### PR TITLE
Use correct multiplicity in scope of lets

### DIFF
--- a/src/Core/LinearCheck.idr
+++ b/src/Core/LinearCheck.idr
@@ -291,6 +291,7 @@ mutual
                       if isErased rig_in
                          then erased
                          else top -- checking as if an inspectable run-time type
+                 Let _ _ _ _ => rig_in
                  _ => if isErased rig_in
                          then erased
                          else linear

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -126,7 +126,7 @@ idrisTestsRegression = MkTestPool []
        "reg015", "reg016", "reg017", "reg018", "reg019", "reg020", "reg021",
        "reg022", "reg023", "reg024", "reg025", "reg026", "reg027", "reg028",
        "reg029", "reg030", "reg031", "reg032", "reg033", "reg034", "reg035",
-       "reg036", "reg037", "reg038"]
+       "reg036", "reg037", "reg038", "reg039"]
 
 idrisTestsData : TestPool
 idrisTestsData = MkTestPool []

--- a/tests/idris2/reg039/dupdup.idr
+++ b/tests/idris2/reg039/dupdup.idr
@@ -1,0 +1,2 @@
+dupLinear : (1 x : a) -> (a, a)
+dupLinear x = dup (let var = 22 in x)

--- a/tests/idris2/reg039/expected
+++ b/tests/idris2/reg039/expected
@@ -1,0 +1,8 @@
+1/1: Building dupdup (dupdup.idr)
+Error: While processing right hand side of dupLinear. Trying to use linear name x in non-linear context.
+
+dupdup.idr:2:24--2:32
+ 1 | dupLinear : (1 x : a) -> (a, a)
+ 2 | dupLinear x = dup (let var = 22 in x)
+                            ^^^^^^^^
+

--- a/tests/idris2/reg039/run
+++ b/tests/idris2/reg039/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 --check dupdup.idr
+
+rm -rf build


### PR DESCRIPTION
The scope should be checked at the same multiplicity as the enclosing expression.