### PR TITLE
Add identity cast

### DIFF
--- a/libs/prelude/Prelude/Cast.idr
+++ b/libs/prelude/Prelude/Cast.idr
@@ -17,7 +17,7 @@ interface Cast from to where
   ||| Perform a (potentially lossy!) cast operation.
   ||| @ orig The original type
   cast : (orig : from) -> to
-  
+
 export
 Cast a a where
   cast = id

--- a/libs/prelude/Prelude/Cast.idr
+++ b/libs/prelude/Prelude/Cast.idr
@@ -17,6 +17,10 @@ interface Cast from to where
   ||| Perform a (potentially lossy!) cast operation.
   ||| @ orig The original type
   cast : (orig : from) -> to
+  
+export
+Cast a a where
+  cast = id
 
 -- To String
 


### PR DESCRIPTION
Add an implementation for `Cast a a` for a more comfortable use of `Cast` interface in implementation of functions, independent of exact input type.