### PR TITLE
Shared C codegen

### DIFF
--- a/idris2api.ipkg
+++ b/idris2api.ipkg
@@ -22,6 +22,7 @@ modules =
     Compiler.ES.RemoveUnused,
     Compiler.ES.TailRec,
 
+    Compiler.RefC.CC,
     Compiler.RefC.RefC,
 
     Compiler.Scheme.Chez,

--- a/src/Compiler/RefC/CC.idr
+++ b/src/Compiler/RefC/CC.idr
@@ -1,6 +1,7 @@
 module Compiler.RefC.CC
 
 import Core.Context
+import Core.Context.Log
 import Core.Options
 
 import System
@@ -37,7 +38,7 @@ compileCObjectFile {asLibrary} sourceFile objectFile =
                        "-I" ++ fullprefix_dir dirs "refc " ++
                        "-I" ++ fullprefix_dir dirs "include"
 
-     coreLift $ putStrLn runccobj
+     log "compiler.refc.cc" 10 runccobj
      0 <- coreLift $ system runccobj
        | _ => pure Nothing
 
@@ -62,7 +63,7 @@ compileCFile {asShared} objectFile outFile =
                        "-L" ++ fullprefix_dir dirs "refc " ++
                        clibdirs (lib_dirs dirs)
 
-     coreLift $ putStrLn runcc
+     log "compiler.refc.cc" 10 runcc
      0 <- coreLift $ system runcc
        | _ => pure Nothing
 

--- a/src/Compiler/RefC/CC.idr
+++ b/src/Compiler/RefC/CC.idr
@@ -1,0 +1,65 @@
+module Compiler.RefC.CC
+
+import Core.Context
+import Core.Options
+
+import System
+
+import Idris.Version
+import Libraries.Utils.Path
+
+findCC : IO String
+findCC
+    = do Nothing <- getEnv "IDRIS2_CC"
+           | Just cc => pure cc
+         Nothing <- getEnv "CC"
+           | Just cc => pure cc
+         pure "cc"
+
+fullprefix_dir : Dirs -> String -> String
+fullprefix_dir dirs sub
+    = prefix_dir dirs </> "idris2-" ++ showVersion False version </> sub
+
+export
+compileCObjectFile : {auto c : Ref Ctxt Defs}
+                  -> (outn : String)
+                  -> (outobj : String)
+                  -> Core (Maybe String)
+compileCObjectFile outn outobj =
+  do cc <- coreLift findCC
+     dirs <- getDirs
+
+     let runccobj = cc ++ " -c " ++ outn ++ " -o " ++ outobj ++ " " ++
+                       "-I" ++ fullprefix_dir dirs "refc " ++
+                       "-I" ++ fullprefix_dir dirs "include"
+
+     coreLift $ putStrLn runccobj
+     0 <- coreLift $ system runccobj
+       | _ => pure Nothing
+
+     pure (Just outobj)
+
+export
+compileCFile : {auto c : Ref Ctxt Defs}
+            -> (outobj : String)
+            -> (outexec : String)
+            -> Core (Maybe String)
+compileCFile outobj outexec =
+  do cc <- coreLift findCC
+     dirs <- getDirs
+
+     let runcc = cc ++ " " ++ outobj ++ " -o " ++ outexec ++ " " ++
+                       fullprefix_dir dirs "lib" </> "libidris2_support.a" ++ " " ++
+                       "-lidris2_refc " ++
+                       "-L" ++ fullprefix_dir dirs "refc " ++
+                       clibdirs (lib_dirs dirs)
+
+     coreLift $ putStrLn runcc
+     0 <- coreLift $ system runcc
+       | _ => pure Nothing
+
+     pure (Just outexec)
+
+  where
+    clibdirs : List String -> String
+    clibdirs ds = concat (map (\d => "-L" ++ d ++ " ") ds)

--- a/src/Compiler/RefC/CC.idr
+++ b/src/Compiler/RefC/CC.idr
@@ -22,14 +22,18 @@ fullprefix_dir dirs sub
 
 export
 compileCObjectFile : {auto c : Ref Ctxt Defs}
+                  -> {default False asLibrary : Bool}
                   -> (outn : String)
                   -> (outobj : String)
                   -> Core (Maybe String)
-compileCObjectFile outn outobj =
+compileCObjectFile {asLibrary} outn outobj =
   do cc <- coreLift findCC
      dirs <- getDirs
 
-     let runccobj = cc ++ " -c " ++ outn ++ " -o " ++ outobj ++ " " ++
+     let libraryFlag = if asLibrary then "-fpic " else ""
+
+     let runccobj = cc ++ " -c " ++ libraryFlag ++ outn ++
+                       " -o " ++ outobj ++ " " ++
                        "-I" ++ fullprefix_dir dirs "refc " ++
                        "-I" ++ fullprefix_dir dirs "include"
 
@@ -41,14 +45,18 @@ compileCObjectFile outn outobj =
 
 export
 compileCFile : {auto c : Ref Ctxt Defs}
+            -> {default False asShared : Bool}
             -> (outobj : String)
             -> (outexec : String)
             -> Core (Maybe String)
-compileCFile outobj outexec =
+compileCFile {asShared} outobj outexec =
   do cc <- coreLift findCC
      dirs <- getDirs
 
