### PR TITLE
Remove all mentions of `realpath` from docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,11 +9,10 @@ The easiest way to install is via the existing generated Scheme code.
 The requirements are:
 
 - A Scheme compiler; either Chez Scheme (default), or Racket.
-- `bash`, with `realpath`. On Linux, you probably already have this.
-  On a macOS, you can install this with `brew install coreutils`.
-  On FreeBSD, OpenBSD and NetBSD, you can install `realpath` and `GNU make`
-  using a package manager.  For instance, on OpenBSD you can install all of them
-  with `pkg_add coreutils gmake` command.
+- `bash`, `GNU make` and `sha256sum`.  On Linux, you probably already have
+  this.  On macOS and major BSD flavours, you can install them using a package
+  manager: for instance, on macOS, you can install this with the `brew install
+  coreutils` and on OpenBSD, with the `pkg_add coreutils bash gmake` command.
 
 On Windows, it has been reported that installing via `MSYS2` works
 [MSYS2](https://www.msys2.org/). On Windows older than Windows 8, you may need to

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,10 +9,11 @@ The easiest way to install is via the existing generated Scheme code.
 The requirements are:
 
 - A Scheme compiler; either Chez Scheme (default), or Racket.
-- `bash`, `GNU make` and `sha256sum`.  On Linux, you probably already have
-  this.  On macOS and major BSD flavours, you can install them using a package
-  manager: for instance, on macOS, you can install this with the `brew install
-  coreutils` and on OpenBSD, with the `pkg_add coreutils bash gmake` command.
+- `bash`, `GNU make`, `sha256sum` and `GMP`.  On Linux, you probably already
+  have this.  On macOS and major BSD flavours, you can install them using a
+  package manager: for instance, on macOS, you can install with the
+  `brew install coreutils gmp` and on OpenBSD, with the `pkg_add coreutils
+  bash gmake gmp` command.
 
 On Windows, it has been reported that installing via `MSYS2` works
 [MSYS2](https://www.msys2.org/). On Windows older than Windows 8, you may need to

--- a/docs/source/tutorial/starting.rst
+++ b/docs/source/tutorial/starting.rst
@@ -90,8 +90,6 @@ which you can run:
     $ ./build/exec/hello
     Hello world
 
-(On macOS you may first need to install realpath: ```brew install coreutils```)
-
 Please note that the dollar sign ``$`` indicates the shell prompt!
 Some useful options to the Idris command are:
 

--- a/tests/base/system_info001/run
+++ b/tests/base/system_info001/run
@@ -3,7 +3,7 @@ rm -rf build
 rm -f expected
 
 if ! NProcs=$(nproc || sysctl -n hw.ncpu) 2>/dev/null; then
-  echo Command nproc not found. Try installing coreutils. >&2
+  echo "Command 'nproc' not found." >&2
   exit 1
 fi
 


### PR DESCRIPTION
`realpath` is no longer needed to run executables.