### PR TITLE
[ doc ] Some documentation on `:=` syntax of `let` bindings

### DIFF
--- a/docs/source/tutorial/typesfuns.rst
+++ b/docs/source/tutorial/typesfuns.rst
@@ -1182,6 +1182,8 @@ Or even:
 More Expressions
 ================
 
+.. _sect-let-bindings:
+
 ``let`` bindings
 ----------------
 
@@ -1204,6 +1206,41 @@ pattern matching at the top level:
     showPerson : Person -> String
     showPerson p = let MkPerson name age = p in
                        name ++ " is " ++ show age ++ " years old"
+
+You can also use symbol ``:=`` in a simple ``let`` binding that calculates intermediate values.
+For example, the following function definitions are precisely the same as the ones above:
+
+.. code-block:: idris
+
+   mirror : List a -> List a
+   mirror xs = let xs' := reverse xs in
+                   xs ++ xs'
+
+.. code-block:: idris
+
+   showPerson : Person -> String
+   showPerson p = let MkPerson name age := p in
+                      name ++ " is " ++ show age ++ " years old"
+
+Also, ``let`` bindings can be used for local function definitions, like ``where``:
+
+.. code-block:: idris
+
+   foldMap : Monoid m => (a -> m) -> Vect n a -> m
+   foldMap f = let fo : m -> a -> m
+                   fo ac el = ac <+> f el
+                in foldl fo neutral
+
+Symbol ``:=`` cannot be used in a local function definition.
+Moreover, it helps to show that local function definition is ended:
+
+.. code-block:: idris
+
+   foldMap : Monoid m => (a -> m) -> Vect n a -> m
+   foldMap f = let fo : m -> a -> m
+                   fo ac el = ac <+> f el
+                   initial := neutral -- this is a separate binding, not relevant to definition of `fo`
+                in foldl fo initial
 
 List comprehensions
 -------------------

--- a/docs/source/tutorial/typesfuns.rst
+++ b/docs/source/tutorial/typesfuns.rst
@@ -1207,22 +1207,27 @@ pattern matching at the top level:
     showPerson p = let MkPerson name age = p in
                        name ++ " is " ++ show age ++ " years old"
 
-You can also use symbol ``:=`` in a simple ``let`` binding that calculates intermediate values.
-For example, the following function definitions are precisely the same as the ones above:
+These let bindings can be annotated with a type:
 
 .. code-block:: idris
 
    mirror : List a -> List a
-   mirror xs = let xs' := reverse xs in
+   mirror xs = let xs' : List a = reverse xs in
                    xs ++ xs'
+
+We can also use the symbol ``:=`` instead of ``=`` to, among other things,
+avoid ambiguities with propositional equality:
 
 .. code-block:: idris
 
-   showPerson : Person -> String
-   showPerson p = let MkPerson name age := p in
-                      name ++ " is " ++ show age ++ " years old"
+   Diag : a -> Type
+   Diag v = let ty : Type := v = v in ty
 
-Also, ``let`` bindings can be used for local function definitions, like ``where``:
+Local definitions can also be introduced using ``let``. Just like top level
+ones and ones defined in a ``where`` clause you need to:
+
+1. declare the function and its type
+2. define the function by pattern matching
 
 .. code-block:: idris
 
@@ -1231,15 +1236,18 @@ Also, ``let`` bindings can be used for local function definitions, like ``where`
                    fo ac el = ac <+> f el
                 in foldl fo neutral
 
-Symbol ``:=`` cannot be used in a local function definition.
-Moreover, it helps to show that local function definition is ended:
+The symbol ``:=`` cannot be used in a local function definition. Which means
+that it can be used to interleave let bindings and local definitions without
+introducing ambiguities.
 
 .. code-block:: idris
 
    foldMap : Monoid m => (a -> m) -> Vect n a -> m
    foldMap f = let fo : m -> a -> m
                    fo ac el = ac <+> f el
-                   initial := neutral -- this is a separate binding, not relevant to definition of `fo`
+                   initial := neutral
+                    --     ^ this indicates that `initial` is a separate binding,
+                    -- not relevant to definition of `fo`
                 in foldl fo initial
 
 List comprehensions

--- a/docs/source/updates/updates.rst
+++ b/docs/source/updates/updates.rst
@@ -357,6 +357,9 @@ If you do need the computational behaviour of a definition, it is now possible
 using local function definitions instead - see Section :ref:`sect-local-defs`
 below.
 
+Also, an alternative syntax ``let x := val in e`` is available.
+See Section :ref:`sect-let-bindings` for more info.
+
 ``auto``-implicits and Interfaces
 ---------------------------------
 


### PR DESCRIPTION
I missed the original PR that adds this syntax and used to wondering what's it until #1485. Let's add some documentation about it.

UPD: A UFO flew and broke CI, thus rebased to restart it.