### PR TITLE
[ fix ] Cast CLOCKS_PER_SEC to float before division

### DIFF
--- a/support/refc/clock.c
+++ b/support/refc/clock.c
@@ -1,7 +1,7 @@
 #include "clock.h"
 
 #define NSEC_PER_SEC 1000000000
-#define CLOCKS_PER_NSEC ((float)(CLOCKS_PER_SEC / NSEC_PER_SEC))
+#define CLOCKS_PER_NSEC ((float)CLOCKS_PER_SEC / NSEC_PER_SEC)
 
 Value *clockTimeMonotonic()
 {


### PR DESCRIPTION
The cast to float needs to happen before the division, otherwise integer
division will be performed, and as a result `CLOCKS_PER_NSEC` will
always be 0 if `CLOCKS_PER_SEC` < `NSEC_PER_SEC`.