### PR TITLE
Cache intermediate results in totality checking

### DIFF
--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -121,7 +121,8 @@ idrisTestsPerformance : TestPool
 idrisTestsPerformance = MkTestPool "Performance" []
        -- Performance: things which have been slow in the past, or which
        -- pose interesting challenges for the elaborator
-      ["perf001", "perf002", "perf003", "perf004", "perf005", "perf006"]
+      ["perf001", "perf002", "perf003", "perf004", "perf005", "perf006",
+       "perf007"]
 
 idrisTestsRegression : TestPool
 idrisTestsRegression = MkTestPool "Various regressions" []

--- a/tests/idris2/error013/expected
+++ b/tests/idris2/error013/expected
@@ -1,5 +1,5 @@
 1/1: Building Issue361 (Issue361.idr)
-Error: main is not total, possibly not terminating due to recursive path Main.main -> Main.Eq implementation at Issue361.idr:5:1--5:11 -> Main.== -> Main./= -> Main.==
+Error: main is not total, possibly not terminating due to call to Main./=
 
 Issue361.idr:7:1--7:13
  3 | data S = T | F
@@ -9,7 +9,7 @@ Issue361.idr:7:1--7:13
  7 | main : IO ()
      ^^^^^^^^^^^^
 
-Error: /= is not total, possibly not terminating due to recursive path Main./= -> Main.== -> Main./= -> Main.==
+Error: /= is not total, possibly not terminating due to recursive path Main.main -> Main.Eq implementation at Issue361.idr:5:1--5:11 -> Main.== -> Main./= -> Main.==
 
 Issue361.idr:5:1--5:11
  1 | %default total

--- a/tests/idris2/perf007/Slooow.idr
+++ b/tests/idris2/perf007/Slooow.idr
@@ -1,0 +1,28 @@
+%default total
+
+data TTy : Nat -> Nat -> Nat -> Nat -> Bool -> Type where
+
+  TA : TTy p1 r1 i1 i2 False ->
+       TTy i1 i2 i1 u2 False ->
+       TTy i1 i2 p2 b1 b2    ->
+       TTy p1 r1 p1 i2 False
+
+  TB : TTy v1 r1 v2 r2 bt ->
+       TTy v1 r1 v1 r2 (be && bt)
+
+  TC : TTy p1 r1 v2 r2 False ->
+       TTy v2 r2 v3 r3 b2    ->
+       TTy p1 r1 v3 r3 b2
+
+n : Nat -> Nat
+n = (+ 2)
+                              
+showInd : (indent : Nat) -> TTy p1 r1 v3 r3 br -> String
+showInd i (TA x1 x2 x3) = if False
+                            then (if False then show' i else show' i)
+                            else showInd (n i) x1 ++ show' (n i)
+                            where
+                              show' : Nat -> String
+                              show' i = showInd (n i) x3 ++ if False then "" else showInd (n i) x2
+showInd i (TB x) = showInd (n i) x ++ if False then "" else showInd (n i) x
+showInd i (TC x y) = if False then showInd i y else showInd i x ++ showInd i y

--- a/tests/idris2/perf007/Slooow.idr
+++ b/tests/idris2/perf007/Slooow.idr
@@ -16,7 +16,7 @@ data TTy : Nat -> Nat -> Nat -> Nat -> Bool -> Type where
 
 n : Nat -> Nat
 n = (+ 2)
-                
+
 showInd : (indent : Nat) -> TTy p1 r1 v3 r3 br -> String
 showInd i (TA x1 x2 x3) = if False
                             then (if False then show' i else show' i)

--- a/tests/idris2/perf007/Slooow.idr
+++ b/tests/idris2/perf007/Slooow.idr
@@ -16,7 +16,7 @@ data TTy : Nat -> Nat -> Nat -> Nat -> Bool -> Type where
 
 n : Nat -> Nat
 n = (+ 2)
-                              
+                
 showInd : (indent : Nat) -> TTy p1 r1 v3 r3 br -> String
 showInd i (TA x1 x2 x3) = if False
                             then (if False then show' i else show' i)

--- a/tests/idris2/perf007/expected
+++ b/tests/idris2/perf007/expected
@@ -1,0 +1,1 @@
+1/1: Building Slooow (Slooow.idr)

--- a/tests/idris2/perf007/run
+++ b/tests/idris2/perf007/run
@@ -1,0 +1,3 @@
+$1 --check Slooow.idr
+
+rm -rf build

--- a/tests/ttimp/total002/expected
+++ b/tests/ttimp/total002/expected
@@ -5,5 +5,5 @@ Yaffle> Main.ack is total
 Yaffle> Main.foo is total
 Yaffle> Main.foo' is total
 Yaffle> Main.foom is total
-Yaffle> Main.pfoom is possibly not terminating due to recursive path Main.pfoom -> Main.pfoom -> Main.pfoom
+Yaffle> Main.pfoom is possibly not terminating due to recursive path Main.pfoom -> Main.pfoom
 Yaffle> Bye for now!


### PR DESCRIPTION
This saves a lot of unnecessary exploring of size change graphs, which can get over the top quite quickly if there's complex mutual
definitions, or even just a single function with an interesting variety of recursive calls.

Fixes #1365
Fixes #1277
Fixes #645

...although only the performance aspects. If there are other issues (e.g. things which are not total with a clear explanation of why they should be) then these probably need minimising differently, so best submitted in new issue reports.