### PR TITLE
A couple of small optimisations

### DIFF
--- a/src/Core/CaseBuilder.idr
+++ b/src/Core/CaseBuilder.idr
@@ -194,6 +194,10 @@ Weaken ArgType where
   weaken (Stuck fty) = Stuck (weaken fty)
   weaken Unknown = Unknown
 
+  weakenNs s (Known c ty) = Known c (weakenNs s ty)
+  weakenNs s (Stuck fty) = Stuck (weakenNs s fty)
+  weakenNs s Unknown = Unknown
+
 Weaken (PatInfo p) where
   weaken (MkInfo p el fty) = MkInfo p (Later el) (weaken fty)
 

--- a/src/Core/Normalise.idr
+++ b/src/Core/Normalise.idr
@@ -216,8 +216,11 @@ parameters (defs : Defs, topopts : EvalOpts)
                FC -> Name -> Int -> List (Closure free) ->
                Stack free -> Core (NF free)
     evalMeta env fc nm i args stk
-        = evalRef env True fc Func (Resolved i) (map (EmptyFC,) args ++ stk)
-                  (NApp fc (NMeta nm i args) stk)
+        = let args' = if isNil stk then map (EmptyFC,) args
+                         else map (EmptyFC,) args ++ stk
+                        in
+              evalRef env True fc Func (Resolved i) args'
+                          (NApp fc (NMeta nm i args) stk)
 
     -- The commented out logging here might still be useful one day, but
     -- evalRef is used a lot and even these tiny checks turn out to be

--- a/src/Core/Unify.idr
+++ b/src/Core/Unify.idr
@@ -865,7 +865,7 @@ mutual
   unifyHole swap mode loc env fc mname mref margs margs' tmnf
       = do defs <- get Ctxt
            empty <- clearDefs defs
-           let args = margs ++ margs'
+           let args = if isNil margs' then margs else margs ++ margs'
            logC "unify.hole" 10
                    (do args' <- traverse (evalArg empty) args
                        qargs <- traverse (quote empty env) args'

--- a/src/Core/UnifyState.idr
+++ b/src/Core/UnifyState.idr
@@ -28,7 +28,6 @@ data Constraint : Type where
      MkConstraint : {vars : _} ->
                     FC ->
                     (withLazy : Bool) ->
-                    (blockedOn : List Name) ->
                     (env : Env Term vars) ->
                     (x : NF vars) -> (y : NF vars) ->
                     Constraint
@@ -279,7 +278,7 @@ addDot fc env dotarg x reason y
          xnf <- nf defs env x
          ynf <- nf defs env y
          put UST (record { dotConstraints $=
-                             ((dotarg, reason, MkConstraint fc False [] env xnf ynf) ::)
+                             ((dotarg, reason, MkConstraint fc False env xnf ynf) ::)
                          } ust)
 
 mkConstantAppArgs : {vars : _} ->
@@ -562,7 +561,7 @@ checkValidHole base (idx, (fc, n))
                      let Just c = lookup con (constraints ust)
                           | Nothing => pure ()
                      case c of
-                          MkConstraint fc l blocked env x y =>
+                          MkConstraint fc l env x y =>
                              do put UST (record { guesses = empty } ust)
                                 empty <- clearDefs defs
                                 xnf <- quote empty env x
@@ -672,7 +671,7 @@ dumpHole' lvl hole
              case lookup n (constraints ust) of
                   Nothing => pure ()
                   Just Resolved => log' lvl "\tResolved"
-                  Just (MkConstraint _ lazy _ env x y) =>
+                  Just (MkConstraint _ lazy env x y) =>
                     do log' lvl $ "\t  " ++ show !(toFullNames !(quote defs env x))
                                        ++ " =?= " ++ show !(toFullNames !(quote defs env y))
                        empty <- clearDefs defs

--- a/src/TTImp/Elab/App.idr
+++ b/src/TTImp/Elab/App.idr
@@ -69,7 +69,7 @@ getNameType rigc env fc x
                  [(pname, i, def)] <- lookupCtxtName x (gamma defs)
                       | [] => undefinedName fc x
                       | ns => throw (AmbiguousName fc (map fst ns))
-                 checkVisibleNS fc !(getFullName pname) (visibility def)
+                 checkVisibleNS fc (fullname def) (visibility def)
                  rigSafe (multiplicity def) rigc
                  let nt = case definition def of
                                PMDef _ _ _ _ _ => Func


### PR DESCRIPTION
Actually one of them is more of an un-pessimisation, given the new way we store postponed unification problems. They are:

* reduce a few calls to ++ (tiny but I did it anyway)
* don't calculate blocked metavariable set, since it takes way longer than just resuming the problem with the new representation of postponed problems