### PR TITLE
Support for incremental compilation with Chez

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,0 +1,37 @@
+---
+###########################
+###########################
+## Markdown Linter rules ##
+###########################
+###########################
+
+# Linter rules doc:
+# - https://github.com/DavidAnson/markdownlint
+#
+# Note:
+# To comment out a single error:
+#   <!-- markdownlint-disable -->
+#   any violations you want
+#   <!-- markdownlint-restore -->
+#
+
+###############
+# Rules by id #
+###############
+MD004: false                  # Unordered list style
+MD007:
+  indent: 2                   # Unordered list indentation
+MD013:
+  line_length: 400            # Line length 80 is far to short
+MD024:
+  siblings_only: true         # allow duplicate headings in CHANGELOG
+MD026:
+  punctuation: ".,;:!。，；:"  # List of not allowed
+MD029: false                  # Ordered list item prefix
+MD033: false                  # Allow inline HTML
+MD036: false                  # Emphasis used instead of a heading
+
+#################
+# Rules by tags #
+#################
+blank_lines: false  # Error on blank lines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Next version]
+
+### Compiler changes
+
+* Added incremental compilation, using either the `--inc` flag or the
+  `IDRIS2_INC_CGS` environment variable, which compiles modules incrementally.
+  In incremental mode, the final build step is much faster than in whole
+  program mode (the default), at the cost of runtime performance being about
+  half as good. The `--whole-program` flag overrides incremental compilation,
+  and reverts to whole program compilation.
+
 ## v0.4.0
 
 ### Syntax changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
   In incremental mode, the final build step is much faster than in whole
   program mode (the default), at the cost of runtime performance being about
   half as good. The `--whole-program` flag overrides incremental compilation,
-  and reverts to whole program compilation.
+  and reverts to whole program compilation. Incremental compilation is currently
+  supported only by the Chez Scheme back end.
 
 ## v0.4.0
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -88,7 +88,14 @@ that everything has worked correctly. Assuming that `idris2` is in your
 After `make all`, type `make test` to check everything works. This uses the
 executable in `./build/exec`.
 
-### 6: (Optional) Installing the Idris 2 API
+### 6: (Optional) Enabling incremental compilation
+
+If you are working on Idris, incremental compilation means that rebuilds are
+much faster, at the cost of runtime performance being slower. To enable
+incremental compilation for the Chez back end, set the environment variable
+`IDRIS2_INC_CGS=chez`, or set the `--inc chez` flag in `idris2.ipkg`.
+
+### 7: (Optional) Installing the Idris 2 API
 
 You'll only need this if you're developing support tools, such as an external
 code generator. To do so, once everything is successfully installed, type:
@@ -99,7 +106,7 @@ The API will only work if you've completed the self-hosting step, step 4, since
 the intermediate code versions need to be consistent throughout. Otherwise, you
 will get an `Error in TTC: TTC data is in an older format` error.
 
-### 7: (Optional) Shell Auto-completion
+### 8: (Optional) Shell Auto-completion
 
 Idris2 supports tab auto-completion for Bash-like shells.
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ NAME = idris2
 TARGETDIR = ${CURDIR}/build/exec
 TARGET = ${TARGETDIR}/${NAME}
 
+# Default code generator. This is passed to the libraries for incremental
+# builds, but overridable via environment variables or arguments to make
+IDRIS2_CG ?= chez
+
 MAJOR=0
 MINOR=4
 PATCH=0
@@ -68,19 +72,19 @@ src/IdrisPaths.idr: FORCE
 FORCE:
 
 prelude:
-	${MAKE} -C libs/prelude IDRIS2=${TARGET} IDRIS2_INC_CGS=chez IDRIS2_PATH=${IDRIS2_BOOT_PATH}
+	${MAKE} -C libs/prelude IDRIS2=${TARGET} IDRIS2_INC_CGS=${IDRIS2_CG} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 
 base: prelude
-	${MAKE} -C libs/base IDRIS2=${TARGET} IDRIS2_INC_CGS=chez IDRIS2_PATH=${IDRIS2_BOOT_PATH}
+	${MAKE} -C libs/base IDRIS2=${TARGET} IDRIS2_INC_CGS=${IDRIS2_CG} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 
 network: prelude
-	${MAKE} -C libs/network IDRIS2=${TARGET} IDRIS2_INC_CGS=chez IDRIS2_PATH=${IDRIS2_BOOT_PATH}
+	${MAKE} -C libs/network IDRIS2=${TARGET} IDRIS2_INC_CGS=${IDRIS2_CG} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 
 contrib: base
