### PR TITLE
A couple of expression search improvements

### DIFF
--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -157,6 +157,7 @@ data Error : Type where
      ||| Contains list of specifiers for which foreign call cannot be resolved
      NoForeignCC : FC -> List String -> Error
      BadMultiline : FC -> String -> Error
+     Timeout : FC -> String -> Error
 
      InType : FC -> Name -> Error -> Error
      InCon : FC -> Name -> Error -> Error
@@ -332,6 +333,7 @@ Show Error where
   show (NoForeignCC fc specs) = show fc ++
        ":The given specifier " ++ show specs ++ " was not accepted by any available backend."
   show (BadMultiline fc str) = "Invalid multiline string: " ++ str
+  show (Timeout fc str) = "Timeout in " ++ str
 
   show (InType fc n err)
        = show fc ++ ":When elaborating type of " ++ show n ++ ":\n" ++
@@ -423,6 +425,7 @@ getErrorLoc (InternalError _) = Nothing
 getErrorLoc (UserError _) = Nothing
 getErrorLoc (NoForeignCC loc _) = Just loc
 getErrorLoc (BadMultiline loc _) = Just loc
+getErrorLoc (Timeout loc _) = Just loc
 getErrorLoc (InType _ _ err) = getErrorLoc err
 getErrorLoc (InCon _ _ err) = getErrorLoc err
 getErrorLoc (InLHS _ _ err) = getErrorLoc err

--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -157,7 +157,7 @@ data Error : Type where
      ||| Contains list of specifiers for which foreign call cannot be resolved
      NoForeignCC : FC -> List String -> Error
      BadMultiline : FC -> String -> Error
-     Timeout : FC -> String -> Error
+     Timeout : String -> Error
 
      InType : FC -> Name -> Error -> Error
      InCon : FC -> Name -> Error -> Error
@@ -333,7 +333,7 @@ Show Error where
   show (NoForeignCC fc specs) = show fc ++
        ":The given specifier " ++ show specs ++ " was not accepted by any available backend."
   show (BadMultiline fc str) = "Invalid multiline string: " ++ str
-  show (Timeout fc str) = "Timeout in " ++ str
+  show (Timeout str) = "Timeout in " ++ str
 
   show (InType fc n err)
        = show fc ++ ":When elaborating type of " ++ show n ++ ":\n" ++
@@ -425,7 +425,7 @@ getErrorLoc (InternalError _) = Nothing
 getErrorLoc (UserError _) = Nothing
 getErrorLoc (NoForeignCC loc _) = Just loc
 getErrorLoc (BadMultiline loc _) = Just loc
-getErrorLoc (Timeout loc _) = Just loc
+getErrorLoc (Timeout _) = Nothing
 getErrorLoc (InType _ _ err) = getErrorLoc err
 getErrorLoc (InCon _ _ err) = getErrorLoc err
 getErrorLoc (InLHS _ _ err) = getErrorLoc err

--- a/src/Core/Normalise.idr
+++ b/src/Core/Normalise.idr
@@ -291,6 +291,9 @@ parameters (defs : Defs, topopts : EvalOpts)
              -- want to shortcut that second check, if we're evaluating
              -- everything, so don't let bind unless we need that log!
              let redok = redok1 || redok2
+             checkTimer -- If we're going to time out anywhere, it'll be
+                        -- when evaluating something recursive, so this is a
+                        -- good place to check
              unless redok2 $ logC "eval.stuck" 5 $ do n' <- toFullNames n
                                                       pure $ "Stuck function: " ++ show n'
              if redok

--- a/src/Core/Options.idr
+++ b/src/Core/Options.idr
@@ -157,6 +157,8 @@ record Session where
   dumpanf : Maybe String -- file to output ANF definitions
   dumpvmcode : Maybe String -- file to output VM code definitions
   profile : Bool -- generate profiling information, if supported
+  searchTimeout : Integer -- maximum number of milliseconds to run
+                          -- expression/program search
   -- Warnings
   warningsAsErrors : Bool
   showShadowingWarning : Bool
@@ -210,7 +212,7 @@ export
 defaultSession : Session
 defaultSession = MkSessionOpts False False False Chez [] False defaultLogLevel
                                False False False Nothing Nothing
-                               Nothing Nothing False False True False
+                               Nothing Nothing False 1000 False True False
 
 export
 defaultElab : ElabDirectives

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -1010,6 +1010,7 @@ mutual
              AmbigDepth n => pure [IPragma [] (\nest, env => setAmbigLimit n)]
              AutoImplicitDepth n => pure [IPragma [] (\nest, env => setAutoImplicitLimit n)]
              NFMetavarThreshold n => pure [IPragma [] (\nest, env => setNFThreshold n)]
