### PR TITLE
[ docs ] Record docs fixes

### DIFF
--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -770,10 +770,15 @@ mutual
                  Core IField
   desugarField ps ns (MkField fc doc rig p n ty)
       = do addDocStringNS ns n doc
+           addDocStringNS ns (toRF n) doc
            syn <- get Syn
            pure (MkIField fc rig !(traverse (desugar AnyExpr ps) p )
                           n !(bindTypeNames fc (usingImpl syn)
                           ps !(desugar AnyExpr ps ty)))
+        where
+          toRF : Name -> Name
+          toRF (UN n) = RF n
+          toRF n = n
 
   export
   desugarFnOpt : {auto s : Ref Syn SyntaxInfo} ->

--- a/src/Idris/Doc/HTML.idr
+++ b/src/Idris/Doc/HTML.idr
@@ -46,8 +46,11 @@ packageInternal _ = pure False
 
 prettyNameRoot : Name -> String
 prettyNameRoot n =
-  let root = htmlEscape $ nameRoot n in
-  if isOpName n then "(" ++ root ++ ")" else root
+  let root = nameRoot n in
+  -- We need to take the root first and then re-wrap in a UN for the op check
+  -- to avoid false positives for record fields (RF) names (which get an
+  -- implicit "."-prefix).
+  htmlEscape (if isOpName (UN root) then "(" ++ root ++ ")" else root)
 
 renderHtml : {auto c : Ref Ctxt Defs} ->
              SimpleDocTree IdrisDocAnn ->

--- a/src/Idris/Doc/String.idr
+++ b/src/Idris/Doc/String.idr
@@ -244,11 +244,10 @@ getDocsForName fc n
                 | Nothing => pure Empty
            ty <- resugar [] =<< normaliseHoles defs [] (type def)
            let prettyName = pretty (nameRoot nm)
-           let projDecl = hsep [ fun nm prettyName, colon, prettyTerm ty ]
+           let projDecl = annotate (Decl nm) $ hsep [ fun nm prettyName, colon, prettyTerm ty ]
            let [(_, str)] = lookupName nm (docstrings syn)
                   | _ => pure projDecl
-           pure $ annotate (Decl nm)
-                $ vcat [ projDecl
+           pure $ vcat [ projDecl
                        , annotate DocStringBody $ vcat (reflowDoc str)
                        ]
 

--- a/src/Idris/Doc/String.idr
+++ b/src/Idris/Doc/String.idr
@@ -245,11 +245,13 @@ getDocsForName fc n
            ty <- resugar [] =<< normaliseHoles defs [] (type def)
            let prettyName = pretty (nameRoot nm)
            let projDecl = annotate (Decl nm) $ hsep [ fun nm prettyName, colon, prettyTerm ty ]
-           let [(_, str)] = lookupName nm (docstrings syn)
-                  | _ => pure projDecl
-           pure $ vcat [ projDecl
-                       , annotate DocStringBody $ vcat (reflowDoc str)
-                       ]
+           case lookupName nm (docstrings syn) of
+                [(_, "")] => pure projDecl
+                [(_, str)] =>
+                  pure $ vcat [ projDecl
+                              , annotate DocStringBody $ vcat (reflowDoc str)
+                              ]
+                _ => pure projDecl
 
     getFieldsDoc : Name -> Core (List (Doc IdrisDocAnn))
     getFieldsDoc recName


### PR DESCRIPTION
This PR fixes a few issues with docs for records:
 * docstrings for field projections were missing when listing the docs for a record type and when looking up docs with the `:doc (.fieldName)` syntax
 * in the HTML docs, all field projections were shown in one line, now they're correctly formatted
 * in the HTML docs, all field names were wrapped in parentheses, now that happens only if their name is an operator