### PR TITLE
Simple signal handling

### DIFF
--- a/libs/base/System.idr
+++ b/libs/base/System.idr
@@ -113,6 +113,14 @@ export
 time : HasIO io => io Integer
 time = pure $ cast !(primIO prim__time)
 
+%foreign support "idris2_getPID"
+prim__getPID : PrimIO Int
+
+||| Get the ID of the currently running process.
+export
+getPID : HasIO io => io Int
+getPID = primIO prim__getPID
+
 %foreign libc "exit"
          "node:lambda:c => process.exit(Number(c))"
 prim__exit : Int -> PrimIO ()

--- a/libs/base/System/Signal.idr
+++ b/libs/base/System/Signal.idr
@@ -114,6 +114,9 @@ prim__collectSignal : Int -> PrimIO Int
 %foreign signalFFI "handle_next_collected_signal"
 prim__handleNextCollectedSignal : PrimIO Int
 
+%foreign signalFFI "send_signal"
+prim__sendSignal : Int -> Int -> PrimIO Int
+
 %foreign "C:idris2_getErrno, libidris2_support, idris_support.h"
 prim__getErrorNo : PrimIO Int
 
@@ -177,3 +180,13 @@ export
 handleNextCollectedSignal : HasIO io => io (Maybe Signal)
 handleNextCollectedSignal =
   toSignal <$> primIO prim__handleNextCollectedSignal
+
+||| Send a signal to a process using a PID to identify the process.
+export
+sendSignal : HasIO io => Signal -> (pid : Int) -> io (Either SignalError ())
+sendSignal sig pid = do
+  res <- primIO $ prim__sendSignal pid (signalCode sig)
+  case isError res of
+       False => pure $ Right ()
+       True  => Left <$> getError
+

--- a/libs/base/System/Signal.idr
+++ b/libs/base/System/Signal.idr
@@ -158,7 +158,7 @@ defaultSignal sig = do
 ||| This replaces the existing handling of the given signal
 ||| and instead results in Idris collecting occurrences of
 ||| the signal until you call `handleNextCollectedSignal`.
-export 
+export
 collectSignal : HasIO io => Signal -> io (Either SignalError ())
 collectSignal sig = do
   res <- primIO $ prim__collectSignal (signalCode sig)
@@ -175,6 +175,5 @@ collectSignal sig = do
 ||| You get back Nothing if there are no pending signals.
 export
 handleNextCollectedSignal : HasIO io => io (Maybe Signal)
-handleNextCollectedSignal = 
+handleNextCollectedSignal =
   toSignal <$> primIO prim__handleNextCollectedSignal
-

