### PR TITLE
Report time taken to check totality.

### DIFF
--- a/src/TTImp/ProcessDecls.idr
+++ b/src/TTImp/ProcessDecls.idr
@@ -96,7 +96,7 @@ checkTotalityOK n
 
     checkTotality : FC -> Core (Maybe Error)
     checkTotality fc
-        = do ignore $ checkTotal fc n
+        = do ignore $ logTime ("+++ Checking Termination " ++ show n) (checkTotal fc n)
              -- ^ checked lazily, so better calculate here
              t <- getTotality fc n
              err <- checkCovering fc (isCovering t)

--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -880,7 +880,7 @@ processDef opts nest env fc n_in cs_in
 
          md <- get MD -- don't need the metadata collected on the coverage check
 
-         cov <- checkCoverage nidx ty mult cs
+         cov <- logTime ("+++ Checking Coverage " ++ show n) $ checkCoverage nidx ty mult cs
          setCovering fc n cov
          put MD md
 


### PR DESCRIPTION
This is a noisy update to the information reported by `--timing`. 

Recent work of mine has suggested bottlenecks with compilation are in the totality checker. The Issue tracker has seen related issues, for example see #1277. 

Although noisy, the output can be grepped away giving the structure in the logs.