### PR TITLE
Make sure _simple_handler is not exported

### DIFF
--- a/support/c/idris_signal.c
+++ b/support/c/idris_signal.c
@@ -91,7 +91,7 @@ void _collect_signal(int signum) {
 }
 
 #ifndef _WIN32
-inline struct sigaction _simple_handler(void (*handler)(int)) {
+static inline struct sigaction _simple_handler(void (*handler)(int)) {
   struct sigaction new_action;
 
   new_action.sa_handler = handler;


### PR DESCRIPTION
Support for simple signal handling was added in a0a417240e69a9951e92b57c8d7fb328e437c71d (CC: @mattpolzin). This commit also adds the `_simple_handler` function. It seems to me that this function is intended as a helper function which should only be visible in `idris_signal.c`, it is not used outside this file. For this purpose it is probably also marked as inline. However, the inline keyword does not require the compiler to actually inline the function. As such, the `_simple_handler` symbol may still be exported if the compiler doesn't inline the function.

On my system this seems to be the case and causes the following error during compilation of idris2:

	Exception: (while loading libidris2_support.so) Error relocating Idris2-0.4.0/build/exec/idris2_app/libidris2_support.so: _simple_handler: symbol not found

By marking the `_simple_handler` function as `static inline` it is ensured that the symbol is not exported, thereby preventing the relocation error.