### PR TITLE
[ refactor/ci ] Enable cache and self-test from previous version

### DIFF
--- a/.github/workflows/ci-ubuntu-combined.yml
+++ b/.github/workflows/ci-ubuntu-combined.yml
@@ -8,11 +8,10 @@ on:
       - '*'
   pull_request:
     branches:
-      - master
-      - main
+      - '*'
 
 env:
-  IDRIS2_VERSION: 0.3.0 # For previous-version build
+  IDRIS2_VERSION: 0.4.0 # For previous-version build
   SCHEME: scheme
 
 jobs:
@@ -61,10 +60,11 @@ jobs:
           name: installed-bootstrapped-idris2-racket
           path: ~/.idris2/
 
-  build-previous-version:
+  build-previous-version-chez:
     runs-on: ubuntu-latest
     env:
       IDRIS2_CG: chez
+      IDRIS2_FLAGS: -Werror -Xcheck-hashes
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -74,6 +74,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y -t hirsute chezscheme
           echo "$HOME/.idris2/bin" >> $GITHUB_PATH
+
       - name: Cache Chez Previous Version
         id: previous-version-cache
         uses: actions/cache@v2
@@ -86,17 +87,91 @@ jobs:
           wget https://www.idris-lang.org/idris2-src/idris2-$IDRIS2_VERSION.tgz
           tar zxvf idris2-$IDRIS2_VERSION.tgz
           cd Idris2-$IDRIS2_VERSION
-          make bootstrap-build
+          make bootstrap
           cd ..
       - name: Install previous version
         run: |
           cd Idris2-$IDRIS2_VERSION
           make install
           cd ..
+
+      - name: Cache Idris2 from Previous Version Build
+        uses: actions/cache@v2
+        with:
+          path: |
+            build/
+            libs/base/build/
+            libs/contrib/build/
+            libs/network/build/
+            libs/prelude/build/
+            libs/test/build/
+          key: ${{ runner.os }}-from-previous-version-${{ github.ref }}-${{ env.IDRIS2_VERSION }}-${{ env.GITHUB_SHA }}
+          restore-keys: |
+            ${{ runner.os }}-from-previous-version-refs/heads/main-${{ env.IDRIS2_VERSION }}
+            ${{ runner.os }}-from-previous-version-refs/heads/master-${{ env.IDRIS2_VERSION }}
+      - name: Build from previous version
+        run: make all && make install
+
       - name: Artifact Idris2
         uses: actions/upload-artifact@v2
         with:
-          name: installed-idris2-${{ env.IDRIS2_VERSION }}-chez
+          name: from-idris2-${{ env.IDRIS2_VERSION }}-chez
+          path: ~/.idris2/
+
+  build-previous-version-racket:
+    runs-on: ubuntu-latest
+    env:
+      IDRIS2_CG: racket
+      IDRIS2_FLAGS: -Werror -Xcheck-hashes
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install build dependencies
+        run: |
+          sudo apt-get install -y racket
+          echo "$HOME/.idris2/bin" >> $GITHUB_PATH
+
+      - name: Cache Racket Previous Version
+        id: previous-version-cache
+        uses: actions/cache@v2
+        with:
+          path: Idris2-${{ env.IDRIS2_VERSION }}
+          key: ${{ runner.os }}-idris2-bootstrapped-racket-${{ env.IDRIS2_VERSION }}
+      - name : Build previous version
+        if: steps.previous-version-cache.outputs.cache-hit != 'true'
+        run: |
+          wget https://www.idris-lang.org/idris2-src/idris2-$IDRIS2_VERSION.tgz
+          tar zxvf idris2-$IDRIS2_VERSION.tgz
+          cd Idris2-$IDRIS2_VERSION
+          make bootstrap-racket
+          cd ..
+      - name: Install previous version
+        run: |
+          cd Idris2-$IDRIS2_VERSION
+          make install
+          cd ..
+
+      - name: Cache Idris2 from Previous Version Build
+        uses: actions/cache@v2
+        with:
+          path: |
+            build/
+            libs/base/build/
+            libs/contrib/build/
+            libs/network/build/
+            libs/prelude/build/
+            libs/test/build/
+          key: ${{ runner.os }}-from-previous-version-${{ github.ref }}-${{ env.IDRIS2_VERSION }}-${{ env.GITHUB_SHA }}
+          restore-keys: |
+            ${{ runner.os }}-from-previous-version-refs/heads/main-${{ env.IDRIS2_VERSION }}
+            ${{ runner.os }}-from-previous-version-refs/heads/master-${{ env.IDRIS2_VERSION }}
+      - name: Build from previous version
+        run: make all && make install
+
+      - name: Artifact Idris2
+        uses: actions/upload-artifact@v2
+        with:
+          name: from-idris2-${{ env.IDRIS2_VERSION }}-racket
           path: ~/.idris2/
 
   #
