### PR TITLE
Add chezscheme binary to search path

### DIFF
--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -38,7 +38,7 @@ findChez : IO String
 findChez
     = do Nothing <- idrisGetEnv "CHEZ"
             | Just chez => pure chez
-         path <- pathLookup ["chez", "chezscheme9.5", "scheme"]
+         path <- pathLookup ["chez", "chezscheme", "chezscheme9.5", "scheme"]
          pure $ fromMaybe "/usr/bin/env scheme" path
 
 ||| Returns the chez scheme version for given executable


### PR DESCRIPTION
The Gentoo Chez package and some versions of the Ubuntu package install Chez scheme as `/usr/bin/chezscheme` which requires manually setting the CHEZ environment variable.  Adding it to the search path makes it easier for these users.

Maybe there is a better solution but I think this is an okay temporary fix.

Closes: https://github.com/idris-lang/Idris2/issues/666