### PR TITLE
[ FFI ] Support new IntX types in foreign function types

### DIFF
--- a/src/Compiler/CompileExpr.idr
+++ b/src/Compiler/CompileExpr.idr
@@ -609,6 +609,10 @@ nfToCFType _ _ (NPrimVal _ Bits8Type) = pure CFUnsigned8
 nfToCFType _ _ (NPrimVal _ Bits16Type) = pure CFUnsigned16
 nfToCFType _ _ (NPrimVal _ Bits32Type) = pure CFUnsigned32
 nfToCFType _ _ (NPrimVal _ Bits64Type) = pure CFUnsigned64
+nfToCFType _ _ (NPrimVal _ Int8Type) = pure CFInt8
+nfToCFType _ _ (NPrimVal _ Int16Type) = pure CFInt16
+nfToCFType _ _ (NPrimVal _ Int32Type) = pure CFInt32
+nfToCFType _ _ (NPrimVal _ Int64Type) = pure CFInt64
 nfToCFType _ False (NPrimVal _ StringType) = pure CFString
 nfToCFType fc True (NPrimVal _ StringType)
     = throw (GenericMsg fc "String not allowed in a foreign struct")

--- a/src/Compiler/RefC/RefC.idr
+++ b/src/Compiler/RefC/RefC.idr
@@ -735,6 +735,7 @@ cTypeOfCFType (CFFun x y)     = "void *"
 cTypeOfCFType (CFIORes x)     = "void *"
 cTypeOfCFType (CFStruct x ys) = "void *"
 cTypeOfCFType (CFUser x ys)   = "void *"
+cTypeOfCFType n = assert_total $ idris_crash ("INTERNAL ERROR: Unknonw FFI type in C backend: " ++ show n)
 
 varNamesFromList : List ty -> Nat -> List String
 varNamesFromList str k = map (("var_" ++) . show) (getArgsNrList str k)
@@ -780,6 +781,7 @@ extractValue (CFIORes x)     varName = extractValue x varName
 extractValue (CFStruct x xs) varName = assert_total $ idris_crash ("INTERNAL ERROR: Struct access not implemented: " ++ varName)
 -- not really total but this way this internal error does not contaminate everything else
 extractValue (CFUser x xs)   varName = "(Value*)" ++ varName
+extractValue n _ = assert_total $ idris_crash ("INTERNAL ERROR: Unknonw FFI type in C backend: " ++ show n)
 
 packCFType : (cfType:CFType) -> (varName:String) -> String
 packCFType CFUnit          varName = "NULL"
@@ -799,6 +801,7 @@ packCFType (CFFun x y)     varName = "makeFunction(" ++ varName ++ ")"
 packCFType (CFIORes x)     varName = packCFType x varName
 packCFType (CFStruct x xs) varName = "makeStruct(" ++ varName ++ ")"
 packCFType (CFUser x xs)   varName = varName
+packCFType n _ = assert_total $ idris_crash ("INTERNAL ERROR: Unknonw FFI type in C backend: " ++ show n)
 
 discardLastArgument : List ty -> List ty
 discardLastArgument [] = []

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -177,6 +177,10 @@ data Structs : Type where
 cftySpec : FC -> CFType -> Core String
 cftySpec fc CFUnit = pure "void"
 cftySpec fc CFInt = pure "int"
+cftySpec fc CFInt8 = pure "integer-8"
+cftySpec fc CFInt16 = pure "integer-16"
+cftySpec fc CFInt32 = pure "integer-32"
+cftySpec fc CFInt64 = pure "integer-64"
 cftySpec fc CFUnsigned8 = pure "unsigned-8"
 cftySpec fc CFUnsigned16 = pure "unsigned-16"
 cftySpec fc CFUnsigned32 = pure "unsigned-32"

