### PR TITLE
Add Vect drop function and fix bug with signal C code

### DIFF
--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -88,10 +88,15 @@ take 0 xs = Nil
 take (S k) (x :: xs) = x :: take k xs
 
 ||| Drop the first `n` elements of a Vect.
-drop : (n : Nat) -> Vect l elem -> Vect (l `minus` n) elem
-drop 0 xs = rewrite minusZeroRight l in xs
-drop (S k) [] = rewrite minusZeroLeft (S k) in []
+drop : (n : Nat) -> Vect (n + m) elem -> Vect m elem
+drop 0 xs = xs
 drop (S k) (x :: xs) = drop k xs
+
+||| Drop up to the first `n` elements of a Vect.
+drop' : (n : Nat) -> Vect l elem -> Vect (l `minus` n) elem
+drop' 0 xs = rewrite minusZeroRight l in xs
+drop' (S k) [] = rewrite minusZeroLeft (S k) in []
+drop' (S k) (x :: xs) = drop' k xs
 
 ||| Extract a particular element from a vector
 |||

--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -87,6 +87,12 @@ take : (n  : Nat)
 take 0 xs = Nil
 take (S k) (x :: xs) = x :: take k xs
 
+||| Drop the first `n` elements of a Vect.
+drop : (n : Nat) -> Vect l elem -> Vect (l `minus` n) elem
+drop 0 xs = rewrite minusZeroRight l in xs
+drop (S k) [] = rewrite minusZeroLeft (S k) in []
+drop (S k) (x :: xs) = drop k xs
+
 ||| Extract a particular element from a vector
 |||
 ||| ```idris example

--- a/support/c/idris_signal.c
+++ b/support/c/idris_signal.c
@@ -132,6 +132,7 @@ int collect_signal(int signum) {
 int handle_next_collected_signal() {
   if (_lock()) {
     if (signals_in_buf == 0) {
+      _unlock();
       return -1;
     }
     int next = signal_buf[signal_buf_next_read_idx];


### PR DESCRIPTION
Two unrelated commits -- I can drop (heh) the `drop` function from this PR if folks don't want it in base.