### PR TITLE
Store postponed unification problems as values

### DIFF
--- a/src/Core/Normalise.idr
+++ b/src/Core/Normalise.idr
@@ -708,6 +708,26 @@ export
 Quote Closure where
   quoteGen q defs env c = quoteGen q defs env !(evalClosure defs c)
 
+-- Resume a previously blocked normalisation with a new environment
+export
+continueNF : {auto c : Ref Ctxt Defs} ->
+             {vars : _} ->
+             Defs -> Env Term vars -> NF vars -> Core (NF vars)
+continueNF defs env stuck@(NApp fc (NRef nt fn) stk)
+    = evalRef defs defaultOpts env False fc nt fn stk stuck
+continueNF defs env (NApp fc (NMeta name idx args) stk)
+    = evalMeta defs defaultOpts env fc name idx args stk
+-- Next batch are already in normal form
+continueNF defs env nf@(NDCon fc x tag arity xs) = pure nf
+continueNF defs env nf@(NTCon fc x tag arity xs) = pure nf
+continueNF defs env nf@(NPrimVal fc x) = pure nf
+continueNF defs env nf@(NErased fc imp) = pure nf
+continueNF defs env nf@(NType fc) = pure nf
+-- For the rest, easiest just to quote and reevaluate
+continueNF defs env tm
+    = do empty <- clearDefs defs
+         nf defs env !(quote empty env tm)
+
 export
 glueBack : {auto c : Ref Ctxt Defs} ->
            {vars : _} ->

--- a/src/Core/Value.idr
+++ b/src/Core/Value.idr
@@ -6,6 +6,7 @@ import Core.Env
 import Core.TT
 
 import Libraries.Data.IntMap
+import Libraries.Data.NameMap
 
 %default covering
 
@@ -98,6 +99,64 @@ ntCon fc n tag Z [] = case isConstantType n of
   Just c => NPrimVal fc c
   Nothing => NTCon fc n tag Z []
 ntCon fc n tag arity args = NTCon fc n tag arity args
+
+-- Look for metavariables which, if later defined, will help unblock
+-- reduction
+mutual
+  export
+  addMetas : NameMap Bool -> NF vars -> NameMap Bool
+  addMetas ns (NBind fc x b sc)
+      = addMetas ns (binderType b) -- we won't be blocked on the scope
+  -- Arguments might be the cause of the blockage here
+  addMetas ns (NApp fc (NMeta n i args) xs)
+     = addMetaArgs (insert n False ns) (args ++ map snd xs)
+  addMetas ns (NApp fc x xs)
+     = addMetaArgs ns (map snd xs)
+  addMetas ns (NDCon fc x tag arity xs)
+     = addMetaArgs ns (map snd xs)
+  addMetas ns (NTCon fc x tag arity xs)
+     = addMetaArgs ns (map snd xs)
+  addMetas ns (NAs fc _ p t)
+    = addMetas (addMetas ns p) t
+  addMetas ns (NDelayed fc x tm)
+    = addMetas ns tm
+  addMetas ns (NDelay fc x t y)
+    = addMetaC (addMetaC ns t) y
+  addMetas ns (NForce fc x t xs)
+    = addMetas (addMetaArgs ns (map snd xs)) t
+  addMetas ns (NPrimVal fc x) = ns
+  addMetas ns (NErased fc imp) = ns
+  addMetas ns (NType fc) = ns
+
+  addEnvMetas : NameMap Bool -> Env Term vars -> NameMap Bool
+  addEnvMetas ns [] = ns
+  addEnvMetas ns (Let _ _ val _ :: env) = addEnvMetas (addMetas ns val) env
+  addEnvMetas ns (_ :: env) = addEnvMetas ns env
+
+  addMetaC : NameMap Bool -> Closure vars ->
+             NameMap Bool
+  addMetaC ns (MkClosure {vars=tvars} opts locs env' tm) = addMetas ns tm
+  addMetaC ns (MkNFClosure x) = addMetas ns x
+
+  addMetaLocalEnv : NameMap Bool -> List (Closure vars) -> NameMap Bool
+  addMetaLocalEnv ns (MkClosure _ locs _ _ :: _)
+      = addMetaArgs ns (getClosures locs)
+    where
+      getClosures : LocalEnv f vs -> List (Closure f)
+      getClosures [] = []
+      getClosures (c :: ls) = c :: getClosures ls
+  addMetaLocalEnv ns (_ :: cs) = addMetaLocalEnv ns cs
+  addMetaLocalEnv ns [] = ns
+
+  addMetaArgs : NameMap Bool -> List (Closure vars) ->
+                NameMap Bool
+  addMetaArgs ns [] = ns
+  addMetaArgs ns (c :: xs)
+      = addMetaLocalEnv (addMetaArgs (addMetaC ns c) xs) (c :: xs)
+
+export
+getMetas : NF vars -> NameMap Bool
+getMetas tm = addMetas empty tm
 
 export
 getLoc : NF vars -> FC

--- a/src/Idris/ProcessIdr.idr
+++ b/src/Idris/ProcessIdr.idr
@@ -56,7 +56,7 @@ processDecls decls
              | Just err => pure (case mapMaybe id xs of
                                       [] => [err]
                                       errs => errs)
-         errs <- getTotalityErrors
+         errs <- logTime ("+++ Totality check overall") getTotalityErrors
          pure (mapMaybe id xs ++ errs)
 
 readModule : {auto c : Ref Ctxt Defs} ->

--- a/src/TTImp/Elab.idr
+++ b/src/TTImp/Elab.idr
@@ -129,11 +129,11 @@ elabTermSub {vars} defining mode opts nest env env' sub tm ty
          logTerm "elab" 5 "Looking for delayed in " chktm
          ust <- get UST
          catch (retryDelayed (sortBy (\x, y => compare (fst x) (fst y))
-                                     (delayedElab ust)))
-               (\err =>
-                  do ust <- get UST
-                     put UST (record { delayedElab = olddelayed } ust)
-                     throw err)
+                                       (delayedElab ust)))
+                 (\err =>
+                    do ust <- get UST
+                       put UST (record { delayedElab = olddelayed } ust)
+                       throw err)
          ust <- get UST
          put UST (record { delayedElab = olddelayed } ust)
          solveConstraintsAfter constart solvemode MatchArgs