+             SearchTimeout n => pure [IPragma [] (\nest, env => setSearchTimeout n)]
              PairNames ty f s => pure [IPragma [] (\nest, env => setPair fc ty f s)]
              RewriteName eq rw => pure [IPragma [] (\nest, env => setRewrite fc eq rw)]
              PrimInteger n => pure [IPragma [] (\nest, env => setFromInteger n)]

--- a/src/Idris/Error.idr
+++ b/src/Idris/Error.idr
@@ -467,6 +467,7 @@ perror (NoForeignCC fc specs) = do
                    ] <+> line <+> !(ploc fc)
     pure res
 perror (BadMultiline fc str) = pure $ errorDesc (reflow "While processing multi-line string" <+> dot <++> pretty str <+> dot) <+> line <+> !(ploc fc)
+perror (Timeout fc str) = pure $ errorDesc (reflow "Timeout in" <++> pretty str)
 
 perror (InType fc n err)
     = pure $ hsep [ errorDesc (reflow "While processing type of" <++> code (pretty !(prettyName n))) <+> dot

--- a/src/Idris/Error.idr
+++ b/src/Idris/Error.idr
@@ -467,7 +467,7 @@ perror (NoForeignCC fc specs) = do
                    ] <+> line <+> !(ploc fc)
     pure res
 perror (BadMultiline fc str) = pure $ errorDesc (reflow "While processing multi-line string" <+> dot <++> pretty str <+> dot) <+> line <+> !(ploc fc)