@@ -104,17 +179,18 @@ jobs:
   #
 
   self-host-chez:
-    needs: build-bootstrap-chez
+    needs: build-previous-version-chez
     runs-on: ubuntu-latest
     env:
       IDRIS2_CG: chez
+      IDRIS2_FLAGS: -Werror -Xcheck-hashes
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Download Idris2 Artifact
         uses: actions/download-artifact@v2
         with:
-          name: installed-bootstrapped-idris2-chez
+          name: from-idris2-${{ env.IDRIS2_VERSION }}-chez
           path: ~/.idris2/
       - name: Install build dependencies
         run: |
@@ -123,58 +199,26 @@ jobs:
           sudo apt-get install -y -t hirsute chezscheme
           echo "$HOME/.idris2/bin" >> $GITHUB_PATH
           chmod +x $HOME/.idris2/bin/idris2 $HOME/.idris2/bin/idris2_app/*
-      - name: Build self-hosted
-        run: make all IDRIS2_BOOT="idris2 -Werror" && make install
-      - name: Test self-hosted
-        run: make test INTERACTIVE=''
 
-  self-host-racket:
-    needs: build-bootstrap-racket
-    runs-on: ubuntu-latest
-    env:
-      IDRIS2_CG: racket
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Download Idris2 Artifact
-        uses: actions/download-artifact@v2
+      - name: Set TTC_VERSION for Cache
+        run: echo "TTC_VERSION=$(grep -P "ttcVersion = \K\d+" src/Core/Binary.idr -o)" >> $GITHUB_ENV
+      - name: Cache Idris2 Self Host from Previous Version Build
+        uses: actions/cache@v2
         with:
-          name: installed-bootstrapped-idris2-racket
-          path: ~/.idris2/
-      - name: Install build dependencies
-        run: |
-          sudo apt-get install -y racket
-          echo "$HOME/.idris2/bin" >> $GITHUB_PATH
-          chmod +x $HOME/.idris2/bin/idris2 $HOME/.idris2/bin/idris2_app/*
-      - name: Build self-hosted
-        run: make all IDRIS2_BOOT="idris2 -Werror" && make install
-      - name: Test self-hosted
-        run: make test INTERACTIVE=''
+          path: |
+            build/
+            libs/base/build/
+            libs/contrib/build/
+            libs/network/build/
+            libs/prelude/build/
+            libs/test/build/
+          key: ${{ runner.os }}-self-host-from-previous-version-${{ github.ref }}-${{ env.TTC_VERSION }}-${{ env.GITHUB_SHA }}
+          restore-keys: |
+            ${{ runner.os }}-self-host-from-previous-version-refs/heads/main-${{ env.TTC_VERSION }}
+            ${{ runner.os }}-self-host-from-previous-version-refs/heads/master-${{ env.TTC_VERSION }}
 
-  self-host-previous-version:
-    needs: build-previous-version
-    runs-on: ubuntu-latest
-    env:
-      IDRIS2_CG: chez
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Download Idris2 Artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: installed-idris2-${{ env.IDRIS2_VERSION }}-chez
-          path: ~/.idris2/
-      - name: Install build dependencies
-        run: |
-          echo "deb http://security.ubuntu.com/ubuntu hirsute universe" | sudo tee -a /etc/apt/sources.list
-          sudo apt-get update
-          sudo apt-get install -y -t hirsute chezscheme
-          echo "$HOME/.idris2/bin" >> $GITHUB_PATH
-          chmod +x $HOME/.idris2/bin/idris2 $HOME/.idris2/bin/idris2_app/*
-      - name: Build from previous version
-        run: make all && make install && make clean
       - name: Build self-hosted from previous version
-        run: make all IDRIS2_BOOT="idris2 -Werror" && make install
+        run: make all && make install
       - name: Test self-hosted from previous version
         run: make test INTERACTIVE=''
       - name: Artifact Idris2
@@ -183,18 +227,66 @@ jobs:
           name: idris2-nightly-chez
           path: ~/.idris2/
 
-  build-api:
-    needs: build-bootstrap-chez
+  self-host-racket:
+    needs: build-previous-version-racket
     runs-on: ubuntu-latest
     env:
-      IDRIS2_CG: chez
+      IDRIS2_CG: racket
+      IDRIS2_FLAGS: -Werror -Xcheck-hashes
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Download Idris2 Artifact
         uses: actions/download-artifact@v2
         with:
-          name: installed-bootstrapped-idris2-chez
+          name: from-idris2-${{ env.IDRIS2_VERSION }}-racket
+          path: ~/.idris2/
+      - name: Install build dependencies
+        run: |
+          sudo apt-get install -y racket
+          echo "$HOME/.idris2/bin" >> $GITHUB_PATH
+          chmod +x $HOME/.idris2/bin/idris2 $HOME/.idris2/bin/idris2_app/*
+
+      - name: Set TTC_VERSION for Cache
+        run: echo "TTC_VERSION=$(grep -P "ttcVersion = \K\d+" src/Core/Binary.idr -o)" >> $GITHUB_ENV
+      - name: Cache Idris2 Self Host from Previous Version Build
+        uses: actions/cache@v2
+        with:
+          path: |
+            build/
+            libs/base/build/
+            libs/contrib/build/
+            libs/network/build/
+            libs/prelude/build/
+            libs/test/build/
+          key: ${{ runner.os }}-self-host-racket-${{ github.ref }}-${{ env.TTC_VERSION }}-${{ env.GITHUB_SHA }}
+          restore-keys: |
+            ${{ runner.os }}-self-host-racket-refs/heads/main-${{ env.TTC_VERSION }}
+            ${{ runner.os }}-self-host-racket-refs/heads/master-${{ env.TTC_VERSION }}
+
+      - name: Build self-hosted from previous version
+        run: make all && make install
+      - name: Test self-hosted from previous version
+        run: make test INTERACTIVE=''
+      - name: Artifact Idris2
+        uses: actions/upload-artifact@v2
+        with:
+          name: idris2-nightly-racket
+          path: ~/.idris2/
+
+  build-api:
+    needs: build-previous-version-chez
+    runs-on: ubuntu-latest
+    env:
+      IDRIS2_CG: chez
+      IDRIS2_FLAGS: -Werror -Xcheck-hashes
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Download Idris2 Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: from-idris2-${{ env.IDRIS2_VERSION }}-chez
           path: ~/.idris2/
       - name: Install build dependencies
         run: |
@@ -203,6 +295,24 @@ jobs:
           sudo apt-get install -y -t hirsute chezscheme
           echo "$HOME/.idris2/bin" >> $GITHUB_PATH
           chmod +x $HOME/.idris2/bin/idris2 $HOME/.idris2/bin/idris2_app/*
+
+      - name: Set TTC_VERSION for Cache
+        run: echo "TTC_VERSION=$(grep -P "ttcVersion = \K\d+" src/Core/Binary.idr -o)" >> $GITHUB_ENV
+      - name: Cache Idris2 API
+        uses: actions/cache@v2
+        with:
+          path: |
+            build/
+            libs/base/build/
+            libs/contrib/build/
+            libs/network/build/
+            libs/prelude/build/
+            libs/test/build/
+          key: ${{ runner.os }}-build-api-${{ github.ref }}-${{ env.TTC_VERSION }}-${{ env.GITHUB_SHA }}
+          restore-keys: |
+            ${{ runner.os }}-build-api-refs/heads/main-${{ env.TTC_VERSION }}
+            ${{ runner.os }}-build-api-refs/heads/master-${{ env.TTC_VERSION }}
+
       - name: Build API
         run: make install-api
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ endif
 
 export IDRIS2_VERSION := ${MAJOR}.${MINOR}.${PATCH}
 export NAME_VERSION := ${NAME}-${IDRIS2_VERSION}
+export IDRIS2_FLAGS
+
 IDRIS2_SUPPORT := libidris2_support${SHLIB_SUFFIX}
 IDRIS2_APP_IPKG := idris2.ipkg
 IDRIS2_LIB_IPKG := idris2api.ipkg
@@ -56,7 +58,7 @@ all: support ${TARGET} libs
 idris2-exec: ${TARGET}
 
 ${TARGET}: src/IdrisPaths.idr
-	${IDRIS2_BOOT} --build ${IDRIS2_APP_IPKG}
+	${IDRIS2_BOOT} --build ${IDRIS2_APP_IPKG} ${IDRIS2_FLAGS}
 
 # We use FORCE to always rebuild IdrisPath so that the git SHA1 info is always up to date
 src/IdrisPaths.idr: FORCE
@@ -147,10 +149,10 @@ clean: clean-libs support-clean testenv-clean
 install: install-idris2 install-support install-libs
 
 install-api: src/IdrisPaths.idr
-	${IDRIS2_BOOT} --install ${IDRIS2_LIB_IPKG}
+	${IDRIS2_BOOT} --install ${IDRIS2_LIB_IPKG} ${IDRIS2_FLAGS}
 
 install-with-src-api: src/IdrisPaths.idr
-	${IDRIS2_BOOT} --install-with-src ${IDRIS2_LIB_IPKG}
+	${IDRIS2_BOOT} --install-with-src ${IDRIS2_LIB_IPKG} ${IDRIS2_FLAGS}
 
 install-idris2:
 	mkdir -p ${PREFIX}/bin/
@@ -178,17 +180,17 @@ install-support:
 
 install-libs:
 	${MAKE} -C libs/prelude install IDRIS2?=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
-	${MAKE} -C libs/base install IDRIS2?=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
+	${MAKE} -C libs/base    install IDRIS2?=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 	${MAKE} -C libs/contrib install IDRIS2?=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 	${MAKE} -C libs/network install IDRIS2?=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
-	${MAKE} -C libs/test  install IDRIS2?=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
+	${MAKE} -C libs/test    install IDRIS2?=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 
 install-with-src-libs:
 	${MAKE} -C libs/prelude install-with-src IDRIS2?=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
-	${MAKE} -C libs/base install-with-src IDRIS2?=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
+	${MAKE} -C libs/base    install-with-src IDRIS2?=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 	${MAKE} -C libs/contrib install-with-src IDRIS2?=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 	${MAKE} -C libs/network install-with-src IDRIS2?=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
-	${MAKE} -C libs/test install-with-src IDRIS2?=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
+	${MAKE} -C libs/test    install-with-src IDRIS2?=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 
 .PHONY: bootstrap bootstrap-build bootstrap-racket bootstrap-racket-build bootstrap-test bootstrap-clean
 

--- a/libs/base/Makefile
+++ b/libs/base/Makefile
@@ -1,11 +1,11 @@
 all:
-	${IDRIS2} --build base.ipkg
+	${IDRIS2} --build base.ipkg ${IDRIS2_FLAGS}
 
 install:
-	${IDRIS2} --install base.ipkg
+	${IDRIS2} --install base.ipkg ${IDRIS2_FLAGS}
 
 install-with-src:
-	${IDRIS2} --install-with-src base.ipkg
+	${IDRIS2} --install-with-src base.ipkg ${IDRIS2_FLAGS}
 
 docs:
 	${IDRIS2} --mkdoc base.ipkg

--- a/libs/contrib/Makefile
+++ b/libs/contrib/Makefile
@@ -1,11 +1,11 @@
 all:
-	${IDRIS2} --build contrib.ipkg
+	${IDRIS2} --build contrib.ipkg ${IDRIS2_FLAGS}
 
 install:
-	${IDRIS2} --install contrib.ipkg
+	${IDRIS2} --install contrib.ipkg ${IDRIS2_FLAGS}
 
 install-with-src:
-	${IDRIS2} --install-with-src contrib.ipkg
+	${IDRIS2} --install-with-src contrib.ipkg ${IDRIS2_FLAGS}
 
 docs:
 	${IDRIS2} --mkdoc contrib.ipkg

--- a/libs/network/Makefile
+++ b/libs/network/Makefile
@@ -1,11 +1,11 @@
 all:
-	${IDRIS2} --build network.ipkg
+	${IDRIS2} --build network.ipkg ${IDRIS2_FLAGS}
 
 install:
-	${IDRIS2} --install network.ipkg
+	${IDRIS2} --install network.ipkg ${IDRIS2_FLAGS}
 
 install-with-src:
-	${IDRIS2} --install-with-src network.ipkg
+	${IDRIS2} --install-with-src network.ipkg ${IDRIS2_FLAGS}
 
 docs:
 	${IDRIS2} --mkdoc network.ipkg

--- a/libs/prelude/Makefile
+++ b/libs/prelude/Makefile
@@ -1,11 +1,11 @@
 all:
-	${IDRIS2} --build prelude.ipkg
+	${IDRIS2} --build prelude.ipkg ${IDRIS2_FLAGS}
 
 install:
-	${IDRIS2} --install prelude.ipkg
+	${IDRIS2} --install prelude.ipkg ${IDRIS2_FLAGS}
 
 install-with-src:
-	${IDRIS2} --install-with-src prelude.ipkg
+	${IDRIS2} --install-with-src prelude.ipkg ${IDRIS2_FLAGS}
 
 docs:
 	${IDRIS2} --mkdoc prelude.ipkg

--- a/libs/test/Makefile
+++ b/libs/test/Makefile
@@ -1,11 +1,11 @@
 all:
-	${IDRIS2} --build test.ipkg
+	${IDRIS2} --build test.ipkg ${IDRIS2_FLAGS}
 
 install:
-	${IDRIS2} --install test.ipkg
+	${IDRIS2} --install test.ipkg ${IDRIS2_FLAGS}
 
 install-with-src:
-	${IDRIS2} --install-with-src test.ipkg
+	${IDRIS2} --install-with-src test.ipkg ${IDRIS2_FLAGS}
 
 docs:
 	${IDRIS2} --mkdoc test.ipkg


### PR DESCRIPTION
NOTICE: For now only the main branch cache will be reused and will be updated by every commit.

Time to completion reduced by 10 minutes (from  [~42 minutes](https://github.com/idris-lang/Idris2/actions/runs/943372960) in the main branch to [~29 minutes](https://github.com/idris-lang/Idris2/actions/runs/943619019) [No changes to main branch], [~31 minutes](https://github.com/idris-lang/Idris2/actions/runs/946580407) [Some changes to JS CodeGen], [~28 minutes](https://github.com/idris-lang/Idris2/actions/runs/947190186) [Changes to Case Splitting], [~30 minutes](https://github.com/idris-lang/Idris2/actions/runs/948299999) [Changes to postfix projections], [~27 minutes](https://github.com/idris-lang/Idris2/actions/runs/951142313), [~27 minutes](https://github.com/idris-lang/Idris2/actions/runs/957427264), [~28 minutes](https://github.com/idris-lang/Idris2/actions/runs/961037825) in this merge request)