### PR TITLE
Reconcile FC and IDE mode

### DIFF
--- a/src/Core/Directory.idr
+++ b/src/Core/Directory.idr
@@ -106,8 +106,8 @@ nsToPath loc ns
             | Nothing => pure (Left (ModuleNotFound loc ns))
          pure (Right f)
 
--- Given a namespace, return the full path to the source module (if it
--- exists in the working directory)
+-- Given a namespace, return the path to the source module relative
+-- to the working directory, if the module exists.
 export
 nsToSource : {auto c : Ref Ctxt Defs} ->
              FC -> ModuleIdent -> Core String


### PR DESCRIPTION
1) Recover the path relative to the working directory when sending file contexts, arisen due to typechecking errors, via the idemode protocol.
    Send that over instead of module identifiers. (This is expected behaviour on the idris2-mode side)
2) Send the absolute path to a found global name in the name-at command.