### PR TITLE
Some tiny HTML doc fixes (including a fix for #1367)

### DIFF
--- a/src/Idris/Doc/HTML.idr
+++ b/src/Idris/Doc/HTML.idr
@@ -44,7 +44,7 @@ packageInternal _ = pure False
 
 prettyNameRoot : Name -> String
 prettyNameRoot n =
-  let root = nameRoot n in
+  let root = htmlEscape $ nameRoot n in
   if isOpName n then "(" ++ root ++ ")" else root
 
 renderHtml : {auto c : Ref Ctxt Defs} ->
@@ -53,7 +53,7 @@ renderHtml : {auto c : Ref Ctxt Defs} ->
 renderHtml STEmpty = pure neutral
 renderHtml (STChar ' ') = pure "&ensp;"
 renderHtml (STChar c) = pure $ cast c
-renderHtml (STText _ text) = pure text
+renderHtml (STText _ text) = pure $ htmlEscape text
 renderHtml (STLine _) = pure "<br>"
 renderHtml (STAnn Declarations rest) = pure $ "<dl class=\"decls\">" <+> !(renderHtml rest) <+> "</dl>"
 renderHtml (STAnn (Decl n) rest) = pure $ "<dt id=\"" ++ (htmlEscape $ show n) ++ "\">" <+> !(renderHtml rest) <+> "</dt>"

--- a/src/Idris/Doc/HTML.idr
+++ b/src/Idris/Doc/HTML.idr
@@ -51,6 +51,7 @@ renderHtml : {auto c : Ref Ctxt Defs} ->
              SimpleDocTree IdrisDocAnn ->
              Core String
 renderHtml STEmpty = pure neutral
+renderHtml (STChar ' ') = pure "&ensp;"
 renderHtml (STChar c) = pure $ cast c
 renderHtml (STText _ text) = pure text
 renderHtml (STLine _) = pure "<br>"

--- a/support/docs/styles.css
+++ b/support/docs/styles.css
@@ -157,7 +157,6 @@ dd.fixity {
 }
 
 .name {
-  display: table-cell;
   white-space: nowrap;
   width: 0;
 }


### PR DESCRIPTION
This includes fixes for the layout (weird indentation and missing spaces) in WebKit based browsers (e.g. Chrome mentioned in #1367), and a small fix to correctly escape operator names and text included in docstrings.