### PR TITLE
Delete tyspec functions

### DIFF
--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -125,25 +125,6 @@ chezString : String -> String
 chezString cs = strCons '"' (showChezString (unpack cs) "\"")
 
 mutual
-  tySpec : NamedCExp -> Core String
-  -- Primitive types have been converted to names for the purpose of matching
-  -- on types
-  tySpec (NmCon fc (UN "Int") _ _ []) = pure "int"
-  tySpec (NmCon fc (UN "String") _ _ []) = pure "string"
-  tySpec (NmCon fc (UN "Double") _ _ []) = pure "double"
-  tySpec (NmCon fc (UN "Char") _ _ []) = pure "char"
-  tySpec (NmCon fc (NS _ n) _ _ [_])
-     = cond [(n == UN "Ptr", pure "void*"),
-             (n == UN "GCPtr", pure "void*"),
-             (n == UN "Buffer", pure "u8*")]
-          (throw (GenericMsg fc ("Can't pass argument of type " ++ show n ++ " to foreign function")))
-  tySpec (NmCon fc (NS _ n) _ _ [])
-     = cond [(n == UN "Unit", pure "void"),
-             (n == UN "AnyPtr", pure "void*"),
-             (n == UN "GCAnyPtr", pure "void*")]
-          (throw (GenericMsg fc ("Can't pass argument of type " ++ show n ++ " to foreign function")))
-  tySpec ty = throw (GenericMsg (getFC ty) ("Can't pass argument of type " ++ show ty ++ " to foreign function"))
-
   handleRet : String -> String -> String
   handleRet "void" op = op ++ " " ++ mkWorld (schConstructor chezString (UN "") (Just 0) [])
   handleRet _ op = mkWorld op

--- a/src/Compiler/Scheme/Gambit.idr
+++ b/src/Compiler/Scheme/Gambit.idr
@@ -73,22 +73,6 @@ gambitString : String -> String
 gambitString cs = strCons '"' (showGambitString (unpack cs) "\"")
 
 mutual
-  -- Primitive types have been converted to names for the purpose of matching
-  -- on types
-  tySpec : NamedCExp -> Core String
-  tySpec (NmCon fc (UN "Int") _ _ []) = pure "int"
-  tySpec (NmCon fc (UN "String") _ _ []) = pure "UTF-8-string"
-  tySpec (NmCon fc (UN "Double") _ _ []) = pure "double"
-  tySpec (NmCon fc (UN "Char") _ _ []) = pure "char"
-  tySpec (NmCon fc (NS _ n) _ _ [_])
-     = cond [(n == UN "Ptr", pure "(pointer void)")]
-          (throw (GenericMsg fc ("Can't pass argument of type " ++ show n ++ " to foreign function")))
-  tySpec (NmCon fc (NS _ n) _ _ [])
-     = cond [(n == UN "Unit", pure "void"),
-             (n == UN "AnyPtr", pure "(pointer void)")]
-          (throw (GenericMsg fc ("Can't pass argument of type " ++ show n ++ " to foreign function")))
-  tySpec ty = throw (GenericMsg (getFC ty) ("Can't pass argument of type " ++ show ty ++ " to foreign function"))
-
   handleRet : String -> String -> String
   handleRet "void" op = op ++ " " ++ mkWorld (schConstructor gambitString (UN "") (Just 0) [])
   handleRet _ op = mkWorld op


### PR DESCRIPTION
I suspect this function is left there accidentally after FFI was
refactored.

These functions can mislead about how FFI works.

Note these functions are private (not exported) and not used.  Idris
compiler could emit a warning about such functions.