-	${MAKE} -C libs/contrib IDRIS2=${TARGET} IDRIS2_INC_CGS=chez IDRIS2_PATH=${IDRIS2_BOOT_PATH}
+	${MAKE} -C libs/contrib IDRIS2=${TARGET} IDRIS2_INC_CGS=${IDRIS2_CG} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 
 test-lib: contrib
-	${MAKE} -C libs/test IDRIS2=${TARGET} IDRIS2_INC_CGS=chez IDRIS2_PATH=${IDRIS2_BOOT_PATH}
+	${MAKE} -C libs/test IDRIS2=${TARGET} IDRIS2_INC_CGS=${IDRIS2_CG} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 
 libs : prelude base contrib network test-lib
 

--- a/Makefile
+++ b/Makefile
@@ -68,19 +68,19 @@ src/IdrisPaths.idr: FORCE
 FORCE:
 
 prelude:
-	${MAKE} -C libs/prelude IDRIS2=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
+	${MAKE} -C libs/prelude IDRIS2=${TARGET} IDRIS2_INC_CGS=chez IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 
 base: prelude
-	${MAKE} -C libs/base IDRIS2=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
+	${MAKE} -C libs/base IDRIS2=${TARGET} IDRIS2_INC_CGS=chez IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 
 network: prelude
-	${MAKE} -C libs/network IDRIS2=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
+	${MAKE} -C libs/network IDRIS2=${TARGET} IDRIS2_INC_CGS=chez IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 
 contrib: base
-	${MAKE} -C libs/contrib IDRIS2=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
+	${MAKE} -C libs/contrib IDRIS2=${TARGET} IDRIS2_INC_CGS=chez IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 
 test-lib: contrib
-	${MAKE} -C libs/test IDRIS2=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
+	${MAKE} -C libs/test IDRIS2=${TARGET} IDRIS2_INC_CGS=chez IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 
 libs : prelude base contrib network test-lib
 

--- a/docs/source/backends/chez.rst
+++ b/docs/source/backends/chez.rst
@@ -68,6 +68,6 @@ Chez Directives
     %foreign "scheme:my-mul"
     myMul : Int -> Int -> Int
 
-  .. code-block::
+  ::
 
     $ idris2 --codegen chez --directive extraRuntime=/path/to/extensions.scm -o main Main.idr

--- a/docs/source/backends/incremental.rst
+++ b/docs/source/backends/incremental.rst
@@ -1,0 +1,73 @@
+***************************
+Incremental Code Generation
+***************************
+
+By default, Idris 2 is a whole program compiler - that is, it finds all the
+necessary function definitions and compiles them only when you build an
+executable. This gives plenty of optimisation opportunities, but can also
+be slow for rebuilding. However, if the backend supports it, you can build
+modules and executables *incrementally*. To do so, you can either:
+
+1. Set the ``--inc <backend>`` flag at the command line, for each backend
+   you want to use incrementally.
+2. Set the ``IDRIS2_INC_CGS`` environment variable with a comma separated list
+   of backends to use incrementally.
+
+At the moment, only the Chez backend supports incremental builds.
+
+Building modules incrementally
+==============================
+
+If either of the above are set, building a module will produce compiled binary
+code for all of the definitions in the module, as well as the usual checked
+TTC file. e.g.:
+
+::
+
+    $ idris2 --inc chez Foo.idr
+    $ IDRIS2_INC_CGS=chez idris2 Foo.idr
+
+On successful type checking, each of these will produce a Chez Scheme file
+(``Foo.ss``) and compiled code for it (``Foo.so``) as well as the usual
+``Foo.ttc``, in the same build directory as ``Foo.ttc``.
+
+In incremental mode, you will see a warning for any holes in the module,
+even if those holes will be defined in a different module.
+
+Building executables incrementally
+==================================
+
+If either ``--inc`` is used or ``IDRIS2_INC_CGS`` is set, compiling to
+an executable will attempt to link all of the compiled modules together,
+rather than generating code for all of the functions at once. For this
+to work, all the imported modules *must* have been built with incremental
+compilation for the current back end (Idris will revert to whole program
+compilation if any are missing, and you will see a warning.)
+
+Therefore, all packages used by the executable must also have been built
+incrementally for the current back end. The ``prelude``, ``base``,
+``contrib``, ``network`` and ``test`` packages are all built with
+incremental compilation support for Chez by default.
+
+When switching between incremental and whole program compilation, it is
+recommended that you remove the ``build`` directory first. This is
+particularly important when switching to incremental compilation, since there
+may be stale object files that Idris does not currently detect!
+
+
+Overriding incremental compilation
+==================================
+
+The ``--whole-program`` flag overrides any incremental compilation settings
+when building an executable.
+
+Performance note
+================
+
+Incremental compilation means that executables are generated much quicker,
+especially when only a small proportion of modules have changed. However,
+it means that there are fewer optimisation opportunities, so the resulting
+executable will not perform as well. For deployment, ``--whole-program``
+compilation is recommended.
+
+

