### PR TITLE
[ docs ] Improve HTML Output

### DIFF
--- a/src/Idris/DocString.idr
+++ b/src/Idris/DocString.idr
@@ -149,13 +149,15 @@ getDocsForName fc n
     getDConDoc con
         = do defs <- get Ctxt
              Just def <- lookupCtxtExact con (gamma defs)
+                  -- should never happen, since we know that the DCon exists:
                   | Nothing => pure Empty
              syn <- get Syn
-             let [(n, str)] = lookupName con (docstrings syn)
-                  | _ => pure Empty
              ty <- resugar [] =<< normaliseHoles defs [] (type def)
+             let conWithTypeDoc = annotate (Decl con) (hsep [dCon (prettyName con), colon, prettyTerm ty])
+             let [(n, str)] = lookupName con (docstrings syn)
+                  | _ => pure conWithTypeDoc
              pure $ vcat
-               [ annotate (Decl con) (hsep [dCon (prettyName n), colon, prettyTerm ty])
+               [ conWithTypeDoc
                , annotate DocStringBody $ vcat $ reflowDoc str
                ]
 

--- a/support/docs/styles.css
+++ b/support/docs/styles.css
@@ -94,7 +94,7 @@ p {
 }
 
 .decls {
-  margin-top: 15px;
+  margin-top: 5px;
 }
 
 .decls > dt {
@@ -111,7 +111,7 @@ p {
 }
 
 .decls > dd {
-  margin: 10px 0 10px 20px;
+  margin: 10px 0 20px 20px;
   font-family: Arial, sans-serif;
   font-size: 10pt;
 }

--- a/tests/idris2/docs002/Doc.idr
+++ b/tests/idris2/docs002/Doc.idr
@@ -13,6 +13,16 @@ export
 hello : Int -> Int
 hello x = x*2
 
+public export
+data WrappedInt : Type where
+  MkWrappedInt : Int -> WrappedInt
+
+public export
+record SimpleRec where
+  constructor MkSimpleRec
+  a : Int
+  b : String
+
 namespace NS
 
   namespace NestedNS

--- a/tests/idris2/docs002/expected
+++ b/tests/idris2/docs002/expected
@@ -1,9 +1,22 @@
 1/1: Building Doc (Doc.idr)
-Doc> hello : Int -> Int
+Doc> MkSimpleRec : Int -> String -> SimpleRec
+MkWrappedInt : Int -> WrappedInt
+SimpleRec : Type
+WrappedInt : Type
+a : SimpleRec -> Int
+b : SimpleRec -> String
+hello : Int -> Int
 	Hello!
 world : Nat -> Nat
 	World!
 Doc> Doc.NS.NestedNS.Foo : Type
   A type of Foo
   
+Doc> Doc.WrappedInt : Type
+  Totality: total
+  Constructor: MkWrappedInt : Int -> WrappedInt
+  
+Doc> Doc.SimpleRec : Type
+  Totality: total
+  Constructor: MkSimpleRec : Int -> String -> SimpleRec
 Doc> Bye for now!

--- a/tests/idris2/docs002/input
+++ b/tests/idris2/docs002/input
@@ -1,3 +1,5 @@
 :browse Doc
 :doc Foo
+:doc WrappedInt
+:doc SimpleRec
 :q


### PR DESCRIPTION
Data constructor docstrings where not wrapped in a `<dd>` tag, and therefore
where not indented correctly.

As a relict of the REPL output, several `<br>` tags where introduced,
where they are not needed or even permitted. This led to some spacing
issues (sometimes the docstring was closer to the next term than to the
one above that it actually described).

To counter the removed forced newlines, some extra margin is added below
each declaration.

As a side-effect, this also makes the W3 "Nu Html Checker" happy (at least for _some_ pages ;)