### PR TITLE
Pattern synonyms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Missing methods in implementations now give a compile time error. This was
   always the intended behaviour, but until now had not been implemented!
+* Directive `%pattern_synonyms` for implicit bidirectional pattern synonyms.
 
 ### Compiler changes
 

--- a/docs/source/updates/updates.rst
+++ b/docs/source/updates/updates.rst
@@ -821,6 +821,40 @@ Another novelty - new update syntax (previous one still functional):
 The ``record`` keyword has been discarded for brevity, symbol ``:=`` replaces ``=``
 in order to not introduce any ambiguity.
 
+Pattern synonyms
+----------------
+
+Pattern synonyms can be introduced for already defined function via the `%pattern_synonym` directive:
+
+.. code-block:: idris
+
+    JustPair : a -> b -> Maybe (a, b)
+    JustPair x y = Just (x, y)
+
+    %pattern_synonym JustPair
+
+    first : Maybe (a, b) -> Maybe a
+    first (JustPair x _) = Just x
+    first _ = Nothing
+
+    FOO : String
+    FOO = "Foo"
+
+    %pattern_synonym FOO
+
+    isFoo : String -> Bool
+    isFoo FOO = True
+    isFoo _ = False
+
+Idris2 only supports implicit bidirectional pattern synonyms, which since are defined as regular functions
+can be used both as expressions, and as synonyms on the LHS of definitions. Additional requirements are:
+
+1. the function must be total;
+
+2. the function definition must have a single pattern-matching clause;
+
+3. the function must have only variable bindings on the LHS, or no arguments at all.
+
 Generate definition
 -------------------
 

--- a/idris2api.ipkg
+++ b/idris2api.ipkg
@@ -56,6 +56,7 @@ modules =
     Core.Normalise,
     Core.Options,
     Core.Options.Log,
+    Core.Pattern,
     Core.Primitives,
     Core.Reflect,
     Core.Termination,

--- a/src/Core/CaseBuilder.idr
+++ b/src/Core/CaseBuilder.idr
@@ -933,7 +933,7 @@ mkPat args orig (Ref fc (DataCon t a) n) = pure $ PCon fc n t a args
 mkPat args orig (Ref fc (TyCon t a) n) = pure $ PTyCon fc n a args
 mkPat args orig (Ref fc Func n)
   = do prims <- getPrimitiveNames
-       mtm <- normalisePrims (const True) isPConst True prims n args orig []
+       mtm <- normalisePrimsOrPattern (const True) isPConst True prims n args orig []
        case mtm of
          Just tm => mkPat [] tm tm
          Nothing =>

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -1091,6 +1091,7 @@ record Defs where
      -- ^ A mapping from names to transformations resulting from a %builtin pragma
      -- seperate to `transforms` because these must always fire globally so run these
      -- when compiling to `CExp`.
+  patternSynonyms : NameMap ()
   namedirectives : NameMap (List String)
   ifaceHash : Int
   importHashes : List (Namespace, Int)
@@ -1161,6 +1162,7 @@ initDefs
            , transforms = empty
            , saveTransforms = []
            , builtinTransforms = initBuiltinTransforms
+           , patternSynonyms = empty
            , namedirectives = empty
            , ifaceHash = 5381
            , importHashes = []