--- a/docs/source/backends/index.rst
+++ b/docs/source/backends/index.rst
@@ -48,6 +48,17 @@ This will compile the expression ``Main.main``, generating an executable
 ``hello`` (with an extension depending on the code generator) in the
 ``build/exec`` directory.
 
+By default, Idris 2 is a whole program compiler - that is, it finds all the
+necessary function definitions and compiles them only when you build an
+executable. This gives plenty of optimisation opportunities, but can also
+be slow for rebuilding. However, if the backend supports it, you can build
+modules and executables *incrementally*:
+
+.. toctree::
+   :maxdepth: 1
+
+   incremental
+
 If the backend supports it, you can generate profiling data by setting
 the ``profile`` flag, either by starting Idris with ``--profile``, or
 running ``:set profile`` at the REPL. The profile data generated will depend

--- a/idris2.ipkg
+++ b/idris2.ipkg
@@ -8,5 +8,12 @@ sourcedir = "src"
 -- (Currently supported by Racket and Chez back ends, others ignore it)
 -- opts = "--profile"
 
+-- Set if you want incremental builds. This is good for development, since
+-- small changes compile faster, but bad for deployment since the resulting
+-- executable runs at around half the speed.
+-- (Alternatively: set the environment variable IDRIS2_INC_CGS=chez)
+-- For this to work, you need to do the initial incremental build from clean.
+-- opts = "--inc chez"
+
 main = Idris.Main
 executable = idris2

--- a/src/Compiler/Common.idr
+++ b/src/Compiler/Common.idr
@@ -39,6 +39,17 @@ record Codegen where
                 ClosedTerm -> (outfile : String) -> Core (Maybe String)
   ||| Execute an Idris 2 expression directly.
   executeExpr : Ref Ctxt Defs -> (tmpDir : String) -> ClosedTerm -> Core ()
+  ||| Incrementally compile definitions in the current module (toIR defs)
+  ||| if supported
+  ||| Takes a source file name, returns the name of the generated object
+  ||| file, if successful, plus any other backend specific data in a list
+  ||| of strings. The generated object file should be placed in the same
+  ||| directory as the associated TTC.
+  incCompileFile : Maybe (Ref Ctxt Defs ->
+                          (sourcefile : String) ->
+                          Core (Maybe (String, List String)))
+  ||| If incremental compilation is supported, get the output file extension
+  incExt : Maybe String
 
 -- Say which phase of compilation is the last one to use - it saves time if
 -- you only ask for what you need.
@@ -106,6 +117,14 @@ execute {c} cg tm
          ensureDirectoryExists tmpDir
          executeExpr cg c tmpDir tm
          pure ()
+
+export
+incCompile : {auto c : Ref Ctxt Defs} ->
+             Codegen -> String -> Core (Maybe (String, List String))
+incCompile {c} cg src
+    = do let Just inc = incCompileFile cg
+             | Nothing => pure Nothing
+         inc c src
 
 -- If an entry isn't already decoded, get the minimal entry we need for
 -- compilation, and record the Binary so that we can put it back when we're
@@ -250,6 +269,15 @@ dumpVMCode fn lns
     dumpDef : (Name, VMDef) -> String
     dumpDef (n, d) = fullShow n ++ " = " ++ show d ++ "\n"
 
+export
+nonErased : {auto c : Ref Ctxt Defs} ->
+            Name -> Core Bool
+nonErased n
+    = do defs <- get Ctxt
+         Just gdef <- lookupCtxtExact n (gamma defs)
+              | Nothing => pure True
+         pure (multiplicity gdef /= erased)
+
 -- Find all the names which need compiling, from a given expression, and compile
 -- them to CExp form (and update that in the Defs).
 -- Return the names, the type tags, and a compiled version of the expression
@@ -324,13 +352,40 @@ getCompileData doLazyAnnots phase tm_in
          pure (MkCompileData compiledtm
                              (mapMaybe id namedefs)
                              lifted anf vmcode)
