### PR TITLE
Don't need benchmarks in the release

### DIFF
--- a/Release/mkdist.sh
+++ b/Release/mkdist.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+IDRIS2_DIR=Idris2-"$1"
+
 set -e
 
 if [ $# -eq 0 ]; then
@@ -8,11 +10,11 @@ if [ $# -eq 0 ]; then
 fi
 
 git clone https://github.com/idris-lang/Idris2.git
-mv Idris2 Idris2-$1
-cd Idris2-$1
+mv Idris2 "$IDRIS2_DIR"
+cd "$IDRIS2_DIR"
 
 # Go to the tag for the release we're making
-git checkout tags/v$1
+git checkout tags/v"$1"
 
 # Remove the directories and files we don't want in the release
 rm -rf .git
@@ -25,6 +27,6 @@ find . -type f -name '.gitignore' -exec rm -f {} \;
 
 cd ..
 
-tar zcf idris2-$1.tgz Idris2-$1
+tar zcf idris2-"$1".tgz "$IDRIS2_DIR"
 
 echo "idris2-$1.tgz created."

--- a/Release/mkdist.sh
+++ b/Release/mkdist.sh
@@ -2,8 +2,7 @@
 
 set -e
 
-if [ $# -eq 0 ]
-  then
+if [ $# -eq 0 ]; then
     echo "No version number supplied"
     exit 1
 fi

--- a/Release/mkdist.sh
+++ b/Release/mkdist.sh
@@ -21,6 +21,7 @@ rm -rf .github
 rm .git*
 rm -f .travis*
 rm -rf Release
+rm -rf benchmark
 find . -type f -name '.gitignore' -exec rm -f {} \;
 
 cd ..


### PR DESCRIPTION
Handy as they might be, they're not really complete yet, and it includes a large file that just makes the tarball twice as big as necessary.