### PR TITLE
Hermetic tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ export IDRIS2_BOOT_PATH := "${IDRIS2_CURDIR}/libs/prelude/build/ttc${SEP}${IDRIS
 export SCHEME
 
 
-.PHONY: all idris2-exec ${TARGET} testbin support support-clean clean distclean FORCE
+.PHONY: all idris2-exec testenv testenv-clean support support-clean clean FORCE
 
 all: support ${TARGET} libs
 

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ ifeq ($(shell git status >/dev/null 2>&1; echo $$?), 0)
 endif
 
 export IDRIS2_VERSION := ${MAJOR}.${MINOR}.${PATCH}
+NAME_VERSION := ${NAME}-${IDRIS2_VERSION}
 IDRIS2_SUPPORT := libidris2_support${SHLIB_SUFFIX}
 IDRIS2_APP_IPKG := idris2.ipkg
 IDRIS2_LIB_IPKG := idris2api.ipkg
@@ -138,14 +139,14 @@ endif
 	install ${TARGETDIR}/${NAME}_app/* ${PREFIX}/bin/${NAME}_app
 
 install-support:
-	mkdir -p ${PREFIX}/idris2-${IDRIS2_VERSION}/support/chez
-	mkdir -p ${PREFIX}/idris2-${IDRIS2_VERSION}/support/racket
-	mkdir -p ${PREFIX}/idris2-${IDRIS2_VERSION}/support/gambit
-	mkdir -p ${PREFIX}/idris2-${IDRIS2_VERSION}/support/js
-	install support/chez/* ${PREFIX}/idris2-${IDRIS2_VERSION}/support/chez
-	install support/racket/* ${PREFIX}/idris2-${IDRIS2_VERSION}/support/racket
-	install support/gambit/* ${PREFIX}/idris2-${IDRIS2_VERSION}/support/gambit
-	install support/js/* ${PREFIX}/idris2-${IDRIS2_VERSION}/support/js
+	mkdir -p ${PREFIX}/${NAME_VERSION}/support/chez
+	mkdir -p ${PREFIX}/${NAME_VERSION}/support/racket
+	mkdir -p ${PREFIX}/${NAME_VERSION}/support/gambit
+	mkdir -p ${PREFIX}/${NAME_VERSION}/support/js
+	install support/chez/* ${PREFIX}/${NAME_VERSION}/support/chez
+	install support/racket/* ${PREFIX}/${NAME_VERSION}/support/racket
+	install support/gambit/* ${PREFIX}/${NAME_VERSION}/support/gambit
+	install support/js/* ${PREFIX}/${NAME_VERSION}/support/js
 	@${MAKE} -C support/c install
 	@${MAKE} -C support/refc install
 
@@ -181,7 +182,7 @@ bootstrap-test:
 	$(MAKE) test INTERACTIVE='' IDRIS2_PREFIX=${IDRIS2_BOOT_PREFIX}
 
 bootstrap-clean:
-	$(RM) -r bootstrap/bin bootstrap/lib bootstrap/idris2-${IDRIS2_VERSION}
+	$(RM) -r bootstrap/bin bootstrap/lib bootstrap/${NAME_VERSION}
 	$(RM) bootstrap/idris2boot* bootstrap/idris2_app/idris2-boot.* bootstrap/idris2_app/${IDRIS2_SUPPORT}
 
 

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ endif
 IDRIS2_TEST_LIBS ?= ${IDRIS2_CURDIR}/lib
 IDRIS2_TEST_DATA ?= ${IDRIS2_CURDIR}/support
 
+TEST_PREFIX ?= ${IDRIS2_CURDIR}/build/env
+
 # Library and data paths for bootstrap-test
 IDRIS2_BOOT_PREFIX := ${IDRIS2_CURDIR}/bootstrap
 
@@ -90,15 +92,25 @@ test-lib: contrib
 
 libs : prelude base contrib network test-lib
 
-testbin:
-	@${MAKE} -C tests testbin IDRIS2=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH} IDRIS2_DATA=${IDRIS2_TEST_DATA} IDRIS2_LIBS=${IDRIS2_TEST_LIBS}
+${TEST_PREFIX}/${NAME_VERSION} :
+	${MAKE} install-support PREFIX=${TEST_PREFIX}
+	ln -s ${IDRIS2_CURDIR}/libs/prelude/build/ttc ${TEST_PREFIX}/${NAME_VERSION}/prelude-${IDRIS2_VERSION}
+	ln -s ${IDRIS2_CURDIR}/libs/base/build/ttc    ${TEST_PREFIX}/${NAME_VERSION}/base-${IDRIS2_VERSION}
+	ln -s ${IDRIS2_CURDIR}/libs/test/build/ttc    ${TEST_PREFIX}/${NAME_VERSION}/test-${IDRIS2_VERSION}
+	ln -s ${IDRIS2_CURDIR}/libs/contrib/build/ttc ${TEST_PREFIX}/${NAME_VERSION}/contrib-${IDRIS2_VERSION}
+	ln -s ${IDRIS2_CURDIR}/libs/network/build/ttc ${TEST_PREFIX}/${NAME_VERSION}/network-${IDRIS2_VERSION}
 
-test: testbin
+testenv:
+	@${MAKE} ${TEST_PREFIX}/${NAME_VERSION}
+	@${MAKE} -C tests testbin IDRIS2=${TARGET} IDRIS2_PREFIX=${TEST_PREFIX}
+
+test: testenv
 	@echo
 	@echo "NOTE: \`${MAKE} test\` does not rebuild Idris or the libraries packaged with it; to do that run \`${MAKE}\`"
 	@if [ ! -x "${TARGET}" ]; then echo "ERROR: Missing IDRIS2 executable. Cannot run tests!\n"; exit 1; fi
 	@echo
-	@${MAKE} -C tests only=$(only) IDRIS2=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH} IDRIS2_DATA=${IDRIS2_TEST_DATA} IDRIS2_LIBS=${IDRIS2_TEST_LIBS}
+	@${MAKE} -C tests only=$(only) IDRIS2=${TARGET} IDRIS2_PREFIX=${TEST_PREFIX}
+
 
 support:
 	@${MAKE} -C support/c

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,7 @@ IDRIS2_TEST_LIBS ?= ${IDRIS2_CURDIR}/lib
 IDRIS2_TEST_DATA ?= ${IDRIS2_CURDIR}/support
 
 # Library and data paths for bootstrap-test
-IDRIS2_BOOT_TEST_LIBS := ${IDRIS2_CURDIR}/bootstrap/${NAME}-${IDRIS2_VERSION}/lib
-IDRIS2_BOOT_TEST_DATA := ${IDRIS2_CURDIR}/bootstrap/${NAME}-${IDRIS2_VERSION}/support
+IDRIS2_BOOT_PREFIX := ${IDRIS2_CURDIR}/bootstrap
 
 # These are the library path in the build dir to be used during build
 export IDRIS2_BOOT_PATH := "${IDRIS2_CURDIR}/libs/prelude/build/ttc${SEP}${IDRIS2_CURDIR}/libs/base/build/ttc${SEP}${IDRIS2_CURDIR}/libs/contrib/build/ttc${SEP}${IDRIS2_CURDIR}/libs/network/build/ttc${SEP}${IDRIS2_CURDIR}/libs/test/build/ttc"
@@ -155,7 +154,7 @@ install-libs:
 	${MAKE} -C libs/base install IDRIS2?=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 	${MAKE} -C libs/contrib install IDRIS2?=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 	${MAKE} -C libs/network install IDRIS2?=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
-	${MAKE} -C libs/test install IDRIS2?=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
+	${MAKE} -C libs/test  install IDRIS2?=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 
 
 .PHONY: bootstrap bootstrap-build bootstrap-racket bootstrap-racket-build bootstrap-test bootstrap-clean
@@ -163,7 +162,7 @@ install-libs:
 # Bootstrapping using SCHEME
 bootstrap: support support-lib
 	cp support/c/${IDRIS2_SUPPORT} bootstrap/idris2_app
-	sed 's/libidris2_support.so/${IDRIS2_SUPPORT}/g; s|__PREFIX__|${IDRIS2_CURDIR}/bootstrap|g' \
+	sed 's/libidris2_support.so/${IDRIS2_SUPPORT}/g; s|__PREFIX__|${IDRIS2_BOOT_PREFIX}|g' \
 		bootstrap/idris2_app/idris2.ss \
 		> bootstrap/idris2_app/idris2-boot.ss
 	$(SHELL) ./bootstrap-stage1-chez.sh
@@ -172,14 +171,14 @@ bootstrap: support support-lib
 # Bootstrapping using racket
 bootstrap-racket: support support-lib
 	cp support/c/${IDRIS2_SUPPORT} bootstrap/idris2_app
-	sed 's|__PREFIX__|${IDRIS2_CURDIR}/bootstrap|g' \
+	sed 's|__PREFIX__|${IDRIS2_BOOT_PREFIX}|g' \
 		bootstrap/idris2_app/idris2.rkt \
 		> bootstrap/idris2_app/idris2-boot.rkt
 	$(SHELL) ./bootstrap-stage1-racket.sh
 	IDRIS2_CG="racket" $(SHELL) ./bootstrap-stage2.sh
 
 bootstrap-test:
-	$(MAKE) test INTERACTIVE='' IDRIS2_PATH=${IDRIS2_BOOT_PATH} IDRIS2_TEST_DATA=${IDRIS2_BOOT_TEST_DATA} IDRIS2_TEST_LIBS=${IDRIS2_BOOT_TEST_LIBS}
+	$(MAKE) test INTERACTIVE='' IDRIS2_PREFIX=${IDRIS2_BOOT_PREFIX}
 
 bootstrap-clean:
 	$(RM) -r bootstrap/bin bootstrap/lib bootstrap/idris2-${IDRIS2_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,6 @@ else
 	SEP := :
 endif
 
-# Library and data paths for test
-IDRIS2_TEST_LIBS ?= ${IDRIS2_CURDIR}/lib
-IDRIS2_TEST_DATA ?= ${IDRIS2_CURDIR}/support
-
 TEST_PREFIX ?= ${IDRIS2_CURDIR}/build/env
 
 # Library and data paths for bootstrap-test
@@ -53,18 +49,14 @@ export IDRIS2_BOOT_PATH := "${IDRIS2_CURDIR}/libs/prelude/build/ttc${SEP}${IDRIS
 export SCHEME
 
 
-.PHONY: all idris2-exec ${TARGET} testbin support support-lib support-clean clean distclean FORCE
+.PHONY: all idris2-exec ${TARGET} testbin support support-clean clean distclean FORCE
 
-all: support ${TARGET} support-lib libs
+all: support ${TARGET} libs
 
 idris2-exec: ${TARGET}
 
 ${TARGET}: src/IdrisPaths.idr
 	${IDRIS2_BOOT} --build ${IDRIS2_APP_IPKG}
-
-support-lib:
-	mkdir -p lib
-	install support/c/${IDRIS2_SUPPORT} lib
 
 # We use FORCE to always rebuild IdrisPath so that the git SHA1 info is always up to date
 src/IdrisPaths.idr: FORCE
@@ -132,7 +124,6 @@ clean: clean-libs support-clean
 	$(RM) src/IdrisPaths.idr
 	${MAKE} -C tests clean
 	$(RM) -r build
-	$(RM) -r lib
 
 install: install-idris2 install-support install-libs
 
@@ -146,7 +137,7 @@ ifeq ($(OS), windows)
 	-install ${TARGET}.cmd ${PREFIX}/bin
 endif
 	mkdir -p ${PREFIX}/lib/
-	install lib/${IDRIS2_SUPPORT} ${PREFIX}/lib
+	install support/c/${IDRIS2_SUPPORT} ${PREFIX}/lib
 	mkdir -p ${PREFIX}/bin/${NAME}_app
 	install ${TARGETDIR}/${NAME}_app/* ${PREFIX}/bin/${NAME}_app
 
@@ -173,7 +164,7 @@ install-libs:
 .PHONY: bootstrap bootstrap-build bootstrap-racket bootstrap-racket-build bootstrap-test bootstrap-clean
 
 # Bootstrapping using SCHEME
-bootstrap: support support-lib
+bootstrap: support
 	cp support/c/${IDRIS2_SUPPORT} bootstrap/idris2_app
 	sed 's/libidris2_support.so/${IDRIS2_SUPPORT}/g; s|__PREFIX__|${IDRIS2_BOOT_PREFIX}|g' \
 		bootstrap/idris2_app/idris2.ss \
@@ -182,7 +173,7 @@ bootstrap: support support-lib
 	IDRIS2_CG="chez" $(SHELL) ./bootstrap-stage2.sh
 
 # Bootstrapping using racket
-bootstrap-racket: support support-lib
+bootstrap-racket: support
 	cp support/c/${IDRIS2_SUPPORT} bootstrap/idris2_app
 	sed 's|__PREFIX__|${IDRIS2_BOOT_PREFIX}|g' \
 		bootstrap/idris2_app/idris2.rkt \

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,9 @@ testenv:
 	@${MAKE} ${TEST_PREFIX}/${NAME_VERSION}
 	@${MAKE} -C tests testbin IDRIS2=${TARGET} IDRIS2_PREFIX=${TEST_PREFIX}
 
+testenv-clean:
+	$(RM) -r ${TEST_PREFIX}/${NAME_VERSION}
+
 test: testenv
 	@echo
 	@echo "NOTE: \`${MAKE} test\` does not rebuild Idris or the libraries packaged with it; to do that run \`${MAKE}\`"
@@ -119,7 +122,7 @@ clean-libs:
 	${MAKE} -C libs/network clean
 	${MAKE} -C libs/test clean
 
-clean: clean-libs support-clean
+clean: clean-libs support-clean testenv-clean
 	-${IDRIS2_BOOT} --clean ${IDRIS2_APP_IPKG}
 	$(RM) src/IdrisPaths.idr
 	${MAKE} -C tests clean

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -5,6 +5,9 @@
 , fetchFromGitHub
 , makeWrapper
 , idris2-version
+, racket
+, gambit
+, nodejs
 }:
 
 # Uses scheme to bootstrap the build of idris2
@@ -28,7 +31,8 @@ stdenv.mkDerivation rec {
   # The name of the main executable of pkgs.chez is `scheme`
   buildFlags = [ "bootstrap" "SCHEME=scheme" ];
 
-  checkTarget = "test";
+  checkInputs = [ gambit nodejs ]; # racket ];
+  checkFlags = [ "INTERACTIVE=" ];
 
   # TODO: Move this into its own derivation, such that this can be changed
   #       without having to recompile idris2 every time.

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -42,3 +42,4 @@ let
 in
 withTests testsTemplate templateBuildDefault
 // withTests testsTemplateWithDeps templateBuildWithDeps
+// { idris2Tests = idris.defaultPackage.${system}.overrideAttrs (a: { doCheck = true; }); }

--- a/tests/tests.ipkg
+++ b/tests/tests.ipkg
@@ -2,3 +2,5 @@ package runtests
 
 main = Main
 executable = runtests
+
+depends = contrib, test


### PR DESCRIPTION
*As I understand the way Idris2 reads paths*, this solves #934.

All CI appears to run correctly and fail correctly, including the new (to us) `checkPhase` in Nix.

`make bootstrap-test` works as I expect, but I don't know how to make it fail without either a) deleting one of the packages I tell it to look for, or b) breaking a test case so `make test` also fails.

---

As a rough summary, currently, `make test` reads `~/.idris2/idris2-${VERSION}/` to see what packages are available, then imports packages preferentially through the local paths.

By setting IDRIS2_PREFIX to a dir containing symlinks to those files instead, we bypass the need to have packages installed. This allows us to run `make test` without having a `~/.idris2`, and lets us use nix for the full test suite*.

The `make bootstrap` already used a variant IDRIS2_PREFIX, so I co-opted that for `make bootstrap-test`.

---

\* Exept for `racket`, which still has a few issues.