### PR TITLE
[ vanity ] Mark bootstrap code as generated -> detect repo's main language as Idris

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-bootstrap/* linguist-vendored
+bootstrap/idris2_app/* linguist-generated


### PR DESCRIPTION
The slightly modified `.gitattributes` helps GitHub's "linguist" to skip the generated bootstrap code when counting lines of code per language. After this change, GitHub shows the repo as 95.5% Idris, which is nice :)

It seems the change only becomes effective after a merge to master and then only after some additional delay (at least that was the case for my personal branch [cypheon/Idris2](https://github.com/cypheon/Idris2)).