### PR TITLE
[ cli ] make package file optional

### DIFF
--- a/src/Idris/CommandLine.idr
+++ b/src/Idris/CommandLine.idr
@@ -104,7 +104,7 @@ data CLOpt
    ||| Add a package as a dependency
   PkgPath String |
    ||| Build or install a given package, depending on PkgCommand
-  Package PkgCommand String |
+  Package PkgCommand (Maybe String) |
    ||| Show locations of data/library directories
   Directory DirCommand |
    ||| The input Idris file
@@ -250,23 +250,27 @@ options = [MkOpt ["--check", "-c"] [] [CheckOnly]
 
            optSeparator,
            MkOpt ["--init"] [Optional "package file"]
-              (\ f => [Package Init (fromMaybe "" f)])
+              (\ f => [Package Init f])
               (Just "Interactively initialise a new project"),
 
-           MkOpt ["--build"] [Required "package file"] (\f => [Package Build f])
+           MkOpt ["--build"] [Optional "package file"]
+               (\f => [Package Build f])
               (Just "Build modules/executable for the given package"),
-           MkOpt ["--install"] [Required "package file"] (\f => [Package Install f])
+           MkOpt ["--install"] [Optional "package file"]
+              (\f => [Package Install f])
               (Just "Install the given package"),
-           MkOpt ["--install-with-src"] [Required "package file"]
-                 (\f => [Package InstallWithSrc f])
+           MkOpt ["--install-with-src"] [Optional "package file"]
+              (\f => [Package InstallWithSrc f])
               (Just "Install the given package"),
-           MkOpt ["--mkdoc"] [Required "package file"] (\f => [Package MkDoc f])
+           MkOpt ["--mkdoc"] [Optional "package file"]
+              (\f => [Package MkDoc f])
               (Just "Build documentation for the given package"),
-           MkOpt ["--typecheck"] [Required "package file"] (\f => [Package Typecheck f])
+           MkOpt ["--typecheck"] [Optional "package file"]
+              (\f => [Package Typecheck f])
               (Just "Typechecks the given package without code generation"),
-           MkOpt ["--clean"] [Required "package file"] (\f => [Package Clean f])
+           MkOpt ["--clean"] [Optional "package file"] (\f => [Package Clean f])
               (Just "Clean intermediate files/executables for the given package"),
-           MkOpt ["--repl"] [Required "package file"] (\f => [Package REPL f])
+           MkOpt ["--repl"] [Optional "package file"] (\f => [Package REPL f])
               (Just "Build the given package and launch a REPL instance."),
            MkOpt ["--find-ipkg"] [] [FindIPKG]
               (Just "Find and use an .ipkg file in a parent directory."),

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -19,6 +19,7 @@ import Data.These
 import Parser.Package
 import System
 import System.Directory
+import Libraries.System.Directory.Tree
 import System.File
 
 import Libraries.Data.StringMap
@@ -439,8 +440,7 @@ install pkg opts installSrc -- not used but might be in the future
          let toInstall = maybe (modules pkg)
                                (:: modules pkg)
                                (mainmod pkg)
-         Just wdir <- coreLift currentDir
-             | Nothing => throw (InternalError "Can't get current directory")
+         wdir <- getWorkingDir
          -- Make the package installation directory
          let targetDir = prefix_dir (dirs (options defs)) </>
                              "idris2-" ++ showVersion False version </>
@@ -580,8 +580,7 @@ clean pkg opts -- `opts` is not used but might be in the future
                                        [] => Nothing
                                        (x :: xs) => Just(xs, x))
                           pkgmods
-         Just srcdir <- coreLift currentDir
-              | Nothing => throw (InternalError "Can't get current directory")
+         srcdir <- getWorkingDir
          let d = dirs (options defs)
          let builddir = srcdir </> build_dir d </> "ttc"
          let outputdir = srcdir </> outputDirWithDefault d
@@ -649,24 +648,37 @@ parsePkgFile file = do
       | Left err => throw err
   addFields fs (initPkgDesc pname)
 
+||| If the user did not provide a package file we can look in the working
+||| directory. If there is exactly one `.ipkg` file then use that!
+localPackageFile : Maybe String -> Core String
+localPackageFile (Just fp) = pure fp
+localPackageFile Nothing
+  = do wdir <- getWorkingDir
+       tree <- coreLift (explore $ parse wdir)
+       let candidates = map fileName tree.files
+       case filter (".ipkg" `isSuffixOf`) candidates of
+         [fp] => pure fp
+         _ => throw $ UserError "No .ipkg file supplied and none could be found in the working directory."
+
 processPackage : {auto c : Ref Ctxt Defs} ->
                  {auto s : Ref Syn SyntaxInfo} ->
                  {auto o : Ref ROpts REPLOpts} ->
                  List CLOpt ->
-                 (PkgCommand, String) ->
+                 (PkgCommand, Maybe String) ->
                  Core ()
-processPackage opts (cmd, file)
+processPackage opts (cmd, mfile)
     = withCtxt . withSyn . withROpts $ case cmd of
         Init =>
           do pkg <- coreLift interactive
-             let fp = if file == "" then pkg.name ++ ".ipkg" else file
+             let fp = fromMaybe (pkg.name ++ ".ipkg") mfile
              False <- coreLift (exists fp)
                | _ => throw (GenericMsg emptyFC ("File " ++ fp ++ " already exists"))
              Right () <- coreLift $ writeFile fp (show $ the (Doc ()) $ pretty pkg)
                | Left err => throw (FileErr fp err)
              pure ()
         _ =>
-          do let Just (dir, filename) = splitParent file
+          do file <- localPackageFile mfile
+             let Just (dir, filename) = splitParent file
                  | _ => throw $ InternalError "Tried to split empty string"
              let True = isSuffixOf ".ipkg" filename
                  | _ => do coreLift $ putStrLn ("Packages must have an '.ipkg' extension: " ++ show file ++ ".")
@@ -704,7 +716,7 @@ processPackage opts (cmd, file)
 
 record PackageOpts where
   constructor MkPFR
-  pkgDetails : List (PkgCommand, String)
+  pkgDetails : List (PkgCommand, Maybe String)
   oopts : List CLOpt
   hasError : Bool
 
@@ -712,7 +724,7 @@ partitionOpts : List CLOpt -> PackageOpts
 partitionOpts opts = foldr pOptUpdate (MkPFR [] [] False) opts
   where
     data OptType : Type where
-      PPackage : PkgCommand -> String -> OptType
+      PPackage : PkgCommand -> Maybe String -> OptType
       POpt : OptType
       PIgnore : OptType
       PErr : OptType

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -658,7 +658,8 @@ localPackageFile Nothing
        let candidates = map fileName tree.files
        case filter (".ipkg" `isSuffixOf`) candidates of
          [fp] => pure fp
-         _ => throw $ UserError "No .ipkg file supplied and none could be found in the working directory."
+         [] => throw $ UserError "No .ipkg file supplied and none could be found in the working directory."
+         _ => throw $ UserError "No .ipkg file supplied and the working directory contains more than one."
 
 processPackage : {auto c : Ref Ctxt Defs} ->
                  {auto s : Ref Syn SyntaxInfo} ->


### PR DESCRIPTION
If no package file is passed to a package command, happily default
to whatever is in the working directory as long as it contains a
single package file.