-     let runcc = cc ++ " " ++ outobj ++ " -o " ++ outexec ++ " " ++
+     let sharedFlag = if asShared then "-shared " else ""
+
+     let runcc = cc ++ " " ++ sharedFlag ++ outobj ++
+                       " -o " ++ outexec ++ " " ++
                        fullprefix_dir dirs "lib" </> "libidris2_support.a" ++ " " ++
                        "-lidris2_refc " ++
                        "-L" ++ fullprefix_dir dirs "refc " ++

--- a/src/Compiler/RefC/CC.idr
+++ b/src/Compiler/RefC/CC.idr
@@ -23,17 +23,17 @@ fullprefix_dir dirs sub
 export
 compileCObjectFile : {auto c : Ref Ctxt Defs}
                   -> {default False asLibrary : Bool}
-                  -> (outn : String)
-                  -> (outobj : String)
+                  -> (sourceFile : String)
+                  -> (objectFile : String)
                   -> Core (Maybe String)
-compileCObjectFile {asLibrary} outn outobj =
+compileCObjectFile {asLibrary} sourceFile objectFile =
   do cc <- coreLift findCC
      dirs <- getDirs
 
      let libraryFlag = if asLibrary then "-fpic " else ""
 
-     let runccobj = cc ++ " -c " ++ libraryFlag ++ outn ++
-                       " -o " ++ outobj ++ " " ++
+     let runccobj = cc ++ " -c " ++ libraryFlag ++ sourceFile ++
+                       " -o " ++ objectFile ++ " " ++
                        "-I" ++ fullprefix_dir dirs "refc " ++
                        "-I" ++ fullprefix_dir dirs "include"
 
@@ -41,22 +41,22 @@ compileCObjectFile {asLibrary} outn outobj =
      0 <- coreLift $ system runccobj
        | _ => pure Nothing
 
-     pure (Just outobj)
+     pure (Just objectFile)
 
 export
 compileCFile : {auto c : Ref Ctxt Defs}
             -> {default False asShared : Bool}
-            -> (outobj : String)
-            -> (outexec : String)
+            -> (objectFile : String)
+            -> (outFile : String)
             -> Core (Maybe String)
-compileCFile {asShared} outobj outexec =
+compileCFile {asShared} objectFile outFile =
   do cc <- coreLift findCC
      dirs <- getDirs
 
      let sharedFlag = if asShared then "-shared " else ""
 
-     let runcc = cc ++ " " ++ sharedFlag ++ outobj ++
-                       " -o " ++ outexec ++ " " ++
+     let runcc = cc ++ " " ++ sharedFlag ++ objectFile ++
+                       " -o " ++ outFile ++ " " ++
                        fullprefix_dir dirs "lib" </> "libidris2_support.a" ++ " " ++
                        "-lidris2_refc " ++
                        "-L" ++ fullprefix_dir dirs "refc " ++
@@ -66,7 +66,7 @@ compileCFile {asShared} outobj outexec =
      0 <- coreLift $ system runcc
        | _ => pure Nothing
 
-     pure (Just outexec)
+     pure (Just outFile)
 
   where
     clibdirs : List String -> String

--- a/src/Compiler/RefC/RefC.idr
+++ b/src/Compiler/RefC/RefC.idr
@@ -7,6 +7,7 @@ import Compiler.CompileExpr
 import Compiler.ANF
 
 import Core.Context
+import Core.Context.Log
 import Core.Directory
 
 import Data.List
@@ -995,7 +996,8 @@ createCFunctions n (MkAError exp) = do
     pure ()
 
 
-header : {auto f : Ref FunctionDefinitions (List String)}
+header : {auto c : Ref Ctxt Defs}
+      -> {auto f : Ref FunctionDefinitions (List String)}
       -> {auto o : Ref OutfileText Output}
       -> {auto il : Ref IndentLevel Nat}
       -> {auto e : Ref ExternalLibs (List String)}
@@ -1006,7 +1008,7 @@ header = do
                     , "#include <idris_support.h> // for libidris2_support"]
     extLibs <- get ExternalLibs
     let extLibLines = map (\lib => "// add header(s) for library: " ++ lib ++ "\n") extLibs
-    traverse_ (\l => coreLift (putStrLn $ " header for " ++ l ++ " needed")) extLibs
+    traverse_ (\l => log "compiler.refc" 20 $ " header for " ++ l ++ " needed") extLibs
     fns <- get FunctionDefinitions
     update OutfileText (appendL (initLines ++ extLibLines ++ ["\n// function definitions"] ++ fns))
 
@@ -1046,7 +1048,7 @@ generateCSourceFile defs outn =
      let code = fastAppend (map (++ "\n") (reify fileContent))
 
      coreLift_ $ writeFile outn code
-     coreLift_ $ putStrLn $ "Generated C file " ++ outn
+     log "compiler.refc" 10 $ "Generated C file " ++ outn
 
 export
 compileExpr : UsePhase


### PR DESCRIPTION
Expose the RefC code for compiling CC object files and executables, and add the option to compile them as libraries.

This should result in no behavioural changes to the RefC backend. I'm exposing these functions to enable other backends to make use of them, such as Python.

I wasn't able to run `make install-api` on `master`, so this branch is instead based off the most recent tag (`v0.3.0`). From a quick glance, it appears the only merge issues are a matter of `import`s, but I'm not able verify if any particular solution is correct.