### PR TITLE
[ perf ] Move unnecessary `toFullNames` calls under a `logC`

### DIFF
--- a/src/Core/Unify.idr
+++ b/src/Core/Unify.idr
@@ -1173,9 +1173,10 @@ mutual
                        (NDCon xfc x tagx ax xs)
                        (NDCon yfc y tagy ay ys)
   unifyNoEta mode loc env (NTCon xfc x tagx ax xs) (NTCon yfc y tagy ay ys)
-   = do x <- toFullNames x
-        y <- toFullNames y
-        log "unify" 20 $ "Comparing type constructors " ++ show x ++ " and " ++ show y
+   = do logC "unify" 20 $ do
+          x <- toFullNames x
+          y <- toFullNames y
+          pure $ "Comparing type constructors " ++ show x ++ " and " ++ show y
         if x == y
            then do let xs = map snd xs
                    let ys = map snd ys

--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -595,7 +595,7 @@ checkClause {vars} mult vis totreq hashit n opts nest env
       let eqName = NS builtinNS (UN "Equal")
       Just (TCon t ar _ _ _ _ _ _) <- lookupDefExact eqName (gamma defs)
         | _ => throw (InternalError "Cannot find builtin Equal")
-      let eqTyCon = Ref vfc (TyCon t ar) eqName
+      let eqTyCon = Ref vfc (TyCon t ar) !(toResolvedNames eqName)
 
       let wargn : Name
           wargn = MN "warg" 0


### PR DESCRIPTION
I assume `toFullNames` is injective?