### PR TITLE
Use socketaddr_storage in getsockname

### DIFF
--- a/support/c/idris_net.c
+++ b/support/c/idris_net.c
@@ -160,14 +160,14 @@ int idrnet_getsockname(int sockfd, void *address, void *len) {
 }
 
 int idrnet_sockaddr_port(int sockfd) {
-  struct sockaddr address;
-  socklen_t addrlen = sizeof(struct sockaddr);
-  int res = getsockname(sockfd, &address, &addrlen);
+  struct sockaddr_storage address;
+  socklen_t addrlen = sizeof(struct sockaddr_storage);
+  int res = getsockname(sockfd, (struct sockaddr*)&address, &addrlen);
   if(res < 0) {
     return -1;
   }
 
-  switch(address.sa_family) {
+  switch(address.ss_family) {
   case AF_INET:
     return ntohs(((struct sockaddr_in*)&address)->sin_port);
   case AF_INET6:


### PR DESCRIPTION
As documented in e.g. [sys_socket.h](https://man7.org/linux/man-pages/man0/sys_socket.h.0p.html), one should use `socketaddr_storage` as a layout compatible version of either `socketaddr_in` or `socketaddr_in6` when reading one from e.g. `getsockname`. Mainly silences a compiler warning, since no bad memory is actually currently read after wrongly casting to `socketaddr_in6*` in

https://github.com/idris-lang/Idris2/blob/aa94dd235115137d56193f0db82d4f297758ee40/support/c/idris_net.c#L174