### PR TITLE
[ cleanup ] logging

### DIFF
--- a/src/Core/Context/Log.idr
+++ b/src/Core/Context/Log.idr
@@ -9,7 +9,36 @@ import System.Clock
 
 %default covering
 
--- Log message with a term, translating back to human readable names first
+logString' : LogLevel -> String -> Core ()
+logString' lvl str = coreLift $ putStrLn
+    $ "LOG " ++ show lvl ++ ": " ++ str
+
+-- if this function is called, then logging must be enabled.
+logString : String -> Nat -> String -> Core ()
+logString str n = logString' (mkUnverifiedLogLevel True str n)
+
+export
+logging' : {auto c : Ref Ctxt Defs} ->
+           LogLevel -> Core Bool
+logging' lvl = do
+    opts <- getSession
+    pure $ keepLog lvl (logEnabled opts) (logLevel opts)
+
+export
+unverifiedLogging : {auto c : Ref Ctxt Defs} ->
+                    String -> Nat -> Core Bool
+unverifiedLogging str n = do
+    opts <- getSession
+    let lvl = mkUnverifiedLogLevel (logEnabled opts) str n
+    logging' lvl
+
+export
+logging : {auto c : Ref Ctxt Defs} ->
+          (s : String) -> {auto 0 _ : KnownTopic s} ->
+          Nat -> Core Bool
+logging str n = unverifiedLogging str n
+
+||| Log message with a term, translating back to human readable names first.
 export
 logTerm : {vars : _} ->
           {auto c : Ref Ctxt Defs} ->
@@ -17,21 +46,16 @@ logTerm : {vars : _} ->
           {auto 0 _ : KnownTopic s} ->
           Nat -> Lazy String -> Term vars -> Core ()
 logTerm str n msg tm
-    = do opts <- getSession
-         let lvl = mkLogLevel (logEnabled opts) str n
-         if keepLog lvl (logEnabled opts) (logLevel opts)
-            then do tm' <- toFullNames tm
-                    coreLift $ putStrLn $ "LOG " ++ show lvl ++ ": " ++ msg
-                                          ++ ": " ++ show tm'
-            else pure ()
+    = when !(logging str n)
+        $ do tm' <- toFullNames tm
+             logString str n $ msg ++ ": " ++ show tm'
+
 export
 log' : {auto c : Ref Ctxt Defs} ->
        LogLevel -> Lazy String -> Core ()
 log' lvl msg
