### PR TITLE
Don't inline holes that are user defined names

### DIFF
--- a/src/Core/Unify.idr
+++ b/src/Core/Unify.idr
@@ -475,7 +475,9 @@ instantiate {newvars} loc mode env mname mref num mdef locs otm tm
          rhs <- mkDef locs INil tm ty
 
          logTerm "unify.instantiate" 5 "Definition" rhs
-         let simpleDef = MkPMDefInfo (SolvedHole num) (isSimple rhs) False
+         let simpleDef = MkPMDefInfo (SolvedHole num)
+                                     (not (isUserName mname) && isSimple rhs)
+                                     False
          let newdef = record { definition =
                                  PMDef simpleDef [] (STerm 0 rhs) (STerm 0 rhs) []
                              } mdef


### PR DESCRIPTION
We inline some holes when solving them if they pose no risk to breaking sharing, since this can speed up a few things. But if the hole was originally a user name, we might want to refer to it, and inlining it means we can't since it won't be saved to disk.
This fixes an occasional issue with proof search on a name that is already solved by unification.