### PR TITLE
PrettyPrint: Fix SimpleDocTree.fromStream dropping parts of documents

### DIFF
--- a/libs/contrib/Text/PrettyPrint/Prettyprinter/SimpleDocTree.idr
+++ b/libs/contrib/Text/PrettyPrint/Prettyprinter/SimpleDocTree.idr
@@ -87,7 +87,7 @@ fromStream sdoc = case sdocToTreeParser sdoc of
     flatten (STConcat [x, STEmpty]) = flatten x
     flatten (STConcat [x, STConcat xs]) = case flatten (STConcat xs) of
       (STConcat xs') => STConcat (x :: xs')
-      y => y
+      y => STConcat [x, y]
     flatten x = x
 
     internalError : SimpleDocTree ann

--- a/src/Libraries/Text/PrettyPrint/Prettyprinter/SimpleDocTree.idr
+++ b/src/Libraries/Text/PrettyPrint/Prettyprinter/SimpleDocTree.idr
@@ -87,7 +87,7 @@ fromStream sdoc = case sdocToTreeParser sdoc of
     flatten (STConcat [x, STEmpty]) = flatten x
     flatten (STConcat [x, STConcat xs]) = case flatten (STConcat xs) of
       (STConcat xs') => STConcat (x :: xs')
-      y => y
+      y => STConcat [x, y]
     flatten x = x
 
     internalError : SimpleDocTree ann


### PR DESCRIPTION
When flattening the `SimpleDocTree` created from a `SimpleDocStream`, the
first part of a concatenated doc is sometimes dropped, depending on the
result of the recursive call to `flatten`.

Can be reproduced by:
`idris2 -p idris2` (Same bug is in corresponding module in `contrib`):

```idris
:module Libraries.Text.PrettyPrint.Prettyprinter.Doc
:module Libraries.Text.PrettyPrint.Prettyprinter.SimpleDocTree
fromStream $ SText 5 "first" (SText 6 "second" SEmpty)
```

Current result: `STText 6 "second"`

Result after this fix: `STConcat [STText 5 "first", STText 6 "second"]`