### PR TITLE
Small pruning fix

### DIFF
--- a/src/TTImp/Elab/Ambiguity.idr
+++ b/src/TTImp/Elab/Ambiguity.idr
@@ -203,6 +203,7 @@ mutual
                Defs -> NF vars -> NF [] -> Core TypeMatch
   mightMatch defs target (NBind fc n (Pi _ _ _ _) sc)
       = mightMatchD defs target !(sc defs (toClosure defaultOpts [] (Erased fc False)))
+  mightMatch defs (NBind _ _ _ _) (NBind _ _ _ _) = pure Poly -- lambdas might match
   mightMatch defs (NTCon _ n t a args) (NTCon _ n' t' a' args')
       = if n == n'
            then do amatch <- mightMatchArgs defs (map snd args) (map snd args')


### PR DESCRIPTION
Check for lambdas when checking if a type might fit for an ambiguous name.