### PR TITLE
[ new ] detect changes using `sha256` rather than timestamps

### DIFF
--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -17,8 +17,6 @@ import Libraries.Utils.Path
 import Data.List
 import Data.List1
 import Data.Maybe
-import Libraries.Data.NameMap
-import Libraries.Data.Version
 import Data.Strings
 import Data.Vect
 
@@ -28,6 +26,10 @@ import System
 import System.Directory
 import System.File
 import System.Info
+
+import Libraries.Data.NameMap
+import Libraries.Data.Version
+import Libraries.Utils.String
 
 %default covering
 
@@ -80,15 +82,6 @@ findLibs ds
              then Just (trim (substr 3 (length d) d))
              else Nothing
 
-export
-escapeString : String -> String
-escapeString s = pack $ foldr escape [] $ unpack s
-  where
-    escape : Char -> List Char -> List Char
-    escape '"' cs = '\\' :: '\"' :: cs
-    escape '\\' cs = '\\' :: '\\' :: cs
-    escape c   cs = c :: cs
-
 schHeader : String -> List String -> String
 schHeader chez libs
   = (if os /= "windows" then "#!" ++ chez ++ " --script\n\n" else "") ++
@@ -101,7 +94,7 @@ schHeader chez libs
     "  [(i3nt ti3nt a6nt ta6nt) (load-shared-object \"msvcrt.dll\")" ++
     "                           (load-shared-object \"ws2_32.dll\")]\n" ++
     "  [else (load-shared-object \"libc.so\")])\n\n" ++
-    showSep "\n" (map (\x => "(load-shared-object \"" ++ escapeString x ++ "\")") libs) ++ "\n\n" ++
+    showSep "\n" (map (\x => "(load-shared-object \"" ++ escapeStringChez x ++ "\")") libs) ++ "\n\n" ++
     "(let ()\n"
 
 schFooter : Bool -> String
@@ -246,7 +239,7 @@ cCall appdir fc cfn clib args ret collectSafe
                            copyLib (appdir </> fname, fullname)
                            put Loaded (clib :: loaded)
                            pure $ "(load-shared-object \""
-                                    ++ escapeString fname
+                                    ++ escapeStringChez fname
                                     ++ "\")\n"
          argTypes <- traverse (\a => cftySpec fc (snd a)) args
          retType <- cftySpec fc ret

--- a/src/Compiler/Scheme/ChezSep.idr
+++ b/src/Compiler/Scheme/ChezSep.idr
@@ -21,8 +21,6 @@ import Libraries.Utils.Path
 import Data.List
 import Data.List1
 import Data.Maybe
-import Libraries.Data.NameMap
-import Libraries.Data.Version
 import Data.Strings
 import Data.Vect
 
@@ -32,6 +30,10 @@ import System
 import System.Directory
 import System.File
 import System.Info
+
+import Libraries.Data.NameMap
+import Libraries.Data.Version
+import Libraries.Utils.String
 
 %default covering
 
@@ -46,7 +48,7 @@ schHeader libs compilationUnits = unlines
   , "  [(i3nt ti3nt a6nt ta6nt) (load-shared-object \"msvcrt.dll\")"
   , "                           (load-shared-object \"ws2_32.dll\")]"
   , "  [else (load-shared-object \"libc.so\")]"
-  , unlines ["  (load-shared-object \"" ++ escapeString lib ++ "\")" | lib <- libs]
+  , unlines ["  (load-shared-object \"" ++ escapeStringChez lib ++ "\")" | lib <- libs]
   , ")"
   ]
 

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -1,3 +1,6 @@
+||| Reading and writing 'Defs' from/to a binary file. In order to be saved, a
+||| name must have been flagged using 'toSave'. (Otherwise we'd save out
+||| everything, not just the things in the current file).
 module Core.Binary
 
 import Core.CaseTree
@@ -12,28 +15,23 @@ import Core.TT
 import Core.TTC
 import Core.UnifyState
 
-import Libraries.Data.IntMap
+import Data.Buffer
 import Data.List
-import Libraries.Data.NameMap
 
 import System.File
 
