### PR TITLE
Some small changes to get Idris 2 working on FreeBSD

### DIFF
--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -72,6 +72,7 @@ schHeader chez libs
     "; @generated\n" ++
     "(import (chezscheme))\n" ++
     "(case (machine-type)\n" ++
+    "  [(i3fb ti3fb a6fb ta6fb) #f]\n" ++
     "  [(i3le ti3le a6le ta6le) (load-shared-object \"libc.so.6\")]\n" ++
     "  [(i3osx ti3osx a6osx ta6osx) (load-shared-object \"libc.dylib\")]\n" ++
     "  [(i3nt ti3nt a6nt ta6nt) (load-shared-object \"msvcrt.dll\")" ++

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -144,6 +144,7 @@ cftySpec fc t = throw (GenericMsg fc ("Can't pass argument of type " ++ show t +
                          " to foreign function"))
 
 loadlib : String -> String -> String
+loadlib "libc" _ = "(define-ffi-definer define-libc (ffi-lib #f))"
 loadlib libn ver
     = "(define-ffi-definer define-" ++ libn ++
       " (ffi-lib \"" ++ libn ++ "\" " ++ ver ++ "))\n"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,10 @@
 INTERACTIVE ?= --interactive
-threads ?= `nproc`
+ifeq ($(shell uname), FreeBSD)
+	NPROC = sysctl -n hw.ncpu
+else
+	NPROC = nproc
+endif
+threads ?= `$(NPROC)`
 
 .PHONY: testbin test
 

--- a/tests/base/system_info001/run
+++ b/tests/base/system_info001/run
@@ -1,5 +1,9 @@
 rm -f expected
-echo "$(nproc) processors" > expected
+if [ "FreeBSD" = "$(uname)" ]; then
+  echo "$(sysctl -n hw.ncpu) processors" > expected
+else
+  echo "$(nproc) processors" > expected
+fi
 
 $1 --no-banner --no-color --console-width 0 NumProcessors.idr --exec main
 


### PR DESCRIPTION
Just a few small changes are required to enable building and installing on FreeBSD. The code then passes all tests on my machine.

For successful bootstrapping, the bootstrap code would need to be updated as well (built by the new compiler version). I think this can be done in a later PR (or just the next release).

The most "invasive" thing of this PR is the special-casing of "libc" FFI for the Racket backend, as it changes the codegen on all OSs. But I'm quite convinced, that this is the correct thing to do, as stated by the Racket documentation ([The Racket Foreign Interface > Loading Foreign Libraries](https://docs.racket-lang.org/foreign/Loading_Foreign_Libraries.html#%28def._%28%28lib._ffi%2Funsafe..rkt%29._ffi-lib%29%29)) (emphasis mine):

> If path is #f, then the resulting foreign-library value represents all libraries loaded in the current process, including libraries previously opened with ffi-lib. **In particular, use #f to access C-level functionality exported by the run-time system** (as described in Inside: Racket C API). The version argument is ignored when path is #f.
