### PR TITLE
[ fix ] generate lower level IRs if the option to dump that use phase is selected

### DIFF
--- a/src/Compiler/Common.idr
+++ b/src/Compiler/Common.idr
@@ -256,9 +256,11 @@ dumpVMCode fn lns
 export
 getCompileData : {auto c : Ref Ctxt Defs} -> (doLazyAnnots : Bool) ->
                  UsePhase -> ClosedTerm -> Core CompileData
-getCompileData doLazyAnnots phase tm_in
+getCompileData doLazyAnnots phase_in tm_in
     = do defs <- get Ctxt
          sopts <- getSession
+         let phase = foldl {t=List} (flip $ maybe id max) phase_in $
+                         [Cases <$ dumpcases sopts, Lifted <$ dumplifted sopts, ANF <$ dumpanf sopts, VMCode <$ dumpvmcode sopts]
          let ns = getRefs (Resolved (-1)) tm_in
          tm <- toFullNames tm_in
          natHackNames' <- traverse toResolvedNames natHackNames


### PR DESCRIPTION
This allows users to inspect IRs without worrying about choosing the right codegen to actually generate the result.
This also allows vmcode to be dumped despite no builtin backends using it.