### PR TITLE
Use gsha256sum when sha256sum doesn't exist

### DIFF
--- a/src/Libraries/Utils/Binary.idr
+++ b/src/Libraries/Utils/Binary.idr
@@ -469,11 +469,10 @@ modTime fname
        coreLift $ closeFile f
        pure t
 
-export
-hashFile : String -> Core String
-hashFile fileName
+hashFileWith : String -> String -> Core String
+hashFileWith sha256Sum fileName
   = do Right fileHandle <- coreLift $ popen
-            ("sha256sum \"" ++ osEscape fileName ++ "\"") Read
+            (sha256Sum ++ " \"" ++ osEscape fileName ++ "\"") Read
          | Left _ => coreFail $ InternalError ("Can't get sha256sum of " ++ fileName)
        Right hashLine <- coreLift $ fGetLine fileHandle
          | Left _ =>
@@ -488,3 +487,15 @@ hashFile fileName
     osEscape = if isWindows
       then id
       else escapeStringUnix
+
+export
+hashFile : String -> Core String
+hashFile fileName =
+  -- Note `popen` call won't fail if there's no `sha256sum` command
+  -- so we can't just catch `popen` error.
+  catch (hashFileWith "sha256sum" fileName)
+        (\err =>
+          catch (hashFileWith "gsha256sum" fileName)
+                -- When `gsha256sum` fails as well, return the error with `sha256sum`.
+                (\_ => coreFail err)
+        )


### PR DESCRIPTION
On my mac laptop there's no `sha256sum` command, but there's
`gsha256sum`: using `g` prefix is common when GNU utilities are
installed on macOS.

```
SCHEME=chez make bootstrap
```

no longer fails on my laptop.

The downside is that compilation now continuously prints a warning
about `sha256sum` command not found (when it is not found).  And I
don't know how to fix it cross-platform way.

```
1/5: Building Network.Socket.Data (Network/Socket/Data.idr)
sh: sha256sum: command not found
2/5: Building Network.FFI (Network/FFI.idr)
sh: sha256sum: command not found
3/5: Building Network.Socket.Raw (Network/Socket/Raw.idr)
sh: sha256sum: command not found
4/5: Building Network.Socket (Network/Socket.idr)
sh: sha256sum: command not found
5/5: Building Control.Linear.Network (Control/Linear/Network.idr)
sh: sha256sum: command not found
```