-  where
-    nonErased : Name -> Core Bool
-    nonErased n
-        = do defs <- get Ctxt
-             Just gdef <- lookupCtxtExact n (gamma defs)
-                  | Nothing => pure True
-             pure (multiplicity gdef /= erased)
+
+export
+compileTerm : {auto c : Ref Ctxt Defs} ->
+              ClosedTerm -> Core (CExp [])
+compileTerm tm_in
+    = do tm <- toFullNames tm_in
+         fixArityExp !(compileExp tm)
+
+export
+getIncCompileData : {auto c : Ref Ctxt Defs} -> (doLazyAnnots : Bool) ->
+                    UsePhase -> Core CompileData
+getIncCompileData doLazyAnnots phase
+    = do defs <- get Ctxt
+         -- Compile all the names in 'toIR', since those are the ones defined
+         -- in the current source file
+         let ns = keys (toIR defs)
+         cns <- traverse toFullNames ns
+         rcns <- filterM nonErased cns
+         traverse_ mkForgetDef rcns
+
+         namedefs <- traverse getNamedDef rcns
+         lifted_in <- if phase >= Lifted
+                         then logTime "++ Lambda lift" $ traverse (lambdaLift doLazyAnnots) rcns
+                         else pure []
+         let lifted = concat lifted_in
+         anf <- if phase >= ANF
+                   then logTime "++ Get ANF" $ traverse (\ (n, d) => pure (n, !(toANF d))) lifted
+                   else pure []
+         vmcode <- if phase >= VMCode
+                      then logTime "++ Get VM Code" $ pure (allDefs anf)
+                      else pure []
+         pure (MkCompileData (CErased emptyFC)
+                             (mapMaybe id namedefs)
+                             lifted anf vmcode)
 
 -- Some things missing from Prelude.File
 

--- a/src/Compiler/CompileExpr.idr
+++ b/src/Compiler/CompileExpr.idr
@@ -6,6 +6,7 @@ import Core.Context
 import Core.Env
 import Core.Name
 import Core.Normalise
+import Core.Options
 import Core.TT
 import Core.Value
 
@@ -683,17 +684,53 @@ getCFTypes args (NBind fc _ (Pi _ _ _ ty) sc)
 getCFTypes args t
     = pure (reverse args, !(nfToCFType (getLoc t) False t))
 
+lamRHSenv : Int -> FC -> (ns : List Name) -> SubstCEnv ns []
+lamRHSenv i fc [] = []
+lamRHSenv i fc (n :: ns)
+    = CRef fc (MN "x" i) :: lamRHSenv (i + 1) fc ns
+
+mkBounds : (xs : _) -> Bounds xs
+mkBounds [] = None
+mkBounds (x :: xs) = Add x x (mkBounds xs)
+
+getNewArgs : {done : _} ->
+             SubstCEnv done args -> List Name
+getNewArgs [] = []
+getNewArgs (CRef _ n :: xs) = n :: getNewArgs xs
+getNewArgs {done = x :: xs} (_ :: sub) = x :: getNewArgs sub
+
+-- If a name is declared in one module and defined in another,
+-- we have to assume arity 0 for incremental compilation because
+-- we have no idea how it's defined, and when we made calls to the
+-- function, they had arity 0.
+lamRHS : (ns : List Name) -> CExp ns -> CExp []
+lamRHS ns tm
+    = let env = lamRHSenv 0 (getFC tm) ns
+          tmExp = substs env (rewrite appendNilRightNeutral ns in tm)
+          newArgs = reverse $ getNewArgs env
+          bounds = mkBounds newArgs
+          expLocs = mkLocals zero {vars = []} bounds tmExp in
+          lamBind (getFC tm) _ expLocs
+  where
+    lamBind : FC -> (ns : List Name) -> CExp ns -> CExp []
+    lamBind fc [] tm = tm
+    lamBind fc (n :: ns) tm = lamBind fc ns (CLam fc n tm)
+
 toCDef : {auto c : Ref Ctxt Defs} ->
          Name -> ClosedTerm -> List Nat -> Def ->
          Core CDef
 toCDef n ty _ None
     = pure $ MkError $ CCrash emptyFC ("Encountered undefined name " ++ show !(getFullName n))