--- a/src/Core/Options/Log.idr
+++ b/src/Core/Options/Log.idr
@@ -116,6 +116,8 @@ knownTopics = [
     ("interaction.search", Nothing),
     ("metadata.names", Nothing),
     ("module.hash", Nothing),
+    ("pattern", Nothing),
+    ("pattern.implicit", Nothing),
     ("quantity", Nothing),
     ("quantity.hole", Nothing),
     ("quantity.hole.update", Nothing),

--- a/src/Core/Pattern.idr
+++ b/src/Core/Pattern.idr
@@ -1,0 +1,37 @@
+module Core.Pattern
+
+import Core.Context
+import Core.Context.Log
+import Core.Env
+import Core.Termination
+import Libraries.Data.NameMap
+
+%default covering
+
+checkLHS : {vars : _} -> Term vars -> Bool
+checkLHS app = all valid (getArgs app)
+  where
+    valid : forall vars . Term vars -> Bool
+    valid (Local _ _ _ _) = True
+    valid (As _ _ _ tm) = valid tm
+    valid _ = False
+
+export
+addImplicitPattern : Ref Ctxt Defs
+                  => FC -> Name -> Core ()
+addImplicitPattern fc name = do
+  log "pattern.implicit" 5 $ "Checking valid pattern synonym " ++ show !(toFullNames name)
+  defs <- get Ctxt
+  nidx <- checkUnambig fc name
+  Just gdef <- lookupCtxtExact nidx defs.gamma
+    | Nothing => undefinedName fc nidx
+  IsTerminating <- checkTotal fc nidx
+    | _ => throw $ GenericMsg fc "Pattern synonym must be total"
+  let IsCovering = gdef.totality.isCovering
+    | _ => throw $ GenericMsg fc "Pattern synonym must be total"
+  let PMDef _ _ _ _ [(vs ** (env, lhs, rhs))] = gdef.definition
+    | PMDef _ _ _ _ pats => throw $ GenericMsg fc $ "Pattern synonym must have a single definition, instead found " ++ show (length pats)
+    | _ => throw $ GenericMsg fc "Pattern synonym must be a pattern-matching definition"
+  let True = checkLHS lhs
+    | False => throw $ GenericMsg fc $ "LHS of pattern synonym must contain only bindings"
+  put Ctxt (record { patternSynonyms $= insert nidx () } defs)

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -6,6 +6,7 @@ import Core.Core
 import Core.Env
 import Core.Metadata
 import Core.Options
+import Core.Pattern
 import Core.TT
 import Core.Unify
 
@@ -1023,6 +1024,7 @@ mutual
              Overloadable n => pure [IPragma [] (\nest, env => setNameFlag fc n Overloadable)]
              Extension e => pure [IPragma [] (\nest, env => setExtension e)]
              DefaultTotality tot => pure [IPragma [] (\_, _ => setDefaultTotalityOption tot)]
+             PatternSynonym n => pure [IPragma [] (\nest, env => addImplicitPattern fc n)]
   desugarDecl ps (PBuiltin fc type name) = pure [IBuiltin fc type name]
 
   export

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1203,6 +1203,10 @@ directive fname indents
                        (decoratedSimpleBinderName fname)
          atEnd indents
          pure (Names n (forget ns))
+  <|> do decorate fname Keyword $ pragma "pattern_synonym"
+         n <- name
+         atEnd indents
+         pure (PatternSynonym n)
   <|> do decorate fname Keyword $ pragma "start"
          e <- expr pdef fname indents
          atEnd indents

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -268,6 +268,7 @@ mutual
        AutoImplicitDepth : Nat -> Directive
        NFMetavarThreshold : Nat -> Directive
        SearchTimeout : Integer -> Directive
+       PatternSynonym : Name -> Directive
 
   public export
   data PField : Type where

--- a/src/TTImp/Elab/App.idr
+++ b/src/TTImp/Elab/App.idr
@@ -781,14 +781,13 @@ checkApp rig elabinfo nest env fc (IVar fc' n) expargs autoargs namedargs exp
                      List Name -> Env Term vs ->
                      (Term vs, Glued vs) ->
                      Core (Term vs, Glued vs)
-    normalisePrims prims env res
-        = do tm <- Normalise.normalisePrims (`boundSafe` elabMode elabinfo)
-                                            isIPrimVal
-                                            (case elabMode elabinfo of
-                                                  InLHS _ => True
-                                                  _ => False)
-                                            prims n expargs (fst res) env
-             pure (fromMaybe (fst res) tm, snd res)
+    normalisePrims prims env res =
+        do tm <- normalisePrimsOrPattern (`boundSafe` elabMode elabinfo) isIPrimVal
+                                         (case elabMode elabinfo of
+                                               InLHS _ => True
+                                               _ => False)
+                                         prims n expargs (fst res) env
+           pure (fromMaybe (fst res) tm, snd res)
 
       where
 

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -108,6 +108,10 @@ idrisTestsLiterate = MkTestPool "Literate programming" [] Nothing
        "literate009", "literate010", "literate011", "literate012",
        "literate013", "literate014", "literate015", "literate016"]
 
+idrisTestsPattern : TestPool
+idrisTestsPattern = MkTestPool "Pattern synonyms" [] Nothing
+      ["pattern001"]
+
 idrisTestsPerformance : TestPool
 idrisTestsPerformance = MkTestPool "Performance" [] Nothing
        -- Performance: things which have been slow in the past, or which
@@ -319,6 +323,7 @@ main = runner $
   , testPaths "idris2" idrisTestsInterface
   , testPaths "idris2" idrisTestsLiterate
   , testPaths "idris2" idrisTestsLinear
+  , testPaths "idris2" idrisTestsPattern
   , testPaths "idris2" idrisTestsPerformance
   , testPaths "idris2" idrisTestsRegression
   , testPaths "idris2" idrisTestsData

--- a/tests/idris2/pattern001/Test.idr
+++ b/tests/idris2/pattern001/Test.idr
@@ -1,0 +1,43 @@
+FOO : String
+FOO = "Foo"
+%pattern_synonym FOO
+
+BAR : String
+BAR = "Bar"
+%pattern_synonym BAR
+
+foobar : String -> Bool
+foobar FOO = True
+foobar BAR = True
+foobar _ = False
+
+JustPair : a -> b -> Maybe (a, b)
+JustPair x y = Just (x, y)
+%pattern_synonym JustPair
+
+first : Maybe (a, b) -> Maybe a
+first (JustPair x _) = Just x
+first _ = Nothing
+
+data Typ = App String (List Typ)
+
+arrow1 : Typ -> Typ -> Typ
+arrow1 t1 t2 = App "->" [t1, t2]
+%pattern_synonym arrow1
+
+collectArgs1 : Typ -> List Typ
+collectArgs1 (arrow1 t1 t2) = t1 :: (collectArgs1 t2)
+collectArgs1 t = [t]
+
+arrow2 : Typ -> Typ -> Typ
+arrow2 (App "F" [t1]) t2 = App "->" [t1, t2]
+%pattern_synonym arrow2
+
+arrow3 : Typ -> Typ -> Typ
+arrow3 t1 t2 = App "->" [t1, t2]
+arrow3 t1 t2 = App "->" [t1, t2]
+%pattern_synonym arrow3
+
+arrow4 : Typ -> Typ -> Typ
+arrow4 (App s t1) t2 = App "->" (t2 :: t1)
+%pattern_synonym arrow4

--- a/tests/idris2/pattern001/expected
+++ b/tests/idris2/pattern001/expected
@@ -1,0 +1,61 @@
+1/1: Building Test (Test.idr)
+Warning: Unreachable clause: arrow3 t1 t2
+
+Test:38:1--38:13
+ 34 | %pattern_synonym arrow2
+ 35 | 
+ 36 | arrow3 : Typ -> Typ -> Typ
+ 37 | arrow3 t1 t2 = App "->" [t1, t2]
+ 38 | arrow3 t1 t2 = App "->" [t1, t2]
+      ^^^^^^^^^^^^
+
+Error: Pattern synonym must be total
+
+Test:34:1--34:24
+ 30 | collectArgs1 t = [t]
+ 31 | 
+ 32 | arrow2 : Typ -> Typ -> Typ
+ 33 | arrow2 (App "F" [t1]) t2 = App "->" [t1, t2]
+ 34 | %pattern_synonym arrow2
+      ^^^^^^^^^^^^^^^^^^^^^^^
+
+Error: Pattern synonym must have a single definition, instead found 2
+
+Test:39:1--39:24
+ 35 | 
+ 36 | arrow3 : Typ -> Typ -> Typ
+ 37 | arrow3 t1 t2 = App "->" [t1, t2]
+ 38 | arrow3 t1 t2 = App "->" [t1, t2]
+ 39 | %pattern_synonym arrow3
+      ^^^^^^^^^^^^^^^^^^^^^^^
+
+Error: LHS of pattern synonym must contain only bindings
+
+Test:43:1--43:24
+ 39 | %pattern_synonym arrow3
+ 40 | 
+ 41 | arrow4 : Typ -> Typ -> Typ
+ 42 | arrow4 (App s t1) t2 = App "->" (t2 :: t1)
+ 43 | %pattern_synonym arrow4
+      ^^^^^^^^^^^^^^^^^^^^^^^
+
+Error: arrow2 is not covering.
+
+Test:32:1--32:27
+ 28 | collectArgs1 : Typ -> List Typ
+ 29 | collectArgs1 (arrow1 t1 t2) = t1 :: (collectArgs1 t2)
+ 30 | collectArgs1 t = [t]
+ 31 | 
+ 32 | arrow2 : Typ -> Typ -> Typ
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Missing cases:
+    arrow2 (App "F" (_ :: (_ :: _))) _
+    arrow2 (App "F" []) _
+    arrow2 (App _ _) _
+
+Main> True
+Main> True
+Main> False
+Main> [App "arg1" [], App "arg2" [], App "arg3" []]
+Main> Bye for now!

--- a/tests/idris2/pattern001/input
+++ b/tests/idris2/pattern001/input
@@ -1,0 +1,5 @@
+foobar FOO
+foobar "Bar"
+foobar ""
+collectArgs1 (App "->" [App "arg1" [], App "->" [App "arg2" [], App "arg3" []]])
+:q

--- a/tests/idris2/pattern001/run
+++ b/tests/idris2/pattern001/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 --no-banner Test.idr < input
+
+rm -rf build


### PR DESCRIPTION
Following the Haskell naming scheme, this PR implements implicit bidirection pattern synonyms. Functions tagged with the `%pattern_synonym <name>` directive, are normalised on the LHS of pattern matching definitions. Allowed functions must be total, use only binding variables (or no argument at all) on the LHS, and must have a single clause.
I've settled for using a directive for three reasons:
1. future compatibility with explicit bidirectional pattern synonyms, where there are two definitions for when the pattern is used on the LHS or the RHS, which can be solved by adding additional optional parameter to the directive;
2. future compatibility with unidirectional pattern synonyms, where the pattern is only valid on the LHS because it uses unbounded `_` on the RHS, which would require a new kind of declaration since are not directly definable with the current syntax for functions.
3. the ability of enabling this behaviour for functions declared on external packages (although I'm not entirely convinced this is a desiderable functionality).

Other option for tagging would be using a modifier like `public` or a function option like `%hint` before the definition, however both options would be problematic for declarations without definitions since they would immediately error on usage, thus defeating the point of having a metavariable in that place.

Example of usage:
```idris
-- Constants
FOO : String
FOO = "foo"
%pattern_synonym FOO

isFoo : String -> Bool
isFoo FOO = True
isFoo  _ = False

Just2 : a -> b -> Maybe (a, b)
Just2 x y = Just (x, y)
%pattern_synonym Just2

first : Maybe (a, b) -> Maybe a
first (Just2 x _) = Just x  -- you can still use _ inside pattern synonyms
first _ = Nothing
```