### PR TITLE
Properly normalise constants on LHS

### DIFF
--- a/src/Core/Normalise.idr
+++ b/src/Core/Normalise.idr
@@ -1439,5 +1439,5 @@ normalisePrims boundSafe viewConstant prims n args tm env
         let True = boundSafe c -- that we should expand
               | _ => pure Nothing
         defs <- get Ctxt
-        tm <- normalise defs env tm
+        tm <- normaliseAll defs env tm
         pure (Just tm)

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -122,7 +122,7 @@ idrisTestsRegression = MkTestPool "Various regressions" []
        "reg015", "reg016", "reg017", "reg018", "reg019", "reg020", "reg021",
        "reg022", "reg023", "reg024", "reg025", "reg026", "reg027", "reg028",
        "reg029", "reg030", "reg031", "reg032", "reg033", "reg034", "reg035",
-       "reg036", "reg037", "reg038", "reg039"]
+       "reg036", "reg037", "reg038", "reg039", "reg040"]
 
 idrisTestsData : TestPool
 idrisTestsData = MkTestPool "Data and record types" []

--- a/tests/idris2/reg040/CoverBug.idr
+++ b/tests/idris2/reg040/CoverBug.idr
@@ -7,13 +7,13 @@ data FastNat : Type where
   MkFastNat : (val : Integer) -> {auto 0 prf : So True} -> FastNat
   
 prv1 : Integer -> (x : Integer ** So $ True)
-prv1 x = 
+prv1 x =
   case choose True of
     Left prf => (x ** Oh)
     Right noprf => absurd noprf
 
 fromInteger : Integer -> FastNat
-fromInteger v = 
+fromInteger v =
   let (v ** p) = prv1 $ v
   in MkFastNat v
     

--- a/tests/idris2/reg040/CoverBug.idr
+++ b/tests/idris2/reg040/CoverBug.idr
@@ -5,7 +5,7 @@ import Data.So
 public export
 data FastNat : Type where
   MkFastNat : (val : Integer) -> {auto 0 prf : So True} -> FastNat
-  
+
 prv1 : Integer -> (x : Integer ** So $ True)
 prv1 x =
   case choose True of
@@ -16,6 +16,6 @@ fromInteger : Integer -> FastNat
 fromInteger v =
   let (v ** p) = prv1 $ v
   in MkFastNat v
-    
+
 doit : FastNat -> FastNat
 doit 0 = 0

--- a/tests/idris2/reg040/CoverBug.idr
+++ b/tests/idris2/reg040/CoverBug.idr
@@ -1,0 +1,21 @@
+module CoverBug
+
+import Data.So
+
+public export
+data FastNat : Type where
+  MkFastNat : (val : Integer) -> {auto 0 prf : So True} -> FastNat
+  
+prv1 : Integer -> (x : Integer ** So $ True)
+prv1 x = 
+  case choose True of
+    Left prf => (x ** Oh)
+    Right noprf => absurd noprf
+
+fromInteger : Integer -> FastNat
+fromInteger v = 
+  let (v ** p) = prv1 $ v
+  in MkFastNat v
+    
+doit : FastNat -> FastNat
+doit 0 = 0

--- a/tests/idris2/reg040/expected
+++ b/tests/idris2/reg040/expected
@@ -1,0 +1,14 @@
+1/1: Building CoverBug (CoverBug.idr)
+Error: doit is not covering.
+
+CoverBug:20:1--20:26
+ 16 | fromInteger v = 
+ 17 |   let (v ** p) = prv1 $ v
+ 18 |   in MkFastNat v
+ 19 |     
+ 20 | doit : FastNat -> FastNat
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Missing cases:
+    doit MkFastNat _
+

--- a/tests/idris2/reg040/expected
+++ b/tests/idris2/reg040/expected
@@ -2,10 +2,10 @@
 Error: doit is not covering.
 
 CoverBug:20:1--20:26
- 16 | fromInteger v = 
+ 16 | fromInteger v =
  17 |   let (v ** p) = prv1 $ v
  18 |   in MkFastNat v
- 19 |     
+ 19 | 
  20 | doit : FastNat -> FastNat
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/idris2/reg040/run
+++ b/tests/idris2/reg040/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 --check CoverBug.idr
+
+rm -rf build


### PR DESCRIPTION
We need to fully evaluate, not just the public export names, otherwise we don't pattern match properly and potentially generate catch all patterns we don't mean.

Fixes #1537