### PR TITLE
Fix issues with use of unix sockets

### DIFF
--- a/libs/network/Network/FFI.idr
+++ b/libs/network/Network/FFI.idr
@@ -40,6 +40,10 @@ prim__idrnet_sockaddr_family : (sockaddr : AnyPtr) -> PrimIO Int
 export
 prim__idrnet_sockaddr_ipv4 : (sockaddr : AnyPtr) -> PrimIO String
 
+%foreign "C:idrnet_sockaddr_unix,libidris2_support"
+export
+prim__idrnet_sockaddr_unix : (sockaddr : AnyPtr) -> PrimIO String
+
 %foreign "C:idrnet_sockaddr_ipv4_port,libidris2_support"
 export
 prim__idrnet_sockaddr_ipv4_port : (sockaddr : AnyPtr) -> PrimIO Int

--- a/libs/network/Network/Socket/Raw.idr
+++ b/libs/network/Network/Socket/Raw.idr
@@ -70,6 +70,7 @@ getSockAddr (SAPtr ptr) = do
 
       pure $ parseIPv4 ipv4_addr
     Just AF_INET6 => pure IPv6Addr
+    Just AF_UNIX => map Hostname $ primIO (prim__idrnet_sockaddr_unix ptr)
     Just AF_UNSPEC => pure InvalidAddress)
 
 export

--- a/support/c/idris_net.c
+++ b/support/c/idris_net.c
@@ -48,6 +48,14 @@ void buf_ntohl(void* buf, int len) {
     }
 }
 
+struct sockaddr_un get_sockaddr_unix(char* host) {
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strcpy(addr.sun_path, host);
+    return addr;
+}
+
 void* idrnet_malloc(int size) {
     return malloc(size);
 }
@@ -119,14 +127,20 @@ int idrnet_getaddrinfo(struct addrinfo** address_res, char* host, int port,
 }
 
 int idrnet_bind(int sockfd, int family, int socket_type, char* host, int port) {
-    struct addrinfo *address_res;
-    int addr_res = idrnet_getaddrinfo(&address_res, host, port, family, socket_type);
-    if (addr_res != 0) {
-        //printf("Lib err: bind getaddrinfo\n");
-        return -1;
-    }
+    int bind_res;
+    if (family == AF_UNIX) {
+        struct sockaddr_un addr = get_sockaddr_unix(host);
+        bind_res = bind(sockfd, (struct sockaddr *)&addr, sizeof(addr));
+    } else {
+        struct addrinfo *address_res;
+        int addr_res = idrnet_getaddrinfo(&address_res, host, port, family, socket_type);
+        if (addr_res != 0) {
+            //printf("Lib err: bind getaddrinfo\n");
+            return -1;
+        }
 
-    int bind_res = bind(sockfd, address_res->ai_addr, address_res->ai_addrlen);
+        bind_res = bind(sockfd, address_res->ai_addr, address_res->ai_addrlen);
+    }
     if (bind_res == -1) {
         //freeaddrinfo(address_res);
         //printf("Lib err: bind\n");
@@ -165,6 +179,10 @@ int idrnet_sockaddr_port(int sockfd) {
 
 
 int idrnet_connect(int sockfd, int family, int socket_type, char* host, int port) {
+    if (family == AF_UNIX) {
+        struct sockaddr_un addr = get_sockaddr_unix(host);
+        return connect(sockfd, (struct sockaddr *)&addr, sizeof(addr));
+    }
     struct addrinfo* remote_host;
     int addr_res = idrnet_getaddrinfo(&remote_host, host, port, family, socket_type);
     if (addr_res != 0) {
@@ -197,6 +215,11 @@ char* idrnet_sockaddr_ipv4(void* sockaddr) {
 int idrnet_sockaddr_ipv4_port(void* sockaddr) {
     struct sockaddr_in* addr = (struct sockaddr_in*) sockaddr;
     return ((int) ntohs(addr->sin_port));
+}
+
+char* idrnet_sockaddr_unix(void* sockaddr) {
+    struct sockaddr_un* addr = (struct sockaddr_un*) sockaddr;
+    return addr->sun_path;
 }
 
 void* idrnet_create_sockaddr() {

--- a/support/c/idris_net.h
+++ b/support/c/idris_net.h
@@ -10,6 +10,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/un.h>
 #endif
 
 struct sockaddr_storage;
@@ -27,6 +28,16 @@ typedef struct idrnet_recvfrom_result {
     void* payload;
     struct sockaddr_storage* remote_addr;
 } idrnet_recvfrom_result;
+
+#ifdef _WIN32
+// mingw-w64 is currently missing the afunix.h header even though windows
+// supports unix sockets so we have to define the unix sockaddr structure
+// ourselves
+struct sockaddr_un {
+    u_short sun_family;
+    char sun_path[108];
+};
+#endif
 
 // Memory management functions
 void* idrnet_malloc(int size);
@@ -58,6 +69,7 @@ int idrnet_connect(int sockfd, int family, int socket_type, char* host, int port
 int idrnet_sockaddr_family(void* sockaddr);
 char* idrnet_sockaddr_ipv4(void* sockaddr);
 int idrnet_sockaddr_ipv4_port(void* sockaddr);
+char* idrnet_sockaddr_unix(void *sockaddr);
 void* idrnet_create_sockaddr();
 
 int idrnet_sockaddr_port(int sockfd);

--- a/tests/chez/chez014/expected
+++ b/tests/chez/chez014/expected
@@ -1,4 +1,6 @@
 1/1: Building Echo (Echo.idr)
-Main> Received: hello world!
-Received: echo: hello world!
+Main> Received: hello world from a ipv4 socket!
+Received: echo: hello world from a ipv4 socket!
+Received: hello world from a unix socket!
+Received: echo: hello world from a unix socket!
 Main> Bye for now!


### PR DESCRIPTION
This change adds logic to set up `sockaddr` correctly for connect and
bind, handles the `AF_UNIX` case for `getSockAddr` and adds a test for unix
sockets.

Mingw-w64 seems to be missing the `afunix.h` header even though windows does support unix sockets, so I've added the structure manually but I might be missing something. It looks like CI only builds windows but doesn't test it, should it be? Can add if so.