### PR TITLE
[ error message ] include space in missing methods error

### DIFF
--- a/src/Idris/Elab/Implementation.idr
+++ b/src/Idris/Elab/Implementation.idr
@@ -205,7 +205,7 @@ elabImplementation {vars} ifc vis opts_in pass env nest is cons iname ps named i
                log "elab.implementation" 5 $ "Missing methods: " ++ show missing
                when (not (isNil missing)) $
                  throw (GenericMsg ifc ("Missing methods in " ++ show iname ++ ": "
-                                        ++ showSep "," (map show missing)))
+                                        ++ showSep ", " (map show missing)))
 
                -- Add the 'using' hints
                defs <- get Ctxt


### PR DESCRIPTION
The error message was missing a space
eg
```
Missing methods in SizedBinary: toBinarySize,KnownSize
```
Now it has one.