-    = do opts <- getSession
-         if keepLog lvl (logEnabled opts) (logLevel opts)
-            then coreLift $ putStrLn $ "LOG " ++ show lvl ++ ": " ++ msg
-            else pure ()
+    = when !(logging' lvl)
+        $ logString' lvl msg
 
 ||| Log a message with the given log level. Use increasingly
 ||| high log level numbers for more granular logging.
@@ -41,20 +65,17 @@ log : {auto c : Ref Ctxt Defs} ->
       {auto 0 _ : KnownTopic s} ->
       Nat -> Lazy String -> Core ()
 log str n msg
-    = do let lvl = mkLogLevel (logEnabled !getSession) str n
-         log' lvl msg
+    = when !(logging str n)
+        $ logString str n msg
 
 export
 unverifiedLogC : {auto c : Ref Ctxt Defs} ->
                  (s : String) ->
                  Nat -> Core String -> Core ()
 unverifiedLogC str n cmsg
-    = do opts <- getSession
-         let lvl = mkUnverifiedLogLevel (logEnabled opts) str n
-         if keepLog lvl (logEnabled opts) (logLevel opts)
-            then do msg <- cmsg
-                    coreLift $ putStrLn $ "LOG " ++ show lvl ++ ": " ++ msg
-            else pure ()
+    = when !(unverifiedLogging str n)
+        $ do msg <- cmsg
+             logString str n msg
 
 export
 logC : {auto c : Ref Ctxt Defs} ->
@@ -63,11 +84,16 @@ logC : {auto c : Ref Ctxt Defs} ->
        Nat -> Core String -> Core ()
 logC str = unverifiedLogC str
 
+nano : Integer
+nano = 1000000000
+
+micro : Integer
+micro = 1000000
+
 export
 logTimeOver : Integer -> Core String -> Core a -> Core a
 logTimeOver nsecs str act
     = do clock <- coreLift (clockTime Process)
-         let nano = 1000000000
          let t = seconds clock * nano + nanoseconds clock
          res <- act
          clock <- coreLift (clockTime Process)
@@ -78,7 +104,7 @@ logTimeOver nsecs str act
               do str' <- str
                  coreLift $ putStrLn $ "TIMING " ++ str' ++ ": " ++
                           show (time `div` nano) ++ "." ++
-                          addZeros (unpack (show ((time `mod` nano) `div` 1000000))) ++
+                          addZeros (unpack (show ((time `mod` nano) `div` micro))) ++
                           "s"
          pure res
   where
@@ -94,7 +120,6 @@ logTimeWhen : {auto c : Ref Ctxt Defs} ->
 logTimeWhen p str act
     = if p
          then do clock <- coreLift (clockTime Process)
-                 let nano = 1000000000
                  let t = seconds clock * nano + nanoseconds clock
                  res <- act
                  clock <- coreLift (clockTime Process)
@@ -103,7 +128,7 @@ logTimeWhen p str act
                  assert_total $ -- We're not dividing by 0
                     coreLift $ putStrLn $ "TIMING " ++ str ++ ": " ++
                              show (time `div` nano) ++ "." ++
-                             addZeros (unpack (show ((time `mod` nano) `div` 1000000))) ++
+                             addZeros (unpack (show ((time `mod` nano) `div` micro))) ++
                              "s"
                  pure res
          else act
@@ -118,7 +143,6 @@ logTimeRecord' : {auto c : Ref Ctxt Defs} ->
                  String -> Core a -> Core a
 logTimeRecord' key act
     = do clock <- coreLift (clockTime Process)
-         let nano = 1000000000
          let t = seconds clock * nano + nanoseconds clock
          res <- act
          clock <- coreLift (clockTime Process)
@@ -163,10 +187,9 @@ showTimeRecord
     showTimeLog : (String, (Bool, Integer)) -> Core ()
     showTimeLog (key, (_, time))
         = do coreLift $ putStr (key ++ ": ")
-             let nano = 1000000000
              assert_total $ -- We're not dividing by 0
                     coreLift $ putStrLn $ show (time `div` nano) ++ "." ++
-                               addZeros (unpack (show ((time `mod` nano) `div` 1000000))) ++
+                               addZeros (unpack (show ((time `mod` nano) `div` micro))) ++
                                "s"
 
 export

--- a/src/Core/Options/Log.idr
+++ b/src/Core/Options/Log.idr
@@ -184,16 +184,15 @@ mkLogLevel' ps n = MkLogLevel (maybe [] forget ps) n
 ||| Use this function to create user defined loglevels, for instance, during
 ||| elaborator reflection.
 export
-mkUnverifiedLogLevel : Bool -> (s : String) -> Nat -> LogLevel
-mkUnverifiedLogLevel False _ = mkLogLevel' Nothing
-mkUnverifiedLogLevel _ "" = mkLogLevel' Nothing
-mkUnverifiedLogLevel _ ps = mkLogLevel' (Just (split (== '.') ps))
+mkUnverifiedLogLevel : (s : String) -> Nat -> LogLevel
+mkUnverifiedLogLevel "" = mkLogLevel' Nothing
+mkUnverifiedLogLevel ps = mkLogLevel' (Just (split (== '.') ps))
 
 ||| Like `mkUnverifiedLogLevel` but with a compile time check that
 ||| the passed string is a known topic.
 export
-mkLogLevel : Bool -> (s : String) -> {auto 0 _ : KnownTopic s} -> Nat -> LogLevel
-mkLogLevel b s = mkUnverifiedLogLevel b s
+mkLogLevel : (s : String) -> {auto 0 _ : KnownTopic s} -> Nat -> LogLevel
+mkLogLevel s = mkUnverifiedLogLevel s
 
 ||| The unsafe constructor should only be used in places where the topic has already
 ||| been appropriately processed.
@@ -239,7 +238,7 @@ parseLogLevel str = do
                 ns = tail nns in
                 case ns of
                      [] => pure (MkLogLevel [], n)
-                     [ns] => pure (mkUnverifiedLogLevel True n, ns)
+                     [ns] => pure (mkUnverifiedLogLevel n, ns)
                      _ => Nothing
   lvl <- parsePositive n
   pure $ c (fromInteger lvl)
@@ -268,9 +267,9 @@ insertLogLevel (MkLogLevel ps n) = insert ps n
 ||| We keep a log if there is a prefix of its path associated to a larger number
 ||| in the LogLevels.
 export
-keepLog : LogLevel -> Bool -> LogLevels -> Bool
-keepLog (MkLogLevel _ Z) _ _ = True
-keepLog (MkLogLevel path n) enabled levels = enabled && go path levels where
+keepLog : LogLevel -> LogLevels -> Bool
+keepLog (MkLogLevel _ Z) _ = True
+keepLog (MkLogLevel path n) levels = go path levels where
 
   go : List String -> StringTrie Nat -> Bool
   go path (MkStringTrie current) = here || there where

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -1179,9 +1179,5 @@ logRaw : {auto c : Ref Ctxt Defs} ->
          {auto 0 _ : KnownTopic s} ->
          Nat -> Lazy String -> RawImp -> Core ()
 logRaw str n msg tm
-    = do opts <- getSession
-         let lvl = mkLogLevel (logEnabled opts) str n
-         if keepLog lvl (logEnabled opts) (logLevel opts)
-            then do coreLift $ putStrLn $ "LOG " ++ show lvl ++ ": " ++ msg
-                                          ++ ": " ++ show tm
-            else pure ()
+    = when !(logging str n) $
+        do logString str n (msg ++ ": " ++ show tm)


### PR DESCRIPTION
Cleanup repeated code in `Core.Context.Log` and add functions to get if a specific log level is enabled.

This could be useful for backend authors, so external tools can be told how much to log.