-perror (Timeout fc str) = pure $ errorDesc (reflow "Timeout in" <++> pretty str)
+perror (Timeout str) = pure $ errorDesc (reflow "Timeout in" <++> pretty str)
 
 perror (InType fc n err)
     = pure $ hsep [ errorDesc (reflow "While processing type of" <++> code (pretty !(prettyName n))) <+> dot

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1166,6 +1166,10 @@ directive fname indents
          dpt <- decorate fname Keyword $ intLit
          atEnd indents
          pure (NFMetavarThreshold (fromInteger dpt))
+  <|> do decorate fname Keyword $ pragma "search_timeout"
+         t <- decorate fname Keyword $ intLit
+         atEnd indents
+         pure (SearchTimeout t)
   <|> do decorate fname Keyword $ pragma "pair"
          ty <- name
          f <- name

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -451,7 +451,7 @@ processEdit (ExprSearch upd line name hints)
                   case holeInfo pi of
                        NotHole => pure $ EditError "Not a searchable hole"
                        SolvedHole locs =>
-                          do let (_ ** (env, tm')) = dropLamsTm locs [] tm
+                          do let (_ ** (env, tm')) = dropLamsTm locs [] !(normaliseHoles defs [] tm)
                              itm <- resugar env tm'
                              let itm' : PTerm = if brack then addBracket replFC itm else itm
                              if upd

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -267,6 +267,7 @@ mutual
        PrefixRecordProjections : Bool -> Directive
        AutoImplicitDepth : Nat -> Directive
        NFMetavarThreshold : Nat -> Directive
+       SearchTimeout : Integer -> Directive
 
   public export
   data PField : Type where

--- a/src/TTImp/Interactive/ExprSearch.idr
+++ b/src/TTImp/Interactive/ExprSearch.idr
@@ -888,6 +888,13 @@ exprSearchOpts opts fc n_in hints
     = do defs <- get Ctxt
          Just (n, idx, gdef) <- lookupHoleName n_in defs
              | Nothing => undefinedName fc n_in
+         -- the REPL does this step, but doing it here too because
+         -- expression search might be invoked some other way
+         let Hole _ _ = definition gdef
+             | PMDef pi [] (STerm _ tm) _ _
+                 => do raw <- unelab [] !(toFullNames !(normaliseHoles defs [] tm))
+                       one raw
+             | _ => throw (GenericMsg fc "Name is already defined")
          lhs <- findHoleLHS !(getFullName (Resolved idx))
          log "interaction.search" 10 $ "LHS hole data " ++ show (n, lhs)
          opts' <- if getRecData opts

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -79,7 +79,7 @@ idrisTestsInteractive = MkTestPool "Interactive editing" [] Nothing
        "interactive021", "interactive022", "interactive023", "interactive024",
        "interactive025", "interactive026", "interactive027", "interactive028",
        "interactive029", "interactive030", "interactive031", "interactive032",
-       "interactive033", "interactive034"]
+       "interactive033", "interactive034", "interactive035"]
 
 idrisTestsInterface : TestPool
 idrisTestsInterface = MkTestPool "Interface" [] Nothing

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -79,7 +79,7 @@ idrisTestsInteractive = MkTestPool "Interactive editing" [] Nothing
        "interactive021", "interactive022", "interactive023", "interactive024",
        "interactive025", "interactive026", "interactive027", "interactive028",
        "interactive029", "interactive030", "interactive031", "interactive032",
-       "interactive033"]
+       "interactive033", "interactive034"]
 
 idrisTestsInterface : TestPool
 idrisTestsInterface = MkTestPool "Interface" [] Nothing

--- a/tests/idris2/interactive034/expected
+++ b/tests/idris2/interactive034/expected
@@ -1,0 +1,3 @@
+1/1: Building timeout (timeout.idr)
+Main> tailIsNotSound contra (ConsIsSound headIsSound tailIsSound) = contra tailIsSound
+Main> Bye for now!

--- a/tests/idris2/interactive034/input
+++ b/tests/idris2/interactive034/input
@@ -1,0 +1,2 @@
+:gd 54 tailIsNotSound
+:q

--- a/tests/idris2/interactive034/run
+++ b/tests/idris2/interactive034/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 --no-banner timeout.idr < input
+
+rm -rf build

--- a/tests/idris2/interactive034/timeout.idr
+++ b/tests/idris2/interactive034/timeout.idr
@@ -1,0 +1,56 @@
+import Data.List
+import Data.List.Elem
+
+%search_timeout 1000
+
+||| A Place has an ID and a number of tokens
+data Place : Type where
+  MkPlace : (i : Nat) -> (nTokens : Nat) -> Place
+
+||| A transition has a name
+data Transition : Type where
+  MkTransition : String -> Transition
+
+||| An Input links a Place and a Transition...
+data Input : Type where
+  MkInput : (from : Place) -> (to : Transition) -> Input
+
+-- Accessor functions for proof
+0 inputFrom : Input -> Place
+inputFrom (MkInput p t) = p
+
+0 inputTo : Input -> Transition
+inputTo (MkInput p t) = t
+
+data SoundInputFrom : Input -> List Place -> Type where
+  MkSoundInputFrom : (i : Input)
+                     -> (ps : List Place)
+                     -> (prf : Elem (inputFrom i) ps)
+                     -> SoundInputFrom i ps
+
+data SoundInputTo : Input -> List Transition -> Type where
+  MkSoundInputTo : (i : Input)
+                   -> (ts : List Transition)
+                   -> (prf : Elem (inputTo i) ts)
+                   -> SoundInputTo i ts
+
+data SoundInput : Input -> List Place -> List Transition -> Type where
+  MkSoundInput : (i : Input)
+                 -> (ps : List Place)
+                 -> (ts : List Transition)
+                 -> (fromOK : SoundInputFrom i ps)
+                 -> (toOK   : SoundInputTo   i ts)
+                 -> SoundInput i ps ts
+
+data AllInputsSound : List Input -> List Place -> List Transition -> Type where
+  NilInputsIsSound : AllInputsSound [] _ _
+  ConsIsSound : (headIsSound : SoundInput i ps ts)
+                -> (tailIsSound : AllInputsSound is ps ts)
+                -> AllInputsSound (i :: is) ps ts
+
+-- Searching here finds the right answer immediately, but then if we don't
+-- have a timeout, it takes ages to explore more non-solutions! So we cut off
+-- after a second
+tailIsNotSound : (contra : (AllInputsSound is ps ts -> Void))
+                 -> AllInputsSound (i :: is) ps ts
+                 -> Void

--- a/tests/idris2/interactive035/expected
+++ b/tests/idris2/interactive035/expected
@@ -1,0 +1,3 @@
+1/1: Building unify (unify.idr)
+Main> 4
+Main> Bye for now!

--- a/tests/idris2/interactive035/input
+++ b/tests/idris2/interactive035/input
@@ -1,0 +1,2 @@
+:ps 7 vlength
+:q

--- a/tests/idris2/interactive035/run
+++ b/tests/idris2/interactive035/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 --no-banner unify.idr < input
+
+rm -rf build

--- a/tests/idris2/interactive035/unify.idr
+++ b/tests/idris2/interactive035/unify.idr
@@ -1,0 +1,7 @@
+import Data.Vect
+
+data VectN : Type -> Type where
+     MkVectN : (n : Nat) -> Vect n a -> VectN a
+
+doSearch : Nat -> VectN Int
+doSearch n = MkVectN ?vlength [1,2,3,4]


### PR DESCRIPTION
Firstly, add a configurable timeout (via `%search_timeout`), defaulting to 1 second (or rather, 1000 milliseconds), after which it will stop searching for more solutions. We search for a batch then sort to find the best of the batch, but in some cases it can start exploring too much, in which case we need the timeout. Typically if it hasn't found a solution in a second, it's not going to find a good one anyway.

Secondly, if a hole already has a solution by unification, we should just give that. We nearly did, but it was rendered incorrectly.

This adds a simple timeout mechanism, in which we can start a timer and check whether it's gone over some threshold. It could be useful elsewhere, e.g. in checking whether ambiguity resolution is struggling (the current check for depth is clearly not what we need, unfortunately.)