### PR TITLE
Read import hashes correctly

### DIFF
--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -495,7 +495,7 @@ getImportHashes : String -> Ref Bin Binary ->
 getImportHashes file b
     = do hdr <- fromBuf {a = String} b
          when (hdr /= "TT2") $ corrupt ("TTC header in " ++ file ++ " " ++ show hdr)
-         ver <- fromBuf {a = Int} b
+         ver <- fromBuf @{Wasteful} b
          checkTTCVersion file ver ttcVersion
          ifaceHash <- fromBuf {a = Int} b
          fromBuf b
@@ -504,7 +504,7 @@ getHash : String -> Ref Bin Binary -> Core Int
 getHash file b
     = do hdr <- fromBuf {a = String} b
          when (hdr /= "TT2") $ corrupt ("TTC header in " ++ file ++ " " ++ show hdr)
-         ver <- fromBuf {a = Int} b
+         ver <- fromBuf @{Wasteful} b
          checkTTCVersion file ver ttcVersion
          fromBuf b
 

--- a/tests/idris2/import001/expected
+++ b/tests/idris2/import001/expected
@@ -4,6 +4,5 @@
 Test> S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S Z)))))))))))))))))
 Test> Bye for now!
 2/3: Building Mult (Mult.idr)
-3/3: Building Test (Test.idr)
 Test> S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S Z)))))))))))))))))
 Test> Bye for now!


### PR DESCRIPTION
Need to use the 8 byte version of Ints for the shortcut version of reading TTCs too, otherwise we'll read the wrong hash and build things unnecessarily.