### PR TITLE
[ fix ] broken unicode parsing in JSON

### DIFF
--- a/libs/contrib/Data/String/Extra.idr
+++ b/libs/contrib/Data/String/Extra.idr
@@ -103,3 +103,21 @@ indent n x = replicate n ' ' ++ x
 public export
 indentLines : (n : Nat) -> String -> String
 indentLines n str = unlines $ map (indent n) $ forget $ lines str
+
+||| Return a string of the given character repeated
+||| `n` times.
+export
+fastReplicate : (n : Nat) -> Char -> String
+fastReplicate n c = fastPack $ replicate n c
+
+||| Left-justify a string to the given length, using the
+||| specified fill character on the right.
+export
+justifyLeft : Nat -> Char -> String -> String
+justifyLeft n c s = s ++ fastReplicate (n `minus` length s) c
+
+||| Right-justify a string to the given length, using the
+||| specified fill character on the left.
+export
+justifyRight : Nat -> Char -> String -> String
+justifyRight n c s = fastReplicate (n `minus` length s) c ++ s

--- a/libs/contrib/Language/JSON/Data.idr
+++ b/libs/contrib/Language/JSON/Data.idr
@@ -56,7 +56,8 @@ showChar c
          '\\' => "\\\\"
          '"'  => "\\\""
          c => if isControl c || c >= '\127'
-                 then "\\u" ++ b16ToHexString (cast $ ord c)
+                 then let hex = b16ToHexString (cast $ ord c)
+                       in "\\u" ++ justifyRight 4 '0' hex
                  else singleton c
 
 private

--- a/libs/contrib/Language/JSON/String/Tokens.idr
+++ b/libs/contrib/Language/JSON/String/Tokens.idr
@@ -1,5 +1,7 @@
 module Language.JSON.String.Tokens
 
+import Data.List
+import Data.String
 import Data.String.Extra
 import Text.Token
 
@@ -48,7 +50,15 @@ simpleEscapeValue x
 
 private
 unicodeEscapeValue : String -> Char
-unicodeEscapeValue x = chr $ cast ("0x" ++ drop 2 x)
+unicodeEscapeValue x = fromHex (drop 2 $ fastUnpack x) 0
+  where hexVal : Char -> Int
+        hexVal c = if c >= 'A'
+                      then ord c - ord 'A' + 10
+                      else ord c - ord '0'
+
+        fromHex : List Char -> Int -> Char
+        fromHex       [] acc = chr acc
+        fromHex (h :: t) acc = fromHex t (hexVal h + 16 * acc)
 
 public export
 TokenKind JSONStringTokenKind where

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -260,6 +260,12 @@ baseLibraryTests = MkTestPool [Chez, Node]
   , "system_info001"
   ]
 
+-- same behavior as `baseLibraryTests`
+contribLibraryTests : TestPool
+contribLibraryTests = MkTestPool [Chez, Node]
+  [ "json_001"
+  ]
+
 codegenTests : TestPool
 codegenTests = MkTestPool []
   [ "con001"
@@ -285,6 +291,7 @@ main = runner
   , testPaths "ideMode" ideModeTests
   , testPaths "prelude" preludeTests
   , testPaths "base" baseLibraryTests
+  , testPaths "contrib" contribLibraryTests
   , testPaths "chez" chezTests
   , testPaths "refc" refcTests
   , testPaths "racket" racketTests

--- a/tests/contrib/json_001/CharEncoding.idr
+++ b/tests/contrib/json_001/CharEncoding.idr
@@ -1,0 +1,18 @@
+import Language.JSON
+
+import Data.List
+import Data.String
+
+main : IO ()
+main = printLn $ filter (not . roundTrips) chars
+  where chars : List Int
+        chars = [0 .. 55295]
+
+        roundTrips : Int -> Bool
+        roundTrips n =
+          let s = singleton $ chr n
+              v = JString s
+           in case parse (show v) of
+                   Just (JString x) => x == s
+                   _                => False
+

--- a/tests/contrib/json_001/expected
+++ b/tests/contrib/json_001/expected
@@ -1,0 +1,3 @@
+1/1: Building CharEncoding (CharEncoding.idr)
+Main> []
+Main> Bye for now!

--- a/tests/contrib/json_001/input
+++ b/tests/contrib/json_001/input
@@ -1,0 +1,2 @@
+:exec main
+:q

--- a/tests/contrib/json_001/run
+++ b/tests/contrib/json_001/run
@@ -1,0 +1,3 @@
+$1 --no-banner --no-color --console-width 0 -p contrib CharEncoding.idr < input
+
+rm -rf build


### PR DESCRIPTION
JSON encoding and decoding of escaped unicode characters in contrib is broken in several ways. Here's the fix plus a test.

As an aside: Whoever implemented the erroneous version was working under the assumption that the `Cast` implementation from `Int` to `String` would behave correctly for hexadecimal strings, i.e. that the following would hold: 

```idris
the Int (cast "0x2") = 2
```

This doesn't work, though. Whether this is yet another bug, I do not know.