-toCDef n ty erased (PMDef _ args _ tree _)
+toCDef n ty erased (PMDef pi args _ tree _)
     = do let (args' ** p) = mkSub 0 args erased
          comptree <- toCExpTree n tree
-         if isNil erased
-            then pure $ MkFun args comptree
-            else pure $ MkFun args' (shrinkCExp p comptree)
+         pure $ toLam (externalDecl pi) $ if isNil erased
+            then MkFun args comptree
+            else MkFun args' (shrinkCExp p comptree)
+  where
+    toLam : Bool -> CDef -> CDef
+    toLam True (MkFun args rhs) = MkFun [] (lamRHS args rhs)
+    toLam _ d = d
 toCDef n ty _ (ExternDef arity)
     = let (ns ** args) = mkArgList 0 arity in
           pure $ MkFun _ (CExtPrim emptyFC !(getFullName n) (map toArgExp (getVars args)))
@@ -759,9 +796,22 @@ compileDef n
     = do defs <- get Ctxt
          Just gdef <- lookupCtxtExact n (gamma defs)
               | Nothing => throw (InternalError ("Trying to compile unknown name " ++ show n))
-         ce <- toCDef n (type gdef) (eraseArgs gdef)
-                             !(toFullNames (definition gdef))
-         setCompiled n ce
+         -- If we're incremental, and the name has no definition yet, it
+         -- might end up defined in another module, so leave it, but warn
+         if noDefYet (definition gdef) (incrementalCGs !getSession)
+           -- This won't be accurate if we have names declared in one module
+           -- and defined elsewhere. It's tricky to do the complete check that
+           -- we do for whole program compilation, though, since that involves
+           -- traversing everything from the main expression.
+           -- For now, consider it an incentive not to have cycles :).
+            then recordWarning (GenericWarn ("Compiling hole " ++ show n))
+            else do ce <- toCDef n (type gdef) (eraseArgs gdef)
+                           !(toFullNames (definition gdef))
+                    setCompiled n ce
+  where
+    noDefYet : Def -> List CG -> Bool
+    noDefYet None (_ :: _) = True
+    noDefYet _ _ = False
 
 export
 mkForgetDef : {auto c : Ref Ctxt Defs} ->

--- a/src/Compiler/ES/Javascript.idr
+++ b/src/Compiler/ES/Javascript.idr
@@ -70,4 +70,4 @@ executeExpr c tmpDir tm =
 ||| Codegen wrapper for Javascript implementation.
 export
 codegenJavascript : Codegen
-codegenJavascript = MkCG compileExpr executeExpr
+codegenJavascript = MkCG compileExpr executeExpr Nothing Nothing

--- a/src/Compiler/ES/Node.idr
+++ b/src/Compiler/ES/Node.idr
@@ -58,4 +58,4 @@ executeExpr c tmpDir tm =
 ||| Codegen wrapper for Node implementation.
 export
 codegenNode : Codegen
-codegenNode = MkCG compileExpr executeExpr
+codegenNode = MkCG compileExpr executeExpr Nothing Nothing

--- a/src/Compiler/RefC/RefC.idr
+++ b/src/Compiler/RefC/RefC.idr
@@ -1046,4 +1046,4 @@ compileExpr _ _ _ _ _ _ = pure Nothing
 
 export
 codegenRefC : Codegen
-codegenRefC = MkCG (compileExpr ANF) executeExpr
+codegenRefC = MkCG (compileExpr ANF) executeExpr Nothing Nothing

--- a/src/Compiler/Scheme/ChezSep.idr
+++ b/src/Compiler/Scheme/ChezSep.idr
@@ -217,8 +217,9 @@ compileToSS c chez appdir tm = do
             ++ "  (import (chezscheme) (support) " ++ imports ++ ")\n\n"
       let footer = ")"
 
-      fgndefs <- traverse (Chez.getFgnCall appdir version) cu.definitions
+      fgndefs <- traverse (Chez.getFgnCall version) cu.definitions
       compdefs <- traverse (getScheme Chez.chezExtPrim Chez.chezString) cu.definitions
+      loadlibs <- traverse (loadLib appdir) (mapMaybe fst fgndefs)
 
       -- write the files
       log "compiler.scheme.chez" 3 $ "Generating code for " ++ chezLib
@@ -226,7 +227,7 @@ compileToSS c chez appdir tm = do
         [header]
         ++ map snd fgndefs  -- definitions using foreign libs
         ++ compdefs
-        ++ map fst fgndefs  -- foreign library load statements
+        ++ loadlibs  -- foreign library load statements
         ++ [footer]
 
       Core.writeFile (appdir </> chezLib <.> "hash") cuHash
@@ -311,4 +312,4 @@ executeExpr c tmpDir tm
 ||| Codegen wrapper for Chez scheme implementation.
 export
 codegenChezSep : Codegen
-codegenChezSep = MkCG (compileExpr True) executeExpr
+codegenChezSep = MkCG (compileExpr True) executeExpr Nothing Nothing

--- a/src/Compiler/Scheme/Gambit.idr
+++ b/src/Compiler/Scheme/Gambit.idr
@@ -423,4 +423,4 @@ executeExpr c tmpDir tm
 
 export
 codegenGambit : Codegen
-codegenGambit = MkCG compileExpr executeExpr
+codegenGambit = MkCG compileExpr executeExpr Nothing Nothing

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -456,4 +456,4 @@ executeExpr c tmpDir tm
 
 export
 codegenRacket : Codegen
