### PR TITLE
Nix: make nixpkgs options overridable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,26 +8,10 @@
   };
 
   outputs = { self, nixpkgs, flake-utils, idris-emacs-src }:
-    let idris2-version = "0.4.0";
-    in flake-utils.lib.eachDefaultSystem (system:
-      let pkgs = import nixpkgs { inherit system; };
-          idris2Pkg = pkgs.callPackage ./nix/package.nix {
-            inherit idris2-version;
-            srcRev = self.shortRev or "dirty";
-          };
-          text-editor = import ./nix/text-editor.nix { inherit pkgs idris-emacs-src idris2Pkg; };
-          buildIdrisPkg = { projectName, src, idrisLibraries }:
-            pkgs.callPackage ./nix/buildIdris.nix
-              { inherit src projectName idrisLibraries idris2-version; idris2 = idris2Pkg; };
-      in if system != "aarch64-linux" then rec {
-        checks = with pkgs; import ./nix/test.nix
-          { inherit nixpkgs flake-utils system stdenv runCommand lib; idris = self; };
-        packages = rec {
-          idris2 = idris2Pkg;
-        } // text-editor;
-        buildIdris = buildIdrisPkg;
-        defaultPackage = packages.idris2;
-      } else {}) // rec {
+    let
+      idris2-version = "0.4.0";
+      lib = import ./nix/lib.nix;
+      sys-agnostic = rec {
         templates.pkg = {
           path = ./nix/templates/pkg;
           description = "A custom Idris 2 package";
@@ -39,4 +23,29 @@
         defaultTemplate = templates.pkg;
         version = idris2-version;
       };
+      per-system = { config ? { }, overlays ? [ ] }: system:
+        let
+          pkgs = import nixpkgs { inherit config system overlays; };
+          idris2Pkg = pkgs.callPackage ./nix/package.nix {
+            inherit idris2-version;
+            srcRev = self.shortRev or "dirty";
+          };
+          buildIdris = { projectName, src, idrisLibraries }:
+            pkgs.callPackage ./nix/buildIdris.nix
+              { inherit src projectName idrisLibraries idris2-version; idris2 = idris2Pkg; };
+        in
+        if system != "aarch64-linux" then rec {
+          checks = import ./nix/test.nix {
+            inherit (pkgs) system stdenv runCommand lib;
+            inherit nixpkgs flake-utils;
+            idris = self;
+          };
+          packages =
+            { idris2 = idris2Pkg; }
+            // (import ./nix/text-editor.nix { inherit pkgs idris-emacs-src idris2Pkg; });
+          inherit buildIdris;
+          defaultPackage = packages.idris2;
+        } else { };
+    in
+    lib.mkOvrOptsFlake (opts: flake-utils.lib.eachDefaultSystem (per-system opts) // sys-agnostic);
 }

--- a/nix/buildIdris.nix
+++ b/nix/buildIdris.nix
@@ -6,18 +6,18 @@
 , idris2-version
 , idrisLibraries
 }:
-with lib.strings;
+
 let
   ipkgName = projectName + ".ipkg";
-  libSuffix = "lib/${idrName}";
   idrName = "idris2-${idris2-version}";
-  lib-dirs = concatMapStringsSep ":" (p: "${p}/${libSuffix}") idrisLibraries;
+  libSuffix = "lib/${idrName}";
+  lib-dirs = lib.strings.concatMapStringsSep ":" (p: "${p}/${libSuffix}") idrisLibraries;
 in
 rec {
   build = stdenv.mkDerivation {
     name = projectName;
     src = src;
-    buildInputs = [ idris2 ];
+    nativeBuildInputs = [ idris2 ];
     configurePhase = ''
       export IDRIS2_PACKAGE_PATH=${lib-dirs}
     '';
@@ -29,11 +29,9 @@ rec {
       mv build/exec/* $out/bin
     '';
   };
-  installLibrary = build.overrideAttrs (oldAttrs: {
+  installLibrary = build.overrideAttrs (_: {
     buildPhase = "";
-    installPhase = let
-      ipkgName = projectName + ".ipkg";
-    in ''
+    installPhase = ''
       mkdir -p $out/${libSuffix}
       export IDRIS2_PREFIX=$out/lib
       idris2 --install ${ipkgName}

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,0 +1,12 @@
+rec {
+  # source: https://nixos.org/guides/nix-pills/override-design-pattern.html
+  # but with the ability to change the name of the override method
+  makeOverridable = kind: f:
+    let inner = oldArgs: (f oldArgs) // { ${kind} = newArgs: inner (oldArgs // newArgs); };
+    in  inner;
+
+  # create a flake with overridable options. useful because we can't pass
+  # fine-grained overrides to flakes otherwise, we can only change inputs
+  # (therefore, this can't change inputs per default, and that should also be unnecessary)
+  mkOvrOptsFlake = flakefn: makeOverridable "overrideOptions" flakefn { };
+}


### PR DESCRIPTION
This allows for cross-flake testing of content-addressible nix derivations without affecting other users of the flake (which would be the cases if CA-drvs would be hard-coded upstream) and without losing the ability to quickly update to the latest idris2 version (which would happen if a fork of the repo would be used).

See also: https://discourse.nixos.org/t/content-addressed-nix-call-for-testers/12881

The flake can still be used as usual, but it will gain an output `overrideOptions`, which can be used like e.g.
```nix
let
  idrisx = idris.overrideOptions {
    config.contentAddressedByDefault = true;
  };
in { ... }
```

Additonally, this tries to improve `buildIdris` a bit.