### PR TITLE
Write files into bootstrap-build directory during bootstrap

### DIFF
--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -91,6 +91,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y -t hirsute chezscheme
           echo "$HOME/.idris2/bin" >> $GITHUB_PATH
+      - name: Make bootstrap folder readonly
+        run: chmod -R a-w bootstrap
       - name: Build from bootstrap
         run: make bootstrap && make install
       - name: Artifact Bootstrapped Idris2
@@ -112,6 +114,8 @@ jobs:
           brew install chezscheme
           brew install coreutils
           echo "$HOME/.idris2/bin" >> $GITHUB_PATH
+      - name: Make bootstrap folder readonly
+        run: chmod -R a-w bootstrap
       - name: Build Idris 2 from bootstrap
         run: make bootstrap && make install
         shell: bash
@@ -183,6 +187,8 @@ jobs:
         run: |
           sudo apt-get install -y racket
           echo "$HOME/.idris2/bin" >> $GITHUB_PATH
+      - name: Make bootstrap folder readonly
+        run: chmod -R a-w bootstrap
       - name: Build from bootstrap
         run: make bootstrap-racket && make install
       - name: Artifact Bootstrapped Idris2

--- a/.gitignore
+++ b/.gitignore
@@ -26,11 +26,7 @@ idris2docs_venv
 /benchmark/**/build
 /benchmark/*.csv
 
-/bootstrap/bin/
-/bootstrap/lib/
-/bootstrap/idris2-[0-9]*/
-/bootstrap/idris2_app/idris2-boot.*
-/bootstrap/idris2_app/libidris2_support.*
+/bootstrap-build
 
 /src/IdrisPaths.idr
 

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ endif
 TEST_PREFIX ?= ${IDRIS2_CURDIR}/build/env
 
 # Library and data paths for bootstrap-test
-IDRIS2_BOOT_PREFIX := ${IDRIS2_CURDIR}/bootstrap
+IDRIS2_BOOT_PREFIX := ${IDRIS2_CURDIR}/bootstrap-build
 
 # These are the library path in the build dir to be used during build
 export IDRIS2_BOOT_PATH := "${IDRIS2_CURDIR}/libs/prelude/build/ttc${SEP}${IDRIS2_CURDIR}/libs/base/build/ttc${SEP}${IDRIS2_CURDIR}/libs/contrib/build/ttc${SEP}${IDRIS2_CURDIR}/libs/network/build/ttc${SEP}${IDRIS2_CURDIR}/libs/test/build/ttc"
@@ -198,19 +198,21 @@ install-with-src-libs:
 
 # Bootstrapping using SCHEME
 bootstrap: support
-	cp support/c/${IDRIS2_SUPPORT} bootstrap/idris2_app
+	mkdir -p bootstrap-build/idris2_app
+	cp support/c/${IDRIS2_SUPPORT} bootstrap-build/idris2_app/
 	sed 's/libidris2_support.so/${IDRIS2_SUPPORT}/g; s|__PREFIX__|${IDRIS2_BOOT_PREFIX}|g' \
 		bootstrap/idris2_app/idris2.ss \
-		> bootstrap/idris2_app/idris2-boot.ss
+		> bootstrap-build/idris2_app/idris2-boot.ss
 	$(SHELL) ./bootstrap-stage1-chez.sh
 	IDRIS2_CG="chez" $(SHELL) ./bootstrap-stage2.sh
 
 # Bootstrapping using racket
 bootstrap-racket: support
-	cp support/c/${IDRIS2_SUPPORT} bootstrap/idris2_app
+	mkdir -p bootstrap-build/idris2_app
+	cp support/c/${IDRIS2_SUPPORT} bootstrap-build/idris2_app/
 	sed 's|__PREFIX__|${IDRIS2_BOOT_PREFIX}|g' \
 		bootstrap/idris2_app/idris2.rkt \
-		> bootstrap/idris2_app/idris2-boot.rkt
+		> bootstrap-build/idris2_app/idris2-boot.rkt
 	$(SHELL) ./bootstrap-stage1-racket.sh
 	IDRIS2_CG="racket" $(SHELL) ./bootstrap-stage2.sh
 
@@ -218,8 +220,7 @@ bootstrap-test:
 	$(MAKE) test INTERACTIVE='' IDRIS2_PREFIX=${IDRIS2_BOOT_PREFIX}
 
 bootstrap-clean:
-	$(RM) -r bootstrap/bin bootstrap/lib bootstrap/${NAME_VERSION}
-	$(RM) bootstrap/idris2boot* bootstrap/idris2_app/idris2-boot.* bootstrap/idris2_app/${IDRIS2_SUPPORT}
+	$(RM) -r bootstrap-build
 
 
 .PHONY: distclean

--- a/bootstrap-stage1-chez.sh
+++ b/bootstrap-stage1-chez.sh
@@ -13,12 +13,12 @@ echo "Bootstrapping SCHEME=$SCHEME IDRIS2_VERSION=$IDRIS2_VERSION"
 
 # Compile the bootstrap scheme
 # TODO: Move boot-build to Makefile in bootstrap/Makefile
-cd bootstrap
+cd bootstrap-build
 echo "Building idris2-boot from idris2-boot.ss"
-${SCHEME} --script compile.ss
+${SCHEME} --script ../bootstrap/compile.ss
 
 # Put the result in the usual place where the target goes
 mkdir -p ../build/exec
 mkdir -p ../build/exec/idris2_app
-install idris2-boot.sh ../build/exec/idris2
+install ../bootstrap/idris2-boot.sh ../build/exec/idris2
 install idris2_app/* ../build/exec/idris2_app

--- a/bootstrap-stage1-racket.sh
+++ b/bootstrap-stage1-racket.sh
@@ -9,12 +9,12 @@ fi
 echo "Bootstrapping IDRIS2_VERSION=$IDRIS2_VERSION"
 
 # Compile the bootstrap scheme
-cd bootstrap
+cd bootstrap-build
 echo "Building idris2-boot from idris2-boot.rkt"
 raco exe idris2_app/idris2-boot.rkt
 
 # Put the result in the usual place where the target goes
 mkdir -p ../build/exec
 mkdir -p ../build/exec/idris2_app
-install idris2-rktboot.sh ../build/exec/idris2
+install ../bootstrap/idris2-rktboot.sh ../build/exec/idris2
 install idris2_app/* ../build/exec/idris2_app

--- a/bootstrap-stage2.sh
+++ b/bootstrap-stage2.sh
@@ -2,7 +2,7 @@
 
 set -e # exit on any error
 
-PREFIX=$PWD/bootstrap
+PREFIX=$PWD/bootstrap-build
 
 if [ "$OS" = "windows" ]; then
     # IDRIS_PREFIX is only used to build IDRIS2_BOOT_PATH


### PR DESCRIPTION
... instead of `bootstrap` which contains source files. Make it easier to understand
how build works, and in particular, which files are sources and
which files are generated.