-codegenRacket = MkCG (compileExpr True) executeExpr
+codegenRacket = MkCG (compileExpr True) executeExpr Nothing Nothing

--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -65,6 +65,7 @@ data Warning : Type where
                          FC -> Env Term vars -> Term vars -> Warning
      ShadowingGlobalDefs : FC -> List1 (String, List1 Name) -> Warning
      Deprecated : String -> Warning
+     GenericWarn : String -> Warning
 
 -- All possible errors, carrying a location
 public export
@@ -183,6 +184,7 @@ Show Warning where
     show (UnreachableClause _ _ _) = ":Unreachable clause"
     show (ShadowingGlobalDefs _ _) = ":Shadowing names"
     show (Deprecated name) = ":Deprecated " ++ name
+    show (GenericWarn msg) = msg
 
 
 export
@@ -359,6 +361,7 @@ getWarningLoc : Warning -> Maybe FC
 getWarningLoc (UnreachableClause fc _ _) = Just fc
 getWarningLoc (ShadowingGlobalDefs fc _) = Just fc
 getWarningLoc (Deprecated _) = Nothing
+getWarningLoc (GenericWarn _) = Nothing
 
 export
 getErrorLoc : Error -> Maybe FC

--- a/src/Core/Directory.idr
+++ b/src/Core/Directory.idr
@@ -207,6 +207,18 @@ getTTCFileName inp ext
          let bdir = build_dir d
          pure $ bdir </> "ttc" </> fname
 
+-- Given a source file, return the name of the corresponding object file.
+-- As above, but without the build directory
+export
+getObjFileName : {auto c : Ref Ctxt Defs} ->
+                 String -> String -> Core String
+getObjFileName inp ext
+    = do -- Get its namespace from the file relative to the working directory
+         -- and generate the ttc file from that
+         ns <- ctxtPathToNS inp
+         let fname = ModuleIdent.toPath ns <.> ext
+         pure $ fname
+
 -- Given a root executable name, return the name in the build directory
 export
 getExecFileName : {auto c : Ref Ctxt Defs} -> String -> Core String

--- a/src/Core/Options.idr
+++ b/src/Core/Options.idr
@@ -164,6 +164,11 @@ record Session where
   showShadowingWarning : Bool
   -- Experimental
   checkHashesInsteadOfModTime : Bool
+  incrementalCGs : List CG
+  wholeProgram : Bool
+     -- Use whole program compilation for executables, no matter what
+     -- incremental CGs are set (intended for overriding any environment
+     -- variables that set incremental compilation)
 
 public export
 record PPrinter where
@@ -212,7 +217,8 @@ export
 defaultSession : Session
 defaultSession = MkSessionOpts False False False Chez [] False defaultLogLevel
                                False False False Nothing Nothing
-                               Nothing Nothing False 1000 False True False
+                               Nothing Nothing False 1000 False True
+                               False [] False
 
 export
 defaultElab : ElabDirectives

--- a/src/Core/TTC.idr
+++ b/src/Core/TTC.idr
@@ -904,10 +904,12 @@ TTC PMDefInfo where
   toBuf b l
       = do toBuf b (holeInfo l)
            toBuf b (alwaysReduce l)
+           toBuf b (externalDecl l)
   fromBuf b
       = do h <- fromBuf b
            r <- fromBuf b
-           pure (MkPMDefInfo h r)
+           e <- fromBuf b
+           pure (MkPMDefInfo h r e)
 
 export
 TTC TypeFlags where

--- a/src/Core/Unify.idr
+++ b/src/Core/Unify.idr
@@ -475,7 +475,7 @@ instantiate {newvars} loc mode env mname mref num mdef locs otm tm
          rhs <- mkDef locs INil tm ty
 
          logTerm "unify.instantiate" 5 "Definition" rhs
-         let simpleDef = MkPMDefInfo (SolvedHole num) (isSimple rhs)
+         let simpleDef = MkPMDefInfo (SolvedHole num) (isSimple rhs) False
          let newdef = record { definition =
                                  PMDef simpleDef [] (STerm 0 rhs) (STerm 0 rhs) []
                              } mdef
@@ -1464,7 +1464,7 @@ retryGuess mode smode (hid, (loc, hname))
                                               do ty <- getType [] tm
                                                  logTerm "unify.retry" 5 "Retry Delay" tm
                                                  pure $ delayMeta r envb !(getTerm ty) tm
