### PR TITLE
[ fix ] nproc missing for non-GNU systems

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,10 +1,5 @@
 INTERACTIVE ?= --interactive
-ifeq ($(shell uname), FreeBSD)
-	NPROC = sysctl -n hw.ncpu
-else
-	NPROC = nproc
-endif
-threads ?= `$(NPROC)`
+threads ?= $(shell (nproc || sysctl -n hw.ncpu) 2>/dev/null || echo 1)
 
 .PHONY: testbin test
 

--- a/tests/base/system_info001/run
+++ b/tests/base/system_info001/run
@@ -1,9 +1,11 @@
 rm -f expected
-if [ "FreeBSD" = "$(uname)" ]; then
-  echo "$(sysctl -n hw.ncpu) processors" > expected
-else
-  echo "$(nproc) processors" > expected
+
+if ! NProcs=$(nproc || sysctl -n hw.ncpu) 2>/dev/null; then
+  echo Command nproc not found. Try installing coreutils. >&2
+  exit 1
 fi
+
+echo "$NProcs processors" > expected
 
 $1 --no-banner --no-color --console-width 0 NumProcessors.idr --exec main
 


### PR DESCRIPTION
Instead of checking environment names, it's simpler to call nproc and fallback to sysctl.
In the unlikely event both commands fail, is `threads ?= 1` a reasonable default?

---
The next step is to remove `brew install coreutils` from ci-macos-combined.yml, once the bootstrap is updated.