### PR TITLE
[ re #1031 ] Disallow `?` patterns on the LHS

### DIFF
--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -73,7 +73,7 @@ idrisTestsError = MkTestPool "Error messages" []
       ["error001", "error002", "error003", "error004", "error005",
        "error006", "error007", "error008", "error009", "error010",
        "error011", "error012", "error013", "error014", "error015",
-       "error016", "error017",
+       "error016", "error017", "error018",
        -- Parse errors
        "perror001", "perror002", "perror003", "perror004", "perror005",
        "perror006", "perror007", "perror008"]

--- a/tests/idris2/error018/Issue1031-2.idr
+++ b/tests/idris2/error018/Issue1031-2.idr
@@ -1,0 +1,4 @@
+%default total
+
+foo : (x : Bool) -> x === True
+foo = \ ? => Refl

--- a/tests/idris2/error018/Issue1031-3.idr
+++ b/tests/idris2/error018/Issue1031-3.idr
@@ -1,0 +1,4 @@
+%default total
+
+cool : (x : Bool) -> x === True
+cool ? = Refl

--- a/tests/idris2/error018/Issue1031-4.idr
+++ b/tests/idris2/error018/Issue1031-4.idr
@@ -1,0 +1,4 @@
+%default total
+
+nice : (x : Bool) -> x === True
+nice .(_) = Refl

--- a/tests/idris2/error018/Issue1031.idr
+++ b/tests/idris2/error018/Issue1031.idr
@@ -1,0 +1,4 @@
+%default total
+
+ohNo : Void
+ohNo = let (? ** x) = the (a ** a) (Int ** 5) in x

--- a/tests/idris2/error018/expected
+++ b/tests/idris2/error018/expected
@@ -1,0 +1,40 @@
+1/1: Building Issue1031 (Issue1031.idr)
+Error: ? is not a valid pattern
+
+Issue1031.idr:4:13--4:14
+ 1 | %default total
+ 2 | 
+ 3 | ohNo : Void
+ 4 | ohNo = let (? ** x) = the (a ** a) (Int ** 5) in x
+                 ^
+
+1/1: Building Issue1031-2 (Issue1031-2.idr)
+Error: ? is not a valid pattern
+
+Issue1031-2.idr:4:9--4:10
+ 1 | %default total
+ 2 | 
+ 3 | foo : (x : Bool) -> x === True
+ 4 | foo = \ ? => Refl
+             ^
+
+1/1: Building Issue1031-3 (Issue1031-3.idr)
+Error: ? is not a valid pattern
+
+Issue1031-3.idr:4:6--4:7
+ 1 | %default total
+ 2 | 
+ 3 | cool : (x : Bool) -> x === True
+ 4 | cool ? = Refl
+          ^
+
+1/1: Building Issue1031-4 (Issue1031-4.idr)
+Error: While processing left hand side of nice. Unsolved holes:
+Main.{dotTm:308} introduced at: 
+Issue1031-4.idr:4:6--4:10
+ 1 | %default total
+ 2 | 
+ 3 | nice : (x : Bool) -> x === True
+ 4 | nice .(_) = Refl
+          ^^^^
+

--- a/tests/idris2/error018/run
+++ b/tests/idris2/error018/run
@@ -1,0 +1,6 @@
+$1 --no-color --console-width 0 --no-banner --check Issue1031.idr
+$1 --no-color --console-width 0 --no-banner --check Issue1031-2.idr
+$1 --no-color --console-width 0 --no-banner --check Issue1031-3.idr
+$1 --no-color --console-width 0 --no-banner --check Issue1031-4.idr
+
+rm -rf build/


### PR DESCRIPTION
Does not currently fix the fact that metavariables may be solved in the body of a
let-binding so the workaround using `.(_)` is unfortunately still accepted.