### PR TITLE
Remove realpath

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,7 +10,7 @@ The requirements are:
 
 - A Scheme compiler; either Chez Scheme (default), or Racket.
 - `bash`, with `realpath`. On Linux, you probably already have this.
-  On a Mac, you can install this with `brew install coreutils`.
+  On a macOS, you can install this with `brew install coreutils`.
   On FreeBSD, OpenBSD and NetBSD, you can install `realpath` and `GNU make`
   using a package manager.  For instance, on OpenBSD you can install all of them
   with `pkg_add coreutils gmake` command.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Idris 2
 [![Documentation Status](https://readthedocs.org/projects/idris2/badge/?version=latest)](https://idris2.readthedocs.io/en/latest/?badge=latest)
 [![Windows Status](https://github.com/idris-lang/Idris2/actions/workflows/ci-windows.yml/badge.svg)](https://github.com/idris-lang/Idris2/actions/workflows/ci-windows.yml)
 [![Ubuntu Status](https://github.com/idris-lang/Idris2/actions/workflows/ci-ubuntu-combined.yml/badge.svg)](https://github.com/idris-lang/Idris2/actions/workflows/ci-ubuntu-combined.yml)
-[![MacOS Status](https://github.com/idris-lang/Idris2/actions/workflows/ci-macos-combined.yml/badge.svg)](https://github.com/idris-lang/Idris2/actions/workflows/ci-macos-combined.yml)
+[![macOS Status](https://github.com/idris-lang/Idris2/actions/workflows/ci-macos-combined.yml/badge.svg)](https://github.com/idris-lang/Idris2/actions/workflows/ci-macos-combined.yml)
 [![Nix Status](https://github.com/idris-lang/Idris2/actions/workflows/ci-nix.yml/badge.svg)](https://github.com/idris-lang/Idris2/actions/workflows/ci-nix.yml)
 
 [Idris 2](https://idris-lang.org/) is a purely functional programming language

--- a/docs/source/tutorial/starting.rst
+++ b/docs/source/tutorial/starting.rst
@@ -90,7 +90,7 @@ which you can run:
     $ ./build/exec/hello
     Hello world
 
-(On Macos you may first need to install realpath: ```brew install coreutils```)
+(On macOS you may first need to install realpath: ```brew install coreutils```)
 
 Please note that the dollar sign ``$`` indicates the shell prompt!
 Some useful options to the Idris command are:

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -377,7 +377,7 @@ startChezWinSh chez appdir target = unlines
     , ""
     , "set -e # exit on any error"
     , ""
-    , "DIR=$(dirname \"$(realpath \"$0\")\")"
+    , "DIR=$(dirname \"$(readlink -f -- \"$0\")\")"
     , "CHEZ=$(cygpath \"" ++ chez ++"\")"
     , "export PATH=\"$DIR/" ++ appdir ++ "\":$PATH"
     , "\"$CHEZ\" --script \"$DIR/" ++ target ++ "\" \"$@\""

--- a/src/Compiler/Scheme/ChezSep.idr
+++ b/src/Compiler/Scheme/ChezSep.idr
@@ -78,7 +78,7 @@ startChezWinSh chez appDirSh targetSh = unlines
     , ""
     , "set -e # exit on any error"
     , ""
-    , "DIR=$(dirname \"$(realpath \"$0\")\")"
+    , "DIR=$(dirname \"$(readlink -f -- \"$0\")\")"
     , "CHEZ=$(cygpath \"" ++ chez ++"\")"
     , "export PATH=\"$DIR/" ++ appDirSh ++ "\":$PATH"
     , "\"$CHEZ\" --program \"$DIR/" ++ targetSh ++ "\" \"$@\""

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -354,7 +354,7 @@ startRacketWinSh racket appdir target = unlines
     , ""
     , "set -e # exit on any error"
     , ""
-    , "DIR=$(dirname \"$(realpath \"$0\")\")"
+    , "DIR=$(dirname \"$(readlink -f -- \"$0\")\")"
     , "export PATH=\"$DIR/" ++ appdir ++ "\":$PATH"
     , racket ++ "\"" ++ target ++ "\" \"$@\""
     ]

--- a/support/refc/prim.c
+++ b/support/refc/prim.c
@@ -75,7 +75,7 @@ Value *sysOS(void)
 #elif _WIN64
     return (Value *)makeString("windows");
 #elif __APPLE__ || __MACH__
-    return (Value *)makeString("Mac OSX");
+    return (Value *)makeString("macOS");
 #elif __linux__
     return (Value *)makeString("Linux");
 #elif __FreeBSD__

--- a/tests/chez/chez016/run
+++ b/tests/chez/chez016/run
@@ -1,6 +1,6 @@
 # This test needs to run `idris2` from a sub-folder. Get the absolute path.
 
-IDRIS2_EXEC="$(realpath "$1")"
+IDRIS2_EXEC="$(readlink -f -- "$1")"
 
 cd "folder with spaces" || exit
 

--- a/tests/chez/chez016/run
+++ b/tests/chez/chez016/run
@@ -1,6 +1,10 @@
 # This test needs to run `idris2` from a sub-folder. Get the absolute path.
 
-IDRIS2_EXEC="$(readlink -f -- "$1")"
+if [ "$(uname)" = Darwin ]; then
+    IDRIS2_EXEC=$(zsh -c 'printf %s "$0:A"' "$1")
+else
+    IDRIS2_EXEC="$(readlink -f -- "$1")"
+fi
 
 cd "folder with spaces" || exit
 


### PR DESCRIPTION
EDIT: 

In addition to #1418 remove `realpath` usage leftovers.

I left the `realpath` requirement in `INSTALL.md` so bootstrapped compiler could still work.