### PR TITLE
Fix for wrong search results in the metadata name PosMap

### DIFF
--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -364,7 +364,7 @@ findInTree p hint m = map snd $ head' $ filter match $ sortBy (\x, y => cmp (mea
   where
     cmp : FileRange -> FileRange -> Ordering
     cmp ((sr1, sc1), (er1, ec1)) ((sr2, sc2), (er2, ec2)) =
-      compare (er1 - sr1, ec1 - sc1) (er2 - sr2, ec2 - sr2)
+      compare (er1 - sr1, ec1 - sc1) (er2 - sr2, ec2 - sc2)
 
     match : (NonEmptyFC, Name) -> Bool
     match (_, n) = matches hint n && userNameRoot n == userNameRoot hint


### PR DESCRIPTION
There was a typo (made by myself 😭) in `Idris.REPL.findInTree` which selects the best result while searching in the metadata `PosMap` of names, this led to some edge cases where it did not select the best answer.