--- a/libs/base/System/Signal.idr
+++ b/libs/base/System/Signal.idr
@@ -1,0 +1,180 @@
+module System.Signal
+
+%default total
+
+signalFFI : String -> String
+signalFFI fn = "C:" ++ fn ++ ", libidris2_support, idris_signal.h"
+
+--
+-- Signals
+--
+%foreign signalFFI "sighup"
+prim__sighup : Int
+
+%foreign signalFFI "sigint"
+prim__sigint : Int
+
+%foreign signalFFI "sigquit"
+prim__sigquit : Int
+
+%foreign signalFFI "sigill"
+prim__sigill : Int
+
+%foreign signalFFI "sigsegv"
+prim__sigsegv : Int
+
+%foreign signalFFI "sigtrap"
+prim__sigtrap : Int
+
+%foreign signalFFI "sigfpe"
+prim__sigfpe : Int
+
+%foreign signalFFI "sigusr1"
+prim__sigusr1 : Int
+
+%foreign signalFFI "sigusr2"
+prim__sigusr2 : Int
+
+public export
+data Signal = ||| Hangup (i.e. controlling terminal closed)
+              SigHUP
+            | ||| Interrupt (e.g. ctrl+c pressed)
+              SigINT
+            | ||| Quit
+              SigQUIT
+            | ||| Ill-formed instruction
+              SigILL
+            | ||| Segmentation fault
+              SigSEGV
+            | ||| Trap (as used by debuggers)
+              SigTRAP
+            | ||| Floating-point error
+              SigFPE
+            | SigUser1
+            | SigUser2
+
+Eq Signal where
+  SigHUP   == SigHUP   = True
+  SigINT   == SigINT   = True
+  SigQUIT  == SigQUIT  = True
+  SigILL   == SigILL   = True
+  SigSEGV  == SigSEGV  = True
+  SigTRAP  == SigTRAP  = True
+  SigFPE   == SigFPE   = True
+  SigUser1 == SigUser1 = True
+  SigUser2 == SigUser2 = True
+  _ == _ = False
+
+signalCode : Signal -> Int
+signalCode SigHUP   = prim__sighup
+signalCode SigINT   = prim__sigint
+signalCode SigQUIT  = prim__sigquit
+signalCode SigILL   = prim__sigill
+signalCode SigSEGV  = prim__sigsegv
+signalCode SigTRAP  = prim__sigtrap
+signalCode SigFPE   = prim__sigfpe
+signalCode SigUser1 = prim__sigusr1
+signalCode SigUser2 = prim__sigusr2
+
+toSignal : Int -> Maybe Signal
+toSignal (-1) = Nothing
+toSignal x    = foldr matchCode Nothing codes
+  where
+    matchCode : (Int, Signal) -> Maybe Signal -> Maybe Signal
+    matchCode x (Just y) = Just y
+    matchCode (code, sig) Nothing = case x == code of
+                                         True  => Just sig
+                                         False => Nothing
+
+    codes : List (Int, Signal)
+    codes = [
+              (prim__sighup , SigHUP)
+            , (prim__sigint , SigINT)
+            , (prim__sigquit, SigQUIT)
+            , (prim__sigill , SigILL)
+            , (prim__sigsegv, SigSEGV)
+            , (prim__sigtrap, SigTRAP)
+            , (prim__sigfpe , SigFPE)
+            , (prim__sigusr1, SigUser1)
+            , (prim__sigusr2, SigUser2)
+            ]
+
+--
+-- Signal Handling
+--
+%foreign signalFFI "ignore_signal"
+prim__ignoreSignal : Int -> PrimIO Int
+
+%foreign signalFFI "default_signal"
+prim__defaultSignal : Int -> PrimIO Int
+
+%foreign signalFFI "collect_signal"
+prim__collectSignal : Int -> PrimIO Int
+
+%foreign signalFFI "handle_next_collected_signal"
+prim__handleNextCollectedSignal : PrimIO Int
+
+%foreign "C:idris2_getErrno, libidris2_support, idris_support.h"
+prim__getErrorNo : PrimIO Int
+
+||| An Error represented by a code. See
+||| relevant `errno` documentation.
+||| https://man7.org/linux/man-pages/man3/errno.3.html
+export
+data SignalError = Error Int
+
+getError : HasIO io => io SignalError
+getError = Error <$> primIO prim__getErrorNo
+
+isError : Int -> Bool
+isError (-1) = True
+isError _    = False
+
+||| Ignore the given signal.
+||| Be careful doing this, as most signals have useful
+||| default behavior -- you might want to set the signal
+||| to its default behavior instead with `defaultSignal`.
+export
+ignoreSignal : HasIO io => Signal -> io (Either SignalError ())
+ignoreSignal sig = do
+  res <- primIO $ prim__ignoreSignal (signalCode sig)
+  case isError res of
+       False => pure $ Right ()
+       True  => Left <$> getError
+
+||| Use the default handler for the given signal.
+||| You can use this function to unset custom
+||| handling of a signal.
+export
+defaultSignal : HasIO io => Signal -> io (Either SignalError ())
+defaultSignal sig = do
+  res <- primIO $ prim__defaultSignal (signalCode sig)
+  case isError res of
+       False => pure $ Right ()
+       True  => Left <$> getError
+
+||| Collect the given signal.
+|||
+||| This replaces the existing handling of the given signal
+||| and instead results in Idris collecting occurrences of
+||| the signal until you call `handleNextCollectedSignal`.
+export 
+collectSignal : HasIO io => Signal -> io (Either SignalError ())
+collectSignal sig = do
+  res <- primIO $ prim__collectSignal (signalCode sig)
+  case isError res of
+       False => pure $ Right ()
+       True  => Left <$> getError
+
+||| Get next collected signal under the pretense of handling it.
+|||
+||| Calling this "marks" the signal as handled so the next time
+||| this function is called you will retrieve the next unhandled
+||| signal instead of the same signal again.
+|||
+||| You get back Nothing if there are no pending signals.
+export
+handleNextCollectedSignal : HasIO io => io (Maybe Signal)
+handleNextCollectedSignal = 
+  toSignal <$> primIO prim__handleNextCollectedSignal
+

--- a/libs/base/System/Signal.idr
+++ b/libs/base/System/Signal.idr
@@ -120,7 +120,7 @@ prim__getErrorNo : PrimIO Int
 ||| An Error represented by a code. See
 ||| relevant `errno` documentation.
 ||| https://man7.org/linux/man-pages/man3/errno.3.html
-export
+public export
 data SignalError = Error Int
 
 getError : HasIO io => io SignalError

--- a/libs/base/System/Signal.idr
+++ b/libs/base/System/Signal.idr
@@ -55,7 +55,7 @@ data PosSignal = ||| Hangup (i.e. controlling terminal closed)
                | SigUser1
                | SigUser2
 
-export 
+export
 Eq PosSignal where
   SigHUP   == SigHUP   = True
   SigQUIT  == SigQUIT  = True

