### PR TITLE
Add missing modules to contrib.ipkg

### DIFF
--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -77,7 +77,7 @@ modules = Control.ANSI,
           Data.Nat.Order.Properties,
           Data.Nat.Properties,
 
-          Data.Num.Exponentiation,
+          Data.Num.Implementations,
 
           Data.OpenUnion,
 

--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -69,6 +69,7 @@ modules = Control.ANSI,
           Data.Nat.Ack,
           Data.Nat.Division,
           Data.Nat.Equational,
+          Data.Nat.Exponentiation,
           Data.Nat.Fact,
           Data.Nat.Factor,
           Data.Nat.Fib,
@@ -76,15 +77,23 @@ modules = Control.ANSI,
           Data.Nat.Order.Properties,
           Data.Nat.Properties,
 
+          Data.Num.Exponentiation,
+
           Data.OpenUnion,
+
+          Data.Order,
 
           Data.Path,
 
           Data.Recursion.Free,
 
+          Data.Rel.Complement,
+
           Data.SortedMap,
           Data.SortedSet,
+
           Data.Stream.Extra,
+
           Data.String.Extra,
           Data.String.Interpolation,
           Data.String.Iterator,


### PR DESCRIPTION
Add 3 missing modules to contrib.ipkg (`Data.Nat.Exponentiation`, `Data.Num.Exponentiation` and `Data.Rel.Complement`) and add tweak formatting to separate unrelated modules.