### PR TITLE
Nix: verbatim URLs are deprecated

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,9 @@
 {
   description = "Idris2 flake";
 
-  inputs.flake-utils.url = github:numtide/flake-utils;
+  inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.idris-emacs-src = {
-    url = github:redfish64/idris2-mode;
+    url = "github:redfish64/idris2-mode";
     flake = false;
   };
 

--- a/nix/templates/pkg/flake.nix
+++ b/nix/templates/pkg/flake.nix
@@ -1,9 +1,9 @@
 {
   description = "My Idris 2 package";
 
-  inputs.flake-utils.url = github:numtide/flake-utils;
+  inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.idris = {
-    url = github:idris-lang/Idris2;
+    url = "github:idris-lang/Idris2";
     inputs.nixpkgs.follows = "nixpkgs";
     inputs.flake-utils.follows = "flake-utils";
   };

--- a/nix/templates/pkgWithDeps/flake.nix
+++ b/nix/templates/pkgWithDeps/flake.nix
@@ -1,14 +1,14 @@
 {
   description = "My Idris 2 package";
 
-  inputs.flake-utils.url = github:numtide/flake-utils;
+  inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.idris = {
-    url = github:idris-lang/Idris2;
+    url = "github:idris-lang/Idris2";
     inputs.nixpkgs.follows = "nixpkgs";
     inputs.flake-utils.follows = "flake-utils";
   };
   inputs.pkg = {
-    url = github:idris-lang/pkg;
+    url = "github:idris-lang/pkg";
     inputs.flake-utils.follows = "flake-utils";
     inputs.idris.follows = "idris";
   };


### PR DESCRIPTION
References:
- https://nix.dev/anti-patterns/language#unquoted-urls
- https://github.com/NixOS/rfcs/pull/45
- https://github.com/NixOS/rfcs/blob/master/rfcs/0045-deprecate-url-syntax.md