### PR TITLE
Allow underscores in integer literals to aid readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ Syntax changes:
   future.
 * Add support for SnocList syntax: `[< 1, 2, 3]` desugars into `Lin :< 1 :< 2 :< 3`
   and their semantic highlighting.
+* Underscores can be used as visual separators for digit grouping purposes in
+  integer literals: `10_000_000` is equivalent to `10000000` and
+  `0b1111_0101_0000` is equivalent to `0b111101010000`.  This can aid
+  readability of long literals, or literals whose value should clearly
+  separate into parts, such as bytes or words in hexadecimal notation.
 
 Compiler changes:
 

--- a/src/Libraries/Text/Lexer.idr
+++ b/src/Libraries/Text/Lexer.idr
@@ -380,6 +380,22 @@ export
 octLit : Lexer
 octLit = exact "0o" <+> octDigits
 
+export
+digitsUnderscoredLit : Lexer
+digitsUnderscoredLit = digits <+> many (is '_' <+> digits)
+
+export
+binUnderscoredLit : Lexer
+binUnderscoredLit = binLit <+> many (is '_' <+> binDigits)
+
+export
+hexUnderscoredLit : Lexer
+hexUnderscoredLit = hexLit <+> many (is '_' <+> hexDigits)
+
+export
+octUnderscoredLit : Lexer
+octUnderscoredLit = octLit <+> many (is '_' <+> octDigits)
+
 ||| Recognise `start`, then recognise all input until a newline is encountered,
 ||| and consume the newline. Will succeed if end-of-input is encountered before
 ||| a newline.

--- a/src/Parser/Lexer/Source.idr
+++ b/src/Parser/Lexer/Source.idr
@@ -321,10 +321,10 @@ mutual
                   Symbol
       <|> match (choice $ exact <$> symbols) Symbol
       <|> match doubleLit (\x => DoubleLit (cast x))
-      <|> match binLit (\x => IntegerLit (fromBinLit x))
-      <|> match hexLit (\x => IntegerLit (fromHexLit x))
-      <|> match octLit (\x => IntegerLit (fromOctLit x))
-      <|> match digits (\x => IntegerLit (cast x))
+      <|> match binUnderscoredLit (\x => IntegerLit (fromBinLit $ removeUnderscores x))
+      <|> match hexUnderscoredLit (\x => IntegerLit (fromHexLit $ removeUnderscores x))
+      <|> match octUnderscoredLit (\x => IntegerLit (fromOctLit $ removeUnderscores x))
+      <|> match digitsUnderscoredLit (\x => IntegerLit (cast $ removeUnderscores x))
       <|> compose multilineBegin
                   (const $ StringBegin True)
                   countHashtag
@@ -349,17 +349,22 @@ mutual
       parseIdent : String -> Token
       parseIdent x = if x `elem` keywords then Keyword x
                      else Ident x
+
       parseNamespace : String -> Token
       parseNamespace ns = case mkNamespacedIdent ns of
                                (Nothing, ident) => parseIdent ident
                                (Just ns, n)     => DotSepIdent ns n
+
       countHashtag : String -> Nat
       countHashtag = count (== '#') . unpack
 
       removeOptionalLeadingSpace : String -> String
       removeOptionalLeadingSpace str = case strM str of
-        StrCons ' ' tail => tail
-        _ => str
+                                            StrCons ' ' tail => tail
+                                            _ => str
+
+      removeUnderscores : String -> String
+      removeUnderscores s = fastPack $ filter (/= '_') (fastUnpack s)
 
 export
 lexTo : Lexer ->

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -36,7 +36,8 @@ idrisTestsBasic = MkTestPool "Fundamental language features" []
        "basic041", "basic042", "basic043", "basic044", "basic045",
        "basic046", "basic047", "basic048", "basic049", "basic050",
        "basic051", "basic052", "basic053", "basic054", "basic055",
-       "basic056", "basic057", "basic058", "basic059", "basic060"]
+       "basic056", "basic057", "basic058", "basic059", "basic060",
+       "basic061"]
 
 idrisTestsCoverage : TestPool
 idrisTestsCoverage = MkTestPool "Coverage checking" []

--- a/tests/idris2/basic061/UnderscoredIntegerLiterals.idr
+++ b/tests/idris2/basic061/UnderscoredIntegerLiterals.idr
@@ -1,0 +1,23 @@
+module UnderscoredIntegerLiterals
+
+-- grouping decimal numbers by thousands
+amount : Integer
+amount = 10_000_000_000
+
+equalAmounts : Bool
+equalAmounts = amount == 10000000000
+
+-- grouping hexadecimal addresses by words
+addr : Int
+addr = 0xCAFE_F00D
+
+equalAddrs : Bool
+equalAddrs = addr == 0xCAFEF00D
+
+-- grouping bits into nibbles in a binary literal
+equalFlags : Bool
+equalFlags = 0b0011_1111_0100_1110 == 0b0011111101001110
+
+-- grouping octals
+equalOctals : Bool
+equalOctals = 0o455_777 == 0o455777

--- a/tests/idris2/basic061/expected
+++ b/tests/idris2/basic061/expected
@@ -1,0 +1,8 @@
+1/1: Building UnderscoredIntegerLiterals (UnderscoredIntegerLiterals.idr)
+UnderscoredIntegerLiterals> 10000000000
+UnderscoredIntegerLiterals> True
+UnderscoredIntegerLiterals> 3405705229
+UnderscoredIntegerLiterals> True
+UnderscoredIntegerLiterals> True
+UnderscoredIntegerLiterals> True
+UnderscoredIntegerLiterals> Bye for now!

--- a/tests/idris2/basic061/input
+++ b/tests/idris2/basic061/input
@@ -1,0 +1,7 @@
+amount
+equalAmounts
+addr
+equalAddrs
+equalFlags
+equalOctals
+:q

--- a/tests/idris2/basic061/run
+++ b/tests/idris2/basic061/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 --no-banner UnderscoredIntegerLiterals.idr < input
+
+rm -rf build


### PR DESCRIPTION
Underscores can be used as visual separators for digit grouping purposes in integer literals.

This can aid the readability of long literals, or literals whose value should clearly separate into parts, such as bytes or words in hexadecimal notation.

For instance: `10_000_000` is equivalent to `10000000` and `0b1111_0101_0000` is equivalent to `0b111101010000`.

