### PR TITLE
Use pragma once instead of include guard

### DIFF
--- a/samples/FFI-readline/readline_glue/idris_readline.h
+++ b/samples/FFI-readline/readline_glue/idris_readline.h
@@ -1,5 +1,4 @@
-#ifndef _IDRIS_READLINE_H
-#define _IDRIS_READLINE_H
+#pragma once
 
 void idrisrl_setCompletion(rl_completion_func_t* fn);
 
@@ -7,5 +6,3 @@ char* getString(void* str);
 void* mkString(char* str);
 void* nullString();
 int isNullString(void* str);
-
-#endif

--- a/support/c/getline.h
+++ b/support/c/getline.h
@@ -1,7 +1,6 @@
-#ifndef GETLINE_H
-#define GETLINE_H
+#pragma once
+
 #include <stdlib.h>
 #include <stdio.h>
 ssize_t getdelim(char **buf, size_t *bufsiz, int delimiter, FILE *fp);
 ssize_t getline(char **buf, size_t *bufsiz, FILE *fp);
-#endif // GETLINE_H

--- a/support/c/idris_directory.h
+++ b/support/c/idris_directory.h
@@ -1,5 +1,4 @@
-#ifndef __IDRIS_DIRECTORY_H
-#define __IDRIS_DIRECTORY_H
+#pragma once
 
 char* idris2_currentDirectory();
 int idris2_changeDir(char* dir);
@@ -8,5 +7,3 @@ void* idris2_openDir(char* dir);
 void idris2_closeDir(void* d);
 int idris2_removeDir(char* path);
 char* idris2_nextDirEntry(void* d);
-
-#endif

--- a/support/c/idris_file.h
+++ b/support/c/idris_file.h
@@ -1,5 +1,4 @@
-#ifndef __IDRIS_FILE_H
-#define __IDRIS_FILE_H
+#pragma once
 
 #include <stdio.h>
 #include <stdint.h>
@@ -37,5 +36,3 @@ int idris2_fileStatusTime(FILE* f);
 FILE* idris2_stdin();
 FILE* idris2_stdout();
 FILE* idris2_stderr();
-
-#endif

--- a/support/c/idris_net.h
+++ b/support/c/idris_net.h
@@ -1,5 +1,4 @@
-#ifndef IDRISNET_H
-#define IDRISNET_H
+#pragma once
 
 // Includes used by the idris-file.
 #ifdef _WIN32
@@ -114,5 +113,3 @@ int idrnet_getaddrinfo(struct addrinfo** address_res, char* host,
 int idrnet_geteagain();
 
 int isNull(void* ptr);
-
-#endif

--- a/support/c/idris_signal.h
+++ b/support/c/idris_signal.h
@@ -1,5 +1,4 @@
-#ifndef __IDRIS_SIGNAL_H
-#define __IDRIS_SIGNAL_H
+#pragma once
 
 #include <signal.h>
 
@@ -42,5 +41,3 @@ int sigquit();
 int sigtrap();
 int sigusr1();
 int sigusr2();
-
-#endif

--- a/support/c/idris_support.h
+++ b/support/c/idris_support.h
@@ -1,5 +1,4 @@
-#ifndef __IDRIS_SUPPORT_H
-#define __IDRIS_SUPPORT_H
+#pragma once
 
 // Return non-zero if the pointer is null
 int idris2_isNull(void*);
@@ -25,5 +24,3 @@ char* idris2_getEnvPair(int i);
 int idris2_getPID();
 
 long idris2_getNProcessors();
-
-#endif

--- a/support/c/idris_term.h
+++ b/support/c/idris_term.h
@@ -1,8 +1,5 @@
-#ifndef __IDRIS_TERM_H
-#define __IDRIS_TERM_H
+#pragma once
 
 void idris2_setupTerm();
 int idris2_getTermCols();
 int idris2_getTermLines();
-
-#endif

--- a/support/refc/buffer.h
+++ b/support/refc/buffer.h
@@ -1,5 +1,4 @@
-#ifndef __IDRIS_BUFFER_H__
-#define __IDRIS_BUFFER_H__
+#pragma once
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -23,5 +22,3 @@ int64_t getBufferInt(void* buffer, int loc);
 double getBufferDouble(void* buffer, int loc);
 char* getBufferString(void* buffer, int loc, int len);
 size_t readBufferData(FILE* h, void* buffer, size_t loc, size_t max);
-
-#endif

--- a/support/refc/cBackend.h
+++ b/support/refc/cBackend.h
@@ -1,5 +1,5 @@
-#ifndef __C_BACKEND_H__
-#define __C_BACKEND_H__
+#pragma once
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -15,5 +15,3 @@
 #include "casts.h"
 #include "conCaseHelper.h"
 #include "prim.h"
-
-#endif

--- a/support/refc/casts.h
+++ b/support/refc/casts.h
@@ -1,5 +1,4 @@
-#ifndef __CASTS_H__
-#define __CASTS_H__
+#pragma once
 
 #include "cBackend.h"
 #include <stdio.h>
@@ -149,5 +148,3 @@ Value *cast_Integer_to_Int64(Value *input);
 Value *cast_Integer_to_double(Value *input);
 Value *cast_Integer_to_char(Value *input);
 Value *cast_Integer_to_string(Value *input);
-
-#endif

--- a/support/refc/clock.h
+++ b/support/refc/clock.h
@@ -1,5 +1,4 @@
-#ifndef __IDRIS_CLOCK_H__
-#define __IDRIS_CLOCK_H__
+#pragma once
 
 #include <time.h>
 
@@ -15,5 +14,3 @@ Value *clockTimeGcReal();
 int clockValid(Value *clock);
 uint64_t clockSecond(Value *clock);
 uint64_t clockNanosecond(Value *clock);
-
-#endif

--- a/support/refc/conCaseHelper.h
+++ b/support/refc/conCaseHelper.h
@@ -1,5 +1,4 @@
-#ifndef __CON_CASE_HELPER_H__
-#define __CON_CASE_HELPER_H__
+#pragma once
 
 #include "cBackend.h"
 
@@ -16,5 +15,3 @@ void freeConstructorField(AConAlt *);
 
 int multiStringCompare(Value *, int, char **);
 int multiDoubleCompare(Value *, int, double *);
-
-#endif

--- a/support/refc/datatypes.h
+++ b/support/refc/datatypes.h
@@ -1,5 +1,5 @@
-#ifndef __DATATYPES_H__
-#define __DATATYPES_H__
+#pragma once
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -204,5 +204,3 @@ typedef struct
     Value_header header;
     IORef_Storage *listIORefs;
 } Value_World;
