### PR TITLE
[ refactor ] type inference and evaluation for the REPL

### DIFF
--- a/idris2api.ipkg
+++ b/idris2api.ipkg
@@ -1,5 +1,4 @@
 package idris2
-version = 0.3.0
 
 modules =
     Algebra,

--- a/idris2api.ipkg
+++ b/idris2api.ipkg
@@ -1,4 +1,5 @@
 package idris2
+version = 0.3.0
 
 modules =
     Algebra,


### PR DESCRIPTION
This creates an `inferAndNormalize` function in `Idris/REPL.idr` that, given an evaluation mode and a `PTerm`, produces the term's type, its normal form, and the resugared version of its normal form. The idea is that other REPL commands and IDE actions, like refining a hole, will likely need this information, so the functionality can be shared.