### PR TITLE
[ totality ] Make `Language.Reflection` modules have `%default total`

### DIFF
--- a/libs/base/Language/Reflection.idr
+++ b/libs/base/Language/Reflection.idr
@@ -3,6 +3,8 @@ module Language.Reflection
 import public Language.Reflection.TT
 import public Language.Reflection.TTImp
 
+%default total
+
 ||| Elaboration scripts
 ||| Where types/terms are returned, binders will have unique, if not
 ||| necessarily human readabe, names
@@ -45,22 +47,18 @@ data Elab : Type -> Type where
      -- Check a group of top level declarations
      Declare : List Decl -> Elab ()
 
-mutual
-  export
-  Functor Elab where
-    map f e = do e' <- e
-                 pure (f e')
+export
+Functor Elab where
+  map f e = Bind e $ Pure . f
 
-  export
-  Applicative Elab where
-    pure = Pure
-    f <*> a = do f' <- f
-                 a' <- a
-                 pure (f' a')
+export
+Applicative Elab where
+  pure = Pure
+  f <*> a = Bind f (<$> a)
 
-  export
-  Monad Elab where
-    (>>=) = Bind
+export
+Monad Elab where
+  (>>=) = Bind
 
 ||| Report an error in elaboration
 export

--- a/libs/base/Language/Reflection/TT.idr
+++ b/libs/base/Language/Reflection/TT.idr
@@ -2,6 +2,8 @@ module Language.Reflection.TT
 
 import public Data.List
 
+%default total
+
 -- 'FilePos' represents the position of
 -- the source information in the file (or REPL).
 -- in the form of '(line-no, column-no)'.

--- a/libs/base/Language/Reflection/TTImp.idr
+++ b/libs/base/Language/Reflection/TTImp.idr
@@ -2,6 +2,8 @@ module Language.Reflection.TTImp
 
 import public Language.Reflection.TT
 
+%default total
+
 -- Unchecked terms and declarations in the intermediate language
 mutual
   public export


### PR DESCRIPTION
As soon as I have a total function that uses `Elab`'s monadic stuff, it's sad that totality checker is unsatisfied.

The original implementations could be preserved but with totality assertions, so why not to inline it all to have an equivalent implementation that satisfies the totality checker?