### PR TITLE
Issue #1572

### DIFF
--- a/libs/prelude/Prelude/EqOrd.idr
+++ b/libs/prelude/Prelude/EqOrd.idr
@@ -137,8 +137,12 @@ Ord Int where
   (>=) x y = intToBool (prim__gte_Int x y)
 
 public export
+compareInteger : (x : Integer) -> (y : Integer) -> Ordering
+compareInteger x y = if (intToBool $ prim__lt_Integer x y) then LT else if (intToBool $ prim__eq_Integer x y) then EQ else GT
+
+public export
 Ord Integer where
-  compare x y = if x < y then LT else if x == y then EQ else GT
+  compare = compareInteger
 
   (<) x y = intToBool (prim__lt_Integer x y)
   (<=) x y = intToBool (prim__lte_Integer x y)

--- a/libs/prelude/Prelude/Types.idr
+++ b/libs/prelude/Prelude/Types.idr
@@ -63,6 +63,19 @@ mult Z y = Z
 mult (S k) y = plus y (mult k y)
 
 public export
+equal : (x : Nat) -> (y : Nat) -> Bool
+equal Z Z = True
+equal (S j) (S k) = equal j k
+equal _ _ = False
+
+public export
+compareNat : (x : Nat) -> (y : Nat) -> Ordering
+compareNat Z Z = EQ
+compareNat Z (S k) = LT
+compareNat (S k) Z = GT
+compareNat (S j) (S k) = compareNat j k
+
+public export
 Num Nat where
   (+) = plus
   (*) = mult
@@ -71,16 +84,11 @@ Num Nat where
 
 public export
 Eq Nat where
-  Z == Z = True
-  S j == S k = j == k
-  _ == _ = False
+  (==) = equal
 
 public export
 Ord Nat where
-  compare Z Z = EQ
-  compare Z (S k) = LT
-  compare (S k) Z = GT
-  compare (S j) (S k) = compare j k
+  compare = compareNat
 
 public export
 natToInteger : Nat -> Integer

--- a/src/Compiler/CompileExpr.idr
+++ b/src/Compiler/CompileExpr.idr
@@ -190,6 +190,10 @@ natHack =
          (\ fc, fc', [m,n] => CApp fc (CRef fc' (UN "prim__add_Integer")) [m, n])
     , MagicCRef (NS typesNS (UN "mult")) 2
          (\ fc, fc', [m,n] => CApp fc (CRef fc' (UN "prim__mul_Integer")) [m, n])
+    , MagicCRef (NS typesNS (UN "equal")) 2
+         (\ fc, fc', [m,n] => CApp fc (CRef fc' (UN "prim__eq_Integer")) [m, n])
+    , MagicCRef (NS typesNS (UN "compareNat")) 2
+         (\ fc, fc', [m,n] => CApp fc (CRef fc' (NS eqOrdNS (UN "compareInteger"))) [m, n])
     , MagicCRef (NS natNS (UN "minus")) 2 natMinus
     ]
 

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -711,6 +711,7 @@ partitionOpts opts = foldr pOptUpdate (MkPFR [] [] False) opts
     optType (OutputDir f)          = POpt
     optType WarningsAsErrors       = POpt
     optType HashesInsteadOfModTime = POpt
+    optType Profile          = POpt
     optType (ConsoleWidth n)       = PIgnore
     optType (Color b)              = PIgnore
     optType NoBanner               = PIgnore


### PR DESCRIPTION
Added "Profile" as a flag that can be used when building a project.  Since, if you try to use :exec within a repl, the profile flag is ignored by the Chez backend, without this flag, and there is no "profile" setting available within the "ipkg" file, there is not way to turn profiling on with the Chez backend.