### PR TITLE
Substantial reduction in TTC size

### DIFF
--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -33,7 +33,7 @@ import Data.Buffer
 -- TTC files can only be compatible if the version number is the same
 export
 ttcVersion : Int
-ttcVersion = 53
+ttcVersion = 54
 
 export
 checkTTCVersion : String -> Int -> Int -> Core ()

--- a/src/Libraries/Utils/Binary.idr
+++ b/src/Libraries/Utils/Binary.idr
@@ -154,23 +154,28 @@ getTag {b}
 export
 TTC Int where
   toBuf b val
-    = do chunk <- get Bin
-         if avail chunk >= 8
-            then
-              do coreLift $ setInt (buf chunk) (loc chunk) val
-                 put Bin (appended 8 chunk)
-            else do chunk' <- extendBinary 8 chunk
-                    coreLift $ setInt (buf chunk') (loc chunk') val
-                    put Bin (appended 8 chunk')
+    = if val >= -127 && val < 128
+         then tag (val + 127)
+         else do tag 255
+                 chunk <- get Bin
+                 if avail chunk >= 8
+                    then
+                      do coreLift $ setInt (buf chunk) (loc chunk) val
+                         put Bin (appended 8 chunk)
+                    else do chunk' <- extendBinary 8 chunk
+                            coreLift $ setInt (buf chunk') (loc chunk') val
+                            put Bin (appended 8 chunk')
 
   fromBuf b
-    = do chunk <- get Bin
-         if toRead chunk >= 8
-            then
-              do val <- coreLift $ getInt (buf chunk) (loc chunk)
-                 put Bin (incLoc 8 chunk)
-                 pure val
-              else throw (TTCError (EndOfBuffer ("Int " ++ show (loc chunk, size chunk))))
+    = case !getTag of
+           255 => do chunk <- get Bin
+                     if toRead chunk >= 8
+                       then
+                         do val <- coreLift $ getInt (buf chunk) (loc chunk)
+                            put Bin (incLoc 8 chunk)
+                            pure val
+                       else throw (TTCError (EndOfBuffer ("Int " ++ show (loc chunk, size chunk))))
+           t => pure (t - 127)
 
 export
 TTC String where


### PR DESCRIPTION
Write small integers out as 1 byte, not 8, at the cost of writing larger integers out in 9 bytes. Most integers fit in 1 byte, since it's string and list lengths from user-written code.