### PR TITLE
Simplify the output of `--paths` CLI option

### DIFF
--- a/src/Core/Options.idr
+++ b/src/Core/Options.idr
@@ -40,16 +40,16 @@ outputDirWithDefault d = fromMaybe (build_dir d </> "exec") (output_dir d)
 public export
 toString : Dirs -> String
 toString d@(MkDirs wdir sdir bdir ldir odir dfix edirs pdirs ldirs ddirs) =
-  unlines [ "+ Working Directory      :: " ++ show wdir
-          , "+ Source Directory       :: " ++ show sdir
-          , "+ Build Directory        :: " ++ show bdir
-          , "+ Local Depend Directory :: " ++ show ldir
-          , "+ Output Directory       :: " ++ show (outputDirWithDefault d)
-          , "+ Installation Prefix    :: " ++ show dfix
-          , "+ Extra Directories      :: " ++ show edirs
-          , "+ Package Directories    :: " ++ show pdirs
-          , "+ CG Library Directories :: " ++ show ldirs
-          , "+ Data Directories       :: " ++ show ddirs]
+  unlines [ "Working Directory:       " ++ show wdir
+          , "Source Directory:        " ++ show sdir
+          , "Build Directory:         " ++ show bdir
+          , "Local Depend Directory:  " ++ show ldir
+          , "Output Directory:        " ++ show (outputDirWithDefault d)
+          , "Installation Prefix:     " ++ show dfix
+          , "Extra Directories:       " ++ show edirs
+          , "Package Directories:     " ++ show pdirs
+          , "CG Library Directories:  " ++ show ldirs
+          , "Data Directories:        " ++ show ddirs]
 
 public export
 data CG = Chez


### PR DESCRIPTION
Make the output of `idris2 --paths` simpler:

Before:
```
+ Working Directory      :: "/home/kamil/.local/idris/idris2"
+ Source Directory       :: Nothing
+ Build Directory        :: "build"
+ Local Depend Directory :: "depends"
+ Output Directory       :: "build/exec"
+ Installation Prefix    :: "/home/kamil/.idris2"
+ Extra Directories      :: [".", "/home/kamil/.idris2/idris2-0.3.0/prelude-0.3.0", "/home/kamil/.idris2/idris2-0.3.0/base-0.3.0"]
+ Package Directories    :: []
+ CG Library Directories :: ["/home/kamil/.idris2/idris2-0.3.0/lib", "/home/kamil/.local/idris/idris2"]
+ Data Directories       :: ["/home/kamil/.idris2/idris2-0.3.0/support"]
```
After:
```
Working Directory:       "/home/kamil/.local/idris/idris2"
Source Directory:        Nothing
Build Directory:         "build"
Local Depend Directory:  "depends"
Output Directory:        "build/exec"
Installation Prefix:     "/home/kamil/.idris2"
Extra Directories:       [".", "/home/kamil/.idris2/idris2-0.3.0/prelude-0.3.0", "/home/kamil/.idris2/idris2-0.3.0/base-0.3.0"]
Package Directories:     []
CG Library Directories:  ["/home/kamil/.idris2/idris2-0.3.0/lib", "/home/kamil/.local/idris/idris2"]
Data Directories:        ["/home/kamil/.idris2/idris2-0.3.0/support"]
```