### PR TITLE
Add clarifying note re: PREFIX in config.mk

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,7 +34,7 @@ of `make` in the following steps.
 
 ### 1: Set installation target directory
 
-- Change the `PREFIX` in `config.mk`. The default is to install in
+- Change the `PREFIX` in `config.mk` to the absolute path of your chosen installation destination. The default is to install in
   `$HOME/.idris2`
 
 If you have an existing Idris 2, go to Step 3. Otherwise, read on...

--- a/config.mk
+++ b/config.mk
@@ -1,6 +1,6 @@
 ##### Options which a user might set before building go here #####
 
-# Where to install idris2 binaries and libraries (must not be a relative path)
+# Where to install idris2 binaries and libraries (must be an absolute path)
 PREFIX ?= $(HOME)/.idris2
 
 # For Windows targets. Set to 1 to support Windows 7.

--- a/config.mk
+++ b/config.mk
@@ -1,6 +1,6 @@
 ##### Options which a user might set before building go here #####
 
-# Where to install idris2 binaries and libraries
+# Where to install idris2 binaries and libraries (must not be a relative path)
 PREFIX ?= $(HOME)/.idris2
 
 # For Windows targets. Set to 1 to support Windows 7.


### PR DESCRIPTION
Found this to be true in the process of trying to install Idris 2 into its own `git clone`d folder.

I initially tried `./.idris2`, but this led to the library files not being installed in the right places.