-
-#endif

--- a/support/refc/mathFunctions.h
+++ b/support/refc/mathFunctions.h
@@ -1,5 +1,5 @@
-#ifndef __MATH_FUNCTIONS_H__
-#define __MATH_FUNCTIONS_H__
+#pragma once
+
 #include "cBackend.h"
 #include <math.h>
 #include <gmp.h>
@@ -202,4 +202,3 @@ Value *gte_Integer(Value *x, Value *y);
 Value *gte_double(Value *x, Value *y);
 Value *gte_char(Value *x, Value *y);
 Value *gte_string(Value *x, Value *y);
-#endif

--- a/support/refc/memoryManagement.h
+++ b/support/refc/memoryManagement.h
@@ -1,5 +1,5 @@
-#ifndef __MEMORY_MANAGEMENT_H__
-#define __MEMORY_MANAGEMENT_H__
+#pragma once
+
 #include "cBackend.h"
 
 Value *newValue(void);
@@ -33,5 +33,3 @@ Value_GCPointer *makeGCPointer(void *ptr_Raw, Value_Closure *onCollectFct);
 Value_Buffer *makeBuffer(void *buf);
 Value_Array *makeArray(int length);
 Value_World *makeWorld(void);
-
-#endif

--- a/support/refc/prim.h
+++ b/support/refc/prim.h
@@ -1,5 +1,4 @@
-#ifndef __PRIM_H__
-#define __PRIM_H__
+#pragma once
 
 #include "cBackend.h"
 
@@ -44,4 +43,3 @@ Value *System_Concurrency_Raw_prim__conditionWaitTimeout(Value *, Value *, Value
 Value *System_Concurrency_Raw_prim__conditionSignal(Value *, Value *);
 
 Value *System_Concurrency_Raw_prim__conditionBroadcast(Value *, Value *);
-#endif

--- a/support/refc/runtime.h
+++ b/support/refc/runtime.h
@@ -1,5 +1,4 @@
-#ifndef __RUNTIME_H__
-#define __RUNTIME_H__
+#pragma once
 
 #include "cBackend.h"
 
@@ -11,4 +10,3 @@ void push_Arglist(Value_Arglist *arglist, Value *arg);
 int extractInt(Value *);
 Value *trampoline(Value *closure);
 Value *tailcall_apply_closure(Value *_clos, Value *arg);
-#endif

--- a/support/refc/stringOps.h
+++ b/support/refc/stringOps.h
@@ -1,5 +1,4 @@
-#ifndef __STRING_OPS_H__
-#define __STRING_OPS_H__
+#pragma once
 
 #include "cBackend.h"
 
@@ -20,5 +19,3 @@ Value *onCollectStringIterator(Value_Pointer *ptr, void *null);
 Value *onCollectStringIterator_arglist(Value_Arglist *arglist);
 Value *stringIteratorToString(void *a, char *str, Value *it_p, Value_Closure *f);
 Value *stringIteratorNext(char *s, Value *it_p);
-
-#endif

--- a/tests/chez/chez013/struct.h
+++ b/tests/chez/chez013/struct.h
@@ -1,5 +1,4 @@
-#ifndef _STRUCT_H
-#define _STRUCT_H
+#pragma once
 
 typedef struct {
     int x;
@@ -18,5 +17,3 @@ namedpoint* mkNamedPoint(char* str, point* p);
 void freeNamedPoint(namedpoint* np);
 
 char* getString(void *p);
-
-#endif


### PR DESCRIPTION
Pragma once is supported by all compilers for the last ten years.
Better use it instead of include guards (which use different styles
in different files).