### PR TITLE
[ fix ] print infix operators with parens

### DIFF
--- a/src/Idris/DocString.idr
+++ b/src/Idris/DocString.idr
@@ -27,6 +27,8 @@ import Libraries.Control.ANSI.SGR
 import public Libraries.Text.PrettyPrint.Prettyprinter
 import public Libraries.Text.PrettyPrint.Prettyprinter.Util
 
+import Parser.Lexer.Source
+
 public export
 data IdrisDocAnn
   = TCon
@@ -126,6 +128,11 @@ getDocsForName fc n
                Unchecked => ""
                _ => header "Totality" <++> pretty tot
 
+    prettyName : Name -> Doc IdrisDocAnn
+    prettyName n =
+      let root = nameRoot n in
+      if isOpName n then parens (pretty root) else pretty root
+
     getDConDoc : Name -> Core (List (Doc IdrisDocAnn))
     getDConDoc con
         = do defs <- get Ctxt
@@ -136,7 +143,7 @@ getDocsForName fc n
                   | _ => pure []
              ty <- resugar [] =<< normaliseHoles defs [] (type def)
              pure $ pure $ vcat $
-               hsep [dCon (pretty (nameRoot n)), colon, pretty (show ty)]
+               hsep [dCon (prettyName n), colon, pretty (show ty)]
                :: reflowDoc str
 
     getImplDoc : Name -> Core (List (Doc IdrisDocAnn))
@@ -153,9 +160,9 @@ getDocsForName fc n
              let [(n, str)] = lookupName meth.name (docstrings syn)
                   | _ => pure []
              ty <- pterm meth.type
-             let nm = nameRoot meth.name
+             let nm = prettyName meth.name
              pure $ pure $ vcat $
-               [hsep [fun (pretty nm), colon, pretty (show ty)]]
+               [hsep [fun nm, colon, pretty (show ty)]]
                ++ toList (indent 2 . pretty . show <$> meth.totalReq)
                ++ reflowDoc str
 

--- a/tests/idris2/docs001/expected
+++ b/tests/idris2/docs001/expected
@@ -17,7 +17,7 @@ Main> Prelude.List : Type -> Type
   Constructors:
     Nil : List a
       Empty list
-    :: : a -> List a -> List a
+    (::) : a -> List a -> List a
 Main> Prelude.Show : Type -> Type
   Things that have a canonical `String` representation.
   Parameters: ty
@@ -64,7 +64,7 @@ Main> Prelude.Monad : (Type -> Type) -> Type
   Parameters: m
   Constraints: Applicative m
   Methods:
-    >>= : m a -> (a -> m b) -> m b
+    (>>=) : m a -> (a -> m b) -> m b
       Also called `bind`.
     join : m (m a) -> m a
       Also called `flatten` or mu.

--- a/tests/idris2/interactive030/expected
+++ b/tests/idris2/interactive030/expected
@@ -22,7 +22,7 @@ Main> Prelude.Monad : (Type -> Type) -> Type
   Parameters: m
   Constraints: Applicative m
   Methods:
-    >>= : m a -> (a -> m b) -> m b
+    (>>=) : m a -> (a -> m b) -> m b
       Also called `bind`.
     join : m (m a) -> m a
       Also called `flatten` or mu.


### PR DESCRIPTION
I noticed that e.g. List's (::) was not printed correctly in `:doc`
so here's a fix.