### PR TITLE
Allow `--directive` command line flag combined with package options

### DIFF
--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -655,6 +655,7 @@ partitionOpts opts = foldr pOptUpdate (MkPFR [] [] False) opts
     optType (DumpVMCode f)   = POpt
     optType DebugElabCheck   = POpt
     optType (SetCG f)        = POpt
+    optType (Directive d)    = POpt
     optType (BuildDir f)     = POpt
     optType (OutputDir f)    = POpt
     optType (ConsoleWidth n) = PIgnore
@@ -682,6 +683,7 @@ errorMsg = unlines
   , "    --dumpvmcode <file>"
   , "    --debug-elab-check"
   , "    --codegen <cg>"
+  , "    --directive <directive>"
   , "    --build-dir <dir>"
   , "    --output-dir <dir>"
   ]

--- a/tests/idris2/pkg003/expected
+++ b/tests/idris2/pkg003/expected
@@ -11,6 +11,7 @@ Overridable options are:
     --dumpvmcode <file>
     --debug-elab-check
     --codegen <cg>
+    --directive <directive>
     --build-dir <dir>
     --output-dir <dir>
 


### PR DESCRIPTION
The `--directive` flag is generally used to pass extra arguments/options to the code generator, since the codegen can be overridden for pkg opts, this should be allowed as well.