--- a/libs/base/System/Signal.idr
+++ b/libs/base/System/Signal.idr
@@ -226,11 +226,11 @@ handleNextCollectedSignal =
 ||| retrieve and use `limit/1` as your fuel.
 export
 handleManyCollectedSignals : HasIO io => Fuel -> io (List Signal)
-handleManyCollectedSignals fuel = catMaybes <$> handleMany fuel
-  where
-    handleMany : Fuel -> io (List (Maybe Signal))
-    handleMany Dry = pure []
-    handleMany (More fuel) = [| handleNextCollectedSignal :: handleMany fuel |]
+handleManyCollectedSignals Dry = pure []
+handleManyCollectedSignals (More fuel) = do
+  Just next <- handleNextCollectedSignal
+    | Nothing => pure []
+  pure $ next :: !(handleManyCollectedSignals fuel)
 
 ||| Send a signal to the current process.
 export

--- a/libs/base/System/Signal.idr
+++ b/libs/base/System/Signal.idr
@@ -107,7 +107,7 @@ signalCode (SigPosix SigUser2) = prim__sigusr2
 toSignal : Int -> Maybe Signal
 toSignal (-1) = Nothing
 toSignal x    = lookup x codes
-
+  where
     codes : List (Int, Signal)
     codes = [
               (prim__sigint , SigINT)

--- a/libs/base/System/Signal.idr
+++ b/libs/base/System/Signal.idr
@@ -106,13 +106,7 @@ signalCode (SigPosix SigUser2) = prim__sigusr2
 
 toSignal : Int -> Maybe Signal
 toSignal (-1) = Nothing
-toSignal x    = foldr matchCode Nothing codes
-  where
-    matchCode : (Int, Signal) -> Maybe Signal -> Maybe Signal
-    matchCode x (Just y) = Just y
-    matchCode (code, sig) Nothing = case x == code of
-                                         True  => Just sig
-                                         False => Nothing
+toSignal x    = lookup x codes
 
     codes : List (Int, Signal)
     codes = [
@@ -256,4 +250,3 @@ namespace Posix
     case isError res of
          False => pure $ Right ()
          True  => Left <$> getError
-

--- a/libs/base/base.ipkg
+++ b/libs/base/base.ipkg
@@ -83,10 +83,11 @@ modules = Control.App,
           Language.Reflection.TTImp,
 
           System,
-          System.Concurrency,
           System.Clock,
+          System.Concurrency,
           System.Directory,
-          System.File,
           System.FFI,
+          System.File,
           System.Info,
-          System.REPL
+          System.REPL,
+          System.Signal

--- a/support/c/idris_signal.c
+++ b/support/c/idris_signal.c
@@ -88,8 +88,16 @@ int handle_next_collected_signal() {
   return next;
 }
 
+int raise_signal(int signum) {
+  return raise(signum);
+}
+
 int send_signal(pid_t pid, int signum) {
+#ifdef _WIN32
+  return raise_signal(signum);
+#else
   return kill(pid, signum);
+#endif
 }
 
 int sighup() {
@@ -104,9 +112,13 @@ int sigint() {
   return SIGINT;
 }
 
+int sigabrt() {
+  return SIGABRT;
+}
+
 int sigquit() {
 #ifdef _WIN32
-  return NSIG + 1;
+  return -1;
 #else
   return SIGQUIT;
 #endif

--- a/support/c/idris_signal.c
+++ b/support/c/idris_signal.c
@@ -72,6 +72,10 @@ int handle_next_collected_signal() {
   return next;
 }
 
+int send_signal(pid_t pid, int signum) {
+  return kill(pid, signum);
+}
+
 int sighup() {
   return SIGHUP;
 }

--- a/support/c/idris_signal.c
+++ b/support/c/idris_signal.c
@@ -4,7 +4,9 @@
 #include <stdio.h>
 #include <signal.h>
 
-// TODO: offer Windows support.
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
 // ring buffer style storage for collected
 // signals.
@@ -77,7 +79,11 @@ int send_signal(pid_t pid, int signum) {
 }
 
 int sighup() {
+#ifdef _WIN32
+  return -1;
+#else
   return SIGHUP;
+#endif
 }
 
 int sigint() {
@@ -85,7 +91,11 @@ int sigint() {
 }
 
 int sigquit() {
+#ifdef _WIN32
+  return NSIG + 1;
+#else
   return SIGQUIT;
+#endif
 }
 
 int sigill() {
@@ -97,7 +107,11 @@ int sigsegv() {
 }
 
 int sigtrap() {
+#ifdef _WIN32
+  return -1;
+#else
   return SIGTRAP;
+#endif
 }
 
 int sigfpe() {
@@ -105,10 +119,18 @@ int sigfpe() {
 }
 
 int sigusr1() {
+#ifdef _WIN32
+  return -1;
+#else
   return SIGUSR1;
+#endif
 }
 
 int sigusr2() {
+#ifdef _WIN32
+  return -1;
+#else
   return SIGUSR2;
+#endif
 }
 

--- a/support/c/idris_signal.c
+++ b/support/c/idris_signal.c
@@ -92,7 +92,7 @@ int raise_signal(int signum) {
   return raise(signum);
 }
 
-int send_signal(pid_t pid, int signum) {
+int send_signal(int pid, int signum) {
 #ifdef _WIN32
   return raise_signal(signum);
 #else

--- a/support/c/idris_signal.c
+++ b/support/c/idris_signal.c
@@ -1,0 +1,110 @@
+#include "idris_signal.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <signal.h>
+
+// TODO: offer Windows support.
+
+// ring buffer style storage for collected
+// signals.
+static int signal_buf_cap = 0;
+static int signals_in_buf = 0;
+static int signal_buf_next_read_idx = 0;
+static int *signal_buf = NULL;
+
+void _init_buf() {
+  if (signal_buf == NULL) {
+    signal_buf_cap = 10;
+    signal_buf = malloc(sizeof(int) * signal_buf_cap);
+  }
+}
+
+void _collect_signal(int signum) {
+  _init_buf();
+  
+  // TODO: mutex lock around rest of function
+
+  // FIXME: allow for adjusting capacity of signal buffer
+  // instead of ignoring new signals when at capacity.
+  if (signals_in_buf == signal_buf_cap) {
+    return;
+  }
+
+  int write_idx = (signal_buf_next_read_idx + signals_in_buf) % signal_buf_cap;
+  signal_buf[write_idx] = signum;
+  signals_in_buf += 1;
+}
+
+inline struct sigaction _simple_handler(void (*handler)(int)) {
+  struct sigaction new_action;
+
+  new_action.sa_handler = handler;
+  sigemptyset (&new_action.sa_mask);
+  new_action.sa_flags = 0;
+
+  return new_action;
+}
+
+int ignore_signal(int signum) {
+  struct sigaction handler = _simple_handler(SIG_IGN);
+  return sigaction(signum, &handler, NULL);
+}
+
+int default_signal(int signum) {
+  struct sigaction handler = _simple_handler(SIG_DFL);
+  return sigaction(signum, &handler, NULL);
+}
+
+int collect_signal(int signum) {
+  struct sigaction handler = _simple_handler(_collect_signal);
+  return sigaction(signum, &handler, NULL);
+}
+
+int handle_next_collected_signal() {
+  // TODO: mutex lock
+  if (signals_in_buf == 0) {
+    return -1;
+  }
+  int next = signal_buf[signal_buf_next_read_idx];
+  signal_buf_next_read_idx = (signal_buf_next_read_idx + 1) % signal_buf_cap;
+  signals_in_buf -= 1;
+  return next;
+}
+
+int sighup() {
+  return SIGHUP;
+}
+
+int sigint() {
+  return SIGINT;
+}
+
+int sigquit() {
+  return SIGQUIT;
+}
+
+int sigill() {
+  return SIGILL;
+}
+
+int sigsegv() {
+  return SIGSEGV;
+}
+
+int sigtrap() {
+  return SIGTRAP;
+}
+
+int sigfpe() {
+  return SIGFPE;
+}
+
+int sigusr1() {
+  return SIGUSR1;
+}
+
+int sigusr2() {
+  return SIGUSR2;
+}
+

--- a/support/c/idris_signal.c
+++ b/support/c/idris_signal.c
@@ -36,6 +36,11 @@ void _collect_signal(int signum) {
   int write_idx = (signal_buf_next_read_idx + signals_in_buf) % signal_buf_cap;
   signal_buf[write_idx] = signum;
   signals_in_buf += 1;
+
+#ifdef _WIN32
+  //re-instate signal handler
+  signal(signum, _collect_signal);
+#endif
 }
 
 #ifndef _WIN32

--- a/support/c/idris_signal.c
+++ b/support/c/idris_signal.c
@@ -38,6 +38,7 @@ void _collect_signal(int signum) {
   signals_in_buf += 1;
 }
 
+#ifndef _WIN32
 inline struct sigaction _simple_handler(void (*handler)(int)) {
   struct sigaction new_action;
 
@@ -47,20 +48,33 @@ inline struct sigaction _simple_handler(void (*handler)(int)) {
 
   return new_action;
 }
+#endif
 
 int ignore_signal(int signum) {
+#ifdef _WIN32
+  return signal(signum, SIG_IGN) == SIG_ERR ? -1 : 0;
+#else
   struct sigaction handler = _simple_handler(SIG_IGN);
   return sigaction(signum, &handler, NULL);
+#endif
 }
 
 int default_signal(int signum) {
+#ifdef _WIN32
+  return signal(signum, SIG_DFL) == SIG_ERR ? -1 : 0;
+#else
   struct sigaction handler = _simple_handler(SIG_DFL);
   return sigaction(signum, &handler, NULL);
+#endif
 }
 
 int collect_signal(int signum) {
+#ifdef _WIN32
+  return signal(signum, _collect_signal) == SIG_ERR ? -1 : 0;
+#else
   struct sigaction handler = _simple_handler(_collect_signal);
   return sigaction(signum, &handler, NULL);
+#endif
 }
 
 int handle_next_collected_signal() {

--- a/support/c/idris_signal.c
+++ b/support/c/idris_signal.c
@@ -56,11 +56,13 @@ int _lock() {
 
 void _unlock() {
 #ifdef _WIN32
-  ReleaseMutex(ghMutex) 
+  ReleaseMutex(ghMutex);
 #else
   pthread_mutex_unlock(&sig_mutex);
 #endif
 }
+
+void _collect_signal(int signum);
 
 void _collect_signal_core(int signum) {
   _init_buf();

--- a/support/c/idris_signal.h
+++ b/support/c/idris_signal.h
@@ -23,7 +23,7 @@ int raise_signal(int signum);
 // IMPORTANT: On Windows you cannot send to other processes
 // so this is implemented as `raise_signal()` which sends the signal
 // to the calling process.
-int send_signal(pid_t pid, int signum);
+int send_signal(int pid, int signum);
 
 // available signals in a cross-platform compatible way;
 // omits SIGKILL and SIGSTOP because those signals cannot

--- a/support/c/idris_signal.h
+++ b/support/c/idris_signal.h
@@ -16,7 +16,13 @@ int collect_signal(int signum);
 // Returns -1 to indicate no pending signals.
 int handle_next_collected_signal();
 
+// Raise a signal to the current process.
+int raise_signal(int signum);
+
 // Send a signal to another process.
+// IMPORTANT: On Windows you cannot send to other processes
+// so this is implemented as `raise_signal()` which sends the signal
+// to the calling process.
 int send_signal(pid_t pid, int signum);
 
 // available signals in a cross-platform compatible way;
@@ -26,12 +32,11 @@ int sigint();
 int sigill();
 int sigsegv();
 int sigfpe();
+int sigabrt();
 
-// Following unavailable in Windows and so mostly defined as -1 in
+// Following unavailable in Windows and defined as -1 in
 // this implementation so that they can be unconditionally
 // defined in Idris.
-// NOTABLE EXCEPTION: SIGQUIT is given a novel code so that it can
-// be sent/received to/from Idris programs even under Windows.
 int sighup();
 int sigquit();
 int sigtrap();

--- a/support/c/idris_signal.h
+++ b/support/c/idris_signal.h
@@ -1,6 +1,8 @@
 #ifndef __IDRIS_SIGNAL_H
 #define __IDRIS_SIGNAL_H
 
+#include <signal.h>
+
 int ignore_signal(int signum);
 int default_signal(int signum);
 
@@ -13,6 +15,9 @@ int collect_signal(int signum);
 // collected but not yet handled with this function.
 // Returns -1 to indicate no pending signals.
 int handle_next_collected_signal();
+
+// Send a signal to another process.
+int send_signal(pid_t pid, int signum);
 
 // available signals in a cross-platform compatible way;
 // omits SIGKILL and SIGSTOP because those signals cannot

--- a/support/c/idris_signal.h
+++ b/support/c/idris_signal.h
@@ -22,13 +22,19 @@ int send_signal(pid_t pid, int signum);
 // available signals in a cross-platform compatible way;
 // omits SIGKILL and SIGSTOP because those signals cannot
 // be handled in a custom way.
-int sighup();
 int sigint();
-int sigquit();
 int sigill();
 int sigsegv();
-int sigtrap();
 int sigfpe();
+
+// Following unavailable in Windows and so mostly defined as -1 in
+// this implementation so that they can be unconditionally
+// defined in Idris.
+// NOTABLE EXCEPTION: SIGQUIT is given a novel code so that it can
+// be sent/received to/from Idris programs even under Windows.
+int sighup();
+int sigquit();
+int sigtrap();
 int sigusr1();
 int sigusr2();
 

--- a/support/c/idris_signal.h
+++ b/support/c/idris_signal.h
@@ -1,0 +1,30 @@
+#ifndef __IDRIS_SIGNAL_H
+#define __IDRIS_SIGNAL_H
+
+int ignore_signal(int signum);
+int default_signal(int signum);
+
+// Add another signal that should be collected. All collected signals
+// should be handled at the earliest convenience by calling
+// get_next_pending_signal().
+int collect_signal(int signum);
+
+// when collecting signals you can get the next one that has been
+// collected but not yet handled with this function.
+// Returns -1 to indicate no pending signals.
+int handle_next_collected_signal();
+
+// available signals in a cross-platform compatible way;
+// omits SIGKILL and SIGSTOP because those signals cannot
+// be handled in a custom way.
+int sighup();
+int sigint();
+int sigquit();
+int sigill();
+int sigsegv();
+int sigtrap();
+int sigfpe();
+int sigusr1();
+int sigusr2();
+
+#endif

--- a/support/c/idris_support.c
+++ b/support/c/idris_support.c
@@ -116,6 +116,14 @@ int idris2_unsetenv(const char *name) {
 #endif
 }
 
+int idris2_getPID() {
+#ifdef _WIN32
+    return win32_getPID();
+#else
+    return getpid();
+#endif
+}
+
 // get the number of processors configured
 long idris2_getNProcessors() {
 #ifdef _WIN32

--- a/support/c/idris_support.h
+++ b/support/c/idris_support.h
@@ -22,6 +22,8 @@ void idris2_setArgs(int argc, char *argv[]);
 char* idris2_getArg(int n);
 char* idris2_getEnvPair(int i);
 
+int idris2_getPID();
+
 long idris2_getNProcessors();
 
 #endif

--- a/support/c/windows/win_utils.c
+++ b/support/c/windows/win_utils.c
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <windows.h>
+#include <process.h>
 
 // THis file exists to avoid clashes between windows.h and idris_rts.h
 //
@@ -81,6 +82,10 @@ int win32_modenv(const char* name, const char* value, int overwrite) {
 
 int win32_getErrno() {
     return GetLastError();
+}
+
+int win32_getPID() {
+    return _getpid();
 }
 
 typedef BOOL (WINAPI *LPFN_GLPI)(

--- a/support/c/windows/win_utils.h
+++ b/support/c/windows/win_utils.h
@@ -11,5 +11,6 @@ void win32_sleep(int ms);
 int win32_modenv(const char* name, const char* value, int overwrite);
 
 int win32_getErrno();
+int win32_getPID();
 long win32_getNProcessors();
 

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -283,7 +283,7 @@ baseLibraryTests = MkTestPool "Base library" [Chez, Node]
   [ "system_file001"
   , "data_bits001"
   , "system_info001"
-  , "system_signal001", "system_signal002", "system_signal003"
+  , "system_signal001", "system_signal002", "system_signal003", "system_signal004"
   ]
 
 -- same behavior as `baseLibraryTests`

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -283,6 +283,7 @@ baseLibraryTests = MkTestPool "Base library" [Chez, Node]
   [ "system_file001"
   , "data_bits001"
   , "system_info001"
+  , "system_signal001", "system_signal002", "system_signal003"
   ]
 
 -- same behavior as `baseLibraryTests`

--- a/tests/base/system_file001/ReadFilePage.idr
+++ b/tests/base/system_file001/ReadFilePage.idr
@@ -42,4 +42,3 @@ main = do totalChecks
           Right l8 <- readFile "test.txt"
             | Left err => putStrLn $ show err
           putStrLn l8
-

--- a/tests/base/system_info001/NumProcessors.idr
+++ b/tests/base/system_info001/NumProcessors.idr
@@ -4,4 +4,3 @@ main : IO ()
 main = do Just np <- getNProcessors
             | Nothing => putStrLn "ERROR: Couldn't get number of processors!"
           putStrLn $ (show np) ++ " processors"
-

--- a/tests/base/system_signal001/IgnoreSignal.idr
+++ b/tests/base/system_signal001/IgnoreSignal.idr
@@ -3,14 +3,13 @@ import System
 
 main : IO ()
 main = do
-  Right () <- ignoreSignal SigQUIT
+  Right () <- ignoreSignal SigABRT
     | Left (Error code) => putStrLn $ "error " ++ (show code)
-  pid <- getPID
   putStrLn "before"
-  Right () <- sendSignal SigQUIT pid
+  Right () <- raiseSignal SigABRT
     | Left (Error code) => putStrLn $ "received error code from signal call: " ++ (show code)
   sleep 1
   putStrLn "after"
-  Right () <- defaultSignal SigQUIT
+  Right () <- defaultSignal SigABRT
     | Left (Error code) => putStrLn $ "error " ++ (show code)
   putStrLn "done."

--- a/tests/base/system_signal001/IgnoreSignal.idr
+++ b/tests/base/system_signal001/IgnoreSignal.idr
@@ -1,0 +1,16 @@
+import System.Signal
+import System
+
+main : IO ()
+main = do 
+  Right () <- ignoreSignal SigQUIT
+    | Left (Error code) => putStrLn $ "error " ++ (show code)
+  pid <- getPID
+  putStrLn "before"
+  Right () <- sendSignal SigQUIT pid
+    | Left (Error code) => putStrLn $ "received error code from signal call: " ++ (show code)
+  sleep 1
+  putStrLn "after"
+  Right () <- defaultSignal SigQUIT
+    | Left (Error code) => putStrLn $ "error " ++ (show code)
+  putStrLn "done."

--- a/tests/base/system_signal001/IgnoreSignal.idr
+++ b/tests/base/system_signal001/IgnoreSignal.idr
@@ -2,7 +2,7 @@ import System.Signal
 import System
 
 main : IO ()
-main = do 
+main = do
   Right () <- ignoreSignal SigQUIT
     | Left (Error code) => putStrLn $ "error " ++ (show code)
   pid <- getPID

--- a/tests/base/system_signal001/expected
+++ b/tests/base/system_signal001/expected
@@ -1,0 +1,6 @@
+1/1: Building IgnoreSignal (IgnoreSignal.idr)
+Main> before
+after
+done.
+Main> 
+Bye for now!

--- a/tests/base/system_signal001/input
+++ b/tests/base/system_signal001/input
@@ -1,0 +1,1 @@
+:exec main

--- a/tests/base/system_signal001/run
+++ b/tests/base/system_signal001/run
@@ -1,3 +1,3 @@
-$1 --no-color --console-width 0 --no-banner IgnoreSignal.idr <<< ':exec main'
+$1 --no-color --console-width 0 --no-banner IgnoreSignal.idr < input
 
 rm -rf build

--- a/tests/base/system_signal001/run
+++ b/tests/base/system_signal001/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 --no-banner IgnoreSignal.idr <<< ':exec main'
+
+rm -rf build

--- a/tests/base/system_signal002/HandleSignal.idr
+++ b/tests/base/system_signal002/HandleSignal.idr
@@ -2,7 +2,7 @@ import System.Signal
 import System
 
 main : IO ()
-main = do 
+main = do
   Right () <- collectSignal SigQUIT
     | Left (Error code) => putStrLn $ "error " ++ (show code)
   pid <- getPID

--- a/tests/base/system_signal002/HandleSignal.idr
+++ b/tests/base/system_signal002/HandleSignal.idr
@@ -1,0 +1,19 @@
+import System.Signal
+import System
+
+main : IO ()
+main = do 
+  Right () <- collectSignal SigQUIT
+    | Left (Error code) => putStrLn $ "error " ++ (show code)
+  pid <- getPID
+  putStrLn "before"
+  Right () <- sendSignal SigQUIT pid
+    | Left (Error code) => putStrLn $ "got non-zero exit from system call: " ++ (show code)
+  sleep 1
+  Just SigQUIT <- handleNextCollectedSignal
+    | Just _  => putStrLn "received the wrong signal."
+    | Nothing => putStrLn "did not receive expected signal."
+  putStrLn "after"
+  Right () <- defaultSignal SigQUIT
+    | Left (Error code) => putStrLn $ "error " ++ (show code)
+  putStrLn "done."

--- a/tests/base/system_signal002/HandleSignal.idr
+++ b/tests/base/system_signal002/HandleSignal.idr
@@ -3,17 +3,16 @@ import System
 
 main : IO ()
 main = do
-  Right () <- collectSignal SigQUIT
+  Right () <- collectSignal SigABRT
     | Left (Error code) => putStrLn $ "error " ++ (show code)
-  pid <- getPID
   putStrLn "before"
-  Right () <- sendSignal SigQUIT pid
+  Right () <- raiseSignal SigABRT
     | Left (Error code) => putStrLn $ "got non-zero exit from system call: " ++ (show code)
   sleep 1
-  Just SigQUIT <- handleNextCollectedSignal
+  Just SigABRT <- handleNextCollectedSignal
     | Just _  => putStrLn "received the wrong signal."
     | Nothing => putStrLn "did not receive expected signal."
   putStrLn "after"
-  Right () <- defaultSignal SigQUIT
+  Right () <- defaultSignal SigABRT
     | Left (Error code) => putStrLn $ "error " ++ (show code)
   putStrLn "done."

--- a/tests/base/system_signal002/expected
+++ b/tests/base/system_signal002/expected
@@ -1,0 +1,6 @@
+1/1: Building HandleSignal (HandleSignal.idr)
+Main> before
+after
+done.
+Main> 
+Bye for now!

--- a/tests/base/system_signal002/input
+++ b/tests/base/system_signal002/input
@@ -1,0 +1,1 @@
+:exec main

--- a/tests/base/system_signal002/run
+++ b/tests/base/system_signal002/run
@@ -1,3 +1,3 @@
-$1 --no-color --console-width 0 --no-banner HandleSignal.idr <<< ':exec main'
+$1 --no-color --console-width 0 --no-banner HandleSignal.idr < input
 
 rm -rf build

--- a/tests/base/system_signal002/run
+++ b/tests/base/system_signal002/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 --no-banner HandleSignal.idr <<< ':exec main'
+
+rm -rf build

--- a/tests/base/system_signal003/DefaultSignal.idr
+++ b/tests/base/system_signal003/DefaultSignal.idr
@@ -1,0 +1,14 @@
+import System.Signal
+import System
+
+main : IO ()
+main = do 
+  Right () <- ignoreSignal SigQUIT
+    | Left (Error code) => putStrLn $ "error " ++ (show code)
+  Right () <- defaultSignal SigQUIT
+    | Left (Error code) => putStrLn $ "error " ++ (show code)
+  pid <- getPID
+  Right () <- sendSignal SigQUIT pid
+    | Left (Error code) => putStrLn $ "received non-zero exit from system call: " ++ (show code)
+  sleep 1
+  putStrLn "(should not get here)."

--- a/tests/base/system_signal003/DefaultSignal.idr
+++ b/tests/base/system_signal003/DefaultSignal.idr
@@ -2,7 +2,7 @@ import System.Signal
 import System
 
 main : IO ()
-main = do 
+main = do
   Right () <- ignoreSignal SigQUIT
     | Left (Error code) => putStrLn $ "error " ++ (show code)
   Right () <- defaultSignal SigQUIT

--- a/tests/base/system_signal003/DefaultSignal.idr
+++ b/tests/base/system_signal003/DefaultSignal.idr
@@ -3,12 +3,11 @@ import System
 
 main : IO ()
 main = do
-  Right () <- ignoreSignal SigQUIT
+  Right () <- ignoreSignal SigABRT
     | Left (Error code) => putStrLn $ "error " ++ (show code)
-  Right () <- defaultSignal SigQUIT
+  Right () <- defaultSignal SigABRT
     | Left (Error code) => putStrLn $ "error " ++ (show code)
-  pid <- getPID
-  Right () <- sendSignal SigQUIT pid
+  Right () <- raiseSignal SigABRT
     | Left (Error code) => putStrLn $ "received non-zero exit from system call: " ++ (show code)
   sleep 1
   putStrLn "(should not get here)."

--- a/tests/base/system_signal003/expected
+++ b/tests/base/system_signal003/expected
@@ -1,0 +1,3 @@
+1/1: Building DefaultSignal (DefaultSignal.idr)
+Main> Main> 
+Bye for now!

--- a/tests/base/system_signal003/input
+++ b/tests/base/system_signal003/input
@@ -1,0 +1,1 @@
+:exec main

--- a/tests/base/system_signal003/run
+++ b/tests/base/system_signal003/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 --no-banner DefaultSignal.idr <<< ':exec main'
+
+rm -rf build

--- a/tests/base/system_signal003/run
+++ b/tests/base/system_signal003/run
@@ -1,3 +1,3 @@
-$1 --no-color --console-width 0 --no-banner DefaultSignal.idr <<< ':exec main'
+$1 --no-color --console-width 0 --no-banner DefaultSignal.idr < input
 
 rm -rf build

--- a/tests/base/system_signal003/run
+++ b/tests/base/system_signal003/run
@@ -1,3 +1,3 @@
-$1 --no-color --console-width 0 --no-banner DefaultSignal.idr < input
+$1 --no-color --console-width 0 --no-banner DefaultSignal.idr < input 2> /dev/null
 
 rm -rf build

--- a/tests/base/system_signal004/HandleManySignals.idr
+++ b/tests/base/system_signal004/HandleManySignals.idr
@@ -1,0 +1,20 @@
+import System.Signal
+import System
+import Data.List
+import Data.Fuel
+
+main : IO ()
+main = do
+  Right () <- collectSignal SigABRT
+    | Left (Error code) => putStrLn $ "error " ++ (show code)
+  putStrLn "before"
+  [Right (), Right (), Right ()] <- sequence $ replicate 3 (raiseSignal SigABRT)
+    | _ => putStrLn $ "got non-zero exit from a system call"
+  sleep 1
+  [SigABRT, SigABRT, SigABRT] <- handleManyCollectedSignals (limit 4)
+    | (_ :: _ :: _ :: [])  => putStrLn "received the wrong signals."
+    | _ => putStrLn "did not receive expected number of signals."
+  putStrLn "after"
+  Right () <- defaultSignal SigABRT
+    | Left (Error code) => putStrLn $ "error " ++ (show code)
+  putStrLn "done."

--- a/tests/base/system_signal004/expected
+++ b/tests/base/system_signal004/expected
@@ -1,0 +1,6 @@
+1/1: Building HandleManySignals (HandleManySignals.idr)
+Main> before
+after
+done.
+Main> 
+Bye for now!

--- a/tests/base/system_signal004/input
+++ b/tests/base/system_signal004/input
@@ -1,0 +1,1 @@
+:exec main

--- a/tests/base/system_signal004/run
+++ b/tests/base/system_signal004/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 --no-banner HandleManySignals.idr < input
+
+rm -rf build


### PR DESCRIPTION
This adds some simple signal handling to the base library.

I chose to implement this as a collector that allows retrieving signals that have been sent to a process since the last time the process checked for signals. This allows Idris developers to handle signals as part of a run loop.

If someone else wants to expand the implementation to offer thread-based interrupt handlers, this PR's C code and Idris types representing the most common signals should offer a solid foundation.

I, for one, am excited to take this and implement graceful shutdown on `SIGINT` (Ctrl+C) for a couple of my utilities!
