### PR TITLE
[ fix ] Nix uses proper version

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,10 @@
     let idris2-version = "0.4.0";
     in flake-utils.lib.eachDefaultSystem (system:
       let pkgs = import nixpkgs { inherit system; };
-          idris2Pkg = pkgs.callPackage ./nix/package.nix { inherit idris2-version; };
+          idris2Pkg = pkgs.callPackage ./nix/package.nix {
+            inherit idris2-version;
+            srcRev = self.shortRev or "dirty";
+          };
           text-editor = import ./nix/text-editor.nix { inherit pkgs idris-emacs-src idris2Pkg; };
           buildIdrisPkg = { projectName, src, idrisLibraries }:
             pkgs.callPackage ./nix/buildIdris.nix

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -6,6 +6,7 @@
 , fetchFromGitHub
 , makeWrapper
 , idris2-version
+, srcRev
 , racket
 , gambit
 , nodejs
@@ -24,8 +25,10 @@ stdenv.mkDerivation rec {
     ++ lib.optional stdenv.isDarwin [ zsh ];
   buildInputs = [ chez gmp ];
 
-  prePatch = ''
+  prePatch = let match = "$\{GIT_SHA1}"; in
+  ''
     patchShebangs --build tests
+    sed 's/${match}/${srcRev}/' -i Makefile
   '';
 
   makeFlags = [ "PREFIX=$(out)" ]


### PR DESCRIPTION
With this PR, after building from nix, `idris2 --version` works as expected if the git tree is clean. Otherwise, it claims the revision is "dirty".

#1507