### PR TITLE
[ towards #1124 ] Statically enforced logging

### DIFF
--- a/src/Core/Context/Log.idr
+++ b/src/Core/Context/Log.idr
@@ -13,7 +13,9 @@ import System.Clock
 export
 logTerm : {vars : _} ->
           {auto c : Ref Ctxt Defs} ->
-          String -> Nat -> Lazy String -> Term vars -> Core ()
+          (s : String) ->
+          {auto 0 _ : KnownTopic s} ->
+          Nat -> Lazy String -> Term vars -> Core ()
 logTerm str n msg tm
     = do opts <- getSession
          let lvl = mkLogLevel (logEnabled opts) str n
@@ -35,21 +37,31 @@ log' lvl msg
 ||| high log level numbers for more granular logging.
 export
 log : {auto c : Ref Ctxt Defs} ->
-      String -> Nat -> Lazy String -> Core ()
+      (s : String) ->
+      {auto 0 _ : KnownTopic s} ->
+      Nat -> Lazy String -> Core ()
 log str n msg
     = do let lvl = mkLogLevel (logEnabled !getSession) str n
          log' lvl msg
 
 export
-logC : {auto c : Ref Ctxt Defs} ->
-       String -> Nat -> Core String -> Core ()
-logC str n cmsg
+unverifiedLogC : {auto c : Ref Ctxt Defs} ->
+                 (s : String) ->
+                 Nat -> Core String -> Core ()
+unverifiedLogC str n cmsg
     = do opts <- getSession
-         let lvl = mkLogLevel (logEnabled opts) str n
+         let lvl = mkUnverifiedLogLevel (logEnabled opts) str n
          if keepLog lvl (logEnabled opts) (logLevel opts)
             then do msg <- cmsg
                     coreLift $ putStrLn $ "LOG " ++ show lvl ++ ": " ++ msg
             else pure ()
+
+export
+logC : {auto c : Ref Ctxt Defs} ->
+       (s : String) ->
+       {auto 0 _ : KnownTopic s} ->
+       Nat -> Core String -> Core ()
+logC str = unverifiedLogC str
 
 export
 logTimeOver : Integer -> Core String -> Core a -> Core a

--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -769,4 +769,3 @@ readFile fname =
   coreLift (File.readFile fname) >>= \case
     Right content => pure content
     Left err => throw $ FileErr fname err
-

--- a/src/Core/Normalise.idr
+++ b/src/Core/Normalise.idr
@@ -1173,7 +1173,9 @@ getArity defs env tm = getValArity defs env !(nf defs env tm)
 export
 logNF : {vars : _} ->
         {auto c : Ref Ctxt Defs} ->
-        String -> Nat -> Lazy String -> Env Term vars -> NF vars -> Core ()
+        (s : String) ->
+        {auto 0 _ : KnownTopic s} ->
+        Nat -> Lazy String -> Env Term vars -> NF vars -> Core ()
 logNF str n msg env tmnf
     = do opts <- getSession
          let lvl = mkLogLevel (logEnabled opts) str n
@@ -1202,7 +1204,9 @@ logTermNF' lvl msg env tm
 export
 logTermNF : {vars : _} ->
             {auto c : Ref Ctxt Defs} ->
-            String -> Nat -> Lazy String -> Env Term vars -> Term vars -> Core ()
+            (s : String) ->
+            {auto 0 _ : KnownTopic s} ->
+            Nat -> Lazy String -> Env Term vars -> Term vars -> Core ()
 logTermNF str n msg env tm
     = do let lvl = mkLogLevel (logEnabled !getSession) str n
          logTermNF' lvl msg env tm
@@ -1210,7 +1214,9 @@ logTermNF str n msg env tm
 export
 logGlue : {vars : _} ->
           {auto c : Ref Ctxt Defs} ->
-          String -> Nat -> Lazy String -> Env Term vars -> Glued vars -> Core ()
+          (s : String) ->
+          {auto 0 _ : KnownTopic s} ->
+          Nat -> Lazy String -> Env Term vars -> Glued vars -> Core ()
 logGlue str n msg env gtm
     = do opts <- getSession
          let lvl = mkLogLevel (logEnabled opts) str n
@@ -1224,7 +1230,9 @@ logGlue str n msg env gtm
 export
 logGlueNF : {vars : _} ->
             {auto c : Ref Ctxt Defs} ->
-            String -> Nat -> Lazy String -> Env Term vars -> Glued vars -> Core ()
+            (s : String) ->
+            {auto 0 _ : KnownTopic s} ->
+            Nat -> Lazy String -> Env Term vars -> Glued vars -> Core ()
 logGlueNF str n msg env gtm
     = do opts <- getSession
          let lvl = mkLogLevel (logEnabled opts) str n
@@ -1239,7 +1247,9 @@ logGlueNF str n msg env gtm
 export
 logEnv : {vars : _} ->
          {auto c : Ref Ctxt Defs} ->
-         String -> Nat -> String -> Env Term vars -> Core ()
+         (s : String) ->
+         {auto 0 _ : KnownTopic s} ->
+         Nat -> String -> Env Term vars -> Core ()
 logEnv str n msg env
     = do opts <- getSession
          when (logEnabled opts &&

--- a/src/Core/Options/Log.idr
+++ b/src/Core/Options/Log.idr
@@ -34,7 +34,7 @@ import Libraries.Text.PrettyPrint.Prettyprinter
 ----------------------------------------------------------------------------------
 -- INDIVIDUAL LOG LEVEL
 
-public export 
+public export
 knownTopics : List (String,String)
 knownTopics = [
     ("", "some documentation of this option"),

--- a/src/Core/Options/Log.idr
+++ b/src/Core/Options/Log.idr
@@ -1,8 +1,8 @@
 module Core.Options.Log
 
-import Data.List
+import public Data.List
 import Data.List1
-import Data.Maybe
+import public Data.Maybe
 import Libraries.Data.StringMap
 import Libraries.Data.StringTrie
 import Data.Strings
@@ -34,6 +34,124 @@ import Libraries.Text.PrettyPrint.Prettyprinter
 ----------------------------------------------------------------------------------
 -- INDIVIDUAL LOG LEVEL
 
+public export 
+knownTopics : List (String,String)
+knownTopics = [
+    ("", "some documentation of this option"),
+    ("auto", "some documentation of this option"),
+    ("builtin.Natural", "some documentation of this option"),
+    ("builtin.Natural.addTransform", "some documentation of this option"),
+    ("builtin.NaturalToInteger", "some documentation of this option"),
+    ("builtin.NaturalToInteger.addTransforms", "some documentation of this option"),
+    ("compile.casetree", "some documentation of this option"),
+    ("compiler.inline.eval", "some documentation of this option"),
+    ("compiler.refc", "some documentation of this option"),
+    ("compiler.refc.cc", "some documentation of this option"),
+    ("compiler.scheme.chez", "some documentation of this option"),
+    ("coverage", "some documentation of this option"),
+    ("coverage.empty", "some documentation of this option"),
+    ("coverage.missing", "some documentation of this option"),
+    ("coverage.recover", "some documentation of this option"),
+    ("declare.data", "some documentation of this option"),
+    ("declare.data.constructor", "some documentation of this option"),
+    ("declare.data.parameters", "some documentation of this option"),
+    ("declare.def", "some documentation of this option"),
+    ("declare.def.clause", "some documentation of this option"),
+    ("declare.def.clause.impossible", "some documentation of this option"),
+    ("declare.def.clause.with", "some documentation of this option"),
+    ("declare.def.impossible", "some documentation of this option"),
+    ("declare.def.lhs", "some documentation of this option"),
+    ("declare.def.lhs.implicits", "some documentation of this option"),
+    ("declare.param", "some documentation of this option"),
+    ("declare.record", "some documentation of this option"),
+    ("declare.record.field", "some documentation of this option"),
+    ("declare.record.projection", "some documentation of this option"),
+    ("declare.record.projection.prefix", "some documentation of this option"),
+    ("declare.type", "some documentation of this option"),
+    ("desugar.idiom", "some documentation of this option"),
+    ("doc.record", "some documentation of this option"),
+    ("elab", "some documentation of this option"),
+    ("elab.ambiguous", "some documentation of this option"),
+    ("elab.app.lhs", "some documentation of this option"),
+    ("elab.as", "some documentation of this option"),
+    ("elab.bindnames", "some documentation of this option"),
+    ("elab.binder", "some documentation of this option"),
+    ("elab.case", "some documentation of this option"),
+    ("elab.def.local", "some documentation of this option"),
+    ("elab.delay", "some documentation of this option"),
+    ("elab.hole", "some documentation of this option"),
+    ("elab.implicits", "some documentation of this option"),
+    ("elab.implementation", "some documentation of this option"),
+    ("elab.interface", "some documentation of this option"),
+    ("elab.interface.default", "some documentation of this option"),
+    ("elab.local", "some documentation of this option"),
+    ("elab.prun", "some documentation of this option"),
+    ("elab.prune", "some documentation of this option"),
+    ("elab.record", "some documentation of this option"),
+    ("elab.retry", "some documentation of this option"),
+    ("elab.rewrite", "some documentation of this option"),
+    ("elab.unify", "some documentation of this option"),
+    ("elab.update", "some documentation of this option"),
+    ("elab.with", "some documentation of this option"),
+    ("eval.casetree", "some documentation of this option"),
+    ("eval.casetree.stuck", "some documentation of this option"),
+    ("eval.eta", "some documentation of this option"),
+    ("eval.stuck", "some documentation of this option"),
+    ("idemode.hole", "some documentation of this option"),
+    ("ide-mode.highlight", "some documentation of this option"),
+    ("ide-mode.highlight.alias", "some documentation of this option"),
+    ("ide-mode.send", "some documentation of this option"),
+    ("import", "some documentation of this option"),
+    ("import.file", "some documentation of this option"),
+    ("interaction.casesplit", "some documentation of this option"),
+    ("interaction.generate", "some documentation of this option"),
+    ("interaction.search", "some documentation of this option"),
+    ("metadata.names", "some documentation of this option"),
+    ("quantity", "some documentation of this option"),
+    ("quantity.hole", "some documentation of this option"),
+    ("quantity.hole.update", "some documentation of this option"),
+    ("repl.eval", "some documentation of this option"),
+    ("specialise", "some documentation of this option"),
+    ("totality", "some documentation of this option"),
+    ("totality.positivity", "some documentation of this option"),
+    ("totality.termination", "some documentation of this option"),
+    ("totality.termination.calc", "some documentation of this option"),
+    ("totality.termination.guarded", "some documentation of this option"),
+    ("totality.termination.sizechange", "some documentation of this option"),
+    ("totality.termination.sizechange.checkCall", "some documentation of this option"),
+    ("totality.termination.sizechange.checkCall.inPath", "some documentation of this option"),
+    ("totality.termination.sizechange.checkCall.inPathNot.restart", "some documentation of this option"),
+    ("totality.termination.sizechange.checkCall.inPathNot.return", "some documentation of this option"),
+    ("totality.termination.sizechange.inPath", "some documentation of this option"),
+    ("totality.termination.sizechange.isTerminating", "some documentation of this option"),
+    ("totality.termination.sizechange.needsChecking", "some documentation of this option"),
+    ("ttc.read", "some documentation of this option"),
+    ("ttc.write", "some documentation of this option"),
+    ("typesearch.equiv", "some documentation of this option"),
+    ("unelab.case", "some documentation of this option"),
+    ("unify", "some documentation of this option"),
+    ("unify.application", "some documentation of this option"),
+    ("unify.binder", "some documentation of this option"),
+    ("unify.constant", "some documentation of this option"),
+    ("unify.constraint", "some documentation of this option"),
+    ("unify.delay", "some documentation of this option"),
+    ("unify.equal", "some documentation of this option"),
+    ("unify.head", "some documentation of this option"),
+    ("unify.hole", "some documentation of this option"),
+    ("unify.instantiate", "some documentation of this option"),
+    ("unify.invertible", "some documentation of this option"),
+    ("unify.meta", "some documentation of this option"),
+    ("unify.noeta", "some documentation of this option"),
+    ("unify.postpone", "some documentation of this option"),
+    ("unify.retry", "some documentation of this option"),
+    ("unify.search", "some documentation of this option"),
+    ("unify.unsolved", "some documentation of this option")
+]
+
+public export
+KnownTopic : String -> Type
+KnownTopic s = IsJust (lookup s knownTopics)
+
 ||| An individual log level is a pair of a list of non-empty strings and a number.
 ||| We keep the representation opaque to force users to call the smart constructor
 export
@@ -49,11 +167,24 @@ mkLogLevel' ps n = MkLogLevel (maybe [] forget ps) n
 ||| The smart constructor makes sure that the empty string is mapped to the empty
 ||| list. This bypasses the fact that the function `split` returns a non-empty
 ||| list no matter what.
+|||
+||| However, invoking this function comes without guarantees that
+||| the passed string corresponds to a known topic. For this,
+||| use `mkLogLevel`.
+|||
+||| Use this function to create user defined loglevels, for instance, during
+||| elaborator reflection.
 export
-mkLogLevel : Bool -> String -> Nat -> LogLevel
-mkLogLevel False _ = mkLogLevel' Nothing
-mkLogLevel _ "" = mkLogLevel' Nothing
-mkLogLevel _ ps = mkLogLevel' (Just (split (== '.') ps))
+mkUnverifiedLogLevel : Bool -> (s : String) -> Nat -> LogLevel
+mkUnverifiedLogLevel False _ = mkLogLevel' Nothing
+mkUnverifiedLogLevel _ "" = mkLogLevel' Nothing
+mkUnverifiedLogLevel _ ps = mkLogLevel' (Just (split (== '.') ps))
+
+||| Like `mkUnverifiedLogLevel` but with a compile time check that
+||| the passed string is a known topic.
+export
+mkLogLevel : Bool -> (s : String) -> {auto 0 _ : KnownTopic s} -> Nat -> LogLevel
+mkLogLevel b s = mkUnverifiedLogLevel b s
 
 ||| The unsafe constructor should only be used in places where the topic has already
 ||| been appropriately processed.
@@ -99,7 +230,7 @@ parseLogLevel str = do
                 ns = tail nns in
                 case ns of
                      [] => pure (MkLogLevel [], n)
-                     [ns] => pure (mkLogLevel True n, ns)
+                     [ns] => pure (mkUnverifiedLogLevel True n, ns)
                      _ => Nothing
   lvl <- parsePositive n
   pure $ c (fromInteger lvl)

--- a/src/Core/Options/Log.idr
+++ b/src/Core/Options/Log.idr
@@ -37,7 +37,6 @@ import Libraries.Text.PrettyPrint.Prettyprinter
 public export
 knownTopics : List (String,String)
 knownTopics = [
-    ("", "some documentation of this option"),
     ("auto", "some documentation of this option"),
     ("builtin.Natural", "some documentation of this option"),
     ("builtin.Natural.addTransform", "some documentation of this option"),
@@ -107,6 +106,7 @@ knownTopics = [
     ("interaction.generate", "some documentation of this option"),
     ("interaction.search", "some documentation of this option"),
     ("metadata.names", "some documentation of this option"),
+    ("module.hash", "some documentation of this option"),
     ("quantity", "some documentation of this option"),
     ("quantity.hole", "some documentation of this option"),
     ("quantity.hole.update", "some documentation of this option"),
@@ -125,6 +125,8 @@ knownTopics = [
     ("totality.termination.sizechange.inPath", "some documentation of this option"),
     ("totality.termination.sizechange.isTerminating", "some documentation of this option"),
     ("totality.termination.sizechange.needsChecking", "some documentation of this option"),
+    ("transform.lhs", "some documentation of this option"),
+    ("transform.rhs", "some documentation of this option"),
     ("ttc.read", "some documentation of this option"),
     ("ttc.write", "some documentation of this option"),
     ("typesearch.equiv", "some documentation of this option"),

--- a/src/Core/Unify.idr
+++ b/src/Core/Unify.idr
@@ -1135,14 +1135,14 @@ mutual
   dumpArg env (MkClosure opts loc lenv tm)
       = do defs <- get Ctxt
            empty <- clearDefs defs
-           logTerm "" 0 "Term: " tm
+           logTerm "unify" 20 "Term: " tm
            nf <- evalClosure empty (MkClosure opts loc lenv tm)
-           logNF "" 0 "  " env nf
+           logNF "unify" 20 "  " env nf
   dumpArg env cl
       = do defs <- get Ctxt
            empty <- clearDefs defs
            nf <- evalClosure empty cl
-           logNF "" 0 "  " env nf
+           logNF "unify" 20 "  " env nf
 
   export
   unifyNoEta : {auto c : Ref Ctxt Defs} ->
@@ -1161,11 +1161,11 @@ mutual
                      -- may prove useful again...
                      {-
                      when (logging ust) $
-                        do log "" 0 $ "Constructor " ++ show !(toFullNames x) ++ " " ++ show loc
-                           log "" 0 "ARGUMENTS:"
+                        do log "unify" 20 $ "Constructor " ++ show !(toFullNames x) ++ " " ++ show loc
+                           log "unify" 20 "ARGUMENTS:"
                            defs <- get Ctxt
                            traverse_ (dumpArg env) xs
-                           log "" 0 "WITH:"
+                           log "unify" 20 "WITH:"
                            traverse_ (dumpArg env) ys
                      -}
                      unifyArgs mode loc env (map snd xs) (map snd ys)

--- a/src/Core/UnifyState.idr
+++ b/src/Core/UnifyState.idr
@@ -718,7 +718,9 @@ dumpHole' lvl hole
 export
 dumpConstraints : {auto u : Ref UST UState} ->
                   {auto c : Ref Ctxt Defs} ->
-                  (topics : String) -> (verbosity : Nat) ->
+                  (topics : String) ->
+                  {auto 0 _ : KnownTopic topics} ->
+                  (verbosity : Nat) ->
                   (all : Bool) ->
                   Core ()
 dumpConstraints str n all

--- a/src/Idris/IDEMode/Holes.idr
+++ b/src/Idris/IDEMode/Holes.idr
@@ -9,7 +9,7 @@ import Idris.Pretty
 
 import Idris.IDEMode.Commands
 
-import Libraries.Data.String.Extra
+import Libraries.Data.String.Extra as L
 import Libraries.Utils.Term
 
 %default covering
@@ -150,7 +150,7 @@ prettyHole defs env fn args ty
                             map (\premise => prettyRigHole premise.multiplicity
                                     <+> prettyImpBracket premise.isImplicit (prettyName premise.name <++> colon <++> prettyTerm premise.type))
                                     hdata.context) <+> hardline
-                    <+> (pretty $ replicate 30 '-') <+> hardline
+                    <+> (pretty $ L.replicate 30 '-') <+> hardline
                     <+> pretty (nameRoot $ hdata.name) <++> colon <++> prettyTerm hdata.type
 
 sexpPremise : HolePremise -> SExp

--- a/src/Idris/ProcessIdr.idr
+++ b/src/Idris/ProcessIdr.idr
@@ -238,11 +238,11 @@ processMod srcf ttcf msg sourcecode
 
         hs <- traverse readHash imps
         defs <- get Ctxt
-        log "" 5 $ "Current hash " ++ show (ifaceHash defs)
-        log "" 5 $ show (moduleNS modh) ++ " hashes:\n" ++
+        log "module.hash" 5 $ "Current hash " ++ show (ifaceHash defs)
+        log "module.hash" 5 $ show (moduleNS modh) ++ " hashes:\n" ++
                 show (sort (map snd hs))
         imphs <- readImportHashes ttcf
-        log "" 5 $ "Old hashes from " ++ ttcf ++ ":\n" ++ show (sort imphs)
+        log "module.hash" 5 $ "Old hashes from " ++ ttcf ++ ":\n" ++ show (sort imphs)
 
         -- If the old hashes are the same as the hashes we've just
         -- read from the imports, and the source file is older than

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -67,14 +67,14 @@ elabScript fc nest env (NDCon nfc nm t ar args) exp
     elabCon defs "LogMsg" [topic, verb, str]
         = do topic' <- evalClosure defs topic
              verb' <- evalClosure defs verb
-             logC !(reify defs topic') !(reify defs verb') $
+             unverifiedLogC !(reify defs topic') !(reify defs verb') $
                   do str' <- evalClosure defs str
                      reify defs str'
              scriptRet ()
     elabCon defs "LogTerm" [topic, verb, str, tm]
         = do topic' <- evalClosure defs topic
              verb' <- evalClosure defs verb
-             logC !(reify defs topic') !(reify defs verb') $
+             unverifiedLogC !(reify defs topic') !(reify defs verb') $
                   do str' <- evalClosure defs str
                      tm' <- evalClosure defs tm
                      pure $ !(reify defs str') ++ ": " ++

--- a/src/TTImp/ProcessTransform.idr
+++ b/src/TTImp/ProcessTransform.idr
@@ -27,9 +27,9 @@ processTransform eopts nest env fc tn_in lhs rhs
          tidx <- resolveName tn
          (_, (vars'  ** (sub', env', nest', lhstm, lhsty))) <-
              checkLHS True top True tidx eopts nest env fc lhs
-         logTerm "" 3 "Transform LHS" lhstm
+         logTerm "transform.lhs" 3 "Transform LHS" lhstm
          rhstm <- wrapError (InRHS fc tn_in) $
                        checkTermSub tidx InExpr (InTrans :: eopts) nest' env' env sub' rhs (gnf env' lhsty)
          clearHoleLHS
-         logTerm "" 3 "Transform RHS" rhstm
+         logTerm "transform.rhs" 3 "Transform RHS" rhstm
          addTransform fc (MkTransform tn env' lhstm rhstm)

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -1175,7 +1175,9 @@ mutual
 -- Log message with a RawImp
 export
 logRaw : {auto c : Ref Ctxt Defs} ->
-         String -> Nat -> Lazy String -> RawImp -> Core ()
+         (s : String) ->
+         {auto 0 _ : KnownTopic s} ->
+         Nat -> Lazy String -> RawImp -> Core ()
 logRaw str n msg tm
     = do opts <- getSession
          let lvl = mkLogLevel (logEnabled opts) str n

--- a/src/TTImp/WithClause.idr
+++ b/src/TTImp/WithClause.idr
@@ -32,7 +32,7 @@ addAlias : {auto m : Ref MD Metadata} ->
 addAlias from to =
   whenJust (isConcreteFC from) $ \ from =>
     whenJust (isConcreteFC to) $ \ to => do
-      log "ide-mode.highlighting.alias" 25 $
+      log "ide-mode.highlight.alias" 25 $
         "Adding alias: " ++ show from ++ " -> " ++ show to
       addSemanticAlias from to
 


### PR DESCRIPTION
This adds a type level check to most log calls to make sure that only known logging topics are used. Exceptions are allowed when topics are coming from client code, for instance during elab reflection.

The list of logging topics is now provably exhaustive (see also discussion in #1397), but the topics are not yet documented, nor is there any functionality for pretty printing all known topics.