--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -445,7 +445,8 @@ checkClause {vars} mult vis totreq hashit n opts nest env (PatClause fc lhs_in r
          log "declare.def.clause" 5 $ "Checking RHS " ++ show rhs
          logEnv "declare.def.clause" 5 "In env" env'
 
-         rhstm <- wrapErrorC opts (InRHS fc !(getFullName (Resolved n))) $
+         rhstm <- logTime ("+++ Check RHS " ++ show fc) $
+                    wrapErrorC opts (InRHS fc !(getFullName (Resolved n))) $
                        checkTermSub n rhsMode opts nest' env' env sub' rhs (gnf env' lhsty')
          clearHoleLHS
 

--- a/tests/ttimp/basic003/expected
+++ b/tests/ttimp/basic003/expected
@@ -1,8 +1,8 @@
 Processing as TTImp
 Written TTC
-Yaffle> Main.foo : (%pi Rig0 Explicit (Just m) Main.Nat (%pi Rig0 Explicit (Just a) %type (%pi Rig0 Explicit (Just {k:26}) Main.Nat (%pi RigW Explicit Nothing a (%pi RigW Explicit Nothing ((Main.Vect {k:26}) a) (%pi RigW Explicit Nothing ((Main.Vect m) a) (%pi Rig0 Explicit (Just _) Main.Nat ((Main.Vect ((Main.plus {k:26}) m)) a))))))))
+Yaffle> Main.foo : (%pi Rig0 Explicit (Just m) Main.Nat (%pi Rig0 Explicit (Just a) %type (%pi Rig0 Explicit (Just {k:25}) Main.Nat (%pi RigW Explicit Nothing a (%pi RigW Explicit Nothing ((Main.Vect {k:25}) a) (%pi RigW Explicit Nothing ((Main.Vect m) a) (%pi Rig0 Explicit (Just _) Main.Nat ((Main.Vect ((Main.plus {k:25}) m)) a))))))))
 Yaffle> Bye for now!
 Processing as TTC
 Read TTC
-Yaffle> Main.foo : (%pi Rig0 Explicit (Just m) Main.Nat (%pi Rig0 Explicit (Just a) %type (%pi Rig0 Explicit (Just {k:26}) Main.Nat (%pi RigW Explicit Nothing a (%pi RigW Explicit Nothing ((Main.Vect {k:26}) a) (%pi RigW Explicit Nothing ((Main.Vect m) a) (%pi Rig0 Explicit (Just _) Main.Nat ((Main.Vect ((Main.plus {k:26}) m)) a))))))))
+Yaffle> Main.foo : (%pi Rig0 Explicit (Just m) Main.Nat (%pi Rig0 Explicit (Just a) %type (%pi Rig0 Explicit (Just {k:25}) Main.Nat (%pi RigW Explicit Nothing a (%pi RigW Explicit Nothing ((Main.Vect {k:25}) a) (%pi RigW Explicit Nothing ((Main.Vect m) a) (%pi Rig0 Explicit (Just _) Main.Nat ((Main.Vect ((Main.plus {k:25}) m)) a))))))))
 Yaffle> Bye for now!

--- a/tests/ttimp/basic006/expected
+++ b/tests/ttimp/basic006/expected
@@ -2,5 +2,5 @@ Processing as TTImp
 Written TTC
 Yaffle> ((Main.Just [a = ((Main.Vect.Vect (Main.S Main.Z)) Integer)]) ((((Main.Vect.Cons [k = Main.Z]) [a = Integer]) 1) (Main.Vect.Nil [a = Integer])))
 Yaffle> ((Main.MkInfer [a = (Main.List.List Integer)]) (((Main.List.Cons [a = Integer]) 1) (Main.List.Nil [a = Integer])))
-Yaffle> (repl):1:9--1:12:Ambiguous elaboration [($resolved383 ?Main.{a:62}_[]), ($resolved363 ?Main.{a:62}_[])]
+Yaffle> (repl):1:9--1:12:Ambiguous elaboration [($resolved381 ?Main.{a:59}_[]), ($resolved362 ?Main.{a:59}_[])]
 Yaffle> Bye for now!

--- a/tests/ttimp/coverage002/expected
+++ b/tests/ttimp/coverage002/expected
@@ -2,6 +2,6 @@ Processing as TTImp
 Written TTC
 Yaffle> Main.lookup: All cases covered
 Yaffle> Main.lookup':
-($resolved410 [__] [__] ($resolved376 [__]) {_:62})
+($resolved408 [__] [__] ($resolved376 [__]) {_:59})
 Yaffle> Main.lookup'': Calls non covering function Main.lookup'
 Yaffle> Bye for now!

--- a/tests/ttimp/eta001/expected
+++ b/tests/ttimp/eta001/expected
@@ -1,5 +1,5 @@
 Processing as TTImp
 Written TTC
-Yaffle> ((Main.Refl [{b:10} = Main.Nat]) [x = (Main.S (Main.S (Main.S (Main.S Main.Z))))])
+Yaffle> ((Main.Refl [{b:9} = Main.Nat]) [x = (Main.S (Main.S (Main.S (Main.S Main.Z))))])
 Yaffle> Main.etaGood1 : ((((Main.Eq [b = (%pi RigW Explicit Nothing Integer (%pi RigW Explicit Nothing Integer Main.Test))]) [a = (%pi RigW Explicit Nothing Integer (%pi RigW Explicit Nothing Integer Main.Test))]) Main.MkTest) (%lam RigW Explicit (Just x) Integer (%lam RigW Explicit (Just y) Integer ((Main.MkTest x) y))))
 Yaffle> Bye for now!

--- a/tests/ttimp/eta002/expected
+++ b/tests/ttimp/eta002/expected
@@ -1,5 +1,5 @@
 Processing as TTImp
 Eta.yaff:16:1--17:1:When elaborating right hand side of Main.etaBad:
-Eta.yaff:16:10--17:1:When unifying: (Main.Eq ({arg:11} : Integer) -> ({arg:12} : Integer) -> Main.Test)) ({arg:11} : Integer) -> ({arg:12} : Integer) -> Main.Test)) \(x : Char) => \(y : ?Main.{_:15}_[x[0]]) => (Main.MkTest x[1] y[0]) \(x : Char) => \(y : ?Main.{_:15}_[x[0]]) => (Main.MkTest x[1] y[0])) and (Main.Eq (x : Char) -> (y : ?Main.{_:15}_[x[0]]) -> Main.Test)) ({arg:11} : Integer) -> ({arg:12} : Integer) -> Main.Test)) Main.MkTest \(x : Char) => \(y : ?Main.{_:15}_[x[0]]) => (Main.MkTest x[1] y[0]))
+Eta.yaff:16:10--17:1:When unifying: (Main.Eq ({arg:10} : Integer) -> ({arg:11} : Integer) -> Main.Test)) ({arg:10} : Integer) -> ({arg:11} : Integer) -> Main.Test)) \(x : Char) => \(y : ?Main.{_:14}_[x[0]]) => (Main.MkTest x[1] y[0]) \(x : Char) => \(y : ?Main.{_:14}_[x[0]]) => (Main.MkTest x[1] y[0])) and (Main.Eq (x : Char) -> (y : ?Main.{_:14}_[x[0]]) -> Main.Test)) ({arg:10} : Integer) -> ({arg:11} : Integer) -> Main.Test)) Main.MkTest \(x : Char) => \(y : ?Main.{_:14}_[x[0]]) => (Main.MkTest x[1] y[0]))
 	Eta.yaff:16:10--17:1:Type mismatch: Integer and Char
 Yaffle> Bye for now!


### PR DESCRIPTION
We stored them as equations between terms, I think because terms are easy to re-evaluate with new information, and because I thought we might want to save them out. It's not usually a problem to do that. However... Going back and forth between terms and values can be expensive if we're stuck in the middle of a complicated unification problem, the like of which can turn up a lot if your types are complicated. So, we need to be able to handle this.
Now store the postponed problems as NF, rather than Term, and add a function to resume evaluating a NF with an updated context.