### PR TITLE
Route System.prim__system through C function

### DIFF
--- a/libs/base/System.idr
+++ b/libs/base/System.idr
@@ -100,8 +100,7 @@ unsetEnv var
    = do ok <- primIO $ prim__unsetEnv var
         pure $ ok == 0
 
-%foreign libc "system"
-         "scheme:blodwen-system"
+%foreign "C:idris2_system, libidris2_support, idris_system.h"
 prim__system : String -> PrimIO Int
 
 export

--- a/support/c/idris_system.c
+++ b/support/c/idris_system.c
@@ -1,0 +1,6 @@
+#include <stdlib.h>
+#include "idris_system.h"
+
+int idris2_system(const char* command) {
+    return system(command);
+}

--- a/support/c/idris_system.h
+++ b/support/c/idris_system.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int idris2_system(const char* command);

--- a/support/chez/support.ss
+++ b/support/chez/support.ss
@@ -403,9 +403,6 @@
 (define (blodwen-hasenv var)
   (if (eq? (getenv var) #f) 0 1))
 
-(define (blodwen-system cmd)
-  (system cmd))
-
 ;; Randoms
 (define random-seed-register 0)
 (define (initialize-random-seed-once)

--- a/support/gambit/support.scm
+++ b/support/gambit/support.scm
@@ -225,6 +225,3 @@
 
 (define (blodwen-hasenv var)
   (if (getenv var #f) 1 0))
-
-(define (blodwen-system cmd)
-  (fxarithmetic-shift-right (shell-command cmd) 8))

--- a/support/racket/support.rkt
+++ b/support/racket/support.rkt
@@ -455,11 +455,6 @@
         (vector-ref (current-command-line-arguments) (- n 1)))
      (else "")))
 
-(define (blodwen-system cmd)
-  (if (system cmd)
-      0
-      1))
-
 ;; Randoms
 (random-seed (date*-nanosecond (current-date))) ; initialize random seed
 


### PR DESCRIPTION
To be able to eventually refactor/extend `system` function: to be
able to specify a directory, environment variables, specify arguments
as array etc. Ideally it should be something like Rust
[`std::process::Command`](https://doc.rust-lang.org/std/process/struct.Command.html).