### PR TITLE
[ fix #1572 ] Add `--profile` to the list of allowed flags in an .ipkg

### DIFF
--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -711,6 +711,7 @@ partitionOpts opts = foldr pOptUpdate (MkPFR [] [] False) opts
     optType (OutputDir f)          = POpt
     optType WarningsAsErrors       = POpt
     optType HashesInsteadOfModTime = POpt
+    optType Profile                = POpt
     optType (ConsoleWidth n)       = PIgnore
     optType (Color b)              = PIgnore
     optType NoBanner               = PIgnore


### PR DESCRIPTION
Added "Profile" as a flag that can be used when building a project.  Since, if you try to use :exec within a repl, the profile flag is ignored by the Chez backend, without this flag, and there is no "profile" setting available within the "ipkg" file, there is not way to turn profiling on with the Chez backend.