--- Reading and writing 'Defs' from/to  a binary file
--- In order to be saved, a name must have been flagged using 'toSave'.
--- (Otherwise we'd save out everything, not just the things in the current
--- file).
+import Libraries.Data.IntMap
+import Libraries.Data.NameMap
 
 import public Libraries.Utils.Binary
 
-import Data.Buffer
-
 %default covering
 
--- increment this when changing anything in the data format
--- TTC files can only be compatible if the version number is the same
+||| TTC files can only be compatible if the version number is the same
+||| (Increment this when changing anything in the data format)
 export
 ttcVersion : Int
-ttcVersion = 55
+ttcVersion = 56
 
 export
 checkTTCVersion : String -> Int -> Int -> Core ()
@@ -43,6 +41,7 @@ checkTTCVersion file ver exp
 record TTCFile extra where
   constructor MkTTCFile
   version : Int
+  sourceHash : String
   ifaceHash : Int
   importHashes : List (Namespace, Int)
   context : List (Name, Binary)
@@ -93,14 +92,14 @@ HasNames (Name, Name, Bool) where
   resolved c (n1, n2, b) = pure (!(resolved c n1), !(resolved c n2), b)
 
 HasNames e => HasNames (TTCFile e) where
-  full gam (MkTTCFile version ifaceHash iHashes
+  full gam (MkTTCFile version sourceHash ifaceHash iHashes
                       context userHoles
                       autoHints typeHints
                       imported nextVar currentNS nestedNS
                       pairnames rewritenames primnames
                       namedirectives cgdirectives trans
                       extra)
-      = pure $ MkTTCFile version ifaceHash iHashes
+      = pure $ MkTTCFile version sourceHash ifaceHash iHashes
                          context userHoles
                          !(traverse (full gam) autoHints)
                          !(traverse (full gam) typeHints)
@@ -131,14 +130,14 @@ HasNames e => HasNames (TTCFile e) where
   -- I don't think we ever actually want to call this, because after we read
   -- from the file we're going to add them to learn what the resolved names
   -- are supposed to be! But for completeness, let's do it right.
-  resolved gam (MkTTCFile version ifaceHash iHashes
+  resolved gam (MkTTCFile version sourceHash ifaceHash iHashes
                       context userHoles
                       autoHints typeHints
                       imported nextVar currentNS nestedNS
                       pairnames rewritenames primnames
                       namedirectives cgdirectives trans
                       extra)
-      = pure $ MkTTCFile version ifaceHash iHashes
+      = pure $ MkTTCFile version sourceHash ifaceHash iHashes
                          context userHoles
                          !(traverse (resolved gam) autoHints)
                          !(traverse (resolved gam) typeHints)
@@ -177,6 +176,7 @@ writeTTCFile b file_in
       = do file <- toFullNames file_in
            toBuf b "TT2"
            toBuf @{Wasteful} b (version file)
+           toBuf b (sourceHash file)
            toBuf b (ifaceHash file)
            toBuf b (importHashes file)
            toBuf b (imported file)
@@ -205,12 +205,13 @@ readTTCFile readall file as b
            when (hdr /= "TT2") $ corrupt ("TTC header in " ++ file ++ " " ++ show hdr)
            ver <- fromBuf @{Wasteful} b
            checkTTCVersion file ver ttcVersion
+           sourceFileHash <- fromBuf b
            ifaceHash <- fromBuf b
            importHashes <- fromBuf b
            imp <- fromBuf b
            ex <- fromBuf b
            if not readall
-              then pure (MkTTCFile ver ifaceHash importHashes [] [] [] [] []
+              then pure (MkTTCFile ver sourceFileHash ifaceHash importHashes [] [] [] [] []
                                    0 (mkNamespace "") [] Nothing
                                    Nothing
                                    (MkPrimNs Nothing Nothing Nothing Nothing)
@@ -229,7 +230,7 @@ readTTCFile readall file as b
                  nds <- fromBuf b
                  cgds <- fromBuf b
                  trans <- fromBuf b
-                 pure (MkTTCFile ver ifaceHash importHashes
+                 pure (MkTTCFile ver sourceFileHash ifaceHash importHashes
                                  (map (replaceNS cns) defs) uholes
                                  autohs typehs imp nextv cns nns
                                  pns rws prims nds cgds trans ex)
@@ -265,15 +266,17 @@ export
 writeToTTC : (HasNames extra, TTC extra) =>
              {auto c : Ref Ctxt Defs} ->
              {auto u : Ref UST UState} ->
-             extra -> (fname : String) -> Core ()
-writeToTTC extradata fname
+             extra -> (sourceFileName : String) ->
+             (ttcFileName : String) -> Core ()
+writeToTTC extradata sourceFileName ttcFileName
     = do bin <- initBinary
          defs <- get Ctxt
          ust <- get UST
          gdefs <- getSaveDefs (currentNS defs) (keys (toSave defs)) [] defs
-         log "ttc.write" 5 $ "Writing " ++ fname ++ " with hash " ++ show (ifaceHash defs)
+         sourceHash <- hashFile sourceFileName
+         log "ttc.write" 5 $ "Writing " ++ ttcFileName ++ " with source hash " ++ sourceHash ++ " and interface hash " ++ show (ifaceHash defs)
          writeTTCFile bin
-                   (MkTTCFile ttcVersion (ifaceHash defs) (importHashes defs)
+                   (MkTTCFile ttcVersion (sourceHash) (ifaceHash defs) (importHashes defs)
                               gdefs
                               (keys (userHoles defs))
                               (saveAutoHints defs)
@@ -290,8 +293,8 @@ writeToTTC extradata fname
                               (saveTransforms defs)
                               extradata)
 
-         Right ok <- coreLift $ writeToFile fname !(get Bin)
-               | Left err => throw (InternalError (fname ++ ": " ++ show err))
+         Right ok <- coreLift $ writeToFile ttcFileName !(get Bin)
+               | Left err => throw (InternalError (ttcFileName ++ ": " ++ show err))
          pure ()
 
 addGlobalDef : {auto c : Ref Ctxt Defs} ->
@@ -497,27 +500,31 @@ getImportHashes file b
          when (hdr /= "TT2") $ corrupt ("TTC header in " ++ file ++ " " ++ show hdr)
          ver <- fromBuf @{Wasteful} b
          checkTTCVersion file ver ttcVersion
-         ifaceHash <- fromBuf {a = Int} b
+         sourceFileHash <- fromBuf {a = String} b
+         interfaceHash <- fromBuf {a = Int} b
          fromBuf b
 
-getHash : String -> Ref Bin Binary -> Core Int
-getHash file b
+export
+getHashes : String -> Ref Bin Binary -> Core (String, Int)
+getHashes file b
     = do hdr <- fromBuf {a = String} b
          when (hdr /= "TT2") $ corrupt ("TTC header in " ++ file ++ " " ++ show hdr)
          ver <- fromBuf @{Wasteful} b
          checkTTCVersion file ver ttcVersion
-         fromBuf b
+         sourceFileHash <- fromBuf b
+         interfaceHash <- fromBuf b
+         pure (sourceFileHash, interfaceHash)
 
 export
-readIFaceHash : (fname : String) -> -- file containing the module
-                Core Int
-readIFaceHash fname
-    = do Right buffer <- coreLift $ readFromFile fname
-            | Left err => pure 0
+readHashes : (fileName : String) -> -- file containing the module
+                Core (String, Int)
+readHashes fileName
+    = do Right buffer <- coreLift $ readFromFile fileName
+            | Left err => pure ("", 0)
          b <- newRef Bin buffer
-         catch (do res <- getHash fname b
-                   pure res)
-               (\err => pure 0)
+         catch (do hashes <- getHashes fileName b
+                   pure hashes)
+               (\err => pure ("", 0))
 
 export
 readImportHashes : (fname : String) -> -- file containing the module

--- a/src/Core/Options.idr
+++ b/src/Core/Options.idr
@@ -160,6 +160,8 @@ record Session where
   -- Warnings
   warningsAsErrors : Bool
   showShadowingWarning : Bool
+  -- Experimental
+  checkHashesInsteadOfModTime : Bool
 
 public export
 record PPrinter where
@@ -208,7 +210,7 @@ export
 defaultSession : Session
 defaultSession = MkSessionOpts False False False Chez [] False defaultLogLevel
                                False False False Nothing Nothing
-                               Nothing Nothing False False True
+                               Nothing Nothing False False True False
 
 export
 defaultElab : ElabDirectives

--- a/src/Idris/CommandLine.idr
+++ b/src/Idris/CommandLine.idr
@@ -136,6 +136,9 @@ data CLOpt
   WarningsAsErrors |
   ||| Do not print shadowing warnings
   IgnoreShadowingWarnings |
+  ||| Use SHA256 hashes to determine if a source file needs rebuilding instead
+  ||| of modification time.
+  HashesInsteadOfModTime |
   ||| Generate bash completion info
   BashCompletion String String |
   ||| Generate bash completion script
@@ -224,6 +227,10 @@ options = [MkOpt ["--check", "-c"] [] [CheckOnly]
               (Just "Treat warnings as errors"),
            MkOpt ["-Wno-shadowing"] [] [IgnoreShadowingWarnings]
               (Just "Do not print shadowing warnings"),
+
+           optSeparator,
+           MkOpt ["-Xcheck-hashes"] [] [HashesInsteadOfModTime]
+             (Just "Use SHA256 hashes instead of modification time to determine if a source file needs rebuilding"),
 
            optSeparator,
            MkOpt ["--prefix"] [] [ShowPrefix]

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -696,24 +696,25 @@ partitionOpts opts = foldr pOptUpdate (MkPFR [] [] False) opts
       PIgnore : OptType
       PErr : OptType
     optType : CLOpt -> OptType
-    optType (Package cmd f)  = PPackage cmd f
-    optType Quiet            = POpt
-    optType Verbose          = POpt
-    optType Timing           = POpt
-    optType (Logging l)      = POpt
-    optType (DumpCases f)    = POpt
-    optType (DumpLifted f)   = POpt
-    optType (DumpVMCode f)   = POpt
-    optType DebugElabCheck   = POpt
-    optType (SetCG f)        = POpt
-    optType (Directive d)    = POpt
-    optType (BuildDir f)     = POpt
-    optType (OutputDir f)    = POpt
-    optType WarningsAsErrors = POpt
-    optType (ConsoleWidth n) = PIgnore
-    optType (Color b)        = PIgnore
-    optType NoBanner         = PIgnore
-    optType x                = PErr
+    optType (Package cmd f)        = PPackage cmd f
+    optType Quiet                  = POpt
+    optType Verbose                = POpt
+    optType Timing                 = POpt
+    optType (Logging l)            = POpt
+    optType (DumpCases f)          = POpt
+    optType (DumpLifted f)         = POpt
+    optType (DumpVMCode f)         = POpt
+    optType DebugElabCheck         = POpt
+    optType (SetCG f)              = POpt
+    optType (Directive d)          = POpt
+    optType (BuildDir f)           = POpt
+    optType (OutputDir f)          = POpt
+    optType WarningsAsErrors       = POpt
+    optType HashesInsteadOfModTime = POpt
+    optType (ConsoleWidth n)       = PIgnore
+    optType (Color b)              = PIgnore
+    optType NoBanner               = PIgnore
+    optType x                      = PErr
 
     pOptUpdate : CLOpt -> (PackageOpts -> PackageOpts)
     pOptUpdate opt with (optType opt)

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -348,6 +348,9 @@ preOptions (WarningsAsErrors :: opts)
 preOptions (IgnoreShadowingWarnings :: opts)
     = do setSession (record { showShadowingWarning = False } !getSession)
          preOptions opts
+preOptions (HashesInsteadOfModTime :: opts)
+    = do setSession (record {checkHashesInsteadOfModTime = True} !getSession)
+         preOptions opts
 preOptions (BashCompletion a b :: _)
     = do os <- opts a b
          coreLift $ putStr $ unlines os

--- a/src/Libraries/Utils/String.idr
+++ b/src/Libraries/Utils/String.idr
@@ -21,11 +21,19 @@ lowerFirst : String -> Bool
 lowerFirst "" = False
 lowerFirst str = assert_total (isLower (prim__strHead str))
 
-export
-escapeStringChez : String -> String
-escapeStringChez s = pack $ foldr escape [] $ unpack s
+escapeGeneric : Char -> List Char -> String -> String
+escapeGeneric esc toEscape = pack . foldr escape [] . unpack
   where
     escape : Char -> List Char -> List Char
-    escape '\'' cs = '\\' :: '\'' :: cs
-    escape '\\' cs = '\\' :: '\\' :: cs
-    escape c   cs = c :: cs
+    escape c cs =
+      if elem c toEscape
+        then (esc :: c :: cs)
+        else (c :: cs)
+
+export
+escapeStringUnix : String -> String
+escapeStringUnix = escapeGeneric '\\' ['"', '\\']
+
+export
+escapeStringChez : String -> String
+escapeStringChez = escapeGeneric '\\' ['\'', '\\']

--- a/src/Libraries/Utils/String.idr
+++ b/src/Libraries/Utils/String.idr
@@ -20,3 +20,12 @@ export
 lowerFirst : String -> Bool
 lowerFirst "" = False
 lowerFirst str = assert_total (isLower (prim__strHead str))
+
+export
+escapeStringChez : String -> String
+escapeStringChez s = pack $ foldr escape [] $ unpack s
+  where
+    escape : Char -> List Char -> List Char
+    escape '\'' cs = '\\' :: '\'' :: cs
+    escape '\\' cs = '\\' :: '\\' :: cs
+    escape c   cs = c :: cs

--- a/src/Yaffle/Main.idr
+++ b/src/Yaffle/Main.idr
@@ -44,24 +44,25 @@ HasNames () where
 
 export
 yaffleMain : String -> List String -> Core ()
-yaffleMain fname args
+yaffleMain sourceFileName args
     = do defs <- initDefs
          c <- newRef Ctxt defs
          t <- processArgs args
-         modIdent <- ctxtPathToNS fname
+         modIdent <- ctxtPathToNS sourceFileName
          m <- newRef MD (initMetadata (PhysicalIdrSrc modIdent))
          u <- newRef UST initUState
          setLogTimings t
          addPrimitives
-         case extension fname of
+         case extension sourceFileName of
               Just "ttc" => do coreLift_ $ putStrLn "Processing as TTC"
-                               ignore $ readFromTTC {extra = ()} True emptyFC True fname (nsAsModuleIdent emptyNS) emptyNS
+                               ignore $ readFromTTC {extra = ()} True emptyFC True sourceFileName (nsAsModuleIdent emptyNS) emptyNS
                                coreLift_ $ putStrLn "Read TTC"
               _ => do coreLift_ $ putStrLn "Processing as TTImp"
-                      ok <- processTTImpFile fname
+                      ok <- processTTImpFile sourceFileName
                       when ok $
                          do makeBuildDirectory modIdent
-                            writeToTTC () !(getTTCFileName fname "ttc")
+                            ttcFileName <- getTTCFileName sourceFileName "ttc"
+                            writeToTTC () sourceFileName ttcFileName
                             coreLift_ $ putStrLn "Written TTC"
          ust <- get UST
 

--- a/tests/idris2/import001/expected
+++ b/tests/idris2/import001/expected
@@ -6,3 +6,5 @@ Test> Bye for now!
 2/3: Building Mult (Mult.idr)
 Test> S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S Z)))))))))))))))))
 Test> Bye for now!
+Test> S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S Z)))))))))))))))))
+Test> Bye for now!

--- a/tests/idris2/import001/run
+++ b/tests/idris2/import001/run
@@ -2,5 +2,8 @@ $1 --no-color --console-width 0 --no-banner --no-prelude Test.idr < input
 sleep 1
 touch Mult.idr
 $1 --no-color --console-width 0 --no-banner --no-prelude Test.idr < input
+sleep 1
+touch Mult.idr
+$1 --no-color --console-width 0 --no-banner --no-prelude -Xcheck-hashes Test.idr < input
 
 rm -rf build


### PR DESCRIPTION
Closes #1519
Fixes #23 (modification time is not stored but read from the filesystem)