### PR TITLE
Add builtin.IntegerToNatural to knownTopics

### DIFF
--- a/src/Core/Options/Log.idr
+++ b/src/Core/Options/Log.idr
@@ -42,6 +42,7 @@ knownTopics = [
     ("builtin.Natural.addTransform", "some documentation of this option"),
     ("builtin.NaturalToInteger", "some documentation of this option"),
     ("builtin.NaturalToInteger.addTransforms", "some documentation of this option"),
+    ("builtin.IntegerToNatural", "some documentation of this option"),
     ("compile.casetree", "some documentation of this option"),
     ("compiler.inline.eval", "some documentation of this option"),
     ("compiler.refc", "some documentation of this option"),


### PR DESCRIPTION
Fixes broken master. Check "Require branches to be up to date before merging" to prevent this from happening again.