### PR TITLE
Missing interface methods now cause an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Next version]
 
+### Language changes
+
+* Missing methods in implementations now give a compile time error. This was
+  always the intended behaviour, but until now had not been implemented!
+
 ### Compiler changes
 
 * Added incremental compilation, using either the `--inc` flag or the

--- a/libs/contrib/Control/Algebra/Implementations.idr
+++ b/libs/contrib/Control/Algebra/Implementations.idr
@@ -18,4 +18,5 @@ Monoid (ty -> ty) where
   neutral = id
 
 MonoidV (ty -> ty) where
+  monoidNeutralIsNeutralL _ = Refl
   monoidNeutralIsNeutralR _ = Refl

--- a/libs/contrib/Control/Validation.idr
+++ b/libs/contrib/Control/Validation.idr
@@ -111,6 +111,8 @@ Monad m => Alternative (ValidatorT m a) where
                 (Right r) => pure $ Right r
                 (Left e') => pure $ Left (e <+> " / " <+> e')
 
+    empty = MkValidator \x => MkEitherT $ pure (Left "invalid")
+
 ||| Alter the input before validation using given function.
 export
 contramap : (a -> b) -> ValidatorT m b c -> ValidatorT m a c

--- a/libs/contrib/Data/Bool/Algebra.idr
+++ b/libs/contrib/Data/Bool/Algebra.idr
@@ -24,6 +24,9 @@ MonoidV Bool where
   monoidNeutralIsNeutralL True = Refl
   monoidNeutralIsNeutralL False = Refl
 
+  monoidNeutralIsNeutralR True = Refl
+  monoidNeutralIsNeutralR False = Refl
+
 Group Bool where
   -- Each Bool is its own additive inverse.
   inverse = id

--- a/src/Idris/Elab/Implementation.idr
+++ b/src/Idris/Elab/Implementation.idr
@@ -203,6 +203,9 @@ elabImplementation {vars} ifc vis opts_in pass env nest is cons iname ps named i
 
                log "elab.implementation" 5 $ "Added defaults: body is " ++ show body
                log "elab.implementation" 5 $ "Missing methods: " ++ show missing
+               when (not (isNil missing)) $
+                 throw (GenericMsg ifc ("Missing methods in " ++ show iname ++ ": "
+                                        ++ showSep "," (map show missing)))
 
                -- Add the 'using' hints
                defs <- get Ctxt

--- a/src/Idris/ProcessIdr.idr
+++ b/src/Idris/ProcessIdr.idr
@@ -338,7 +338,8 @@ processMod sourceFileName ttcFileName msg sourcecode origin
                             processDecls (decls mod)
 --                 coreLift $ gc
 
-                logTime "++ Compile defs" $ compileAndInlineAll
+                when (isNil errs) $
+                   logTime "++ Compile defs" $ compileAndInlineAll
 
                 -- Save the import hashes for the imports we just read.
                 -- If they haven't changed next time, and the source

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -124,7 +124,7 @@ idrisTestsRegression = MkTestPool "Various regressions" [] Nothing
        "reg022", "reg023", "reg024", "reg025", "reg026", "reg027", "reg028",
        "reg029", "reg030", "reg031", "reg032", "reg033", "reg034", "reg035",
        "reg036", "reg037", "reg038", "reg039", "reg040", "reg041", "reg042",
-       "reg043"]
+       "reg043", "reg044"]
 
 idrisTestsData : TestPool
 idrisTestsData = MkTestPool "Data and record types" [] Nothing

--- a/tests/idris2/interface001/IFace.idr
+++ b/tests/idris2/interface001/IFace.idr
@@ -34,6 +34,8 @@ Eq a => Eq (List a) where
 (Eq a, Eq b) => Eq (a, b) where
    (==) (x, y) (x', y') = x == x' && y == y'
 
+   (/=) x y = not (x == y)
+
 [alsoSilly] Eq a => Eq (List a) where
    (==) [] [] = False
    (==) (x :: xs) (y :: ys) = x == y && xs == ys
@@ -79,3 +81,5 @@ v2 = MkDPair _ [Z, Z]
        = case decEq l l' of
               Yes Refl => r == r'
               No _ => False
+
+   (/=) x y = not (x == y)

--- a/tests/idris2/interface001/IFace1.idr
+++ b/tests/idris2/interface001/IFace1.idr
@@ -34,6 +34,8 @@ Eq a => Eq (List a) where
 (Eq a, Eq b) => Eq (a, b) where
    (==) (x, y) (x', y') = x == x' && y == y'
 
+   (/=) x y = not (x == y)
+
 [alsoSilly] Eq a => Eq (List a) where
    (==) [] [] = False
    (==) (x :: xs) (y :: ys) = x == y && xs == ys
@@ -79,3 +81,5 @@ v2 = MkDPair _ [Z, Z]
        = case decEq l l' of
               Yes Refl => ?foo
               No _ => False
+
+   (/=) x y = not (x == y)

--- a/tests/idris2/reg044/Methods.idr
+++ b/tests/idris2/reg044/Methods.idr
@@ -1,0 +1,12 @@
+data Foo = A | B | C
+
+Eq Foo where
+   A == A = True
+   B == B = True
+   C == C = True
+   _ == _ = False
+
+Ord Foo where
+   A < B = True
+   B < C = True
+   _ < _ = False

--- a/tests/idris2/reg044/expected
+++ b/tests/idris2/reg044/expected
@@ -1,0 +1,9 @@
+1/1: Building Methods (Methods.idr)
+Error: Missing methods in Ord: compare
+
+Methods:9:1--12:17
+ 09 | Ord Foo where
+ 10 |    A < B = True
+ 11 |    B < C = True
+ 12 |    _ < _ = False
+

--- a/tests/idris2/reg044/run
+++ b/tests/idris2/reg044/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 --check Methods.idr
+
+rm -rf build


### PR DESCRIPTION
This was always the intended behaviour, but until now not implemented! This caught a couple of issues in contrib and a test.