### PR TITLE
Add comment about import from the contrib library

### DIFF
--- a/docs/source/typedd/typedd.rst
+++ b/docs/source/typedd/typedd.rst
@@ -276,7 +276,7 @@ generates a case tree splitting on ``input1`` and ``input2`` instead of the
 This doesn't yet get past the totality checker, however, because it doesn't
 know about looking inside pairs.
 
-For the ``VList`` view in the exercise 4 after Chapter 10-2 ``import Data.List.Views.Extra`` from `contrib` library.
+For the ``VList`` view in the exercise 4 after Chapter 10-2 ``import Data.List.Views.Extra`` from ``contrib`` library.
 
 In ``DataStore.idr``: Well this is embarrassing - I've no idea how Idris 1 lets
 this through! I think perhaps it's too "helpful" when solving unification

--- a/docs/source/typedd/typedd.rst
+++ b/docs/source/typedd/typedd.rst
@@ -276,6 +276,8 @@ generates a case tree splitting on ``input1`` and ``input2`` instead of the
 This doesn't yet get past the totality checker, however, because it doesn't
 know about looking inside pairs.
 
+For the ``VList`` view in the exercise 4 after Chapter 10-2 ``import Data.List.Views.Extra`` from `contrib` library.
+
 In ``DataStore.idr``: Well this is embarrassing - I've no idea how Idris 1 lets
 this through! I think perhaps it's too "helpful" when solving unification
 problems. To fix it, add an extra parameter ``schema`` to ``StoreView``, and change


### PR DESCRIPTION
The `VList` view is now located there, mention it in the `typedd.rst`

The extra view for Vect I didn't find in idris2, so for that one see https://github.com/idris-lang/Idris2/pull/1624

Regard,