-                                  let gdef = record { definition = PMDef (MkPMDefInfo NotHole True)
+                                  let gdef = record { definition = PMDef (MkPMDefInfo NotHole True False)
                                                                          [] (STerm 0 tm') (STerm 0 tm') [] } def
                                   logTerm "unify.retry" 5 ("Resolved " ++ show hname) tm'
                                   ignore $ addDef (Resolved hid) gdef
@@ -1490,7 +1490,7 @@ retryGuess mode smode (hid, (loc, hname))
                          -- All constraints resolved, so turn into a
                          -- proper definition and remove it from the
                          -- hole list
-                         [] => do let gdef = record { definition = PMDef (MkPMDefInfo NotHole True)
+                         [] => do let gdef = record { definition = PMDef (MkPMDefInfo NotHole True False)
                                                                          [] (STerm 0 tm) (STerm 0 tm) [] } def
                                   logTerm "unify.retry" 5 ("Resolved " ++ show hname) tm
                                   ignore $ addDef (Resolved hid) gdef

--- a/src/Idris/CommandLine.idr
+++ b/src/Idris/CommandLine.idr
@@ -139,6 +139,10 @@ data CLOpt
   ||| Use SHA256 hashes to determine if a source file needs rebuilding instead
   ||| of modification time.
   HashesInsteadOfModTime |
+  ||| Use incremental code generation, if the backend supports it
+  IncrementalCG String |
+  ||| Use whole program compilation - overrides IncrementalCG if set
+  WholeProgram |
   ||| Generate bash completion info
   BashCompletion String String |
   ||| Generate bash completion script
@@ -209,6 +213,10 @@ options = [MkOpt ["--check", "-c"] [] [CheckOnly]
               (Just "Don't implicitly import Prelude"),
            MkOpt ["--codegen", "--cg"] [Required "backend"] (\f => [SetCG f])
               (Just $ "Set code generator " ++ showDefault (codegen defaultSession)),
+           MkOpt ["--incremental-cg", "--inc"] [Required "backend"] (\f => [IncrementalCG f])
+             (Just "Incremental code generation on given backend"),
+           MkOpt ["--whole-program", "--wp"] [] [WholeProgram]
+             (Just "Use whole program compilation (overrides --inc)"),
            MkOpt ["--directive"] [Required "directive"] (\d => [Directive d])
               (Just $ "Pass a directive to the current code generator"),
            MkOpt ["--package", "-p"] [Required "package"] (\f => [PkgPath f])

--- a/src/Idris/Env.idr
+++ b/src/Idris/Env.idr
@@ -27,6 +27,7 @@ envs = [
          MkEnvDesc "IDRIS2_DATA"   "Places Idris2 looks for data files",
          MkEnvDesc "IDRIS2_LIBS"   "Places Idris2 looks for libraries (for code generation)",
          MkEnvDesc "IDRIS2_CG"     "Codegen backend",
+         MkEnvDesc "IDRIS2_INC_CGS" "Code generators to use (comma separated) when compiling modules incrementally",
          MkEnvDesc "CHEZ"          "chez executable used in Chez codegen",
          MkEnvDesc "RACKET"        "racket executable used in Racket codegen",
          MkEnvDesc "RACKET_RACO"   "raco executable used in Racket codegen",

--- a/src/Idris/Error.idr
+++ b/src/Idris/Error.idr
@@ -174,6 +174,8 @@ pwarning (ShadowingGlobalDefs _ ns)
 
 pwarning (Deprecated s)
     = pure $ pretty "Deprecation warning:" <++> pretty s
+pwarning (GenericWarn s)
+    = pure $ pretty s
 
 export
 perror : {auto c : Ref Ctxt Defs} ->

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -349,7 +349,20 @@ preOptions (IgnoreShadowingWarnings :: opts)
     = do setSession (record { showShadowingWarning = False } !getSession)
          preOptions opts
 preOptions (HashesInsteadOfModTime :: opts)
-    = do setSession (record {checkHashesInsteadOfModTime = True} !getSession)
+    = do setSession (record { checkHashesInsteadOfModTime = True } !getSession)
+         preOptions opts
+preOptions (IncrementalCG e :: opts)
+    = do defs <- get Ctxt
+         case getCG (options defs) e of
+           Just cg => do setSession (record { incrementalCGs $= (cg :: )} !getSession)
+                         preOptions opts
+           Nothing =>
+              do coreLift $ putStrLn "No such code generator"
+                 coreLift $ putStrLn $ "Code generators available: " ++
+                                 showSep ", " (map fst (availableCGs (options defs)))
+                 coreLift $ exitWith (ExitFailure 1)
+preOptions (WholeProgram :: opts)
+    = do setSession (record { wholeProgram = True } !getSession)
          preOptions opts
 preOptions (BashCompletion a b :: _)
     = do os <- opts a b

--- a/src/TTImp/Elab/Delayed.idr
+++ b/src/TTImp/Elab/Delayed.idr
@@ -253,7 +253,8 @@ retryDelayed' errmode acc (d@(_, i, hints, elab) :: ds)
                let ds' = reverse (delayedElab ust) ++ ds
 
                updateDef (Resolved i) (const (Just
-                    (PMDef (MkPMDefInfo NotHole True) [] (STerm 0 tm) (STerm 0 tm) [])))
+                    (PMDef (MkPMDefInfo NotHole True False)
+                           [] (STerm 0 tm) (STerm 0 tm) [])))
                logTerm "elab.update" 5 ("Resolved delayed hole " ++ show i) tm
                logTermNF "elab.update" 5 ("Resolved delayed hole NF " ++ show i) [] tm
                removeHole i

--- a/src/TTImp/Elab/Hole.idr
+++ b/src/TTImp/Elab/Hole.idr
@@ -54,7 +54,7 @@ checkHole rig elabinfo nest env fc n_in (Just gexpty)
          -- Record the LHS for this hole in the metadata
          withCurrentLHS (Resolved idx)
          addNameLoc fc nm
-         addUserHole nm
+         addUserHole False nm
          saveHole nm
          pure (metaval, gexpty)
 checkHole rig elabinfo nest env fc n_in exp
@@ -71,6 +71,6 @@ checkHole rig elabinfo nest env fc n_in exp
          (idx, metaval) <- metaVarI fc rig env' nm ty
          withCurrentLHS (Resolved idx)
          addNameLoc fc nm
-         addUserHole nm
+         addUserHole False nm
          saveHole nm
          pure (metaval, gnf env ty)

--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -871,11 +871,16 @@ processDef opts nest env fc n_in cs_in
                  do t <- toFullNames tree_ct
                     pure ("Case tree for " ++ show n ++ ": " ++ show t)
 
+         -- check whether the name was declared in a different source file
+         defs <- get Ctxt
+         let pi = case lookup n (userHoles defs) of
+                        Nothing => defaultPI
+                        Just e => record { externalDecl = e } defaultPI
          -- Add compile time tree as a placeholder for the runtime tree,
          -- but we'll rebuild that in a later pass once all the case
          -- blocks etc are resolved
          ignore $ addDef (Resolved nidx)
-                  (record { definition = PMDef defaultPI cargs tree_ct tree_ct pats
+                  (record { definition = PMDef pi cargs tree_ct tree_ct pats
                           } gdef)
 
          when (visibility gdef == Public) $

--- a/src/TTImp/ProcessType.idr
+++ b/src/TTImp/ProcessType.idr
@@ -203,7 +203,7 @@ initDef : {vars : _} ->
           {auto u : Ref UST UState} ->
           Name -> Env Term vars -> Term vars -> List FnOpt -> Core Def
 initDef n env ty []
-    = do addUserHole n
+    = do addUserHole False n
          pure None
 initDef n env ty (ExternFn :: opts)
     = do defs <- get Ctxt

--- a/tests/idris2/api001/LazyCodegen.idr
+++ b/tests/idris2/api001/LazyCodegen.idr
@@ -13,7 +13,7 @@ execute : Ref Ctxt Defs -> (execDir : String) -> ClosedTerm -> Core ()
 execute defs dir term = do coreLift $ putStrLn "Maybe in an hour."
 
 lazyCodegen : Codegen
-lazyCodegen = MkCG compile execute
+lazyCodegen = MkCG compile execute Nothing Nothing
 
 main : IO ()
 main = mainWithCodegens [("lazy", lazyCodegen)]


### PR DESCRIPTION
This adds a new flag '--inc <backend>' which, if set, compiles all modules incrementally, and for executables, links the incrementally compiled modules rather than building the whole program. Also, adds an environment variable IDRIS2_INC_CGS for providing a comma separated list of backends to use for incremental builds.

Also, adds '--whole-program', which overrides incremental builds for an executable.

Libraries are now built with IDRIS2_INC_CGS set, which means they'll still build okay on older versions, but now also allow Idris itself to be built incrementally. This massively reduces turnaround time during development (I know because I've been using this feature to implement this feature :)).

Incremental builds are much faster if there's nothing to recompile, but for the Chez backend, generate code which runs at about half the speed.

Currently only works for Chez - other backends ignore the flag.

Also, incremental building of an executable will only work if *all* required modules have been built incrementally for the backend in use. I've added a page to the documentation to explain all this, and updated the CHANGELOG and INSTALL with brief details.

We may want to consider adding a CI job for an incremental build too.