### PR TITLE
[ feature ] Expose 'resolvedAs' and 'getSimilarNames'

### DIFF
--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -359,6 +359,10 @@ export
 getContent : Context -> Ref Arr (IOArray ContextEntry)
 getContent = content
 
+export
+namesResolvedAs : Context -> NameMap Name
+namesResolvedAs ctxt = map Resolved ctxt.resolvedAs
+
 -- Implemented later, once we can convert to and from full names
 -- Defined in Core.TTC
 export
@@ -1182,6 +1186,7 @@ getFieldNames ctxt recNS
         Just (ns, field) => ns == recNS
 
 -- Find similar looking names in the context
+export
 getSimilarNames : {auto c : Ref Ctxt Defs} -> Name -> Core (List String)
 getSimilarNames nm = case userNameRoot nm of
   Nothing => pure []


### PR DESCRIPTION
For LSP these functionality is helpful. When we have a way to
request all the names we known about, we can use the information
for different purposes, such as, suggesting names to fill the
holes, or creating document symbols map for a module.