### PR TITLE
Don't rule out ambiguous names too early

### DIFF
--- a/src/TTImp/Elab/Check.idr
+++ b/src/TTImp/Elab/Check.idr
@@ -537,26 +537,27 @@ successful allowCons ((tm, elab) :: elabs)
                    defs' <- get Ctxt
 
                    -- Reset to previous state and try the rest
-                   put UST ust
-                   put EST est
-                   put MD md
-                   put Ctxt defs
                    logC "elab" 5 $
                             do tm' <- maybe (pure (UN "__"))
                                             toFullNames tm
                                pure ("Success " ++ show tm' ++
                                      " (" ++ show ncons' ++ " - "
                                           ++ show ncons ++ ")")
+                   put UST ust
+                   put EST est
+                   put MD md
+                   put Ctxt defs
                    elabs' <- successful allowCons elabs
                    -- Record success, and the state we ended at
                    pure (Right (minus ncons' ncons,
                                 res, defs', ust', est', md') :: elabs'))
-               (\err => do put UST ust
+               (\err => do err' <- normaliseErr err
+                           put UST ust
                            put EST est
                            put MD md
                            put Ctxt defs
                            elabs' <- successful allowCons elabs
-                           pure (Left (tm, !(normaliseErr err)) :: elabs'))
+                           pure (Left (tm, err') :: elabs'))
 
 export
 exactlyOne' : {vars : _} ->

--- a/tests/idris2/basic044/expected
+++ b/tests/idris2/basic044/expected
@@ -105,29 +105,17 @@ LOG declare.def:2: Case tree for Vec.::: case {arg:N}[4] : (Data.Fin.Fin (Prelud
  | Data.Fin.FS {e:N} {e:N} => [1] ({arg:N}[5] {e:N}[1])
  }
 LOG declare.type:1: Processing Vec.test
-LOG elab.ambiguous:5: Ambiguous elaboration [($resolvedN 2), ($resolvedN 2)] at Vec.idr:L:C--L:C
-With default. Target type : Prelude.Types.Nat
+LOG elab.ambiguous:5: Ambiguous elaboration  [($resolvedN 2), ($resolvedN 2)] at Vec.idr:L:C--L:C
 LOG elab.ambiguous:5: Ambiguous elaboration False [(($resolvedN Nil) ((:: ((:: (fromInteger 0)) Nil)) Nil)), (($resolvedN Nil) ((:: ((:: (fromInteger 0)) Nil)) Nil)), (($resolvedN Nil) ((:: ((:: (fromInteger 0)) Nil)) Nil))] at Vec.idr:L:C--L:C
-Target type : ({arg:N} : (Data.Fin.Fin (Prelude.Types.S (Prelude.Types.S Prelude.Types.Z)))) -> (Prelude.Basics.List Prelude.Types.Nat))
 LOG elab.ambiguous:5: Ambiguous elaboration False [$resolvedN, $resolvedN] at Vec.idr:L:C--L:C
-Target type : ?Vec.{a:N}_[]
 LOG elab.ambiguous:5: Ambiguous elaboration False [(($resolvedN ((:: (fromInteger 0)) Nil)) Nil), (($resolvedN ((:: (fromInteger 0)) Nil)) Nil), (($resolvedN ((:: (fromInteger 0)) Nil)) Nil)] at Vec.idr:L:C--L:C
-Target type : ({arg:N} : (Data.Fin.Fin ?Vec.{n:N}_[])) -> ?Vec.{a:N}_[])
 LOG elab.ambiguous:5: Ambiguous elaboration False [(($resolvedN (fromInteger 0)) Nil), (($resolvedN (fromInteger 0)) Nil), (($resolvedN (fromInteger 0)) Nil)] at Vec.idr:L:C--L:C
-Target type : ?Vec.{a:N}_[]
-LOG elab.ambiguous:5: Ambiguous elaboration [($resolvedN 0), ($resolvedN 0)] at Vec.idr:L:C--L:C
-With default. Target type : ?Vec.{a:N}_[]
+LOG elab.ambiguous:5: Ambiguous elaboration  [($resolvedN 0), ($resolvedN 0)] at Vec.idr:L:C--L:C
 LOG elab.ambiguous:5: Ambiguous elaboration False [$resolvedN, $resolvedN] at Vec.idr:L:C--L:C
-Target type : ({arg:N} : (Data.Fin.Fin ?Vec.{n:N}_[])) -> ?Vec.{a:N}_[])
-LOG elab.ambiguous:5: Ambiguous elaboration [($resolvedN 0), ($resolvedN 0)] at Vec.idr:L:C--L:C
-With default. Target type : ?Vec.{a:N}_[]
+LOG elab.ambiguous:5: Ambiguous elaboration  [($resolvedN 0), ($resolvedN 0)] at Vec.idr:L:C--L:C
 LOG elab.ambiguous:5: Ambiguous elaboration False [$resolvedN, $resolvedN] at Vec.idr:L:C--L:C
-Target type : ({arg:N} : (Data.Fin.Fin ?Vec.{n:N}_[])) -> ?Vec.{a:N}_[])
 LOG elab.ambiguous:5: Ambiguous elaboration True [(($resolvedN (fromInteger 0)) Nil)] at Vec.idr:L:C--L:C
-Target type : (Prelude.Basics.List Prelude.Types.Nat)
-LOG elab.ambiguous:5: Ambiguous elaboration [($resolvedN 0), ($resolvedN 0)] at Vec.idr:L:C--L:C
-With default. Target type : Prelude.Types.Nat
+LOG elab.ambiguous:5: Ambiguous elaboration  [($resolvedN 0), ($resolvedN 0)] at Vec.idr:L:C--L:C
 LOG elab.ambiguous:5: Ambiguous elaboration True [$resolvedN] at Vec.idr:L:C--L:C
-Target type : (Prelude.Basics.List Prelude.Types.Nat)
 LOG declare.def:2: Case tree for Vec.test: [0] (Vec.:: (Prelude.Types.S Prelude.Types.Z) (Prelude.Basics.List Prelude.Types.Nat) (Prelude.Basics.Nil Prelude.Types.Nat) (Vec.:: Prelude.Types.Z (Prelude.Basics.List Prelude.Types.Nat) (Prelude.Basics.:: Prelude.Types.Nat Prelude.Types.Z (Prelude.Basics.Nil Prelude.Types.Nat)) (Vec.Nil (Prelude.Basics.List Prelude.Types.Nat))))
 Vec> Bye for now!


### PR DESCRIPTION
Implementing the rules as described on https://idris2.readthedocs.io/en/latest/updates/updates.html#ambiguous-name-resolution
We should only take a concrete name over a polymorphic one if it's the *only* possible concrete name. We might get more information later.

This caused some things to fail when they shouldn't in some cases, and other things to take ages to elaborate.

I don't have a small enough test case, sorry - the problem was hard to minimise.