--- a/src/Compiler/Scheme/Gambit.idr
+++ b/src/Compiler/Scheme/Gambit.idr
@@ -152,6 +152,10 @@ cType fc t = throw (GenericMsg fc ("Can't pass argument of type " ++ show t ++
 cftySpec : FC -> CFType -> Core String
 cftySpec fc CFUnit = pure "void"
 cftySpec fc CFInt = pure "int"
+cftySpec fc CFInt8 = pure "char"
+cftySpec fc CFInt16 = pure "short"
+cftySpec fc CFInt32 = pure "int"
+cftySpec fc CFInt64 = pure "long"
 cftySpec fc CFUnsigned8 = pure "unsigned-char"
 cftySpec fc CFUnsigned16 = pure "unsigned-short"
 cftySpec fc CFUnsigned32 = pure "unsigned-int"

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -119,6 +119,10 @@ data Done : Type where
 cftySpec : FC -> CFType -> Core String
 cftySpec fc CFUnit = pure "_void"
 cftySpec fc CFInt = pure "_int"
+cftySpec fc CFUnsigned8 = pure "_int8"
+cftySpec fc CFUnsigned16 = pure "_int16"
+cftySpec fc CFUnsigned32 = pure "_int32"
+cftySpec fc CFUnsigned64 = pure "_int64"
 cftySpec fc CFUnsigned8 = pure "_uint8"
 cftySpec fc CFUnsigned16 = pure "_uint16"
 cftySpec fc CFUnsigned32 = pure "_uint32"

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -33,7 +33,7 @@ import Data.Buffer
 -- TTC files can only be compatible if the version number is the same
 export
 ttcVersion : Int
-ttcVersion = 54
+ttcVersion = 55
 
 export
 checkTTCVersion : String -> Int -> Int -> Core ()

--- a/src/Core/CompileExpr.idr
+++ b/src/Core/CompileExpr.idr
@@ -153,6 +153,10 @@ public export
 data CFType : Type where
      CFUnit : CFType
      CFInt : CFType
+     CFInt8 : CFType
+     CFInt16 : CFType
+     CFInt32 : CFType
+     CFInt64 : CFType
      CFUnsigned8 : CFType
      CFUnsigned16 : CFType
      CFUnsigned32 : CFType
@@ -346,6 +350,10 @@ export
 Show CFType where
   show CFUnit = "Unit"
   show CFInt = "Int"
+  show CFInt8 = "Int_8"
+  show CFInt16 = "Int_16"
+  show CFInt32 = "Int_32"
+  show CFInt64 = "Int_64"
   show CFUnsigned8 = "Bits_8"
   show CFUnsigned16 = "Bits_16"
   show CFUnsigned32 = "Bits_32"

--- a/src/Core/Hash.idr
+++ b/src/Core/Hash.idr
@@ -227,6 +227,14 @@ Hashable CFType where
       h `hashWithSalt` 15 `hashWithSalt` n `hashWithSalt` fs
     CFUser n xs =>
       h `hashWithSalt` 16 `hashWithSalt` n `hashWithSalt` xs
+    CFInt8 =>
+      h `hashWithSalt` 17
+    CFInt16 =>
+      h `hashWithSalt` 18
+    CFInt32 =>
+      h `hashWithSalt` 19
+    CFInt64 =>
+      h `hashWithSalt` 20
 
 export
 Hashable Constant where

--- a/src/Core/TTC.idr
+++ b/src/Core/TTC.idr
@@ -756,6 +756,10 @@ TTC CFType where
   toBuf b (CFUser n a) = do tag 14; toBuf b n; toBuf b a
   toBuf b CFGCPtr = tag 15
   toBuf b CFBuffer = tag 16
+  toBuf b CFInt8 = tag 17
+  toBuf b CFInt16 = tag 18
+  toBuf b CFInt32 = tag 19
+  toBuf b CFInt64 = tag 20
 
   fromBuf b
       = case !getTag of
@@ -776,6 +780,10 @@ TTC CFType where
              14 => do n <- fromBuf b; a <- fromBuf b; pure (CFUser n a)
              15 => pure CFGCPtr
              16 => pure CFBuffer
+             17 => pure CFInt8
+             18 => pure CFInt16
+             19 => pure CFInt32
+             20 => pure CFInt64
              _ => corrupt "CFType"
 
 export


### PR DESCRIPTION
As mentioned on [discord](https://discord.com/channels/827106007712661524/827109161857712128/844065173756837930) I'm not sure I used the correct type names in the Scheme backends and in the RefC backend these int types are not supported and fail with a crash.