### PR TITLE
Use clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+IndentWidth: 4
+AllowShortFunctionsOnASingleLine: false

--- a/samples/FFI-readline/readline_glue/idris_readline.c
+++ b/samples/FFI-readline/readline_glue/idris_readline.c
@@ -1,38 +1,37 @@
 #include <readline/readline.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 
-rl_compentry_func_t* my_compentry;
+rl_compentry_func_t *my_compentry;
 
-char* compentry_wrapper(const char* text, int i) {
-    char* res = my_compentry(text, i); // Idris frees this
+char *compentry_wrapper(const char *text, int i) {
+    char *res = my_compentry(text, i); // Idris frees this
     if (res != NULL) {
-        char* comp = malloc(strlen(res)+1); // Readline frees this
+        char *comp = malloc(strlen(res) + 1); // Readline frees this
         strcpy(comp, res);
         return comp;
-    }
-    else {
+    } else {
         return NULL;
     }
 }
 
-void idrisrl_setCompletion(rl_compentry_func_t* fn) {
+void idrisrl_setCompletion(rl_compentry_func_t *fn) {
     rl_completion_entry_function = compentry_wrapper;
     my_compentry = fn;
 }
 
-char* getString(void* str) {
-    return (char*)str;
+char *getString(void *str) {
+    return (char *)str;
 }
 
-void* mkString(char* str) {
-    return (void*)str;
+void *mkString(char *str) {
+    return (void *)str;
 }
 
-void* nullString() {
+void *nullString() {
     return NULL;
 }
 
-int isNullString(void* str) {
+int isNullString(void *str) {
     return str == NULL;
 }

--- a/samples/FFI-readline/readline_glue/idris_readline.h
+++ b/samples/FFI-readline/readline_glue/idris_readline.h
@@ -1,8 +1,8 @@
 #pragma once
 
-void idrisrl_setCompletion(rl_completion_func_t* fn);
+void idrisrl_setCompletion(rl_completion_func_t *fn);
 
-char* getString(void* str);
-void* mkString(char* str);
-void* nullString();
-int isNullString(void* str);
+char *getString(void *str);
+void *mkString(char *str);
+void *nullString();
+int isNullString(void *str);

--- a/samples/ffi/smallc.c
+++ b/samples/ffi/smallc.c
@@ -1,32 +1,33 @@
-// To compile this file for the samples `sample/ffi/Small.dir` and `sample/ffi/Struct.idr`, you will
-// need to manually compile and link it into a `.so` file, and place it in a location where the
-// resulting exectuable can find it. For example:
+// To compile this file for the samples `sample/ffi/Small.dir` and
+// `sample/ffi/Struct.idr`, you will need to manually compile and link it into a
+// `.so` file, and place it in a location where the resulting exectuable can
+// find it. For example:
 //      gcc -c -fPIC smallc.c -o smallc.o
 //      gcc smallc.o -shared -o libsmallc.so
 //      idris2 Small.idr
-// For an example of using Idris packages to build external (FFI) libraries, see the `FFI-readline`
-// sample, and specifically `readline.ipkg`
+// For an example of using Idris packages to build external (FFI) libraries, see
+// the `FFI-readline` sample, and specifically `readline.ipkg`
 
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 int add(int x, int y) {
-    return x+y;
+    return x + y;
 }
 
-int addWithMessage(char* msg, int x, int y) {
-    printf("%s: %d + %d = %d\n", msg, x, y, x+y);
-    return x+y;
+int addWithMessage(char *msg, int x, int y) {
+    printf("%s: %d + %d = %d\n", msg, x, y, x + y);
+    return x + y;
 }
 
-typedef char*(*StringFn)(char*, int);
+typedef char *(*StringFn)(char *, int);
 
-char* applyFn(char* x, int y, StringFn f) {
+char *applyFn(char *x, int y, StringFn f) {
     printf("Applying callback to %s %d\n", x, y);
     return f(x, y);
 }
 
-char* applyFnPure(char* x, int y, StringFn f) {
+char *applyFnPure(char *x, int y, StringFn f) {
     return f(x, y);
 }
 
@@ -35,13 +36,13 @@ typedef struct {
     int y;
 } point;
 
-point* mkPoint(int x, int y) {
-    point* pt = malloc(sizeof(point));
+point *mkPoint(int x, int y) {
+    point *pt = malloc(sizeof(point));
     pt->x = x;
     pt->y = y;
     return pt;
 }
 
-void freePoint(point* pt) {
+void freePoint(point *pt) {
     free(pt);
 }

--- a/support/c/getline.c
+++ b/support/c/getline.c
@@ -29,15 +29,13 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <unistd.h>
 #include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
-ssize_t
-getdelim(char **buf, size_t *bufsiz, int delimiter, FILE *fp)
-{
+ssize_t getdelim(char **buf, size_t *bufsiz, int delimiter, FILE *fp) {
     char *ptr, *eptr;
 
     if (*buf == NULL || *bufsiz == 0) {
@@ -75,8 +73,6 @@ getdelim(char **buf, size_t *bufsiz, int delimiter, FILE *fp)
     }
 }
 
-ssize_t
-getline(char **buf, size_t *bufsiz, FILE *fp)
-{
-  return getdelim(buf, bufsiz, '\n', fp);
+ssize_t getline(char **buf, size_t *bufsiz, FILE *fp) {
+    return getdelim(buf, bufsiz, '\n', fp);
 }

--- a/support/c/getline.h
+++ b/support/c/getline.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 ssize_t getdelim(char **buf, size_t *bufsiz, int delimiter, FILE *fp);
 ssize_t getline(char **buf, size_t *bufsiz, FILE *fp);

--- a/support/c/idris_directory.c
+++ b/support/c/idris_directory.c
@@ -1,21 +1,22 @@
 #include "idris_directory.h"
 
-#include <sys/stat.h>
-#include <sys/types.h>
 #include <dirent.h>
 #include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
 
-char* idris2_currentDirectory() {
-   char* cwd = malloc(1024); // probably ought to deal with the unlikely event of this being too small
-   return getcwd(cwd, 1024); // Freed by RTS
+char *idris2_currentDirectory() {
+    char *cwd = malloc(1024); // probably ought to deal with the unlikely event
+                              // of this being too small
+    return getcwd(cwd, 1024); // Freed by RTS
 }
 
-int idris2_changeDir(char* dir) {
+int idris2_changeDir(char *dir) {
     return chdir(dir);
 }
 
-int idris2_createDir(char* dir) {
+int idris2_createDir(char *dir) {
 #ifdef _WIN32
     return mkdir(dir);
 #else
@@ -24,37 +25,37 @@ int idris2_createDir(char* dir) {
 }
 
 typedef struct {
-    DIR* dirptr;
+    DIR *dirptr;
     int error;
 } DirInfo;
 
-void* idris2_openDir(char* dir) {
+void *idris2_openDir(char *dir) {
     DIR *d = opendir(dir);
     if (d == NULL) {
         return NULL;
     } else {
-        DirInfo* di = malloc(sizeof(DirInfo));
+        DirInfo *di = malloc(sizeof(DirInfo));
         di->dirptr = d;
         di->error = 0;
 
-        return (void*)di;
+        return (void *)di;
     }
 }
 
-void idris2_closeDir(void* d) {
-    DirInfo* di = (DirInfo*)d;
+void idris2_closeDir(void *d) {
+    DirInfo *di = (DirInfo *)d;
 
     closedir(di->dirptr);
     free(di);
 }
 
-int idris2_removeDir(char* path) {
+int idris2_removeDir(char *path) {
     return rmdir(path);
 }
 
-char* idris2_nextDirEntry(void* d) {
-    DirInfo* di = (DirInfo*)d;
-    struct dirent* de = readdir(di->dirptr);
+char *idris2_nextDirEntry(void *d) {
+    DirInfo *di = (DirInfo *)d;
+    struct dirent *de = readdir(di->dirptr);
 
     if (de == NULL) {
         di->error = -1;

--- a/support/c/idris_directory.h
+++ b/support/c/idris_directory.h
@@ -1,9 +1,9 @@
 #pragma once
 
-char* idris2_currentDirectory();
-int idris2_changeDir(char* dir);
-int idris2_createDir(char* dir);
-void* idris2_openDir(char* dir);
-void idris2_closeDir(void* d);
-int idris2_removeDir(char* path);
-char* idris2_nextDirEntry(void* d);
+char *idris2_currentDirectory();
+int idris2_changeDir(char *dir);
+int idris2_createDir(char *dir);
+void *idris2_openDir(char *dir);
+void idris2_closeDir(void *d);
+int idris2_removeDir(char *path);
+char *idris2_nextDirEntry(void *d);

--- a/support/c/idris_file.c
+++ b/support/c/idris_file.c
@@ -1,12 +1,12 @@
-#include "getline.h"
 #include "idris_file.h"
+#include "getline.h"
 
-#include <fcntl.h>
-#include <errno.h>
-#include <sys/stat.h>
-#include <time.h>
-#include <sys/time.h>
 #include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <time.h>
 #include <unistd.h>
 
 #ifdef _WIN32
@@ -15,7 +15,7 @@
 #include <sys/select.h>
 #endif
 
-FILE* idris2_openFile(char* name, char* mode) {
+FILE *idris2_openFile(char *name, char *mode) {
 #ifdef _WIN32
     FILE *f = win32_u8fopen(name, mode);
 #else
@@ -24,16 +24,16 @@ FILE* idris2_openFile(char* name, char* mode) {
     return (void *)f;
 }
 
-void idris2_closeFile(FILE* f) {
+void idris2_closeFile(FILE *f) {
     fclose(f);
 }
 
-int idris2_fileError(FILE* f) {
+int idris2_fileError(FILE *f) {
     return ferror(f);
 }
 
 int idris2_fileErrno() {
-    switch(errno) {
+    switch (errno) {
     case ENOENT:
         return 2;
     case EACCES:
@@ -49,7 +49,7 @@ int idris2_removeFile(const char *filename) {
     return remove(filename);
 }
 
-int idris2_fileSize(FILE* f) {
+int idris2_fileSize(FILE *f) {
     int fd = fileno(f);
 
     struct stat buf;
@@ -60,8 +60,7 @@ int idris2_fileSize(FILE* f) {
     }
 }
 
-int idris2_fpoll(FILE* f)
-{
+int idris2_fpoll(FILE *f) {
 #ifdef _WIN32
     return win_fpoll(f);
 #else
@@ -74,7 +73,7 @@ int idris2_fpoll(FILE* f)
     FD_ZERO(&x);
     FD_SET(fd, &x);
 
-    int r = select(fd+1, &x, 0, 0, &timeout);
+    int r = select(fd + 1, &x, 0, 0, &timeout);
     return r;
 #endif
 }
@@ -98,8 +97,7 @@ void idris2_pclose(void *stream) {
 
 // seek through the next newline, consuming and
 // throwing away anything until then.
-int idris2_seekLine(FILE *f)
-{
+int idris2_seekLine(FILE *f) {
     while (1) {
         int c = fgetc(f);
         if (c == -1) {
@@ -115,19 +113,20 @@ int idris2_seekLine(FILE *f)
     }
 }
 
-char* idris2_readLine(FILE* f) {
+char *idris2_readLine(FILE *f) {
     char *buffer = NULL;
     size_t n = 0;
     ssize_t len;
     len = getline(&buffer, &n, f);
     if (len < 0 && buffer != NULL) {
-        buffer[0] = '\0'; // Copy Idris 1 behaviour - empty string if nothing read
+        buffer[0] =
+            '\0'; // Copy Idris 1 behaviour - empty string if nothing read
     }
     return buffer; // freed by RTS if not NULL
 }
 
-char* idris2_readChars(int num, FILE* f) {
-    char *buffer = malloc((num+1)*sizeof(char));
+char *idris2_readChars(int num, FILE *f) {
+    char *buffer = malloc((num + 1) * sizeof(char));
     size_t len;
     len = fread(buffer, sizeof(char), (size_t)num, f);
     buffer[len] = '\0';
@@ -139,11 +138,11 @@ char* idris2_readChars(int num, FILE* f) {
     }
 }
 
-size_t idris2_readBufferData(FILE* h, char* buffer, size_t loc, size_t max) {
+size_t idris2_readBufferData(FILE *h, char *buffer, size_t loc, size_t max) {
     return fread(buffer + loc, sizeof(uint8_t), max, h);
 }
 
-int idris2_writeLine(FILE* f, char* str) {
+int idris2_writeLine(FILE *f, char *str) {
     if (fputs(str, f) == EOF) {
         return 0;
     } else {
@@ -151,15 +150,16 @@ int idris2_writeLine(FILE* f, char* str) {
     }
 }
 
-size_t idris2_writeBufferData(FILE* h, const char* buffer, size_t loc, size_t len) {
+size_t idris2_writeBufferData(FILE *h, const char *buffer, size_t loc,
+                              size_t len) {
     return fwrite(buffer + loc, sizeof(uint8_t), len, h);
 }
 
-int idris2_eof(FILE* f) {
+int idris2_eof(FILE *f) {
     return feof(f);
 }
 
-int idris2_fileAccessTime(FILE* f) {
+int idris2_fileAccessTime(FILE *f) {
     int fd = fileno(f);
 
     struct stat buf;
@@ -170,7 +170,7 @@ int idris2_fileAccessTime(FILE* f) {
     }
 }
 
-int idris2_fileModifiedTime(FILE* f) {
+int idris2_fileModifiedTime(FILE *f) {
     int fd = fileno(f);
 
     struct stat buf;
@@ -181,7 +181,7 @@ int idris2_fileModifiedTime(FILE* f) {
     }
 }
 
-int idris2_fileStatusTime(FILE* f) {
+int idris2_fileStatusTime(FILE *f) {
     int fd = fileno(f);
 
     struct stat buf;
@@ -192,14 +192,14 @@ int idris2_fileStatusTime(FILE* f) {
     }
 }
 
-FILE* idris2_stdin() {
+FILE *idris2_stdin() {
     return stdin;
 }
 
-FILE* idris2_stdout() {
+FILE *idris2_stdout() {
     return stdout;
 }
 
-FILE* idris2_stderr() {
+FILE *idris2_stderr() {
     return stderr;
 }

--- a/support/c/idris_file.h
+++ b/support/c/idris_file.h
@@ -1,38 +1,39 @@
 #pragma once
 
-#include <stdio.h>
 #include <stdint.h>
+#include <stdio.h>
 
-FILE* idris2_openFile(char* name, char* mode);
-void idris2_closeFile(FILE* f);
+FILE *idris2_openFile(char *name, char *mode);
+void idris2_closeFile(FILE *f);
 
-int idris2_fileError(FILE* f);
+int idris2_fileError(FILE *f);
 
 // Turn errno into an integer understandable by System.File
 int idris2_fileErrno();
 
 int idris2_removeFile(const char *filename);
-int idris2_fileSize(FILE* h);
+int idris2_fileSize(FILE *h);
 
-int idris2_fpoll(FILE* f);
+int idris2_fpoll(FILE *f);
 
 // Seek through the next newline without
 // saving anything along the way
-int idris2_seekLine(FILE* f);
+int idris2_seekLine(FILE *f);
 
 // Treat as a Ptr String (might be NULL)
-char* idris2_readLine(FILE* f);
-char* idris2_readChars(int num, FILE* f);
-size_t idris2_readBufferData(FILE* h, char* buffer, size_t loc, size_t max);
+char *idris2_readLine(FILE *f);
+char *idris2_readChars(int num, FILE *f);
+size_t idris2_readBufferData(FILE *h, char *buffer, size_t loc, size_t max);
 
-int idris2_writeLine(FILE* f, char* str);
-size_t idris2_writeBufferData(FILE* h, const char* buffer, size_t loc, size_t len);
+int idris2_writeLine(FILE *f, char *str);
+size_t idris2_writeBufferData(FILE *h, const char *buffer, size_t loc,
+                              size_t len);
 
-int idris2_eof(FILE* f);
-int idris2_fileAccessTime(FILE* f);
-int idris2_fileModifiedTime(FILE* f);
-int idris2_fileStatusTime(FILE* f);
+int idris2_eof(FILE *f);
+int idris2_fileAccessTime(FILE *f);
+int idris2_fileModifiedTime(FILE *f);
+int idris2_fileStatusTime(FILE *f);
 
-FILE* idris2_stdin();
-FILE* idris2_stdout();
-FILE* idris2_stderr();
+FILE *idris2_stdin();
+FILE *idris2_stdout();
+FILE *idris2_stderr();

--- a/support/c/idris_memory.c
+++ b/support/c/idris_memory.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-void* idris2_malloc(int size) {
+void *idris2_malloc(int size) {
     if (size < 0) {
         fprintf(stderr, "malloc negative argument: %d\n", size);
         abort();
@@ -16,7 +16,7 @@ void* idris2_malloc(int size) {
         return NULL;
     }
 
-    void* ptr = malloc(size);
+    void *ptr = malloc(size);
     if (!ptr) {
         fprintf(stderr, "malloc failed: %s\n", strerror(errno));
         abort();
@@ -24,7 +24,7 @@ void* idris2_malloc(int size) {
     return ptr;
 }
 
-void idris2_free(void* ptr) {
+void idris2_free(void *ptr) {
     if (!ptr) {
         return;
     }
@@ -33,10 +33,10 @@ void idris2_free(void* ptr) {
 
 // TODO: remove `idrnet_malloc` and `idrnet_free` after bootstrap update
 
-void* idrnet_malloc(int size) {
+void *idrnet_malloc(int size) {
     return idris2_malloc(size);
 }
 
-void idrnet_free(void* ptr) {
+void idrnet_free(void *ptr) {
     idris2_free(ptr);
 }

--- a/support/c/idris_memory.h
+++ b/support/c/idris_memory.h
@@ -1,4 +1,4 @@
 #pragma once
 
-void* idris2_malloc(int size);
-void idris2_free(void* ptr);
+void *idris2_malloc(int size);
+void idris2_free(void *ptr);

--- a/support/c/idris_net.c
+++ b/support/c/idris_net.c
@@ -4,13 +4,13 @@
 #include "idris_net.h"
 #include <errno.h>
 #include <stdbool.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #ifndef _WIN32
-#include <netinet/in.h>
 #include <arpa/inet.h>
+#include <netinet/in.h>
 #else
 static int socket_inited = 0;
 static WSADATA wsa_data;
@@ -31,24 +31,23 @@ static int check_init(void) {
 }
 #endif
 
-
-void buf_htonl(void* buf, int len) {
-    int* buf_i = (int*) buf;
+void buf_htonl(void *buf, int len) {
+    int *buf_i = (int *)buf;
     int i;
     for (i = 0; i < (len / sizeof(int)) + 1; i++) {
         buf_i[i] = htonl(buf_i[i]);
     }
 }
 
-void buf_ntohl(void* buf, int len) {
-    int* buf_i = (int*) buf;
+void buf_ntohl(void *buf, int len) {
+    int *buf_i = (int *)buf;
     int i;
     for (i = 0; i < (len / sizeof(int)) + 1; i++) {
         buf_i[i] = ntohl(buf_i[i]);
     }
 }
 
-struct sockaddr_un get_sockaddr_unix(char* host) {
+struct sockaddr_un get_sockaddr_unix(char *host) {
     struct sockaddr_un addr;
     memset(&addr, 0, sizeof(addr));
     addr.sun_family = AF_UNIX;
@@ -57,15 +56,14 @@ struct sockaddr_un get_sockaddr_unix(char* host) {
 }
 
 unsigned int idrnet_peek(void *ptr, unsigned int offset) {
-  unsigned char *buf_c = (unsigned char*) ptr;
-  return (unsigned int) buf_c[offset];
+    unsigned char *buf_c = (unsigned char *)ptr;
+    return (unsigned int)buf_c[offset];
 }
 
 void idrnet_poke(void *ptr, unsigned int offset, char val) {
-  char *buf_c = (char*)ptr;
-  buf_c[offset] = val;
+    char *buf_c = (char *)ptr;
+    buf_c[offset] = val;
 }
-
 
 int idrnet_socket(int domain, int type, int protocol) {
 #ifdef _WIN32
@@ -93,9 +91,9 @@ int idrnet_af_inet6() {
     return AF_INET6;
 }
 
-// We call this from quite a few functions. Given a textual host and an int port,
-// populates a struct addrinfo.
-int idrnet_getaddrinfo(struct addrinfo** address_res, char* host, int port,
+// We call this from quite a few functions. Given a textual host and an int
+// port, populates a struct addrinfo.
+int idrnet_getaddrinfo(struct addrinfo **address_res, char *host, int port,
                        int family, int socket_type) {
 
     struct addrinfo hints;
@@ -115,27 +113,27 @@ int idrnet_getaddrinfo(struct addrinfo** address_res, char* host, int port,
         return getaddrinfo(NULL, str_port, &hints, address_res);
     }
     return getaddrinfo(host, str_port, &hints, address_res);
-
 }
 
-int idrnet_bind(int sockfd, int family, int socket_type, char* host, int port) {
+int idrnet_bind(int sockfd, int family, int socket_type, char *host, int port) {
     int bind_res;
     if (family == AF_UNIX) {
         struct sockaddr_un addr = get_sockaddr_unix(host);
         bind_res = bind(sockfd, (struct sockaddr *)&addr, sizeof(addr));
     } else {
         struct addrinfo *address_res;
-        int addr_res = idrnet_getaddrinfo(&address_res, host, port, family, socket_type);
+        int addr_res =
+            idrnet_getaddrinfo(&address_res, host, port, family, socket_type);
         if (addr_res != 0) {
-            //printf("Lib err: bind getaddrinfo\n");
+            // printf("Lib err: bind getaddrinfo\n");
             return -1;
         }
 
         bind_res = bind(sockfd, address_res->ai_addr, address_res->ai_addrlen);
     }
     if (bind_res == -1) {
-        //freeaddrinfo(address_res);
-        //printf("Lib err: bind\n");
+        // freeaddrinfo(address_res);
+        // printf("Lib err: bind\n");
         return -1;
     }
     return 0;
@@ -143,45 +141,47 @@ int idrnet_bind(int sockfd, int family, int socket_type, char* host, int port) {
 
 // to retrieve information about a socket bound to port 0
 int idrnet_getsockname(int sockfd, void *address, void *len) {
-  int res = getsockname(sockfd, address, len);
-  if(res != 0) {
-    return -1;
-  }
+    int res = getsockname(sockfd, address, len);
+    if (res != 0) {
+        return -1;
+    }
 
-  return 0;
+    return 0;
 }
 
 int idrnet_sockaddr_port(int sockfd) {
-  struct sockaddr_storage address;
-  socklen_t addrlen = sizeof(struct sockaddr_storage);
-  int res = getsockname(sockfd, (struct sockaddr*)&address, &addrlen);
-  if(res < 0) {
-    return -1;
-  }
+    struct sockaddr_storage address;
+    socklen_t addrlen = sizeof(struct sockaddr_storage);
+    int res = getsockname(sockfd, (struct sockaddr *)&address, &addrlen);
+    if (res < 0) {
+        return -1;
+    }
 
-  switch(address.ss_family) {
-  case AF_INET:
-    return ntohs(((struct sockaddr_in*)&address)->sin_port);
-  case AF_INET6:
-    return ntohs(((struct sockaddr_in6*)&address)->sin6_port);
-  default:
-    return -1;
-  }
+    switch (address.ss_family) {
+    case AF_INET:
+        return ntohs(((struct sockaddr_in *)&address)->sin_port);
+    case AF_INET6:
+        return ntohs(((struct sockaddr_in6 *)&address)->sin6_port);
+    default:
+        return -1;
+    }
 }
 
-
-int idrnet_connect(int sockfd, int family, int socket_type, char* host, int port) {
+int idrnet_connect(int sockfd, int family, int socket_type, char *host,
+                   int port) {
     if (family == AF_UNIX) {
         struct sockaddr_un addr = get_sockaddr_unix(host);
         return connect(sockfd, (struct sockaddr *)&addr, sizeof(addr));
     }
-    struct addrinfo* remote_host;
-    int addr_res = idrnet_getaddrinfo(&remote_host, host, port, family, socket_type);
+    struct addrinfo *remote_host;
+    int addr_res =
+        idrnet_getaddrinfo(&remote_host, host, port, family, socket_type);
     if (addr_res != 0) {
         return -1;
     }
 
-    int connect_res = connect(sockfd, remote_host->ai_addr, remote_host->ai_addrlen);
+    int connect_res =
+        connect(sockfd, remote_host->ai_addr, remote_host->ai_addrlen);
     if (connect_res == -1) {
         freeaddrinfo(remote_host);
         return -1;
@@ -190,48 +190,46 @@ int idrnet_connect(int sockfd, int family, int socket_type, char* host, int port
     return 0;
 }
 
-
-int idrnet_sockaddr_family(void* sockaddr) {
-    struct sockaddr* addr = (struct sockaddr*) sockaddr;
-    return (int) addr->sa_family;
+int idrnet_sockaddr_family(void *sockaddr) {
+    struct sockaddr *addr = (struct sockaddr *)sockaddr;
+    return (int)addr->sa_family;
 }
 
-char* idrnet_sockaddr_ipv4(void* sockaddr) {
-    struct sockaddr_in* addr = (struct sockaddr_in*) sockaddr;
-    char* ip_addr = (char*) malloc(sizeof(char) * INET_ADDRSTRLEN);
+char *idrnet_sockaddr_ipv4(void *sockaddr) {
+    struct sockaddr_in *addr = (struct sockaddr_in *)sockaddr;
+    char *ip_addr = (char *)malloc(sizeof(char) * INET_ADDRSTRLEN);
     inet_ntop(AF_INET, &(addr->sin_addr), ip_addr, INET_ADDRSTRLEN);
-    //printf("Lib: ip_addr: %s\n", ip_addr);
+    // printf("Lib: ip_addr: %s\n", ip_addr);
     return ip_addr;
 }
 
-int idrnet_sockaddr_ipv4_port(void* sockaddr) {
-    struct sockaddr_in* addr = (struct sockaddr_in*) sockaddr;
-    return ((int) ntohs(addr->sin_port));
+int idrnet_sockaddr_ipv4_port(void *sockaddr) {
+    struct sockaddr_in *addr = (struct sockaddr_in *)sockaddr;
+    return ((int)ntohs(addr->sin_port));
 }
 
-char* idrnet_sockaddr_unix(void* sockaddr) {
-    struct sockaddr_un* addr = (struct sockaddr_un*) sockaddr;
+char *idrnet_sockaddr_unix(void *sockaddr) {
+    struct sockaddr_un *addr = (struct sockaddr_un *)sockaddr;
     return addr->sun_path;
 }
 
-void* idrnet_create_sockaddr() {
+void *idrnet_create_sockaddr() {
     return malloc(sizeof(struct sockaddr_storage));
 }
 
-
-int idrnet_accept(int sockfd, void* sockaddr) {
-    struct sockaddr* addr = (struct sockaddr*) sockaddr;
+int idrnet_accept(int sockfd, void *sockaddr) {
+    struct sockaddr *addr = (struct sockaddr *)sockaddr;
     socklen_t addr_size = sizeof(struct sockaddr_storage);
     return accept(sockfd, addr, &addr_size);
 }
 
-int idrnet_send(int sockfd, char* data) {
+int idrnet_send(int sockfd, char *data) {
     int len = strlen(data); // For now.
-    return send(sockfd, (void*) data, len, 0);
+    return send(sockfd, (void *)data, len, 0);
 }
 
-int idrnet_send_buf(int sockfd, void* data, int len) {
-    void* buf_cpy = malloc(len);
+int idrnet_send_buf(int sockfd, void *data, int len) {
+    void *buf_cpy = malloc(len);
     memset(buf_cpy, 0, len);
     memcpy(buf_cpy, data, len);
     buf_htonl(buf_cpy, len);
@@ -240,22 +238,22 @@ int idrnet_send_buf(int sockfd, void* data, int len) {
     return res;
 }
 
-void* idrnet_recv(int sockfd, int len) {
-    idrnet_recv_result* res_struct =
-        (idrnet_recv_result*) malloc(sizeof(idrnet_recv_result));
-    char* buf = malloc(len + 1);
+void *idrnet_recv(int sockfd, int len) {
+    idrnet_recv_result *res_struct =
+        (idrnet_recv_result *)malloc(sizeof(idrnet_recv_result));
+    char *buf = malloc(len + 1);
     memset(buf, 0, len + 1);
     int recv_res = recv(sockfd, buf, len, 0);
     res_struct->result = recv_res;
 
-    if (recv_res > 0) { // Data was received
+    if (recv_res > 0) {           // Data was received
         buf[recv_res + 1] = 0x00; // Null-term, so Idris can interpret it
     }
     res_struct->payload = buf;
-    return (void*) res_struct;
+    return (void *)res_struct;
 }
 
-int idrnet_recv_buf(int sockfd, void* buf, int len) {
+int idrnet_recv_buf(int sockfd, void *buf, int len) {
     int recv_res = recv(sockfd, buf, len, 0);
     if (recv_res != -1) {
         buf_ntohl(buf, len);
@@ -263,17 +261,16 @@ int idrnet_recv_buf(int sockfd, void* buf, int len) {
     return recv_res;
 }
 
-int idrnet_get_recv_res(void* res_struct) {
-    return (((idrnet_recv_result*) res_struct)->result);
+int idrnet_get_recv_res(void *res_struct) {
+    return (((idrnet_recv_result *)res_struct)->result);
 }
 
-char* idrnet_get_recv_payload(void* res_struct) {
-    return (((idrnet_recv_result*) res_struct)->payload);
+char *idrnet_get_recv_payload(void *res_struct) {
+    return (((idrnet_recv_result *)res_struct)->payload);
 }
 
-void idrnet_free_recv_struct(void* res_struct) {
-    idrnet_recv_result* i_res_struct =
-        (idrnet_recv_result*) res_struct;
+void idrnet_free_recv_struct(void *res_struct) {
+    idrnet_recv_result *i_res_struct = (idrnet_recv_result *)res_struct;
     if (i_res_struct->payload != NULL) {
         free(i_res_struct->payload);
     }
@@ -284,60 +281,61 @@ int idrnet_errno() {
     return errno;
 }
 
+int idrnet_sendto(int sockfd, char *data, char *host, int port, int family) {
 
-int idrnet_sendto(int sockfd, char* data, char* host, int port, int family) {
-
-    struct addrinfo* remote_host;
-    int addr_res = idrnet_getaddrinfo(&remote_host, host, port, family, SOCK_DGRAM);
+    struct addrinfo *remote_host;
+    int addr_res =
+        idrnet_getaddrinfo(&remote_host, host, port, family, SOCK_DGRAM);
     if (addr_res != 0) {
         return -1;
     }
 
-    int send_res = sendto(sockfd, data, strlen(data), 0,
-                        remote_host->ai_addr, remote_host->ai_addrlen);
+    int send_res = sendto(sockfd, data, strlen(data), 0, remote_host->ai_addr,
+                          remote_host->ai_addrlen);
     freeaddrinfo(remote_host);
     return send_res;
 }
 
-int idrnet_sendto_buf(int sockfd, void* buf, int buf_len, char* host, int port, int family) {
+int idrnet_sendto_buf(int sockfd, void *buf, int buf_len, char *host, int port,
+                      int family) {
 
-    struct addrinfo* remote_host;
-    int addr_res = idrnet_getaddrinfo(&remote_host, host, port, family, SOCK_DGRAM);
+    struct addrinfo *remote_host;
+    int addr_res =
+        idrnet_getaddrinfo(&remote_host, host, port, family, SOCK_DGRAM);
     if (addr_res != 0) {
-        //printf("lib err: sendto getaddrinfo \n");
+        // printf("lib err: sendto getaddrinfo \n");
         return -1;
     }
 
     buf_htonl(buf, buf_len);
 
-    int send_res = sendto(sockfd, buf, buf_len, 0,
-                        remote_host->ai_addr, remote_host->ai_addrlen);
+    int send_res = sendto(sockfd, buf, buf_len, 0, remote_host->ai_addr,
+                          remote_host->ai_addrlen);
     if (send_res == -1) {
         perror("lib err: sendto \n");
     }
-    //freeaddrinfo(remote_host);
+    // freeaddrinfo(remote_host);
     return send_res;
 }
 
-
-
-void* idrnet_recvfrom(int sockfd, int len) {
-/*
- * int recvfrom(int sockfd, void *buf, int len, unsigned int flags,
-             struct sockaddr *from, int *fromlen);
-*/
+void *idrnet_recvfrom(int sockfd, int len) {
+    /*
+     * int recvfrom(int sockfd, void *buf, int len, unsigned int flags,
+                 struct sockaddr *from, int *fromlen);
+    */
     // Allocate the required structures, and nuke them
-    struct sockaddr_storage* remote_addr =
-        (struct sockaddr_storage*) malloc(sizeof(struct sockaddr_storage));
-    char* buf = (char*) malloc(len + 1);
-    idrnet_recvfrom_result* ret =
-        (idrnet_recvfrom_result*) malloc(sizeof(idrnet_recvfrom_result));
+    struct sockaddr_storage *remote_addr =
+        (struct sockaddr_storage *)malloc(sizeof(struct sockaddr_storage));
+    char *buf = (char *)malloc(len + 1);
+    idrnet_recvfrom_result *ret =
+        (idrnet_recvfrom_result *)malloc(sizeof(idrnet_recvfrom_result));
     memset(remote_addr, 0, sizeof(struct sockaddr_storage));
     memset(buf, 0, len + 1);
     memset(ret, 0, sizeof(idrnet_recvfrom_result));
     socklen_t fromlen = sizeof(struct sockaddr_storage);
 
-    int recv_res = recvfrom(sockfd, buf, len, 0, (struct sockaddr*) remote_addr, &fromlen);
+    int recv_res =
+        recvfrom(sockfd, buf, len, 0, (struct sockaddr *)remote_addr, &fromlen);
     ret->result = recv_res;
     // Check for failure...
     if (recv_res == -1) {
@@ -347,32 +345,35 @@ void* idrnet_recvfrom(int sockfd, int len) {
         // If data was received, process and populate
         ret->result = recv_res;
         ret->remote_addr = remote_addr;
-        // Ensure the last byte is NULL, since in this mode we're sending strings
+        // Ensure the last byte is NULL, since in this mode we're sending
+        // strings
         buf[len] = 0x00;
-        ret->payload = (void*) buf;
+        ret->payload = (void *)buf;
     }
 
     return ret;
 }
 
-void* idrnet_recvfrom_buf(int sockfd, void* buf, int len) {
+void *idrnet_recvfrom_buf(int sockfd, void *buf, int len) {
     // Allocate the required structures, and nuke them
-    struct sockaddr_storage* remote_addr =
-        (struct sockaddr_storage*) malloc(sizeof(struct sockaddr_storage));
-    idrnet_recvfrom_result* ret =
-        (idrnet_recvfrom_result*) malloc(sizeof(idrnet_recvfrom_result));
+    struct sockaddr_storage *remote_addr =
+        (struct sockaddr_storage *)malloc(sizeof(struct sockaddr_storage));
+    idrnet_recvfrom_result *ret =
+        (idrnet_recvfrom_result *)malloc(sizeof(idrnet_recvfrom_result));
     memset(remote_addr, 0, sizeof(struct sockaddr_storage));
     memset(ret, 0, sizeof(idrnet_recvfrom_result));
     socklen_t fromlen = 0;
 
-    int recv_res = recvfrom(sockfd, buf, len, 0, (struct sockaddr*) remote_addr, &fromlen);
+    int recv_res =
+        recvfrom(sockfd, buf, len, 0, (struct sockaddr *)remote_addr, &fromlen);
     // Check for failure... But don't free the buffer! Not our job.
     ret->result = recv_res;
     if (recv_res == -1) {
         free(remote_addr);
     }
-    // Payload will be NULL -- since it's been put into the user-specified buffer. We
-    // still need the return struct to get our hands on the remote address, though.
+    // Payload will be NULL -- since it's been put into the user-specified
+    // buffer. We still need the return struct to get our hands on the remote
+    // address, though.
     if (recv_res > 0) {
         buf_ntohl(buf, len);
         ret->payload = NULL;
@@ -381,31 +382,31 @@ void* idrnet_recvfrom_buf(int sockfd, void* buf, int len) {
     return ret;
 }
 
-int idrnet_get_recvfrom_res(void* res_struct) {
-    return (((idrnet_recvfrom_result*) res_struct)->result);
+int idrnet_get_recvfrom_res(void *res_struct) {
+    return (((idrnet_recvfrom_result *)res_struct)->result);
 }
 
-char* idrnet_get_recvfrom_payload(void* res_struct) {
-    return (((idrnet_recvfrom_result*) res_struct)->payload);
+char *idrnet_get_recvfrom_payload(void *res_struct) {
+    return (((idrnet_recvfrom_result *)res_struct)->payload);
 }
 
-void* idrnet_get_recvfrom_sockaddr(void* res_struct) {
-    idrnet_recvfrom_result* recv_struct = (idrnet_recvfrom_result*) res_struct;
+void *idrnet_get_recvfrom_sockaddr(void *res_struct) {
+    idrnet_recvfrom_result *recv_struct = (idrnet_recvfrom_result *)res_struct;
     return recv_struct->remote_addr;
 }
 
-int idrnet_get_recvfrom_port(void* res_struct) {
-    idrnet_recvfrom_result* recv_struct = (idrnet_recvfrom_result*) res_struct;
+int idrnet_get_recvfrom_port(void *res_struct) {
+    idrnet_recvfrom_result *recv_struct = (idrnet_recvfrom_result *)res_struct;
     if (recv_struct->remote_addr != NULL) {
-        struct sockaddr_in* remote_addr_in =
-            (struct sockaddr_in*) recv_struct->remote_addr;
-        return ((int) ntohs(remote_addr_in->sin_port));
+        struct sockaddr_in *remote_addr_in =
+            (struct sockaddr_in *)recv_struct->remote_addr;
+        return ((int)ntohs(remote_addr_in->sin_port));
     }
     return -1;
 }
 
-void idrnet_free_recvfrom_struct(void* res_struct) {
-    idrnet_recvfrom_result* recv_struct = (idrnet_recvfrom_result*) res_struct;
+void idrnet_free_recvfrom_struct(void *res_struct) {
+    idrnet_recvfrom_result *recv_struct = (idrnet_recvfrom_result *)res_struct;
     if (recv_struct != NULL) {
         if (recv_struct->payload != NULL) {
             free(recv_struct->payload);
@@ -420,6 +421,6 @@ int idrnet_geteagain() {
     return EAGAIN;
 }
 
-int isNull(void* ptr) {
-    return ptr==NULL;
+int isNull(void *ptr) {
+    return ptr == NULL;
 }

--- a/support/c/idris_net.h
+++ b/support/c/idris_net.h
@@ -2,14 +2,14 @@
 
 // Includes used by the idris-file.
 #ifdef _WIN32
-#include <winsock2.h>
 #include <Ws2tcpip.h>
+#include <winsock2.h>
 #else
 #include <netdb.h>
-#include <unistd.h>
-#include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/types.h>
 #include <sys/un.h>
+#include <unistd.h>
 #endif
 
 struct sockaddr_storage;
@@ -17,15 +17,15 @@ struct addrinfo;
 
 typedef struct idrnet_recv_result {
     int result;
-    void* payload;
+    void *payload;
 } idrnet_recv_result;
 
 // Same type of thing as idrnet_recv_result, but for UDP, so stores some
 // address information
 typedef struct idrnet_recvfrom_result {
     int result;
-    void* payload;
-    struct sockaddr_storage* remote_addr;
+    void *payload;
+    struct sockaddr_storage *remote_addr;
 } idrnet_recvfrom_result;
 
 #ifdef _WIN32
@@ -53,60 +53,60 @@ int idrnet_af_inet(void);
 int idrnet_af_inet6(void);
 
 // Bind
-int idrnet_bind(int sockfd, int family, int socket_type, char* host, int port);
+int idrnet_bind(int sockfd, int family, int socket_type, char *host, int port);
 
 // Retrieve information about socket
 int idrnet_getsockname(int sockfd, void *address, void *len);
 
 // Connect
-int idrnet_connect(int sockfd, int family, int socket_type, char* host, int port);
+int idrnet_connect(int sockfd, int family, int socket_type, char *host,
+                   int port);
 
 // Accessor functions for struct_sockaddr
-int idrnet_sockaddr_family(void* sockaddr);
-char* idrnet_sockaddr_ipv4(void* sockaddr);
-int idrnet_sockaddr_ipv4_port(void* sockaddr);
-char* idrnet_sockaddr_unix(void *sockaddr);
-void* idrnet_create_sockaddr();
+int idrnet_sockaddr_family(void *sockaddr);
+char *idrnet_sockaddr_ipv4(void *sockaddr);
+int idrnet_sockaddr_ipv4_port(void *sockaddr);
+char *idrnet_sockaddr_unix(void *sockaddr);
+void *idrnet_create_sockaddr();
 
 int idrnet_sockaddr_port(int sockfd);
 
 // Accept
-int idrnet_accept(int sockfd, void* sockaddr);
+int idrnet_accept(int sockfd, void *sockaddr);
 
 // Send
-int idrnet_send(int sockfd, char* data);
-int idrnet_send_buf(int sockfd, void* data, int len);
+int idrnet_send(int sockfd, char *data);
+int idrnet_send_buf(int sockfd, void *data, int len);
 
 // Receive
 // Creates a result structure containing result and payload
-void* idrnet_recv(int sockfd, int len);
+void *idrnet_recv(int sockfd, int len);
 // Receives directly into a buffer
-int idrnet_recv_buf(int sockfd, void* buf, int len);
+int idrnet_recv_buf(int sockfd, void *buf, int len);
 
 // UDP Send
-int idrnet_sendto(int sockfd, char* data, char* host, int port, int family);
-int idrnet_sendto_buf(int sockfd, void* buf, int buf_len, char* host, int port, int family);
-
+int idrnet_sendto(int sockfd, char *data, char *host, int port, int family);
+int idrnet_sendto_buf(int sockfd, void *buf, int buf_len, char *host, int port,
+                      int family);
 
 // UDP Receive
-void* idrnet_recvfrom(int sockfd, int len);
-void* idrnet_recvfrom_buf(int sockfd, void* buf, int len);
+void *idrnet_recvfrom(int sockfd, int len);
+void *idrnet_recvfrom_buf(int sockfd, void *buf, int len);
 
 // Receive structure accessors
-int idrnet_get_recv_res(void* res_struct);
-char* idrnet_get_recv_payload(void* res_struct);
-void idrnet_free_recv_struct(void* res_struct);
+int idrnet_get_recv_res(void *res_struct);
+char *idrnet_get_recv_payload(void *res_struct);
+void idrnet_free_recv_struct(void *res_struct);
 
 // Recvfrom structure accessors
-int idrnet_get_recvfrom_res(void* res_struct);
-char* idrnet_get_recvfrom_payload(void* res_struct);
-void* idrnet_get_recvfrom_sockaddr(void* res_struct);
-void idrnet_free_recvfrom_struct(void* res_struct);
+int idrnet_get_recvfrom_res(void *res_struct);
+char *idrnet_get_recvfrom_payload(void *res_struct);
+void *idrnet_get_recvfrom_sockaddr(void *res_struct);
+void idrnet_free_recvfrom_struct(void *res_struct);
 
-
-int idrnet_getaddrinfo(struct addrinfo** address_res, char* host,
-    int port, int family, int socket_type);
+int idrnet_getaddrinfo(struct addrinfo **address_res, char *host, int port,
+                       int family, int socket_type);
 
 int idrnet_geteagain();
 
-int isNull(void* ptr);
+int isNull(void *ptr);

--- a/support/c/idris_signal.c
+++ b/support/c/idris_signal.c
@@ -8,158 +8,158 @@
 #include <stdlib.h>
 
 static_assert(ATOMIC_LONG_LOCK_FREE == 2,
-  "when not lock free, atomic functions are not async-signal-safe");
+              "when not lock free, atomic functions are not async-signal-safe");
 
 #define N_SIGNALS 32
 static atomic_long signal_count[N_SIGNALS];
 
 void _collect_signal(int signum) {
-  if (signum < 0 || signum >= N_SIGNALS) {
-    abort();
-  }
+    if (signum < 0 || signum >= N_SIGNALS) {
+        abort();
+    }
 
-  long prev = atomic_fetch_add(&signal_count[signum], 1);
-  if (prev == LONG_MAX) {
-    // Practically impossible, but better crash explicitly
-    fprintf(stderr, "signal count overflow\n");
-    abort();
-  }
+    long prev = atomic_fetch_add(&signal_count[signum], 1);
+    if (prev == LONG_MAX) {
+        // Practically impossible, but better crash explicitly
+        fprintf(stderr, "signal count overflow\n");
+        abort();
+    }
 
 #ifdef _WIN32
-  //re-instate signal handler
-  signal(signum, _collect_signal);
+    // re-instate signal handler
+    signal(signum, _collect_signal);
 #endif
 }
 
 #ifndef _WIN32
 static inline struct sigaction _simple_handler(void (*handler)(int)) {
-  struct sigaction new_action;
+    struct sigaction new_action;
 
-  new_action.sa_handler = handler;
-  sigemptyset (&new_action.sa_mask);
-  new_action.sa_flags = 0;
+    new_action.sa_handler = handler;
+    sigemptyset(&new_action.sa_mask);
+    new_action.sa_flags = 0;
 
-  return new_action;
+    return new_action;
 }
 #endif
 
 int ignore_signal(int signum) {
 #ifdef _WIN32
-  return signal(signum, SIG_IGN) == SIG_ERR ? -1 : 0;
+    return signal(signum, SIG_IGN) == SIG_ERR ? -1 : 0;
 #else
-  struct sigaction handler = _simple_handler(SIG_IGN);
-  return sigaction(signum, &handler, NULL);
+    struct sigaction handler = _simple_handler(SIG_IGN);
+    return sigaction(signum, &handler, NULL);
 #endif
 }
 
 int default_signal(int signum) {
 #ifdef _WIN32
-  return signal(signum, SIG_DFL) == SIG_ERR ? -1 : 0;
+    return signal(signum, SIG_DFL) == SIG_ERR ? -1 : 0;
 #else
-  struct sigaction handler = _simple_handler(SIG_DFL);
-  return sigaction(signum, &handler, NULL);
+    struct sigaction handler = _simple_handler(SIG_DFL);
+    return sigaction(signum, &handler, NULL);
 #endif
 }
 
 int collect_signal(int signum) {
 #ifdef _WIN32
-  return signal(signum, _collect_signal) == SIG_ERR ? -1 : 0;
+    return signal(signum, _collect_signal) == SIG_ERR ? -1 : 0;
 #else
-  struct sigaction handler = _simple_handler(_collect_signal);
-  return sigaction(signum, &handler, NULL);
+    struct sigaction handler = _simple_handler(_collect_signal);
+    return sigaction(signum, &handler, NULL);
 #endif
 }
 
 int handle_next_collected_signal() {
-  for (int signum = 0; signum != N_SIGNALS; ++signum) {
-    for (;;) {
-      long count = atomic_load(&signal_count[signum]);
-      if (count == 0) {
-        break;
-      }
-      if (count < 0) {
-        // Practically impossible, but better crash explicitly
-        fprintf(stderr, "signal count overflow\n");
-        abort();
-      }
-      if (atomic_compare_exchange_strong(&signal_count[signum], &count, count - 1)) {
-        return signum;
-      }
+    for (int signum = 0; signum != N_SIGNALS; ++signum) {
+        for (;;) {
+            long count = atomic_load(&signal_count[signum]);
+            if (count == 0) {
+                break;
+            }
+            if (count < 0) {
+                // Practically impossible, but better crash explicitly
+                fprintf(stderr, "signal count overflow\n");
+                abort();
+            }
+            if (atomic_compare_exchange_strong(&signal_count[signum], &count,
+                                               count - 1)) {
+                return signum;
+            }
+        }
     }
-  }
-  return -1;
+    return -1;
 }
 
 int raise_signal(int signum) {
-  return raise(signum);
+    return raise(signum);
 }
 
 int send_signal(int pid, int signum) {
 #ifdef _WIN32
-  // TODO: ignores pid
-  return raise_signal(signum);
+    // TODO: ignores pid
+    return raise_signal(signum);
 #else
-  return kill(pid, signum);
+    return kill(pid, signum);
 #endif
 }
 
 int sighup() {
 #ifdef _WIN32
-  return -1;
+    return -1;
 #else
-  return SIGHUP;
+    return SIGHUP;
 #endif
 }
 
 int sigint() {
-  return SIGINT;
+    return SIGINT;
 }
 
 int sigabrt() {
-  return SIGABRT;
+    return SIGABRT;
 }
 
 int sigquit() {
 #ifdef _WIN32
-  return -1;
+    return -1;
 #else
-  return SIGQUIT;
+    return SIGQUIT;
 #endif
 }
 
 int sigill() {
-  return SIGILL;
+    return SIGILL;
 }
 
 int sigsegv() {
-  return SIGSEGV;
+    return SIGSEGV;
 }
 
 int sigtrap() {
 #ifdef _WIN32
-  return -1;
+    return -1;
 #else
-  return SIGTRAP;
+    return SIGTRAP;
 #endif
 }
 
 int sigfpe() {
-  return SIGFPE;
+    return SIGFPE;
 }
 
 int sigusr1() {
 #ifdef _WIN32
-  return -1;
+    return -1;
 #else
-  return SIGUSR1;
+    return SIGUSR1;
 #endif
 }
 
 int sigusr2() {
 #ifdef _WIN32
-  return -1;
+    return -1;
 #else
-  return SIGUSR2;
+    return SIGUSR2;
 #endif
 }
-

--- a/support/c/idris_support.c
+++ b/support/c/idris_support.c
@@ -3,10 +3,9 @@
 
 #include <errno.h>
 #include <stdio.h>
-#include <string.h>
-#include <time.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 
 int _argc;
@@ -17,10 +16,10 @@ extern char **_environ;
 #include "windows/win_utils.h"
 #define environ _environ
 #else
-extern char** environ;
+extern char **environ;
 #endif
 
-int idris2_isNull(void* ptr) {
+int idris2_isNull(void *ptr) {
     return (ptr == NULL);
 }
 
@@ -28,8 +27,8 @@ void *idris2_getNull() {
     return NULL;
 }
 
-char* idris2_getString(void *p) {
-    return (char*)p;
+char *idris2_getString(void *p) {
+    return (char *)p;
 }
 
 int idris2_getErrno() {
@@ -40,15 +39,15 @@ int idris2_getErrno() {
 #endif
 }
 
-char* idris2_strerror(int errnum) {
+char *idris2_strerror(int errnum) {
     return strerror(errnum);
 }
 
-char* idris2_getStr() {
+char *idris2_getStr() {
     char *inp = idris2_readLine(stdin);
     // Remove trailing newline; easier to do this than in PrimIO which
     // doesn't have the relevant functions available yet
-    for(char *c = inp; *c != '\0'; ++c) {
+    for (char *c = inp; *c != '\0'; ++c) {
         if (*c == '\n' || *c == '\r') {
             *c = '\0';
         }
@@ -56,13 +55,13 @@ char* idris2_getStr() {
     return inp;
 }
 
-void idris2_putStr(char* f) {
+void idris2_putStr(char *f) {
     idris2_writeLine(stdout, f);
 }
 
 void idris2_sleep(int sec) {
 #ifdef _WIN32
-    win32_sleep(sec*1000);
+    win32_sleep(sec * 1000);
 #else
     struct timespec t;
     t.tv_sec = sec;
@@ -74,7 +73,7 @@ void idris2_sleep(int sec) {
 
 void idris2_usleep(int usec) {
 #ifdef _WIN32
-    win32_sleep(usec/1000);
+    win32_sleep(usec / 1000);
 #else
     struct timespec t;
     t.tv_sec = usec / 1000000;
@@ -97,11 +96,11 @@ int idris2_getArgCount() {
     return _argc;
 }
 
-char* idris2_getArg(int n) {
+char *idris2_getArg(int n) {
     return _argv[n];
 }
 
-char* idris2_getEnvPair(int i) {
+char *idris2_getEnvPair(int i) {
     return *(environ + i);
 }
 
@@ -137,4 +136,3 @@ long idris2_getNProcessors() {
     return sysconf(_SC_NPROCESSORS_CONF);
 #endif
 }
-

--- a/support/c/idris_support.h
+++ b/support/c/idris_support.h
@@ -1,17 +1,17 @@
 #pragma once
 
 // Return non-zero if the pointer is null
-int idris2_isNull(void*);
+int idris2_isNull(void *);
 // Returns a NULL
 void *idris2_getNull();
 // Convert a Ptr String intro a String, assuming the string has been checked
 // to be non-null
-char* idris2_getString(void *p);
+char *idris2_getString(void *p);
 int idris2_getErrno();
-char* idris2_strerror(int errnum);
+char *idris2_strerror(int errnum);
 
-char* idris2_getStr();
-void idris2_putStr(char* f);
+char *idris2_getStr();
+void idris2_putStr(char *f);
 
 void idris2_sleep(int sec);
 void idris2_usleep(int usec);
@@ -19,8 +19,8 @@ int idris2_time();
 
 int idris2_getArgCount();
 void idris2_setArgs(int argc, char *argv[]);
-char* idris2_getArg(int n);
-char* idris2_getEnvPair(int i);
+char *idris2_getArg(int n);
+char *idris2_getEnvPair(int i);
 
 int idris2_getPID();
 

--- a/support/c/idris_system.c
+++ b/support/c/idris_system.c
@@ -1,6 +1,6 @@
-#include <stdlib.h>
 #include "idris_system.h"
+#include <stdlib.h>
 
-int idris2_system(const char* command) {
+int idris2_system(const char *command) {
     return system(command);
 }

--- a/support/c/idris_system.h
+++ b/support/c/idris_system.h
@@ -1,3 +1,3 @@
 #pragma once
 
-int idris2_system(const char* command);
+int idris2_system(const char *command);

--- a/support/c/idris_term.c
+++ b/support/c/idris_term.c
@@ -3,7 +3,7 @@
 #include <windows.h>
 
 #ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
-#define ENABLE_VIRTUAL_TERMINAL_PROCESSING  0x0004
+#define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
 #endif
 
 void idris2_setupTerm() {
@@ -17,13 +17,13 @@ void idris2_setupTerm() {
 int idris2_getTermCols() {
     CONSOLE_SCREEN_BUFFER_INFO csbi;
     GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);
-    return (int) csbi.srWindow.Right - csbi.srWindow.Left + 1;
+    return (int)csbi.srWindow.Right - csbi.srWindow.Left + 1;
 }
 
 int idris2_getTermLines() {
     CONSOLE_SCREEN_BUFFER_INFO csbi;
     GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);
-    return (int) csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
+    return (int)csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
 }
 
 #else
@@ -37,13 +37,13 @@ void idris2_setupTerm() {
 int idris2_getTermCols() {
     struct winsize ts;
     ioctl(0, TIOCGWINSZ, &ts);
-    return (int) ts.ws_col;
+    return (int)ts.ws_col;
 }
 
 int idris2_getTermLines() {
     struct winsize ts;
     ioctl(0, TIOCGWINSZ, &ts);
-    return (int) ts.ws_row;
+    return (int)ts.ws_row;
 }
 
 #endif

--- a/support/c/windows/win_hack.c
+++ b/support/c/windows/win_hack.c
@@ -1,3 +1,3 @@
-int chmod(char** str, int perm) {
+int chmod(char **str, int perm) {
     return 0;
 }

--- a/support/c/windows/win_utils.h
+++ b/support/c/windows/win_utils.h
@@ -6,11 +6,10 @@
 int win_fpoll(FILE *h);
 FILE *win32_u8fopen(const char *path, const char *mode);
 FILE *win32_u8popen(const char *path, const char *mode);
-void win32_gettime(int64_t* sec, int64_t* nsec);
+void win32_gettime(int64_t *sec, int64_t *nsec);
 void win32_sleep(int ms);
-int win32_modenv(const char* name, const char* value, int overwrite);
+int win32_modenv(const char *name, const char *value, int overwrite);
 
 int win32_getErrno();
 int win32_getPID();
 long win32_getNProcessors();
-

--- a/support/refc/buffer.c
+++ b/support/refc/buffer.c
@@ -1,16 +1,16 @@
 #include "buffer.h"
-#include <sys/stat.h>
 #include <string.h>
+#include <sys/stat.h>
 
 typedef struct {
     int size;
     uint8_t data[];
 } Buffer;
 
-void* newBuffer(int bytes) {
-    size_t size = sizeof(Buffer) + bytes*sizeof(uint8_t);
+void *newBuffer(int bytes) {
+    size_t size = sizeof(Buffer) + bytes * sizeof(uint8_t);
 
-    Buffer* buf = malloc(size);
+    Buffer *buf = malloc(size);
     if (buf == NULL) {
         return NULL;
     }
@@ -18,72 +18,71 @@ void* newBuffer(int bytes) {
     buf->size = bytes;
     memset(buf->data, 0, bytes);
 
-    return (void*)buf;
+    return (void *)buf;
 }
 
-void copyBuffer(void* from, int start, int len,
-                void* to, int loc) {
-    Buffer* bfrom = from;
-    Buffer* bto = to;
+void copyBuffer(void *from, int start, int len, void *to, int loc) {
+    Buffer *bfrom = from;
+    Buffer *bto = to;
 
-    if (loc >= 0 && loc+len <= bto->size) {
+    if (loc >= 0 && loc + len <= bto->size) {
         memcpy(bto->data + loc, bfrom->data + start, len);
     }
 }
 
-int getBufferSize(void* buffer) {
-    return ((Buffer*)buffer)->size;
+int getBufferSize(void *buffer) {
+    return ((Buffer *)buffer)->size;
 }
 
-void setBufferByte(void* buffer, int loc, int byte) {
-    Buffer* b = buffer;
+void setBufferByte(void *buffer, int loc, int byte) {
+    Buffer *b = buffer;
     if (loc >= 0 && loc < b->size) {
         b->data[loc] = byte;
     }
 }
 
-void setBufferInt(void* buffer, int loc, int64_t val) {
-    Buffer* b = buffer;
-    if (loc >= 0 && loc+3 < b->size) {
-        b->data[loc  ] =  val        & 0xff;
-        b->data[loc+1] = (val >>  8) & 0xff;
-        b->data[loc+2] = (val >> 16) & 0xff;
-        b->data[loc+3] = (val >> 24) & 0xff;
-        b->data[loc+4] = (val >> 32) & 0xff;
-        b->data[loc+5] = (val >> 40) & 0xff;
-        b->data[loc+6] = (val >> 48) & 0xff;
-        b->data[loc+7] = (val >> 56) & 0xff;
+void setBufferInt(void *buffer, int loc, int64_t val) {
+    Buffer *b = buffer;
+    if (loc >= 0 && loc + 3 < b->size) {
+        b->data[loc] = val & 0xff;
+        b->data[loc + 1] = (val >> 8) & 0xff;
+        b->data[loc + 2] = (val >> 16) & 0xff;
+        b->data[loc + 3] = (val >> 24) & 0xff;
+        b->data[loc + 4] = (val >> 32) & 0xff;
+        b->data[loc + 5] = (val >> 40) & 0xff;
+        b->data[loc + 6] = (val >> 48) & 0xff;
+        b->data[loc + 7] = (val >> 56) & 0xff;
     }
 }
 
-void setBufferDouble(void* buffer, int loc, double val) {
-    Buffer* b = buffer;
+void setBufferDouble(void *buffer, int loc, double val) {
+    Buffer *b = buffer;
     // I am not proud of this
     if (loc >= 0 && loc + sizeof(double) <= b->size) {
-        unsigned char* c = (unsigned char*)(& val);
+        unsigned char *c = (unsigned char *)(&val);
         int i;
         for (i = 0; i < sizeof(double); ++i) {
-            b->data[loc+i] = c[i];
+            b->data[loc + i] = c[i];
         }
     }
 }
 
-void setBufferString(void* buffer, int loc, char* str) {
-    Buffer* b = buffer;
+void setBufferString(void *buffer, int loc, char *str) {
+    Buffer *b = buffer;
     int len = strlen(str);
 
-    if (loc >= 0 && loc+len <= b->size) {
-        memcpy((b->data)+loc, str, len);
+    if (loc >= 0 && loc + len <= b->size) {
+        memcpy((b->data) + loc, str, len);
     }
 }
 
-size_t writeBufferData(FILE* h, void* buffer, size_t loc, size_t len) {
-    Buffer* b = buffer;
+size_t writeBufferData(FILE *h, void *buffer, size_t loc, size_t len) {
+    Buffer *b = buffer;
     return fwrite(b->data + loc, sizeof(uint8_t), len, h);
 }
 
-uint8_t getBufferByte(void* buffer, int loc) {
-    Buffer* b = buffer;
+uint8_t getBufferByte(void *buffer, int loc) {
+    Buffer *b = buffer;
     if (loc >= 0 && loc < b->size) {
         return b->data[loc];
     } else {
@@ -91,11 +90,11 @@ uint8_t getBufferByte(void* buffer, int loc) {
     }
 }
 
-int64_t getBufferInt(void* buffer, int loc) {
-    Buffer* b = buffer;
-    if (loc >= 0 && loc+7 < b->size) {
+int64_t getBufferInt(void *buffer, int loc) {
+    Buffer *b = buffer;
+    if (loc >= 0 && loc + 7 < b->size) {
         int64_t result = 0;
-        for (size_t i=0; i<8; i++) {
+        for (size_t i = 0; i < 8; i++) {
             result |= (int64_t)b->data[loc + i] << (8 * i);
         }
         return result;
@@ -104,33 +103,32 @@ int64_t getBufferInt(void* buffer, int loc) {
     }
 }
 
-double getBufferDouble(void* buffer, int loc) {
-    Buffer* b = buffer;
+double getBufferDouble(void *buffer, int loc) {
+    Buffer *b = buffer;
     double d;
     // I am even less proud of this
-    unsigned char *c = (unsigned char*)(& d);
+    unsigned char *c = (unsigned char *)(&d);
     if (loc >= 0 && loc + sizeof(double) <= b->size) {
         int i;
         for (i = 0; i < sizeof(double); ++i) {
-            c[i] = b->data[loc+i];
+            c[i] = b->data[loc + i];
         }
         return d;
-    }
-    else {
+    } else {
         return 0;
     }
 }
 
-char* getBufferString(void* buffer, int loc, int len) {
-    Buffer* b = buffer;
-    char * s = (char*)(b->data + loc);
-    char * rs = malloc(len + 1);
+char *getBufferString(void *buffer, int loc, int len) {
+    Buffer *b = buffer;
+    char *s = (char *)(b->data + loc);
+    char *rs = malloc(len + 1);
     strncpy(rs, s, len);
     rs[len] = '\0';
     return rs;
 }
 
-size_t readBufferData(FILE* h, void* buffer, size_t loc, size_t max) {
-    Buffer* b = buffer;
+size_t readBufferData(FILE *h, void *buffer, size_t loc, size_t max) {
+    Buffer *b = buffer;
     return fread(b->data + loc, sizeof(uint8_t), max, h);
 }

--- a/support/refc/buffer.h
+++ b/support/refc/buffer.h
@@ -1,24 +1,23 @@
 #pragma once
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
 
-void* newBuffer(int bytes);
+void *newBuffer(int bytes);
 
-int getBufferSize(void* buffer);
+int getBufferSize(void *buffer);
 
-void setBufferByte(void* buffer, int loc, int byte);
-void setBufferInt(void* buffer, int loc, int64_t val);
-void setBufferDouble(void* buffer, int loc, double val);
-void setBufferString(void* buffer, int loc, char* str);
-size_t writeBufferData(FILE* h, void* buffer, size_t loc, size_t len);
+void setBufferByte(void *buffer, int loc, int byte);
+void setBufferInt(void *buffer, int loc, int64_t val);
+void setBufferDouble(void *buffer, int loc, double val);
+void setBufferString(void *buffer, int loc, char *str);
+size_t writeBufferData(FILE *h, void *buffer, size_t loc, size_t len);
 
-void copyBuffer(void* from, int start, int len,
-                void* to, int loc);
+void copyBuffer(void *from, int start, int len, void *to, int loc);
 
-uint8_t getBufferByte(void* buffer, int loc);
-int64_t getBufferInt(void* buffer, int loc);
-double getBufferDouble(void* buffer, int loc);
-char* getBufferString(void* buffer, int loc, int len);
-size_t readBufferData(FILE* h, void* buffer, size_t loc, size_t max);
+uint8_t getBufferByte(void *buffer, int loc);
+int64_t getBufferInt(void *buffer, int loc);
+double getBufferDouble(void *buffer, int loc);
+char *getBufferString(void *buffer, int loc, int len);
+size_t readBufferData(FILE *h, void *buffer, size_t loc, size_t max);

--- a/support/refc/cBackend.h
+++ b/support/refc/cBackend.h
@@ -1,17 +1,17 @@
 #pragma once
 
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <pthread.h>
 
+#include "buffer.h"
+#include "casts.h"
+#include "clock.h"
+#include "conCaseHelper.h"
 #include "datatypes.h"
-#include "memoryManagement.h"
 #include "mathFunctions.h"
+#include "memoryManagement.h"
+#include "prim.h"
 #include "runtime.h"
 #include "stringOps.h"
-#include "buffer.h"
-#include "clock.h"
-#include "casts.h"
-#include "conCaseHelper.h"
-#include "prim.h"

--- a/support/refc/casts.c
+++ b/support/refc/casts.c
@@ -2,50 +2,42 @@
 #include <inttypes.h>
 
 /*  conversions from Int8  */
-Value *cast_Int8_to_Bits8(Value *input)
-{
+Value *cast_Int8_to_Bits8(Value *input) {
     Value_Int8 *from = (Value_Int8 *)input;
     return (Value *)makeBits8((uint8_t)from->i8);
 }
 
-Value *cast_Int8_to_Bits16(Value *input)
-{
+Value *cast_Int8_to_Bits16(Value *input) {
     Value_Int8 *from = (Value_Int8 *)input;
     return (Value *)makeBits16((uint16_t)from->i8);
 }
 
-Value *cast_Int8_to_Bits32(Value *input)
-{
+Value *cast_Int8_to_Bits32(Value *input) {
     Value_Int8 *from = (Value_Int8 *)input;
     return (Value *)makeBits32((uint32_t)from->i8);
 }
 
-Value *cast_Int8_to_Bits64(Value *input)
-{
+Value *cast_Int8_to_Bits64(Value *input) {
     Value_Int8 *from = (Value_Int8 *)input;
     return (Value *)makeBits64((uint64_t)from->i8);
 }
 
-Value *cast_Int8_to_Int16(Value *input)
-{
+Value *cast_Int8_to_Int16(Value *input) {
     Value_Int8 *from = (Value_Int8 *)input;
     return (Value *)makeInt16((int16_t)from->i8);
 }
 
-Value *cast_Int8_to_Int32(Value *input)
-{
+Value *cast_Int8_to_Int32(Value *input) {
     Value_Int8 *from = (Value_Int8 *)input;
     return (Value *)makeInt32((int32_t)from->i8);
 }
 
-Value *cast_Int8_to_Int64(Value *input)
-{
+Value *cast_Int8_to_Int64(Value *input) {
     Value_Int8 *from = (Value_Int8 *)input;
     return (Value *)makeInt64((int64_t)from->i8);
 }
 
-Value *cast_Int8_to_Integer(Value *input)
-{
+Value *cast_Int8_to_Integer(Value *input) {
     Value_Int8 *from = (Value_Int8 *)input;
 
     Value_Integer *retVal = makeInteger();
@@ -54,20 +46,17 @@ Value *cast_Int8_to_Integer(Value *input)
     return (Value *)retVal;
 }
 
-Value *cast_Int8_to_double(Value *input)
-{
+Value *cast_Int8_to_double(Value *input) {
     Value_Int8 *from = (Value_Int8 *)input;
     return (Value *)makeDouble((double)from->i8);
 }
 
-Value *cast_Int8_to_char(Value *input)
-{
+Value *cast_Int8_to_char(Value *input) {
     Value_Int8 *from = (Value_Int8 *)input;
     return (Value *)makeChar((unsigned char)from->i8);
 }
 
-Value *cast_Int8_to_string(Value *input)
-{
+Value *cast_Int8_to_string(Value *input) {
     Value_Int8 *from = (Value_Int8 *)input;
 
     int l = snprintf(NULL, 0, "%" PRId8 "", from->i8);
@@ -78,50 +67,42 @@ Value *cast_Int8_to_string(Value *input)
 }
 
 /*  conversions from Int16  */
-Value *cast_Int16_to_Bits8(Value *input)
-{
+Value *cast_Int16_to_Bits8(Value *input) {
     Value_Int16 *from = (Value_Int16 *)input;
     return (Value *)makeBits8((uint8_t)from->i16);
 }
 
-Value *cast_Int16_to_Bits16(Value *input)
-{
+Value *cast_Int16_to_Bits16(Value *input) {
     Value_Int16 *from = (Value_Int16 *)input;
     return (Value *)makeBits16((uint16_t)from->i16);
 }
 
-Value *cast_Int16_to_Bits32(Value *input)
-{
+Value *cast_Int16_to_Bits32(Value *input) {
     Value_Int16 *from = (Value_Int16 *)input;
     return (Value *)makeBits32((uint32_t)from->i16);
 }
 
-Value *cast_Int16_to_Bits64(Value *input)
-{
+Value *cast_Int16_to_Bits64(Value *input) {
     Value_Int16 *from = (Value_Int16 *)input;
     return (Value *)makeBits64((uint64_t)from->i16);
 }
 
-Value *cast_Int16_to_Int8(Value *input)
-{
+Value *cast_Int16_to_Int8(Value *input) {
     Value_Int16 *from = (Value_Int16 *)input;
     return (Value *)makeInt8((int8_t)from->i16);
 }
 
-Value *cast_Int16_to_Int32(Value *input)
-{
+Value *cast_Int16_to_Int32(Value *input) {
     Value_Int16 *from = (Value_Int16 *)input;
     return (Value *)makeInt32((int32_t)from->i16);
 }
 
-Value *cast_Int16_to_Int64(Value *input)
-{
+Value *cast_Int16_to_Int64(Value *input) {
     Value_Int16 *from = (Value_Int16 *)input;
     return (Value *)makeInt64((int64_t)from->i16);
 }
 
-Value *cast_Int16_to_Integer(Value *input)
-{
+Value *cast_Int16_to_Integer(Value *input) {
     Value_Int16 *from = (Value_Int16 *)input;
 
     Value_Integer *retVal = makeInteger();
@@ -130,20 +111,17 @@ Value *cast_Int16_to_Integer(Value *input)
     return (Value *)retVal;
 }
 
-Value *cast_Int16_to_double(Value *input)
-{
+Value *cast_Int16_to_double(Value *input) {
     Value_Int16 *from = (Value_Int16 *)input;
     return (Value *)makeDouble((double)from->i16);
 }
 
-Value *cast_Int16_to_char(Value *input)
-{
+Value *cast_Int16_to_char(Value *input) {
     Value_Int16 *from = (Value_Int16 *)input;
     return (Value *)makeChar((unsigned char)from->i16);
 }
 
-Value *cast_Int16_to_string(Value *input)
-{
+Value *cast_Int16_to_string(Value *input) {
     Value_Int16 *from = (Value_Int16 *)input;
 
     int l = snprintf(NULL, 0, "%" PRId16 "", from->i16);
@@ -154,50 +132,42 @@ Value *cast_Int16_to_string(Value *input)
 }
 
 /*  conversions from Int32  */
-Value *cast_Int32_to_Bits8(Value *input)
-{
+Value *cast_Int32_to_Bits8(Value *input) {
     Value_Int32 *from = (Value_Int32 *)input;
     return (Value *)makeBits8((uint8_t)from->i32);
 }
 
-Value *cast_Int32_to_Bits16(Value *input)
-{
+Value *cast_Int32_to_Bits16(Value *input) {
     Value_Int32 *from = (Value_Int32 *)input;
     return (Value *)makeBits16((uint16_t)from->i32);
 }
 
-Value *cast_Int32_to_Bits32(Value *input)
-{
+Value *cast_Int32_to_Bits32(Value *input) {
     Value_Int32 *from = (Value_Int32 *)input;
     return (Value *)makeBits32((uint32_t)from->i32);
 }
 
-Value *cast_Int32_to_Bits64(Value *input)
-{
+Value *cast_Int32_to_Bits64(Value *input) {
     Value_Int32 *from = (Value_Int32 *)input;
     return (Value *)makeBits64((uint64_t)from->i32);
 }
 
-Value *cast_Int32_to_Int8(Value *input)
-{
+Value *cast_Int32_to_Int8(Value *input) {
     Value_Int32 *from = (Value_Int32 *)input;
     return (Value *)makeInt8((int8_t)from->i32);
 }
 
-Value *cast_Int32_to_Int16(Value *input)
-{
+Value *cast_Int32_to_Int16(Value *input) {
     Value_Int32 *from = (Value_Int32 *)input;
     return (Value *)makeInt16((int16_t)from->i32);
 }
 
-Value *cast_Int32_to_Int64(Value *input)
-{
+Value *cast_Int32_to_Int64(Value *input) {
     Value_Int32 *from = (Value_Int32 *)input;
     return (Value *)makeInt64((int64_t)from->i32);
 }
 
-Value *cast_Int32_to_Integer(Value *input)
-{
+Value *cast_Int32_to_Integer(Value *input) {
     Value_Int32 *from = (Value_Int32 *)input;
 
     Value_Integer *retVal = makeInteger();
@@ -206,20 +176,17 @@ Value *cast_Int32_to_Integer(Value *input)
     return (Value *)retVal;
 }
 
-Value *cast_Int32_to_double(Value *input)
-{
+Value *cast_Int32_to_double(Value *input) {
     Value_Int32 *from = (Value_Int32 *)input;
     return (Value *)makeDouble((double)from->i32);
 }
 
-Value *cast_Int32_to_char(Value *input)
-{
+Value *cast_Int32_to_char(Value *input) {
     Value_Int32 *from = (Value_Int32 *)input;
     return (Value *)makeChar((unsigned char)from->i32);
 }
 
-Value *cast_Int32_to_string(Value *input)
-{
+Value *cast_Int32_to_string(Value *input) {
     Value_Int32 *from = (Value_Int32 *)input;
 
     int l = snprintf(NULL, 0, "%" PRId32 "", from->i32);
@@ -230,56 +197,47 @@ Value *cast_Int32_to_string(Value *input)
 }
 
 /*  conversions from Int64  */
-Value *cast_Int64_to_Bits8(Value *input)
-{
+Value *cast_Int64_to_Bits8(Value *input) {
     Value_Int64 *from = (Value_Int64 *)input;
     return (Value *)makeBits8((uint8_t)from->i64);
 }
 
-Value *cast_Int64_to_Bits16(Value *input)
-{
+Value *cast_Int64_to_Bits16(Value *input) {
     Value_Int64 *from = (Value_Int64 *)input;
     return (Value *)makeBits16((uint16_t)from->i64);
 }
 
-Value *cast_Int64_to_Bits32(Value *input)
-{
+Value *cast_Int64_to_Bits32(Value *input) {
     Value_Int64 *from = (Value_Int64 *)input;
     return (Value *)makeBits32((uint32_t)from->i64);
 }
 
-Value *cast_Int64_to_Bits64(Value *input)
-{
+Value *cast_Int64_to_Bits64(Value *input) {
     Value_Int64 *from = (Value_Int64 *)input;
     return (Value *)makeBits64((uint64_t)from->i64);
 }
 
-Value *cast_Int64_to_Int8(Value *input)
-{
+Value *cast_Int64_to_Int8(Value *input) {
     Value_Int64 *from = (Value_Int64 *)input;
     return (Value *)makeInt8((int8_t)from->i64);
 }
 
-Value *cast_Int64_to_Int16(Value *input)
-{
+Value *cast_Int64_to_Int16(Value *input) {
     Value_Int64 *from = (Value_Int64 *)input;
     return (Value *)makeInt16((int16_t)from->i64);
 }
 
-Value *cast_Int64_to_Int32(Value *input)
-{
+Value *cast_Int64_to_Int32(Value *input) {
     Value_Int64 *from = (Value_Int64 *)input;
     return (Value *)makeInt32((int32_t)from->i64);
 }
 
-Value *cast_Int64_to_Int64(Value *input)
-{
+Value *cast_Int64_to_Int64(Value *input) {
     // Identity cast required as Value_Int64 represents both Int and Int64 types
     return newReference(input);
 }
 
-Value *cast_Int64_to_Integer(Value *input)
-{
+Value *cast_Int64_to_Integer(Value *input) {
     Value_Int64 *from = (Value_Int64 *)input;
 
     Value_Integer *retVal = makeInteger();
@@ -288,20 +246,17 @@ Value *cast_Int64_to_Integer(Value *input)
     return (Value *)retVal;
 }
 
-Value *cast_Int64_to_double(Value *input)
-{
+Value *cast_Int64_to_double(Value *input) {
     Value_Int64 *from = (Value_Int64 *)input;
     return (Value *)makeDouble((double)from->i64);
 }
 
-Value *cast_Int64_to_char(Value *input)
-{
+Value *cast_Int64_to_char(Value *input) {
     Value_Int64 *from = (Value_Int64 *)input;
     return (Value *)makeChar((unsigned char)from->i64);
 }
 
-Value *cast_Int64_to_string(Value *input)
-{
+Value *cast_Int64_to_string(Value *input) {
     Value_Int64 *from = (Value_Int64 *)input;
 
     int l = snprintf(NULL, 0, "%" PRId64 "", from->i64);
@@ -311,56 +266,47 @@ Value *cast_Int64_to_string(Value *input)
     return (Value *)retVal;
 }
 
-Value *cast_double_to_Bits8(Value *input)
-{
+Value *cast_double_to_Bits8(Value *input) {
     Value_Double *from = (Value_Double *)input;
     return (Value *)makeBits8((uint8_t)from->d);
 }
 
-Value *cast_double_to_Bits16(Value *input)
-{
+Value *cast_double_to_Bits16(Value *input) {
     Value_Double *from = (Value_Double *)input;
     return (Value *)makeBits16((uint16_t)from->d);
 }
 
-Value *cast_double_to_Bits32(Value *input)
-{
+Value *cast_double_to_Bits32(Value *input) {
     Value_Double *from = (Value_Double *)input;
     return (Value *)makeBits32((uint32_t)from->d);
 }
 
-Value *cast_double_to_Bits64(Value *input)
-{
+Value *cast_double_to_Bits64(Value *input) {
     Value_Double *from = (Value_Double *)input;
     return (Value *)makeBits64((uint64_t)from->d);
 }
 
-Value *cast_double_to_Int8(Value *input)
-{
+Value *cast_double_to_Int8(Value *input) {
     Value_Double *from = (Value_Double *)input;
     return (Value *)makeInt8((int8_t)from->d);
 }
 
-Value *cast_double_to_Int16(Value *input)
-{
+Value *cast_double_to_Int16(Value *input) {
     Value_Double *from = (Value_Double *)input;
     return (Value *)makeInt16((int16_t)from->d);
 }
 
-Value *cast_double_to_Int32(Value *input)
-{
+Value *cast_double_to_Int32(Value *input) {
     Value_Double *from = (Value_Double *)input;
     return (Value *)makeInt32((int32_t)from->d);
 }
 
-Value *cast_double_to_Int64(Value *input)
-{
+Value *cast_double_to_Int64(Value *input) {
     Value_Double *from = (Value_Double *)input;
     return (Value *)makeInt64((int64_t)from->d);
 }
 
-Value *cast_double_to_Integer(Value *input)
-{
+Value *cast_double_to_Integer(Value *input) {
     Value_Double *from = (Value_Double *)input;
 
     Value_Integer *retVal = makeInteger();
@@ -369,14 +315,12 @@ Value *cast_double_to_Integer(Value *input)
     return (Value *)retVal;
 }
 
-Value *cast_double_to_char(Value *input)
-{
+Value *cast_double_to_char(Value *input) {
     Value_Double *from = (Value_Double *)input;
     return (Value *)makeChar((unsigned char)from->d);
 }
 
-Value *cast_double_to_string(Value *input)
-{
+Value *cast_double_to_string(Value *input) {
     Value_Double *from = (Value_Double *)input;
 
     int l = snprintf(NULL, 0, "%f", from->d);
@@ -386,72 +330,61 @@ Value *cast_double_to_string(Value *input)
     return (Value *)retVal;
 }
 
-Value *cast_char_to_Bits8(Value *input)
-{
+Value *cast_char_to_Bits8(Value *input) {
     Value_Char *from = (Value_Char *)input;
     return (Value *)makeBits8((uint8_t)from->c);
 }
 
-Value *cast_char_to_Bits16(Value *input)
-{
+Value *cast_char_to_Bits16(Value *input) {
     Value_Char *from = (Value_Char *)input;
     return (Value *)makeBits16((uint16_t)from->c);
 }
 
-Value *cast_char_to_Bits32(Value *input)
-{
+Value *cast_char_to_Bits32(Value *input) {
     Value_Char *from = (Value_Char *)input;
     return (Value *)makeBits32((uint32_t)from->c);
 }
 
-Value *cast_char_to_Bits64(Value *input)
-{
+Value *cast_char_to_Bits64(Value *input) {
     Value_Char *from = (Value_Char *)input;
     return (Value *)makeBits64((uint64_t)from->c);
 }
 
-Value *cast_char_to_Int8(Value *input)
-{
+Value *cast_char_to_Int8(Value *input) {
     Value_Char *from = (Value_Char *)input;
     return (Value *)makeInt8((int8_t)from->c);
 }
 
-Value *cast_char_to_Int16(Value *input)
-{
+Value *cast_char_to_Int16(Value *input) {
     Value_Char *from = (Value_Char *)input;
     return (Value *)makeInt16((int16_t)from->c);
 }
 
-Value *cast_char_to_Int32(Value *input)
-{
+Value *cast_char_to_Int32(Value *input) {
     Value_Char *from = (Value_Char *)input;
     return (Value *)makeInt32((int32_t)from->c);
 }
 
-Value *cast_char_to_Int64(Value *input)
-{
+Value *cast_char_to_Int64(Value *input) {
     Value_Char *from = (Value_Char *)input;
     return (Value *)makeInt64((int64_t)from->c);
 }
 
-Value *cast_char_to_Integer(Value *input)
-{
-	Value_Char *from = (Value_Char *)input;
+Value *cast_char_to_Integer(Value *input) {
+    Value_Char *from = (Value_Char *)input;
 
-	Value_Integer *retVal = makeInteger();
-	mpz_set_si(retVal->i, from->c);
+    Value_Integer *retVal = makeInteger();
+    mpz_set_si(retVal->i, from->c);
 
-	return (Value *)retVal;
+    return (Value *)retVal;
 }
 
-Value *cast_char_to_double(Value *input)
-{
+Value *cast_char_to_double(Value *input) {
     Value_Char *from = (Value_Char *)input;
     return (Value *)makeDouble((unsigned char)from->c);
 }
 
-Value *cast_char_to_string(Value *input)
-{
+Value *cast_char_to_string(Value *input) {
     Value_Char *from = (Value_Char *)input;
 
     Value_String *retVal = makeEmptyString(2);
@@ -460,56 +393,47 @@ Value *cast_char_to_string(Value *input)
     return (Value *)retVal;
 }
 
-Value *cast_string_to_Bits8(Value *input)
-{
+Value *cast_string_to_Bits8(Value *input) {
     Value_String *from = (Value_String *)input;
     return (Value *)makeBits8((uint8_t)atoi(from->str));
 }
 
-Value *cast_string_to_Bits16(Value *input)
-{
+Value *cast_string_to_Bits16(Value *input) {
     Value_String *from = (Value_String *)input;
     return (Value *)makeBits16((uint16_t)atoi(from->str));
 }
 
-Value *cast_string_to_Bits32(Value *input)
-{
+Value *cast_string_to_Bits32(Value *input) {
     Value_String *from = (Value_String *)input;
     return (Value *)makeBits32((uint32_t)atoi(from->str));
 }
 
-Value *cast_string_to_Bits64(Value *input)
-{
+Value *cast_string_to_Bits64(Value *input) {
     Value_String *from = (Value_String *)input;
     return (Value *)makeBits64((uint64_t)atoi(from->str));
 }
 
-Value *cast_string_to_Int8(Value *input)
-{
+Value *cast_string_to_Int8(Value *input) {
     Value_String *from = (Value_String *)input;
     return (Value *)makeInt8((int8_t)atoi(from->str));
 }
 
-Value *cast_string_to_Int16(Value *input)
-{
+Value *cast_string_to_Int16(Value *input) {
     Value_String *from = (Value_String *)input;
     return (Value *)makeInt16((int16_t)atoi(from->str));
 }
 
-Value *cast_string_to_Int32(Value *input)
-{
+Value *cast_string_to_Int32(Value *input) {
     Value_String *from = (Value_String *)input;
     return (Value *)makeInt32((int32_t)atoi(from->str));
 }
 
-Value *cast_string_to_Int64(Value *input)
-{
+Value *cast_string_to_Int64(Value *input) {
     Value_String *from = (Value_String *)input;
     return (Value *)makeInt64((int64_t)atoi(from->str));
 }
 
-Value *cast_string_to_Integer(Value *input)
-{
+Value *cast_string_to_Integer(Value *input) {
     Value_String *from = (Value_String *)input;
 
     Value_Integer *retVal = makeInteger();
@@ -518,8 +442,7 @@ Value *cast_string_to_Integer(Value *input)
     return (Value *)retVal;
 }
 
-Value *cast_string_to_double(Value *input)
-{
+Value *cast_string_to_double(Value *input) {
     Value_Double *retVal = (Value_Double *)newValue();
     retVal->header.tag = DOUBLE_TAG;
     Value_String *from = (Value_String *)input;
@@ -528,8 +451,7 @@ Value *cast_string_to_double(Value *input)
     return (Value *)retVal;
 }
 
-Value *cast_string_to_char(Value *input)
-{
+Value *cast_string_to_char(Value *input) {
     Value_Char *retVal = (Value_Char *)newValue();
     retVal->header.tag = CHAR_TAG;
     Value_String *from = (Value_String *)input;
@@ -539,50 +461,42 @@ Value *cast_string_to_char(Value *input)
 }
 
 /*  conversions from Bits8  */
-Value *cast_Bits8_to_Bits16(Value *input)
-{
+Value *cast_Bits8_to_Bits16(Value *input) {
     Value_Bits8 *from = (Value_Bits8 *)input;
     return (Value *)makeBits16((uint16_t)from->ui8);
 }
 
-Value *cast_Bits8_to_Bits32(Value *input)
-{
+Value *cast_Bits8_to_Bits32(Value *input) {
     Value_Bits8 *from = (Value_Bits8 *)input;
     return (Value *)makeBits32((uint32_t)from->ui8);
 }
 
-Value *cast_Bits8_to_Bits64(Value *input)
-{
+Value *cast_Bits8_to_Bits64(Value *input) {
     Value_Bits8 *from = (Value_Bits8 *)input;
     return (Value *)makeBits64((uint64_t)from->ui8);
 }
 
-Value *cast_Bits8_to_Int8(Value *input)
-{
+Value *cast_Bits8_to_Int8(Value *input) {
     Value_Bits8 *from = (Value_Bits8 *)input;
     return (Value *)makeInt8((int8_t)from->ui8);
 }
 
-Value *cast_Bits8_to_Int16(Value *input)
-{
+Value *cast_Bits8_to_Int16(Value *input) {
     Value_Bits8 *from = (Value_Bits8 *)input;
     return (Value *)makeInt16((int16_t)from->ui8);
 }
 
-Value *cast_Bits8_to_Int32(Value *input)
-{
+Value *cast_Bits8_to_Int32(Value *input) {
     Value_Bits8 *from = (Value_Bits8 *)input;
     return (Value *)makeInt32((int32_t)from->ui8);
 }
 
-Value *cast_Bits8_to_Int64(Value *input)
-{
+Value *cast_Bits8_to_Int64(Value *input) {
     Value_Bits8 *from = (Value_Bits8 *)input;
     return (Value *)makeInt64((int64_t)from->ui8);
 }
 
-Value *cast_Bits8_to_Integer(Value *input)
-{
+Value *cast_Bits8_to_Integer(Value *input) {
     Value_Bits8 *from = (Value_Bits8 *)input;
 
     Value_Integer *retVal = makeInteger();
@@ -591,20 +505,17 @@ Value *cast_Bits8_to_Integer(Value *input)
     return (Value *)retVal;
 }
 
-Value *cast_Bits8_to_double(Value *input)
-{
+Value *cast_Bits8_to_double(Value *input) {
     Value_Bits8 *from = (Value_Bits8 *)input;
     return (Value *)makeDouble((double)from->ui8);
 }
 
-Value *cast_Bits8_to_char(Value *input)
-{
+Value *cast_Bits8_to_char(Value *input) {
     Value_Bits8 *from = (Value_Bits8 *)input;
     return (Value *)makeChar((unsigned char)from->ui8);
 }
 
-Value *cast_Bits8_to_string(Value *input)
-{
+Value *cast_Bits8_to_string(Value *input) {
     Value_Bits8 *from = (Value_Bits8 *)input;
 
     int l = snprintf(NULL, 0, "%" PRIu8 "", from->ui8);
@@ -615,50 +526,42 @@ Value *cast_Bits8_to_string(Value *input)
 }
 
 /*  conversions from Bits16  */
-Value *cast_Bits16_to_Bits8(Value *input)
-{
+Value *cast_Bits16_to_Bits8(Value *input) {
     Value_Bits16 *from = (Value_Bits16 *)input;
     return (Value *)makeBits8((uint8_t)from->ui16);
 }
 
-Value *cast_Bits16_to_Bits32(Value *input)
-{
+Value *cast_Bits16_to_Bits32(Value *input) {
     Value_Bits16 *from = (Value_Bits16 *)input;
     return (Value *)makeBits32((uint32_t)from->ui16);
 }
 
-Value *cast_Bits16_to_Bits64(Value *input)
-{
+Value *cast_Bits16_to_Bits64(Value *input) {
     Value_Bits16 *from = (Value_Bits16 *)input;
     return (Value *)makeBits64((uint64_t)from->ui16);
 }
 
-Value *cast_Bits16_to_Int8(Value *input)
-{
+Value *cast_Bits16_to_Int8(Value *input) {
     Value_Bits16 *from = (Value_Bits16 *)input;
     return (Value *)makeInt8((int8_t)from->ui16);
 }
 
-Value *cast_Bits16_to_Int16(Value *input)
-{
+Value *cast_Bits16_to_Int16(Value *input) {
     Value_Bits16 *from = (Value_Bits16 *)input;
     return (Value *)makeInt16((int16_t)from->ui16);
 }
 
-Value *cast_Bits16_to_Int32(Value *input)
-{
+Value *cast_Bits16_to_Int32(Value *input) {
     Value_Bits16 *from = (Value_Bits16 *)input;
     return (Value *)makeInt32((int32_t)from->ui16);
 }
 
-Value *cast_Bits16_to_Int64(Value *input)
-{
+Value *cast_Bits16_to_Int64(Value *input) {
     Value_Bits16 *from = (Value_Bits16 *)input;
     return (Value *)makeInt64((int64_t)from->ui16);
 }
 
-Value *cast_Bits16_to_Integer(Value *input)
-{
+Value *cast_Bits16_to_Integer(Value *input) {
     Value_Bits16 *from = (Value_Bits16 *)input;
 
     Value_Integer *retVal = makeInteger();
@@ -667,20 +570,17 @@ Value *cast_Bits16_to_Integer(Value *input)
     return (Value *)retVal;
 }
 
-Value *cast_Bits16_to_double(Value *input)
-{
+Value *cast_Bits16_to_double(Value *input) {
     Value_Bits16 *from = (Value_Bits16 *)input;
     return (Value *)makeDouble((double)from->ui16);
 }
 
-Value *cast_Bits16_to_char(Value *input)
-{
+Value *cast_Bits16_to_char(Value *input) {
     Value_Bits16 *from = (Value_Bits16 *)input;
     return (Value *)makeChar((unsigned char)from->ui16);
 }
 
-Value *cast_Bits16_to_string(Value *input)
-{
+Value *cast_Bits16_to_string(Value *input) {
     Value_Bits16 *from = (Value_Bits16 *)input;
 
     int l = snprintf(NULL, 0, "%" PRIu16 "", from->ui16);
@@ -691,50 +591,42 @@ Value *cast_Bits16_to_string(Value *input)
 }
 
 /*  conversions from Bits32  */
-Value *cast_Bits32_to_Bits8(Value *input)
-{
+Value *cast_Bits32_to_Bits8(Value *input) {
     Value_Bits32 *from = (Value_Bits32 *)input;
     return (Value *)makeBits8((uint8_t)from->ui32);
 }
 
-Value *cast_Bits32_to_Bits16(Value *input)
-{
+Value *cast_Bits32_to_Bits16(Value *input) {
     Value_Bits32 *from = (Value_Bits32 *)input;
     return (Value *)makeBits16((uint16_t)from->ui32);
 }
 
-Value *cast_Bits32_to_Bits64(Value *input)
-{
+Value *cast_Bits32_to_Bits64(Value *input) {
     Value_Bits32 *from = (Value_Bits32 *)input;
     return (Value *)makeBits64((uint64_t)from->ui32);
 }
 
-Value *cast_Bits32_to_Int8(Value *input)
-{
+Value *cast_Bits32_to_Int8(Value *input) {
     Value_Bits32 *from = (Value_Bits32 *)input;
     return (Value *)makeInt8((int8_t)from->ui32);
 }
 
-Value *cast_Bits32_to_Int16(Value *input)
-{
+Value *cast_Bits32_to_Int16(Value *input) {
     Value_Bits32 *from = (Value_Bits32 *)input;
     return (Value *)makeInt16((int16_t)from->ui32);
 }
 
-Value *cast_Bits32_to_Int32(Value *input)
-{
+Value *cast_Bits32_to_Int32(Value *input) {
     Value_Bits32 *from = (Value_Bits32 *)input;
     return (Value *)makeInt32((int32_t)from->ui32);
 }
 
-Value *cast_Bits32_to_Int64(Value *input)
-{
+Value *cast_Bits32_to_Int64(Value *input) {
     Value_Bits32 *from = (Value_Bits32 *)input;
     return (Value *)makeInt64((int64_t)from->ui32);
 }
 
-Value *cast_Bits32_to_Integer(Value *input)
-{
+Value *cast_Bits32_to_Integer(Value *input) {
     Value_Bits32 *from = (Value_Bits32 *)input;
 
     Value_Integer *retVal = makeInteger();
@@ -743,20 +635,17 @@ Value *cast_Bits32_to_Integer(Value *input)
     return (Value *)retVal;
 }
 
-Value *cast_Bits32_to_double(Value *input)
-{
+Value *cast_Bits32_to_double(Value *input) {
     Value_Bits32 *from = (Value_Bits32 *)input;
     return (Value *)makeDouble((double)from->ui32);
 }
 
-Value *cast_Bits32_to_char(Value *input)
-{
+Value *cast_Bits32_to_char(Value *input) {
     Value_Bits32 *from = (Value_Bits32 *)input;
     return (Value *)makeChar((unsigned char)from->ui32);
 }
 
-Value *cast_Bits32_to_string(Value *input)
-{
+Value *cast_Bits32_to_string(Value *input) {
     Value_Bits32 *from = (Value_Bits32 *)input;
 
     int l = snprintf(NULL, 0, "%" PRIu32 "", from->ui32);
@@ -767,50 +656,42 @@ Value *cast_Bits32_to_string(Value *input)
 }
 
 /*  conversions from Bits64  */
-Value *cast_Bits64_to_Bits8(Value *input)
-{
+Value *cast_Bits64_to_Bits8(Value *input) {
     Value_Bits64 *from = (Value_Bits64 *)input;
     return (Value *)makeBits8((uint8_t)from->ui64);
 }
 
-Value *cast_Bits64_to_Bits16(Value *input)
-{
+Value *cast_Bits64_to_Bits16(Value *input) {
     Value_Bits64 *from = (Value_Bits64 *)input;
     return (Value *)makeBits16((uint16_t)from->ui64);
 }
 
-Value *cast_Bits64_to_Bits32(Value *input)
-{
+Value *cast_Bits64_to_Bits32(Value *input) {
     Value_Bits64 *from = (Value_Bits64 *)input;
     return (Value *)makeBits32((uint32_t)from->ui64);
 }
 
-Value *cast_Bits64_to_Int8(Value *input)
-{
+Value *cast_Bits64_to_Int8(Value *input) {
     Value_Bits64 *from = (Value_Bits64 *)input;
     return (Value *)makeInt8((int8_t)from->ui64);
 }
 
-Value *cast_Bits64_to_Int16(Value *input)
-{
+Value *cast_Bits64_to_Int16(Value *input) {
     Value_Bits64 *from = (Value_Bits64 *)input;
     return (Value *)makeInt16((int16_t)from->ui64);
 }
 
-Value *cast_Bits64_to_Int32(Value *input)
-{
+Value *cast_Bits64_to_Int32(Value *input) {
     Value_Bits64 *from = (Value_Bits64 *)input;
     return (Value *)makeInt32((int32_t)from->ui64);
 }
 
-Value *cast_Bits64_to_Int64(Value *input)
-{
+Value *cast_Bits64_to_Int64(Value *input) {
     Value_Bits64 *from = (Value_Bits64 *)input;
     return (Value *)makeInt64((int64_t)from->ui64);
 }
 
-Value *cast_Bits64_to_Integer(Value *input)
-{
+Value *cast_Bits64_to_Integer(Value *input) {
     Value_Bits64 *from = (Value_Bits64 *)input;
 
     Value_Integer *retVal = makeInteger();
@@ -819,20 +700,17 @@ Value *cast_Bits64_to_Integer(Value *input)
     return (Value *)retVal;
 }
 
-Value *cast_Bits64_to_double(Value *input)
-{
+Value *cast_Bits64_to_double(Value *input) {
     Value_Bits64 *from = (Value_Bits64 *)input;
     return (Value *)makeDouble((double)from->ui64);
 }
 
-Value *cast_Bits64_to_char(Value *input)
-{
+Value *cast_Bits64_to_char(Value *input) {
     Value_Bits64 *from = (Value_Bits64 *)input;
     return (Value *)makeChar((unsigned char)from->ui64);
 }
 
-Value *cast_Bits64_to_string(Value *input)
-{
+Value *cast_Bits64_to_string(Value *input) {
     Value_Bits64 *from = (Value_Bits64 *)input;
 
     int l = snprintf(NULL, 0, "%" PRIu64 "", from->ui64);
@@ -843,8 +721,7 @@ Value *cast_Bits64_to_string(Value *input)
 }
 
 /*  conversions from Integer */
-uint64_t mpz_get_lsb(mpz_t i, mp_bitcnt_t b)
-{
+uint64_t mpz_get_lsb(mpz_t i, mp_bitcnt_t b) {
     mpz_t r;
     mpz_init(r);
     mpz_fdiv_r_2exp(r, i, b);
@@ -853,68 +730,57 @@ uint64_t mpz_get_lsb(mpz_t i, mp_bitcnt_t b)
     return retVal;
 }
 
-Value *cast_Integer_to_Bits8(Value *input)
-{
+Value *cast_Integer_to_Bits8(Value *input) {
     Value_Integer *from = (Value_Integer *)input;
     return (Value *)makeBits8((uint8_t)mpz_get_lsb(from->i, 8));
 }
 
-Value *cast_Integer_to_Bits16(Value *input)
-{
+Value *cast_Integer_to_Bits16(Value *input) {
     Value_Integer *from = (Value_Integer *)input;
     return (Value *)makeBits16((uint16_t)mpz_get_lsb(from->i, 16));
 }
 
-Value *cast_Integer_to_Bits32(Value *input)
-{
+Value *cast_Integer_to_Bits32(Value *input) {
     Value_Integer *from = (Value_Integer *)input;
     return (Value *)makeBits32((uint32_t)mpz_get_lsb(from->i, 32));
 }
 
-Value *cast_Integer_to_Bits64(Value *input)
-{
+Value *cast_Integer_to_Bits64(Value *input) {
     Value_Integer *from = (Value_Integer *)input;
     return (Value *)makeBits64((uint64_t)mpz_get_lsb(from->i, 64));
 }
 
-Value *cast_Integer_to_Int8(Value *input)
-{
+Value *cast_Integer_to_Int8(Value *input) {
     Value_Integer *from = (Value_Integer *)input;
     return (Value *)makeInt8((int8_t)mpz_get_lsb(from->i, 8));
 }
 
-Value *cast_Integer_to_Int16(Value *input)
-{
+Value *cast_Integer_to_Int16(Value *input) {
     Value_Integer *from = (Value_Integer *)input;
     return (Value *)makeInt16((int16_t)mpz_get_lsb(from->i, 16));
 }
 
-Value *cast_Integer_to_Int32(Value *input)
-{
+Value *cast_Integer_to_Int32(Value *input) {
     Value_Integer *from = (Value_Integer *)input;
     return (Value *)makeInt32((int32_t)mpz_get_lsb(from->i, 32));
 }
 
-Value *cast_Integer_to_Int64(Value *input)
-{
+Value *cast_Integer_to_Int64(Value *input) {
     Value_Integer *from = (Value_Integer *)input;
     return (Value *)makeInt64((int64_t)mpz_get_lsb(from->i, 64));
 }
 
-Value *cast_Integer_to_double(Value *input)
-{
+Value *cast_Integer_to_double(Value *input) {
     Value_Integer *from = (Value_Integer *)input;
     return (Value *)makeDouble(mpz_get_d(from->i));
 }
 
-Value *cast_Integer_to_char(Value *input)
-{
+Value *cast_Integer_to_char(Value *input) {
     Value_Integer *from = (Value_Integer *)input;
     return (Value *)makeChar((unsigned char)mpz_get_lsb(from->i, 8));
 }
 
-Value *cast_Integer_to_string(Value *input)
-{
+Value *cast_Integer_to_string(Value *input) {
     Value_Integer *from = (Value_Integer *)input;
 
     Value_String *retVal = (Value_String *)newValue();

--- a/support/refc/casts.h
+++ b/support/refc/casts.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include "cBackend.h"
-#include <stdio.h>
+#include "datatypes.h"
 #include <gmp.h>
+#include <stdio.h>
 
 Value *cast_Int8_to_Bits8(Value *);
 Value *cast_Int8_to_Bits16(Value *);

--- a/support/refc/clock.c
+++ b/support/refc/clock.c
@@ -3,50 +3,41 @@
 #define NSEC_PER_SEC 1000000000
 #define CLOCKS_PER_NSEC ((float)CLOCKS_PER_SEC / NSEC_PER_SEC)
 
-Value *clockTimeMonotonic()
-{
+Value *clockTimeMonotonic() {
     return clockTimeUtc();
 }
 
-Value *clockTimeUtc()
-{
+Value *clockTimeUtc() {
     return (Value *)makeBits64(time(NULL) * NSEC_PER_SEC);
 }
 
-Value *clockTimeProcess()
-{
+Value *clockTimeProcess() {
     uint64_t time_ns = clock() / CLOCKS_PER_NSEC;
     return (Value *)makeBits64(time_ns);
 }
 
-Value *clockTimeThread()
-{
+Value *clockTimeThread() {
     return clockTimeProcess();
 }
 
-Value *clockTimeGcCpu()
-{
+Value *clockTimeGcCpu() {
     return NULL;
 }
 
-Value *clockTimeGcReal()
-{
+Value *clockTimeGcReal() {
     return NULL;
 }
 
-int clockValid(Value *clock)
-{
+int clockValid(Value *clock) {
     return clock != NULL;
 }
 
-uint64_t clockSecond(Value *clock)
-{
+uint64_t clockSecond(Value *clock) {
     uint64_t totalNano = ((Value_Bits64 *)clock)->ui64;
     return totalNano / NSEC_PER_SEC;
 }
 
-uint64_t clockNanosecond(Value *clock)
-{
+uint64_t clockNanosecond(Value *clock) {
     uint64_t totalNano = ((Value_Bits64 *)clock)->ui64;
     return totalNano % NSEC_PER_SEC;
 }

--- a/support/refc/clock.h
+++ b/support/refc/clock.h
@@ -3,6 +3,7 @@
 #include <time.h>
 
 #include "cBackend.h"
+#include "datatypes.h"
 
 Value *clockTimeMonotonic();
 Value *clockTimeUtc();

--- a/support/refc/conCaseHelper.c
+++ b/support/refc/conCaseHelper.c
@@ -1,47 +1,37 @@
 #include "conCaseHelper.h"
 
-AConAlt *newConstructorField(int nr)
-{
+AConAlt *newConstructorField(int nr) {
     AConAlt *retVal = (AConAlt *)malloc(nr * sizeof(AConAlt));
-    for (int i = 0; i < nr; i++)
-    {
+    for (int i = 0; i < nr; i++) {
         retVal[i].tag = -1;
     }
     return retVal;
 }
 
-void freeConstructorField(AConAlt *cf)
-{
+void freeConstructorField(AConAlt *cf) {
     free(cf);
 }
 
-void constructorFieldFNextEntry(AConAlt *field, char *name, int tag)
-{
+void constructorFieldFNextEntry(AConAlt *field, char *name, int tag) {
     AConAlt *nextEntry = field;
-    while (nextEntry->tag == -1)
-    {
+    while (nextEntry->tag == -1) {
         nextEntry++;
     }
     nextEntry->name = name;
     nextEntry->tag = tag;
 }
 
-int compareConstructors(Value *sc, AConAlt *field, int nr)
-{
+int compareConstructors(Value *sc, AConAlt *field, int nr) {
     Value_Constructor *constr = (Value_Constructor *)sc;
-    for (int i = 0; i < nr; i++)
-    {
-        if (field->name) //decide my name
+    for (int i = 0; i < nr; i++) {
+        if (field->name) // decide my name
         {
-            if (!strcmp(field->name, constr->name))
-            {
+            if (!strcmp(field->name, constr->name)) {
                 return i;
             }
-        }
-        else // decide by tag
+        } else // decide by tag
         {
-            if (field->tag == constr->tag)
-            {
+            if (field->tag == constr->tag) {
                 return i;
             }
         }
@@ -50,24 +40,18 @@ int compareConstructors(Value *sc, AConAlt *field, int nr)
     return -1;
 }
 
-int multiStringCompare(Value *sc, int nrDecicionOptions, char **options)
-{
-    for (int i = 0; i < nrDecicionOptions; i++)
-    {
-        if (!strcmp(((Value_String *)sc)->str, options[i]))
-        {
+int multiStringCompare(Value *sc, int nrDecicionOptions, char **options) {
+    for (int i = 0; i < nrDecicionOptions; i++) {
+        if (!strcmp(((Value_String *)sc)->str, options[i])) {
             return i;
         }
     }
     return -1;
 }
 
-int multiDoubleCompare(Value *sc, int nrDecicionOptions, double *options)
-{
-    for (int i = 0; i < nrDecicionOptions; i++)
-    {
-        if (((Value_Double *)sc)->d == options[i])
-        {
+int multiDoubleCompare(Value *sc, int nrDecicionOptions, double *options) {
+    for (int i = 0; i < nrDecicionOptions; i++) {
+        if (((Value_Double *)sc)->d == options[i]) {
             return i;
         }
     }

--- a/support/refc/conCaseHelper.h
+++ b/support/refc/conCaseHelper.h
@@ -2,8 +2,7 @@
 
 #include "cBackend.h"
 
-typedef struct
-{
+typedef struct {
     char *name;
     int tag;
 } AConAlt;

--- a/support/refc/datatypes.h
+++ b/support/refc/datatypes.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <gmp.h>
+#include <pthread.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <pthread.h>
-#include <stdint.h>
-#include <gmp.h>
 
 #define NO_TAG 0
 #define BITS8_TAG 1
@@ -37,92 +37,77 @@
 #define COMPLETE_CLOSURE_TAG 98 // for trampoline tail recursion handling
 #define WORLD_TAG 99
 
-typedef struct
-{
+typedef struct {
     int refCounter;
     int tag;
 } Value_header;
 
-typedef struct
-{
+typedef struct {
     Value_header header;
     char payload[25];
 } Value;
 
-typedef struct
-{
+typedef struct {
     Value_header header;
     uint8_t ui8;
 } Value_Bits8;
 
-typedef struct
-{
+typedef struct {
     Value_header header;
     uint16_t ui16;
 } Value_Bits16;
 
-typedef struct
-{
+typedef struct {
     Value_header header;
     uint32_t ui32;
 } Value_Bits32;
 
-typedef struct
-{
+typedef struct {
     Value_header header;
     uint64_t ui64;
 } Value_Bits64;
 
-typedef struct
-{
+typedef struct {
     Value_header header;
     int8_t i8;
 } Value_Int8;
 
-typedef struct
-{
+typedef struct {
     Value_header header;
     int16_t i16;
 } Value_Int16;
 
-typedef struct
-{
+typedef struct {
     Value_header header;
     int32_t i32;
 } Value_Int32;
 
-typedef struct
-{
+typedef struct {
     Value_header header;
     int64_t i64;
 } Value_Int64;
 
-typedef struct
-{
+typedef struct {
     Value_header header;
     mpz_t i;
 } Value_Integer;
 
-typedef struct
-{
+typedef struct {
     Value_header header;
     double d;
 } Value_Double;
 
-typedef struct
-{
+typedef struct {
     Value_header header;
     unsigned char c;
 } Value_Char;
 
-typedef struct
-{
+typedef struct {
     Value_header header;
     char *str;
 } Value_String;
 
-typedef struct
-{
+typedef struct {
     Value_header header;
     int32_t total;
     int32_t tag;
@@ -130,8 +115,7 @@ typedef struct
     Value **args;
 } Value_Constructor;
 
-typedef struct
-{
+typedef struct {
     Value_header header;
     int32_t total;
     int32_t filled;
@@ -140,67 +124,57 @@ typedef struct
 
 typedef Value *(*fun_ptr_t)(Value_Arglist *);
 
-typedef struct
-{
+typedef struct {
     Value_header header;
     fun_ptr_t f;
     Value_Arglist *arglist;
 } Value_Closure;
 
-typedef struct
-{
+typedef struct {
     Value_header header;
     int32_t index;
 } Value_IORef;
 
-typedef struct
-{
+typedef struct {
     Value_header header;
     void *p;
 } Value_Pointer;
 
-typedef struct
-{
+typedef struct {
     Value_header header;
     Value_Pointer *p;
     Value_Closure *onCollectFct;
 } Value_GCPointer;
 
-typedef struct
-{
+typedef struct {
     Value_header header;
     int capacity;
     Value **arr;
 } Value_Array;
 
-typedef struct
-{
+typedef struct {
     Value_header header;
     size_t len;
     char *buffer;
 } Value_Buffer;
 
-typedef struct
-{
+typedef struct {
     Value_header header;
     pthread_mutex_t *mutex;
 } Value_Mutex;
 
-typedef struct
-{
+typedef struct {
     Value_header header;
     pthread_cond_t *cond;
 } Value_Condition;
 
-typedef struct
-{
+typedef struct {
     Value **refs;
     int filled;
     int total;
 } IORef_Storage;
 
-typedef struct
-{
+typedef struct {
     Value_header header;
     IORef_Storage *listIORefs;
 } Value_World;

--- a/support/refc/mathFunctions.c
+++ b/support/refc/mathFunctions.c
@@ -1,263 +1,234 @@
 #include "mathFunctions.h"
-#include "runtime.h"
 #include "memoryManagement.h"
+#include "runtime.h"
 
-double unpackDouble(Value *d)
-{
+double unpackDouble(Value *d) {
     return ((Value_Double *)d)->d;
 }
 
 /* add */
-Value *add_Bits8(Value *x, Value *y)
-{
-    return (Value *)makeBits8(((Value_Bits8 *)x)->ui8 + ((Value_Bits8 *)y)->ui8);
+Value *add_Bits8(Value *x, Value *y) {
+    return (Value *)makeBits8(((Value_Bits8 *)x)->ui8 +
+                              ((Value_Bits8 *)y)->ui8);
 }
-Value *add_Bits16(Value *x, Value *y)
-{
-    return (Value *)makeBits16(((Value_Bits16 *)x)->ui16 + ((Value_Bits16 *)y)->ui16);
+Value *add_Bits16(Value *x, Value *y) {
+    return (Value *)makeBits16(((Value_Bits16 *)x)->ui16 +
+                               ((Value_Bits16 *)y)->ui16);
 }
-Value *add_Bits32(Value *x, Value *y)
-{
-    return (Value *)makeBits32(((Value_Bits32 *)x)->ui32 + ((Value_Bits32 *)y)->ui32);
+Value *add_Bits32(Value *x, Value *y) {
+    return (Value *)makeBits32(((Value_Bits32 *)x)->ui32 +
+                               ((Value_Bits32 *)y)->ui32);
 }
-Value *add_Bits64(Value *x, Value *y)
-{
-    return (Value *)makeBits64(((Value_Bits64 *)x)->ui64 + ((Value_Bits64 *)y)->ui64);
+Value *add_Bits64(Value *x, Value *y) {
+    return (Value *)makeBits64(((Value_Bits64 *)x)->ui64 +
+                               ((Value_Bits64 *)y)->ui64);
 }
-Value *add_Int8(Value *x, Value *y)
-{
+Value *add_Int8(Value *x, Value *y) {
     return (Value *)makeInt8(((Value_Int8 *)x)->i8 + ((Value_Int8 *)y)->i8);
 }
-Value *add_Int16(Value *x, Value *y)
-{
-    return (Value *)makeInt16(((Value_Int16 *)x)->i16 + ((Value_Int16 *)y)->i16);
+Value *add_Int16(Value *x, Value *y) {
+    return (Value *)makeInt16(((Value_Int16 *)x)->i16 +
+                              ((Value_Int16 *)y)->i16);
 }
-Value *add_Int32(Value *x, Value *y)
-{
-    return (Value *)makeInt32(((Value_Int32 *)x)->i32 + ((Value_Int32 *)y)->i32);
+Value *add_Int32(Value *x, Value *y) {
+    return (Value *)makeInt32(((Value_Int32 *)x)->i32 +
+                              ((Value_Int32 *)y)->i32);
 }
-Value *add_Int64(Value *x, Value *y)
-{
-    return (Value *)makeInt64(((Value_Int64 *)x)->i64 + ((Value_Int64 *)y)->i64);
+Value *add_Int64(Value *x, Value *y) {
+    return (Value *)makeInt64(((Value_Int64 *)x)->i64 +
+                              ((Value_Int64 *)y)->i64);
 }
-Value *add_Integer(Value *x, Value *y)
-{
+Value *add_Integer(Value *x, Value *y) {
     Value_Integer *retVal = makeInteger();
     mpz_add(retVal->i, ((Value_Integer *)x)->i, ((Value_Integer *)y)->i);
     return (Value *)retVal;
 }
-Value *add_double(Value *x, Value *y)
-{
+Value *add_double(Value *x, Value *y) {
     return (Value *)makeDouble(((Value_Double *)x)->d + ((Value_Double *)y)->d);
 }
 
 /* sub */
-Value *sub_Bits8(Value *x, Value *y)
-{
-    return (Value *)makeBits8(((Value_Bits8 *)x)->ui8 - ((Value_Bits8 *)y)->ui8);
+Value *sub_Bits8(Value *x, Value *y) {
+    return (Value *)makeBits8(((Value_Bits8 *)x)->ui8 -
+                              ((Value_Bits8 *)y)->ui8);
 }
-Value *sub_Bits16(Value *x, Value *y)
-{
-    return (Value *)makeBits16(((Value_Bits16 *)x)->ui16 - ((Value_Bits16 *)y)->ui16);
+Value *sub_Bits16(Value *x, Value *y) {
+    return (Value *)makeBits16(((Value_Bits16 *)x)->ui16 -
+                               ((Value_Bits16 *)y)->ui16);
 }
-Value *sub_Bits32(Value *x, Value *y)
-{
-    return (Value *)makeBits32(((Value_Bits32 *)x)->ui32 - ((Value_Bits32 *)y)->ui32);
+Value *sub_Bits32(Value *x, Value *y) {
+    return (Value *)makeBits32(((Value_Bits32 *)x)->ui32 -
+                               ((Value_Bits32 *)y)->ui32);
 }
-Value *sub_Bits64(Value *x, Value *y)
-{
-    return (Value *)makeBits64(((Value_Bits64 *)x)->ui64 - ((Value_Bits64 *)y)->ui64);
+Value *sub_Bits64(Value *x, Value *y) {
+    return (Value *)makeBits64(((Value_Bits64 *)x)->ui64 -
+                               ((Value_Bits64 *)y)->ui64);
 }
-Value *sub_Int8(Value *x, Value *y)
-{
+Value *sub_Int8(Value *x, Value *y) {
     return (Value *)makeInt8(((Value_Int8 *)x)->i8 - ((Value_Int8 *)y)->i8);
 }
-Value *sub_Int16(Value *x, Value *y)
-{
-    return (Value *)makeInt16(((Value_Int16 *)x)->i16 - ((Value_Int16 *)y)->i16);
+Value *sub_Int16(Value *x, Value *y) {
+    return (Value *)makeInt16(((Value_Int16 *)x)->i16 -
+                              ((Value_Int16 *)y)->i16);
 }
-Value *sub_Int32(Value *x, Value *y)
-{
-    return (Value *)makeInt32(((Value_Int32 *)x)->i32 - ((Value_Int32 *)y)->i32);
+Value *sub_Int32(Value *x, Value *y) {
+    return (Value *)makeInt32(((Value_Int32 *)x)->i32 -
+                              ((Value_Int32 *)y)->i32);
 }
-Value *sub_Int64(Value *x, Value *y)
-{
-    return (Value *)makeInt64(((Value_Int64 *)x)->i64 - ((Value_Int64 *)y)->i64);
+Value *sub_Int64(Value *x, Value *y) {
+    return (Value *)makeInt64(((Value_Int64 *)x)->i64 -
+                              ((Value_Int64 *)y)->i64);
 }
-Value *sub_Integer(Value *x, Value *y)
-{
+Value *sub_Integer(Value *x, Value *y) {
     Value_Integer *retVal = makeInteger();
     mpz_sub(retVal->i, ((Value_Integer *)x)->i, ((Value_Integer *)y)->i);
     return (Value *)retVal;
 }
-Value *sub_double(Value *x, Value *y)
-{
+Value *sub_double(Value *x, Value *y) {
     return (Value *)makeDouble(((Value_Double *)x)->d - ((Value_Double *)y)->d);
 }
 
 /* negate */
-Value *negate_Bits8(Value *x)
-{
+Value *negate_Bits8(Value *x) {
     return (Value *)makeBits8(-((Value_Bits8 *)x)->ui8);
 }
-Value *negate_Bits16(Value *x)
-{
+Value *negate_Bits16(Value *x) {
     return (Value *)makeBits16(-((Value_Bits16 *)x)->ui16);
 }
-Value *negate_Bits32(Value *x)
-{
+Value *negate_Bits32(Value *x) {
     return (Value *)makeBits32(-((Value_Bits32 *)x)->ui32);
 }
-Value *negate_Bits64(Value *x)
-{
+Value *negate_Bits64(Value *x) {
     return (Value *)makeBits64(-((Value_Bits64 *)x)->ui64);
 }
-Value *negate_Int8(Value *x)
-{
+Value *negate_Int8(Value *x) {
     return (Value *)makeInt8(-((Value_Int8 *)x)->i8);
 }
-Value *negate_Int16(Value *x)
-{
+Value *negate_Int16(Value *x) {
     return (Value *)makeInt16(-((Value_Int16 *)x)->i16);
 }
-Value *negate_Int32(Value *x)
-{
+Value *negate_Int32(Value *x) {
     return (Value *)makeInt32(-((Value_Int32 *)x)->i32);
 }
-Value *negate_Int64(Value *x)
-{
+Value *negate_Int64(Value *x) {
     return (Value *)makeInt64(-((Value_Int64 *)x)->i64);
 }
-Value *negate_Integer(Value *x)
-{
+Value *negate_Integer(Value *x) {
     Value_Integer *retVal = makeInteger();
     mpz_neg(retVal->i, ((Value_Integer *)x)->i);
     return (Value *)retVal;
 }
-Value *negate_double(Value *x)
-{
+Value *negate_double(Value *x) {
     return (Value *)makeDouble(-((Value_Double *)x)->d);
 }
 
 /* mul */
-Value *mul_Bits8(Value *x, Value *y)
-{
-    return (Value *)makeBits8(((Value_Bits8 *)x)->ui8 * ((Value_Bits8 *)y)->ui8);
+Value *mul_Bits8(Value *x, Value *y) {
+    return (Value *)makeBits8(((Value_Bits8 *)x)->ui8 *
+                              ((Value_Bits8 *)y)->ui8);
 }
-Value *mul_Bits16(Value *x, Value *y)
-{
-    return (Value *)makeBits16(((Value_Bits16 *)x)->ui16 * ((Value_Bits16 *)y)->ui16);
+Value *mul_Bits16(Value *x, Value *y) {
+    return (Value *)makeBits16(((Value_Bits16 *)x)->ui16 *
+                               ((Value_Bits16 *)y)->ui16);
 }
-Value *mul_Bits32(Value *x, Value *y)
-{
-    return (Value *)makeBits32(((Value_Bits32 *)x)->ui32 * ((Value_Bits32 *)y)->ui32);
+Value *mul_Bits32(Value *x, Value *y) {
+    return (Value *)makeBits32(((Value_Bits32 *)x)->ui32 *
+                               ((Value_Bits32 *)y)->ui32);
 }
-Value *mul_Bits64(Value *x, Value *y)
-{
-    return (Value *)makeBits64(((Value_Bits64 *)x)->ui64 * ((Value_Bits64 *)y)->ui64);
+Value *mul_Bits64(Value *x, Value *y) {
+    return (Value *)makeBits64(((Value_Bits64 *)x)->ui64 *
+                               ((Value_Bits64 *)y)->ui64);
 }
-Value *mul_Int8(Value *x, Value *y)
-{
+Value *mul_Int8(Value *x, Value *y) {
     return (Value *)makeInt8(((Value_Int8 *)x)->i8 * ((Value_Int8 *)y)->i8);
 }
-Value *mul_Int16(Value *x, Value *y)
-{
-    return (Value *)makeInt16(((Value_Int16 *)x)->i16 * ((Value_Int16 *)y)->i16);
+Value *mul_Int16(Value *x, Value *y) {
+    return (Value *)makeInt16(((Value_Int16 *)x)->i16 *
+                              ((Value_Int16 *)y)->i16);
 }
-Value *mul_Int32(Value *x, Value *y)
-{
-    return (Value *)makeInt32(((Value_Int32 *)x)->i32 * ((Value_Int32 *)y)->i32);
+Value *mul_Int32(Value *x, Value *y) {
+    return (Value *)makeInt32(((Value_Int32 *)x)->i32 *
+                              ((Value_Int32 *)y)->i32);
 }
-Value *mul_Int64(Value *x, Value *y)
-{
-    return (Value *)makeInt64(((Value_Int64 *)x)->i64 * ((Value_Int64 *)y)->i64);
+Value *mul_Int64(Value *x, Value *y) {
+    return (Value *)makeInt64(((Value_Int64 *)x)->i64 *
+                              ((Value_Int64 *)y)->i64);
 }
-Value *mul_Integer(Value *x, Value *y)
-{
+Value *mul_Integer(Value *x, Value *y) {
     Value_Integer *retVal = makeInteger();
     mpz_mul(retVal->i, ((Value_Integer *)x)->i, ((Value_Integer *)y)->i);
     return (Value *)retVal;
 }
-Value *mul_double(Value *x, Value *y)
-{
+Value *mul_double(Value *x, Value *y) {
     return (Value *)makeDouble(((Value_Double *)x)->d * ((Value_Double *)y)->d);
 }
 
 /* div */
-Value *div_Bits8(Value *x, Value *y)
-{
-    return (Value *)makeBits8(((Value_Bits8 *)x)->ui8 / ((Value_Bits8 *)y)->ui8);
+Value *div_Bits8(Value *x, Value *y) {
+    return (Value *)makeBits8(((Value_Bits8 *)x)->ui8 /
+                              ((Value_Bits8 *)y)->ui8);
 }
-Value *div_Bits16(Value *x, Value *y)
-{
-    return (Value *)makeBits16(((Value_Bits16 *)x)->ui16 / ((Value_Bits16 *)y)->ui16);
+Value *div_Bits16(Value *x, Value *y) {
+    return (Value *)makeBits16(((Value_Bits16 *)x)->ui16 /
+                               ((Value_Bits16 *)y)->ui16);
 }
-Value *div_Bits32(Value *x, Value *y)
-{
-    return (Value *)makeBits32(((Value_Bits32 *)x)->ui32 / ((Value_Bits32 *)y)->ui32);
+Value *div_Bits32(Value *x, Value *y) {
+    return (Value *)makeBits32(((Value_Bits32 *)x)->ui32 /
+                               ((Value_Bits32 *)y)->ui32);
 }
-Value *div_Bits64(Value *x, Value *y)
-{
-    return (Value *)makeBits64(((Value_Bits64 *)x)->ui64 / ((Value_Bits64 *)y)->ui64);
+Value *div_Bits64(Value *x, Value *y) {
+    return (Value *)makeBits64(((Value_Bits64 *)x)->ui64 /
+                               ((Value_Bits64 *)y)->ui64);
 }
-Value *div_Int8(Value *x, Value *y)
-{
-    // Correction term added to convert from truncated division (C default) to Euclidean division
-    // For proof of correctness, see Division and Modulus for Computer Scientists (Daan Leijen)
+Value *div_Int8(Value *x, Value *y) {
+    // Correction term added to convert from truncated division (C default) to
+    // Euclidean division For proof of correctness, see Division and Modulus for
+    // Computer Scientists (Daan Leijen)
     // https://www.microsoft.com/en-us/research/publication/division-and-modulus-for-computer-scientists/
 
     int8_t num = ((Value_Int8 *)x)->i8;
     int8_t denom = ((Value_Int8 *)y)->i8;
     int8_t rem = num % denom;
-    return (Value *)makeInt8(
-        num / denom
-        + ((rem < 0) ? (denom < 0) ? 1 : -1 : 0)
-    );
+    return (Value *)makeInt8(num / denom +
+                             ((rem < 0) ? (denom < 0) ? 1 : -1 : 0));
 }
-Value *div_Int16(Value *x, Value *y)
-{
-    // Correction term added to convert from truncated division (C default) to Euclidean division
-    // For proof of correctness, see Division and Modulus for Computer Scientists (Daan Leijen)
+Value *div_Int16(Value *x, Value *y) {
+    // Correction term added to convert from truncated division (C default) to
+    // Euclidean division For proof of correctness, see Division and Modulus for
+    // Computer Scientists (Daan Leijen)
     // https://www.microsoft.com/en-us/research/publication/division-and-modulus-for-computer-scientists/
 
     int16_t num = ((Value_Int16 *)x)->i16;
     int16_t denom = ((Value_Int16 *)y)->i16;
     int16_t rem = num % denom;
-    return (Value *)makeInt16(
-        num / denom
-        + ((rem < 0) ? (denom < 0) ? 1 : -1 : 0)
-    );
+    return (Value *)makeInt16(num / denom +
+                              ((rem < 0) ? (denom < 0) ? 1 : -1 : 0));
 }
-Value *div_Int32(Value *x, Value *y)
-{
-    // Correction term added to convert from truncated division (C default) to Euclidean division
-    // For proof of correctness, see Division and Modulus for Computer Scientists (Daan Leijen)
+Value *div_Int32(Value *x, Value *y) {
+    // Correction term added to convert from truncated division (C default) to
+    // Euclidean division For proof of correctness, see Division and Modulus for
+    // Computer Scientists (Daan Leijen)
     // https://www.microsoft.com/en-us/research/publication/division-and-modulus-for-computer-scientists/
 
     int32_t num = ((Value_Int32 *)x)->i32;
     int32_t denom = ((Value_Int32 *)y)->i32;
     int32_t rem = num % denom;
-    return (Value *)makeInt32(
-        num / denom
-        + ((rem < 0) ? (denom < 0) ? 1 : -1 : 0)
-    );
+    return (Value *)makeInt32(num / denom +
+                              ((rem < 0) ? (denom < 0) ? 1 : -1 : 0));
 }
-Value *div_Int64(Value *x, Value *y)
-{
-    // Correction term added to convert from truncated division (C default) to Euclidean division
-    // For proof of correctness, see Division and Modulus for Computer Scientists (Daan Leijen)
+Value *div_Int64(Value *x, Value *y) {
+    // Correction term added to convert from truncated division (C default) to
+    // Euclidean division For proof of correctness, see Division and Modulus for
+    // Computer Scientists (Daan Leijen)
     // https://www.microsoft.com/en-us/research/publication/division-and-modulus-for-computer-scientists/
 
     int64_t num = ((Value_Int64 *)x)->i64;
     int64_t denom = ((Value_Int64 *)y)->i64;
     int64_t rem = num % denom;
-    return (Value *)makeInt64(
-        num / denom
-        + ((rem < 0) ? (denom < 0) ? 1 : -1 : 0)
-    );
+    return (Value *)makeInt64(num / denom +
+                              ((rem < 0) ? (denom < 0) ? 1 : -1 : 0));
 }
-Value *div_Integer(Value *x, Value *y)
-{
+Value *div_Integer(Value *x, Value *y) {
     mpz_t rem, yq;
     mpz_inits(rem, yq, NULL);
 
@@ -271,98 +242,90 @@ Value *div_Integer(Value *x, Value *y)
 
     return (Value *)retVal;
 }
-Value *div_double(Value *x, Value *y)
-{
+Value *div_double(Value *x, Value *y) {
     return (Value *)makeDouble(((Value_Double *)x)->d / ((Value_Double *)y)->d);
 }
 
 /* mod */
-Value *mod_Bits8(Value *x, Value *y)
-{
-    return (Value *)makeBits8(((Value_Bits8 *)x)->ui8 % ((Value_Bits8 *)y)->ui8);
+Value *mod_Bits8(Value *x, Value *y) {
+    return (Value *)makeBits8(((Value_Bits8 *)x)->ui8 %
+                              ((Value_Bits8 *)y)->ui8);
 }
-Value *mod_Bits16(Value *x, Value *y)
-{
-    return (Value *)makeBits16(((Value_Bits16 *)x)->ui16 % ((Value_Bits16 *)y)->ui16);
+Value *mod_Bits16(Value *x, Value *y) {
+    return (Value *)makeBits16(((Value_Bits16 *)x)->ui16 %
+                               ((Value_Bits16 *)y)->ui16);
 }
-Value *mod_Bits32(Value *x, Value *y)
-{
-    return (Value *)makeBits32(((Value_Bits32 *)x)->ui32 % ((Value_Bits32 *)y)->ui32);
+Value *mod_Bits32(Value *x, Value *y) {
+    return (Value *)makeBits32(((Value_Bits32 *)x)->ui32 %
+                               ((Value_Bits32 *)y)->ui32);
 }
-Value *mod_Bits64(Value *x, Value *y)
-{
-    return (Value *)makeBits64(((Value_Bits64 *)x)->ui64 % ((Value_Bits64 *)y)->ui64);
+Value *mod_Bits64(Value *x, Value *y) {
+    return (Value *)makeBits64(((Value_Bits64 *)x)->ui64 %
+                               ((Value_Bits64 *)y)->ui64);
 }
-Value *mod_Int8(Value *x, Value *y)
-{
+Value *mod_Int8(Value *x, Value *y) {
     int8_t num = ((Value_Int8 *)x)->i8;
     int8_t denom = ((Value_Int8 *)y)->i8;
-    denom = (denom < 0) ? - denom : denom;
+    denom = (denom < 0) ? -denom : denom;
     return (Value *)makeInt8(num % denom + (num < 0 ? denom : 0));
 }
-Value *mod_Int16(Value *x, Value *y)
-{
+Value *mod_Int16(Value *x, Value *y) {
     int16_t num = ((Value_Int16 *)x)->i16;
     int16_t denom = ((Value_Int16 *)y)->i16;
-    denom = (denom < 0) ? - denom : denom;
+    denom = (denom < 0) ? -denom : denom;
     return (Value *)makeInt16(num % denom + (num < 0 ? denom : 0));
 }
-Value *mod_Int32(Value *x, Value *y)
-{
+Value *mod_Int32(Value *x, Value *y) {
     int32_t num = ((Value_Int32 *)x)->i32;
     int32_t denom = ((Value_Int32 *)y)->i32;
-    denom = (denom < 0) ? - denom : denom;
+    denom = (denom < 0) ? -denom : denom;
     return (Value *)makeInt32(num % denom + (num < 0 ? denom : 0));
 }
-Value *mod_Int64(Value *x, Value *y)
-{
+Value *mod_Int64(Value *x, Value *y) {
     int64_t num = ((Value_Int64 *)x)->i64;
     int64_t denom = ((Value_Int64 *)y)->i64;
-    denom = (denom < 0) ? - denom : denom;
+    denom = (denom < 0) ? -denom : denom;
     return (Value *)makeInt64(num % denom + (num < 0 ? denom : 0));
 }
-Value *mod_Integer(Value *x, Value *y)
-{
+Value *mod_Integer(Value *x, Value *y) {
     Value_Integer *retVal = makeInteger();
     mpz_mod(retVal->i, ((Value_Integer *)x)->i, ((Value_Integer *)y)->i);
     return (Value *)retVal;
 }
 
 /* shiftl */
-Value *shiftl_Bits8(Value *x, Value *y)
-{
-    return (Value *)makeBits8(((Value_Bits8 *)x)->ui8 << ((Value_Bits8 *)y)->ui8);
+Value *shiftl_Bits8(Value *x, Value *y) {
+    return (Value *)makeBits8(((Value_Bits8 *)x)->ui8
+                              << ((Value_Bits8 *)y)->ui8);
 }
-Value *shiftl_Bits16(Value *x, Value *y)
-{
-    return (Value *)makeBits16(((Value_Bits16 *)x)->ui16 << ((Value_Bits16 *)y)->ui16);
+Value *shiftl_Bits16(Value *x, Value *y) {
+    return (Value *)makeBits16(((Value_Bits16 *)x)->ui16
+                               << ((Value_Bits16 *)y)->ui16);
 }
-Value *shiftl_Bits32(Value *x, Value *y)
-{
-    return (Value *)makeBits32(((Value_Bits32 *)x)->ui32 << ((Value_Bits32 *)y)->ui32);
+Value *shiftl_Bits32(Value *x, Value *y) {
+    return (Value *)makeBits32(((Value_Bits32 *)x)->ui32
+                               << ((Value_Bits32 *)y)->ui32);
 }
-Value *shiftl_Bits64(Value *x, Value *y)
-{
-    return (Value *)makeBits64(((Value_Bits64 *)x)->ui64 << ((Value_Bits64 *)y)->ui64);
+Value *shiftl_Bits64(Value *x, Value *y) {
+    return (Value *)makeBits64(((Value_Bits64 *)x)->ui64
+                               << ((Value_Bits64 *)y)->ui64);
 }
-Value *shiftl_Int8(Value *x, Value *y)
-{
+Value *shiftl_Int8(Value *x, Value *y) {
     return (Value *)makeInt8(((Value_Int8 *)x)->i8 << ((Value_Int8 *)y)->i8);
 }
-Value *shiftl_Int16(Value *x, Value *y)
-{
-    return (Value *)makeInt16(((Value_Int16 *)x)->i16 << ((Value_Int16 *)y)->i16);
+Value *shiftl_Int16(Value *x, Value *y) {
+    return (Value *)makeInt16(((Value_Int16 *)x)->i16
+                              << ((Value_Int16 *)y)->i16);
 }
-Value *shiftl_Int32(Value *x, Value *y)
-{
-    return (Value *)makeInt32(((Value_Int32 *)x)->i32 << ((Value_Int32 *)y)->i32);
+Value *shiftl_Int32(Value *x, Value *y) {
+    return (Value *)makeInt32(((Value_Int32 *)x)->i32
+                              << ((Value_Int32 *)y)->i32);
 }
-Value *shiftl_Int64(Value *x, Value *y)
-{
-    return (Value *)makeInt64(((Value_Int64 *)x)->i64 << ((Value_Int64 *)y)->i64);
+Value *shiftl_Int64(Value *x, Value *y) {
+    return (Value *)makeInt64(((Value_Int64 *)x)->i64
+                              << ((Value_Int64 *)y)->i64);
 }
-Value *shiftl_Integer(Value *x, Value *y)
-{
+Value *shiftl_Integer(Value *x, Value *y) {
     Value_Integer *retVal = makeInteger();
     mp_bitcnt_t cnt = (mp_bitcnt_t)mpz_get_ui(((Value_Integer *)y)->i);
     mpz_mul_2exp(retVal->i, ((Value_Integer *)x)->i, cnt);
@@ -370,40 +333,38 @@ Value *shiftl_Integer(Value *x, Value *y)
 }
 
 /* shiftr */
-Value *shiftr_Bits8(Value *x, Value *y)
-{
-    return (Value *)makeBits8(((Value_Bits8 *)x)->ui8 >> ((Value_Bits8 *)y)->ui8);
+Value *shiftr_Bits8(Value *x, Value *y) {
+    return (Value *)makeBits8(((Value_Bits8 *)x)->ui8 >>
+                              ((Value_Bits8 *)y)->ui8);
 }
-Value *shiftr_Bits16(Value *x, Value *y)
-{
-    return (Value *)makeBits16(((Value_Bits16 *)x)->ui16 >> ((Value_Bits16 *)y)->ui16);
+Value *shiftr_Bits16(Value *x, Value *y) {
+    return (Value *)makeBits16(((Value_Bits16 *)x)->ui16 >>
+                               ((Value_Bits16 *)y)->ui16);
 }
-Value *shiftr_Bits32(Value *x, Value *y)
-{
-    return (Value *)makeBits32(((Value_Bits32 *)x)->ui32 >> ((Value_Bits32 *)y)->ui32);
+Value *shiftr_Bits32(Value *x, Value *y) {
+    return (Value *)makeBits32(((Value_Bits32 *)x)->ui32 >>
+                               ((Value_Bits32 *)y)->ui32);
 }
-Value *shiftr_Bits64(Value *x, Value *y)
-{
-    return (Value *)makeBits64(((Value_Bits64 *)x)->ui64 >> ((Value_Bits64 *)y)->ui64);
+Value *shiftr_Bits64(Value *x, Value *y) {
+    return (Value *)makeBits64(((Value_Bits64 *)x)->ui64 >>
+                               ((Value_Bits64 *)y)->ui64);
 }
-Value *shiftr_Int8(Value *x, Value *y)
-{
+Value *shiftr_Int8(Value *x, Value *y) {
     return (Value *)makeInt8(((Value_Int8 *)x)->i8 >> ((Value_Int8 *)y)->i8);
 }
-Value *shiftr_Int16(Value *x, Value *y)
-{
-    return (Value *)makeInt16(((Value_Int16 *)x)->i16 >> ((Value_Int16 *)y)->i16);
+Value *shiftr_Int16(Value *x, Value *y) {
+    return (Value *)makeInt16(((Value_Int16 *)x)->i16 >>
+                              ((Value_Int16 *)y)->i16);
 }
-Value *shiftr_Int32(Value *x, Value *y)
-{
-    return (Value *)makeInt32(((Value_Int32 *)x)->i32 >> ((Value_Int32 *)y)->i32);
+Value *shiftr_Int32(Value *x, Value *y) {
+    return (Value *)makeInt32(((Value_Int32 *)x)->i32 >>
+                              ((Value_Int32 *)y)->i32);
 }
-Value *shiftr_Int64(Value *x, Value *y)
-{
-    return (Value *)makeInt64(((Value_Int64 *)x)->i64 >> ((Value_Int64 *)y)->i64);
+Value *shiftr_Int64(Value *x, Value *y) {
+    return (Value *)makeInt64(((Value_Int64 *)x)->i64 >>
+                              ((Value_Int64 *)y)->i64);
 }
-Value *shiftr_Integer(Value *x, Value *y)
-{
+Value *shiftr_Integer(Value *x, Value *y) {
     Value_Integer *retVal = makeInteger();
     mp_bitcnt_t cnt = (mp_bitcnt_t)mpz_get_ui(((Value_Integer *)y)->i);
     mpz_fdiv_q_2exp(retVal->i, ((Value_Integer *)x)->i, cnt);
@@ -411,381 +372,342 @@ Value *shiftr_Integer(Value *x, Value *y)
 }
 
 /* and */
-Value *and_Bits8(Value *x, Value *y)
-{
-    return (Value *)makeBits8(((Value_Bits8 *)x)->ui8 & ((Value_Bits8 *)y)->ui8);
+Value *and_Bits8(Value *x, Value *y) {
+    return (Value *)makeBits8(((Value_Bits8 *)x)->ui8 &
+                              ((Value_Bits8 *)y)->ui8);
 }
-Value *and_Bits16(Value *x, Value *y)
-{
-    return (Value *)makeBits16(((Value_Bits16 *)x)->ui16 & ((Value_Bits16 *)y)->ui16);
+Value *and_Bits16(Value *x, Value *y) {
+    return (Value *)makeBits16(((Value_Bits16 *)x)->ui16 &
+                               ((Value_Bits16 *)y)->ui16);
 }
-Value *and_Bits32(Value *x, Value *y)
-{
-    return (Value *)makeBits32(((Value_Bits32 *)x)->ui32 & ((Value_Bits32 *)y)->ui32);
+Value *and_Bits32(Value *x, Value *y) {
+    return (Value *)makeBits32(((Value_Bits32 *)x)->ui32 &
+                               ((Value_Bits32 *)y)->ui32);
 }
-Value *and_Bits64(Value *x, Value *y)
-{
-    return (Value *)makeBits64(((Value_Bits64 *)x)->ui64 & ((Value_Bits64 *)y)->ui64);
+Value *and_Bits64(Value *x, Value *y) {
+    return (Value *)makeBits64(((Value_Bits64 *)x)->ui64 &
+                               ((Value_Bits64 *)y)->ui64);
 }
-Value *and_Int8(Value *x, Value *y)
-{
+Value *and_Int8(Value *x, Value *y) {
     return (Value *)makeInt8(((Value_Int8 *)x)->i8 & ((Value_Int8 *)y)->i8);
 }
-Value *and_Int16(Value *x, Value *y)
-{
-    return (Value *)makeInt16(((Value_Int16 *)x)->i16 & ((Value_Int16 *)y)->i16);
+Value *and_Int16(Value *x, Value *y) {
+    return (Value *)makeInt16(((Value_Int16 *)x)->i16 &
+                              ((Value_Int16 *)y)->i16);
 }
-Value *and_Int32(Value *x, Value *y)
-{
-    return (Value *)makeInt32(((Value_Int32 *)x)->i32 & ((Value_Int32 *)y)->i32);
+Value *and_Int32(Value *x, Value *y) {
+    return (Value *)makeInt32(((Value_Int32 *)x)->i32 &
+                              ((Value_Int32 *)y)->i32);
 }
-Value *and_Int64(Value *x, Value *y)
-{
-    return (Value *)makeInt64(((Value_Int64 *)x)->i64 & ((Value_Int64 *)y)->i64);
+Value *and_Int64(Value *x, Value *y) {
+    return (Value *)makeInt64(((Value_Int64 *)x)->i64 &
+                              ((Value_Int64 *)y)->i64);
 }
-Value *and_Integer(Value *x, Value *y)
-{
+Value *and_Integer(Value *x, Value *y) {
     Value_Integer *retVal = makeInteger();
     mpz_and(retVal->i, ((Value_Integer *)x)->i, ((Value_Integer *)y)->i);
     return (Value *)retVal;
 }
 
 /* or */
-Value *or_Bits8(Value *x, Value *y)
-{
-    return (Value *)makeBits8(((Value_Bits8 *)x)->ui8 | ((Value_Bits8 *)y)->ui8);
+Value *or_Bits8(Value *x, Value *y) {
+    return (Value *)makeBits8(((Value_Bits8 *)x)->ui8 |
+                              ((Value_Bits8 *)y)->ui8);
 }
-Value *or_Bits16(Value *x, Value *y)
-{
-    return (Value *)makeBits16(((Value_Bits16 *)x)->ui16 | ((Value_Bits16 *)y)->ui16);
+Value *or_Bits16(Value *x, Value *y) {
+    return (Value *)makeBits16(((Value_Bits16 *)x)->ui16 |
+                               ((Value_Bits16 *)y)->ui16);
 }
-Value *or_Bits32(Value *x, Value *y)
-{
-    return (Value *)makeBits32(((Value_Bits32 *)x)->ui32 | ((Value_Bits32 *)y)->ui32);
+Value *or_Bits32(Value *x, Value *y) {
+    return (Value *)makeBits32(((Value_Bits32 *)x)->ui32 |
+                               ((Value_Bits32 *)y)->ui32);
 }
-Value *or_Bits64(Value *x, Value *y)
-{
-    return (Value *)makeBits64(((Value_Bits64 *)x)->ui64 | ((Value_Bits64 *)y)->ui64);
+Value *or_Bits64(Value *x, Value *y) {
+    return (Value *)makeBits64(((Value_Bits64 *)x)->ui64 |
+                               ((Value_Bits64 *)y)->ui64);
 }
-Value *or_Int8(Value *x, Value *y)
-{
+Value *or_Int8(Value *x, Value *y) {
     return (Value *)makeInt8(((Value_Int8 *)x)->i8 | ((Value_Int8 *)y)->i8);
 }
-Value *or_Int16(Value *x, Value *y)
-{
-    return (Value *)makeInt16(((Value_Int16 *)x)->i16 | ((Value_Int16 *)y)->i16);
+Value *or_Int16(Value *x, Value *y) {
+    return (Value *)makeInt16(((Value_Int16 *)x)->i16 |
+                              ((Value_Int16 *)y)->i16);
 }
-Value *or_Int32(Value *x, Value *y)
-{
-    return (Value *)makeInt32(((Value_Int32 *)x)->i32 | ((Value_Int32 *)y)->i32);
+Value *or_Int32(Value *x, Value *y) {
+    return (Value *)makeInt32(((Value_Int32 *)x)->i32 |
+                              ((Value_Int32 *)y)->i32);
 }
-Value *or_Int64(Value *x, Value *y)
-{
-    return (Value *)makeInt64(((Value_Int64 *)x)->i64 | ((Value_Int64 *)y)->i64);
+Value *or_Int64(Value *x, Value *y) {
+    return (Value *)makeInt64(((Value_Int64 *)x)->i64 |
+                              ((Value_Int64 *)y)->i64);
 }
-Value *or_Integer(Value *x, Value *y)
-{
+Value *or_Integer(Value *x, Value *y) {
     Value_Integer *retVal = makeInteger();
     mpz_ior(retVal->i, ((Value_Integer *)x)->i, ((Value_Integer *)y)->i);
     return (Value *)retVal;
 }
 
 /* xor */
-Value *xor_Bits8(Value *x, Value *y)
-{
-    return (Value *)makeBits8(((Value_Bits8 *)x)->ui8 ^ ((Value_Bits8 *)y)->ui8);
+Value *xor_Bits8(Value *x, Value *y) {
+    return (Value *)makeBits8(((Value_Bits8 *)x)->ui8 ^
+                              ((Value_Bits8 *)y)->ui8);
 }
-Value *xor_Bits16(Value *x, Value *y)
-{
-    return (Value *)makeBits16(((Value_Bits16 *)x)->ui16 ^ ((Value_Bits16 *)y)->ui16);
+Value *xor_Bits16(Value *x, Value *y) {
+    return (Value *)makeBits16(((Value_Bits16 *)x)->ui16 ^
+                               ((Value_Bits16 *)y)->ui16);
 }
-Value *xor_Bits32(Value *x, Value *y)
-{
-    return (Value *)makeBits32(((Value_Bits32 *)x)->ui32 ^ ((Value_Bits32 *)y)->ui32);
+Value *xor_Bits32(Value *x, Value *y) {
+    return (Value *)makeBits32(((Value_Bits32 *)x)->ui32 ^
+                               ((Value_Bits32 *)y)->ui32);
 }
-Value *xor_Bits64(Value *x, Value *y)
-{
-    return (Value *)makeBits64(((Value_Bits64 *)x)->ui64 ^ ((Value_Bits64 *)y)->ui64);
+Value *xor_Bits64(Value *x, Value *y) {
+    return (Value *)makeBits64(((Value_Bits64 *)x)->ui64 ^
+                               ((Value_Bits64 *)y)->ui64);
 }
-Value *xor_Int8(Value *x, Value *y)
-{
+Value *xor_Int8(Value *x, Value *y) {
     return (Value *)makeInt8(((Value_Int8 *)x)->i8 ^ ((Value_Int8 *)y)->i8);
 }
-Value *xor_Int16(Value *x, Value *y)
-{
-    return (Value *)makeInt16(((Value_Int16 *)x)->i16 ^ ((Value_Int16 *)y)->i16);
+Value *xor_Int16(Value *x, Value *y) {
+    return (Value *)makeInt16(((Value_Int16 *)x)->i16 ^
+                              ((Value_Int16 *)y)->i16);
 }
-Value *xor_Int32(Value *x, Value *y)
-{
-    return (Value *)makeInt32(((Value_Int32 *)x)->i32 ^ ((Value_Int32 *)y)->i32);
+Value *xor_Int32(Value *x, Value *y) {
+    return (Value *)makeInt32(((Value_Int32 *)x)->i32 ^
+                              ((Value_Int32 *)y)->i32);
 }
-Value *xor_Int64(Value *x, Value *y)
-{
-    return (Value *)makeInt64(((Value_Int64 *)x)->i64 ^ ((Value_Int64 *)y)->i64);
+Value *xor_Int64(Value *x, Value *y) {
+    return (Value *)makeInt64(((Value_Int64 *)x)->i64 ^
+                              ((Value_Int64 *)y)->i64);
 }
-Value *xor_Integer(Value *x, Value *y)
-{
+Value *xor_Integer(Value *x, Value *y) {
     Value_Integer *retVal = makeInteger();
     mpz_xor(retVal->i, ((Value_Integer *)x)->i, ((Value_Integer *)y)->i);
     return (Value *)retVal;
 }
 
 /* lt */
-Value *lt_Bits8(Value *x, Value *y)
-{
+Value *lt_Bits8(Value *x, Value *y) {
     return (Value *)makeBool(((Value_Bits8 *)x)->ui8 < ((Value_Bits8 *)y)->ui8);
 }
-Value *lt_Bits16(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Bits16 *)x)->ui16 < ((Value_Bits16 *)y)->ui16);
+Value *lt_Bits16(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Bits16 *)x)->ui16 <
+                             ((Value_Bits16 *)y)->ui16);
 }
-Value *lt_Bits32(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Bits32 *)x)->ui32 < ((Value_Bits32 *)y)->ui32);
+Value *lt_Bits32(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Bits32 *)x)->ui32 <
+                             ((Value_Bits32 *)y)->ui32);
 }
-Value *lt_Bits64(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Bits64 *)x)->ui64 < ((Value_Bits64 *)y)->ui64);
+Value *lt_Bits64(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Bits64 *)x)->ui64 <
+                             ((Value_Bits64 *)y)->ui64);
 }
-Value *lt_Int8(Value *x, Value *y)
-{
+Value *lt_Int8(Value *x, Value *y) {
     return (Value *)makeBool(((Value_Int8 *)x)->i8 < ((Value_Int8 *)y)->i8);
 }
-Value *lt_Int16(Value *x, Value *y)
-{
+Value *lt_Int16(Value *x, Value *y) {
     return (Value *)makeBool(((Value_Int16 *)x)->i16 < ((Value_Int16 *)y)->i16);
 }
-Value *lt_Int32(Value *x, Value *y)
-{
+Value *lt_Int32(Value *x, Value *y) {
     return (Value *)makeBool(((Value_Int32 *)x)->i32 < ((Value_Int32 *)y)->i32);
 }
-Value *lt_Int64(Value *x, Value *y)
-{
+Value *lt_Int64(Value *x, Value *y) {
     return (Value *)makeBool(((Value_Int64 *)x)->i64 < ((Value_Int64 *)y)->i64);
 }
-Value *lt_Integer(Value *x, Value *y)
-{
+Value *lt_Integer(Value *x, Value *y) {
     return (Value *)makeBool(
-        mpz_cmp(((Value_Integer *)x)->i, ((Value_Integer *)y)->i) < 0
-    );
+        mpz_cmp(((Value_Integer *)x)->i, ((Value_Integer *)y)->i) < 0);
 }
-Value *lt_double(Value *x, Value *y)
-{
+Value *lt_double(Value *x, Value *y) {
     return (Value *)makeBool(((Value_Double *)x)->d < ((Value_Double *)y)->d);
 }
-Value *lt_char(Value *x, Value *y)
-{
+Value *lt_char(Value *x, Value *y) {
     return (Value *)makeBool(((Value_Char *)x)->c < ((Value_Char *)y)->c);
 }
-Value *lt_string(Value *x, Value *y)
-{
-    return (Value *)makeBool(strcmp(((Value_String *)x)->str, ((Value_String *)y)->str) < 0);
+Value *lt_string(Value *x, Value *y) {
+    return (Value *)makeBool(
+        strcmp(((Value_String *)x)->str, ((Value_String *)y)->str) < 0);
 }
 
 /* gt */
-Value *gt_Bits8(Value *x, Value *y)
-{
+Value *gt_Bits8(Value *x, Value *y) {
     return (Value *)makeBool(((Value_Bits8 *)x)->ui8 > ((Value_Bits8 *)y)->ui8);
 }
-Value *gt_Bits16(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Bits16 *)x)->ui16 > ((Value_Bits16 *)y)->ui16);
+Value *gt_Bits16(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Bits16 *)x)->ui16 >
+                             ((Value_Bits16 *)y)->ui16);
 }
-Value *gt_Bits32(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Bits32 *)x)->ui32 > ((Value_Bits32 *)y)->ui32);
+Value *gt_Bits32(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Bits32 *)x)->ui32 >
+                             ((Value_Bits32 *)y)->ui32);
 }
-Value *gt_Bits64(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Bits64 *)x)->ui64 > ((Value_Bits64 *)y)->ui64);
+Value *gt_Bits64(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Bits64 *)x)->ui64 >
+                             ((Value_Bits64 *)y)->ui64);
 }
-Value *gt_Int8(Value *x, Value *y)
-{
+Value *gt_Int8(Value *x, Value *y) {
     return (Value *)makeBool(((Value_Int8 *)x)->i8 > ((Value_Int8 *)y)->i8);
 }
-Value *gt_Int16(Value *x, Value *y)
-{
+Value *gt_Int16(Value *x, Value *y) {
     return (Value *)makeBool(((Value_Int16 *)x)->i16 > ((Value_Int16 *)y)->i16);
 }
-Value *gt_Int32(Value *x, Value *y)
-{
+Value *gt_Int32(Value *x, Value *y) {
     return (Value *)makeBool(((Value_Int32 *)x)->i32 > ((Value_Int32 *)y)->i32);
 }
-Value *gt_Int64(Value *x, Value *y)
-{
+Value *gt_Int64(Value *x, Value *y) {
     return (Value *)makeBool(((Value_Int64 *)x)->i64 > ((Value_Int64 *)y)->i64);
 }
-Value *gt_Integer(Value *x, Value *y)
-{
+Value *gt_Integer(Value *x, Value *y) {
     return (Value *)makeBool(
-        mpz_cmp(((Value_Integer *)x)->i, ((Value_Integer *)y)->i) > 0
-    );
+        mpz_cmp(((Value_Integer *)x)->i, ((Value_Integer *)y)->i) > 0);
 }
-Value *gt_double(Value *x, Value *y)
-{
+Value *gt_double(Value *x, Value *y) {
     return (Value *)makeBool(((Value_Double *)x)->d > ((Value_Double *)y)->d);
 }
-Value *gt_char(Value *x, Value *y)
-{
+Value *gt_char(Value *x, Value *y) {
     return (Value *)makeBool(((Value_Char *)x)->c > ((Value_Char *)y)->c);
 }
-Value *gt_string(Value *x, Value *y)
-{
-    return (Value *)makeBool(strcmp(((Value_String *)x)->str, ((Value_String *)y)->str) > 0);
+Value *gt_string(Value *x, Value *y) {
+    return (Value *)makeBool(
+        strcmp(((Value_String *)x)->str, ((Value_String *)y)->str) > 0);
 }
 
 /* eq */
-Value *eq_Bits8(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Bits8 *)x)->ui8 == ((Value_Bits8 *)y)->ui8);
+Value *eq_Bits8(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Bits8 *)x)->ui8 ==
+                             ((Value_Bits8 *)y)->ui8);
 }
-Value *eq_Bits16(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Bits16 *)x)->ui16 == ((Value_Bits16 *)y)->ui16);
+Value *eq_Bits16(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Bits16 *)x)->ui16 ==
+                             ((Value_Bits16 *)y)->ui16);
 }
-Value *eq_Bits32(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Bits32 *)x)->ui32 == ((Value_Bits32 *)y)->ui32);
+Value *eq_Bits32(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Bits32 *)x)->ui32 ==
+                             ((Value_Bits32 *)y)->ui32);
 }
-Value *eq_Bits64(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Bits64 *)x)->ui64 == ((Value_Bits64 *)y)->ui64);
+Value *eq_Bits64(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Bits64 *)x)->ui64 ==
+                             ((Value_Bits64 *)y)->ui64);
 }
-Value *eq_Int8(Value *x, Value *y)
-{
+Value *eq_Int8(Value *x, Value *y) {
     return (Value *)makeBool(((Value_Int8 *)x)->i8 == ((Value_Int8 *)y)->i8);
 }
-Value *eq_Int16(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Int16 *)x)->i16 == ((Value_Int16 *)y)->i16);
+Value *eq_Int16(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Int16 *)x)->i16 ==
+                             ((Value_Int16 *)y)->i16);
 }
-Value *eq_Int32(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Int32 *)x)->i32 == ((Value_Int32 *)y)->i32);
+Value *eq_Int32(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Int32 *)x)->i32 ==
+                             ((Value_Int32 *)y)->i32);
 }
-Value *eq_Int64(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Int64 *)x)->i64 == ((Value_Int64 *)y)->i64);
+Value *eq_Int64(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Int64 *)x)->i64 ==
+                             ((Value_Int64 *)y)->i64);
 }
-Value *eq_Integer(Value *x, Value *y)
-{
+Value *eq_Integer(Value *x, Value *y) {
     return (Value *)makeBool(
-        mpz_cmp(((Value_Integer *)x)->i, ((Value_Integer *)y)->i) == 0
-    );
+        mpz_cmp(((Value_Integer *)x)->i, ((Value_Integer *)y)->i) == 0);
 }
-Value *eq_double(Value *x, Value *y)
-{
+Value *eq_double(Value *x, Value *y) {
     return (Value *)makeBool(((Value_Double *)x)->d == ((Value_Double *)y)->d);
 }
-Value *eq_char(Value *x, Value *y)
-{
+Value *eq_char(Value *x, Value *y) {
     return (Value *)makeBool(((Value_Char *)x)->c == ((Value_Char *)y)->c);
 }
-Value *eq_string(Value *x, Value *y)
-{
-    return (Value *)makeBool(!strcmp(((Value_String *)x)->str, ((Value_String *)y)->str));
+Value *eq_string(Value *x, Value *y) {
+    return (Value *)makeBool(
+        !strcmp(((Value_String *)x)->str, ((Value_String *)y)->str));
 }
 
 /* lte */
-Value *lte_Bits8(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Bits8 *)x)->ui8 <= ((Value_Bits8 *)y)->ui8);
+Value *lte_Bits8(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Bits8 *)x)->ui8 <=
+                             ((Value_Bits8 *)y)->ui8);
 }
-Value *lte_Bits16(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Bits16 *)x)->ui16 <= ((Value_Bits16 *)y)->ui16);
+Value *lte_Bits16(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Bits16 *)x)->ui16 <=
+                             ((Value_Bits16 *)y)->ui16);
 }
-Value *lte_Bits32(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Bits32 *)x)->ui32 <= ((Value_Bits32 *)y)->ui32);
+Value *lte_Bits32(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Bits32 *)x)->ui32 <=
+                             ((Value_Bits32 *)y)->ui32);
 }
-Value *lte_Bits64(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Bits64 *)x)->ui64 <= ((Value_Bits64 *)y)->ui64);
+Value *lte_Bits64(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Bits64 *)x)->ui64 <=
+                             ((Value_Bits64 *)y)->ui64);
 }
-Value *lte_Int8(Value *x, Value *y)
-{
+Value *lte_Int8(Value *x, Value *y) {
     return (Value *)makeBool(((Value_Int8 *)x)->i8 <= ((Value_Int8 *)y)->i8);
 }
-Value *lte_Int16(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Int16 *)x)->i16 <= ((Value_Int16 *)y)->i16);
+Value *lte_Int16(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Int16 *)x)->i16 <=
+                             ((Value_Int16 *)y)->i16);
 }
-Value *lte_Int32(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Int32 *)x)->i32 <= ((Value_Int32 *)y)->i32);
+Value *lte_Int32(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Int32 *)x)->i32 <=
+                             ((Value_Int32 *)y)->i32);
 }
-Value *lte_Int64(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Int64 *)x)->i64 <= ((Value_Int64 *)y)->i64);
+Value *lte_Int64(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Int64 *)x)->i64 <=
+                             ((Value_Int64 *)y)->i64);
 }
-Value *lte_Integer(Value *x, Value *y)
-{
+Value *lte_Integer(Value *x, Value *y) {
     return (Value *)makeBool(
-        mpz_cmp(((Value_Integer *)x)->i, ((Value_Integer *)y)->i) <= 0
-    );
+        mpz_cmp(((Value_Integer *)x)->i, ((Value_Integer *)y)->i) <= 0);
 }
-Value *lte_double(Value *x, Value *y)
-{
+Value *lte_double(Value *x, Value *y) {
     return (Value *)makeBool(((Value_Double *)x)->d <= ((Value_Double *)y)->d);
 }
-Value *lte_char(Value *x, Value *y)
-{
+Value *lte_char(Value *x, Value *y) {
     return (Value *)makeBool(((Value_Char *)x)->c <= ((Value_Char *)y)->c);
 }
-Value *lte_string(Value *x, Value *y)
-{
-    return (Value *)makeBool(strcmp(((Value_String *)x)->str, ((Value_String *)y)->str) <= 0);
+Value *lte_string(Value *x, Value *y) {
+    return (Value *)makeBool(
+        strcmp(((Value_String *)x)->str, ((Value_String *)y)->str) <= 0);
 }
 
 /* gte */
-Value *gte_Bits8(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Bits8 *)x)->ui8 >= ((Value_Bits8 *)y)->ui8);
+Value *gte_Bits8(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Bits8 *)x)->ui8 >=
+                             ((Value_Bits8 *)y)->ui8);
 }
-Value *gte_Bits16(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Bits16 *)x)->ui16 >= ((Value_Bits16 *)y)->ui16);
+Value *gte_Bits16(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Bits16 *)x)->ui16 >=
+                             ((Value_Bits16 *)y)->ui16);
 }
-Value *gte_Bits32(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Bits32 *)x)->ui32 >= ((Value_Bits32 *)y)->ui32);
+Value *gte_Bits32(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Bits32 *)x)->ui32 >=
+                             ((Value_Bits32 *)y)->ui32);
 }
-Value *gte_Bits64(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Bits64 *)x)->ui64 >= ((Value_Bits64 *)y)->ui64);
+Value *gte_Bits64(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Bits64 *)x)->ui64 >=
+                             ((Value_Bits64 *)y)->ui64);
 }
-Value *gte_Int8(Value *x, Value *y)
-{
+Value *gte_Int8(Value *x, Value *y) {
     return (Value *)makeBool(((Value_Int8 *)x)->i8 >= ((Value_Int8 *)y)->i8);
 }
-Value *gte_Int16(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Int16 *)x)->i16 >= ((Value_Int16 *)y)->i16);
+Value *gte_Int16(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Int16 *)x)->i16 >=
+                             ((Value_Int16 *)y)->i16);
 }
-Value *gte_Int32(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Int32 *)x)->i32 >= ((Value_Int32 *)y)->i32);
+Value *gte_Int32(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Int32 *)x)->i32 >=
+                             ((Value_Int32 *)y)->i32);
 }
-Value *gte_Int64(Value *x, Value *y)
-{
-    return (Value *)makeBool(((Value_Int64 *)x)->i64 >= ((Value_Int64 *)y)->i64);
+Value *gte_Int64(Value *x, Value *y) {
+    return (Value *)makeBool(((Value_Int64 *)x)->i64 >=
+                             ((Value_Int64 *)y)->i64);
 }
-Value *gte_Integer(Value *x, Value *y)
-{
+Value *gte_Integer(Value *x, Value *y) {
     return (Value *)makeBool(
-        mpz_cmp(((Value_Integer *)x)->i, ((Value_Integer *)y)->i) >= 0
-    );
+        mpz_cmp(((Value_Integer *)x)->i, ((Value_Integer *)y)->i) >= 0);
 }
-Value *gte_double(Value *x, Value *y)
-{
+Value *gte_double(Value *x, Value *y) {
     return (Value *)makeBool(((Value_Double *)x)->d >= ((Value_Double *)y)->d);
 }
-Value *gte_char(Value *x, Value *y)
-{
+Value *gte_char(Value *x, Value *y) {
     return (Value *)makeBool(((Value_Char *)x)->c >= ((Value_Char *)y)->c);
 }
-Value *gte_string(Value *x, Value *y)
-{
-    return (Value *)makeBool(strcmp(((Value_String *)x)->str, ((Value_String *)y)->str) >= 0);
+Value *gte_string(Value *x, Value *y) {
+    return (Value *)makeBool(
+        strcmp(((Value_String *)x)->str, ((Value_String *)y)->str) >= 0);
 }

--- a/support/refc/mathFunctions.h
+++ b/support/refc/mathFunctions.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "cBackend.h"
-#include <math.h>
 #include <gmp.h>
+#include <math.h>
 
 double unpackDouble(Value *d);
 Value *believe_me(Value *, Value *, Value *);

--- a/support/refc/memoryManagement.c
+++ b/support/refc/memoryManagement.c
@@ -1,15 +1,13 @@
 #include "runtime.h"
 
-Value *newValue()
-{
+Value *newValue() {
     Value *retVal = (Value *)malloc(sizeof(Value));
     retVal->header.refCounter = 1;
     retVal->header.tag = NO_TAG;
     return retVal;
 }
 
-Value_Arglist *newArglist(int missing, int total)
-{
+Value_Arglist *newArglist(int missing, int total) {
     Value_Arglist *retVal = (Value_Arglist *)newValue();
     retVal->header.tag = ARGLIST_TAG;
     retVal->total = total;
@@ -19,8 +17,7 @@ Value_Arglist *newArglist(int missing, int total)
     return retVal;
 }
 
-Value_Constructor *newConstructor(int total, int tag, const char *name)
-{
+Value_Constructor *newConstructor(int total, int tag, const char *name) {
     Value_Constructor *retVal = (Value_Constructor *)newValue();
     retVal->header.tag = CONSTRUCTOR_TAG;
     retVal->total = total;
@@ -33,121 +30,106 @@ Value_Constructor *newConstructor(int total, int tag, const char *name)
     return retVal;
 }
 
-Value_Closure *makeClosureFromArglist(fun_ptr_t f, Value_Arglist *arglist)
-{
+Value_Closure *makeClosureFromArglist(fun_ptr_t f, Value_Arglist *arglist) {
     Value_Closure *retVal = (Value_Closure *)newValue();
     retVal->header.tag = CLOSURE_TAG;
-    retVal->arglist = arglist; // (Value_Arglist *)newReference((Value*)arglist);
+    retVal->arglist =
+        arglist; // (Value_Arglist *)newReference((Value*)arglist);
     retVal->f = f;
-    if (retVal->arglist->filled >= retVal->arglist->total)
-    {
+    if (retVal->arglist->filled >= retVal->arglist->total) {
         retVal->header.tag = COMPLETE_CLOSURE_TAG;
     }
     return retVal;
 }
 
-Value_Double *makeDouble(double d)
-{
+Value_Double *makeDouble(double d) {
     Value_Double *retVal = (Value_Double *)newValue();
     retVal->header.tag = DOUBLE_TAG;
     retVal->d = d;
     return retVal;
 }
 
-Value_Char *makeChar(char c)
-{
+Value_Char *makeChar(char c) {
     Value_Char *retVal = (Value_Char *)newValue();
     retVal->header.tag = CHAR_TAG;
     retVal->c = c;
     return retVal;
 }
 
-Value_Bits8 *makeBits8(uint8_t i)
-{
+Value_Bits8 *makeBits8(uint8_t i) {
     Value_Bits8 *retVal = (Value_Bits8 *)newValue();
     retVal->header.tag = BITS8_TAG;
     retVal->ui8 = i;
     return retVal;
 }
 
-Value_Bits16 *makeBits16(uint16_t i)
-{
+Value_Bits16 *makeBits16(uint16_t i) {
     Value_Bits16 *retVal = (Value_Bits16 *)newValue();
     retVal->header.tag = BITS16_TAG;
     retVal->ui16 = i;
     return retVal;
 }
 
-Value_Bits32 *makeBits32(uint32_t i)
-{
+Value_Bits32 *makeBits32(uint32_t i) {
     Value_Bits32 *retVal = (Value_Bits32 *)newValue();
     retVal->header.tag = BITS32_TAG;
     retVal->ui32 = i;
     return retVal;
 }
 
-Value_Bits64 *makeBits64(uint64_t i)
-{
+Value_Bits64 *makeBits64(uint64_t i) {
     Value_Bits64 *retVal = (Value_Bits64 *)newValue();
     retVal->header.tag = BITS64_TAG;
     retVal->ui64 = i;
     return retVal;
 }
 
-Value_Int8 *makeInt8(int8_t i)
-{
+Value_Int8 *makeInt8(int8_t i) {
     Value_Int8 *retVal = (Value_Int8 *)newValue();
     retVal->header.tag = INT8_TAG;
     retVal->i8 = i;
     return retVal;
 }
 
-Value_Int16 *makeInt16(int16_t i)
-{
+Value_Int16 *makeInt16(int16_t i) {
     Value_Int16 *retVal = (Value_Int16 *)newValue();
     retVal->header.tag = INT16_TAG;
     retVal->i16 = i;
     return retVal;
 }
 
-Value_Int32 *makeInt32(int32_t i)
-{
+Value_Int32 *makeInt32(int32_t i) {
     Value_Int32 *retVal = (Value_Int32 *)newValue();
     retVal->header.tag = INT32_TAG;
     retVal->i32 = i;
     return retVal;
 }
 
-Value_Int64 *makeInt64(int64_t i)
-{
+Value_Int64 *makeInt64(int64_t i) {
     Value_Int64 *retVal = (Value_Int64 *)newValue();
     retVal->header.tag = INT64_TAG;
     retVal->i64 = i;
     return retVal;
 }
 
-Value_Int8 *makeBool(int p)
-{
+Value_Int8 *makeBool(int p) {
     return makeInt8(p ? 1 : 0);
 }
 
-Value_Integer *makeInteger()
-{
+Value_Integer *makeInteger() {
     Value_Integer *retVal = (Value_Integer *)newValue();
     retVal->header.tag = INTEGER_TAG;
     mpz_init(retVal->i);
     return retVal;
 }
 
-Value_Integer *makeIntegerLiteral(char *i)
-{
+Value_Integer *makeIntegerLiteral(char *i) {
     Value_Integer *retVal = makeInteger();
     mpz_set_str(retVal->i, i, 10);
     return retVal;
 }
 
-Value_String *makeEmptyString(size_t l)
-{
+Value_String *makeEmptyString(size_t l) {
     Value_String *retVal = (Value_String *)newValue();
     retVal->header.tag = STRING_TAG;
     retVal->str = malloc(l);
@@ -155,8 +137,7 @@ Value_String *makeEmptyString(size_t l)
     return retVal;
 }
 
-Value_String *makeString(char *s)
-{
+Value_String *makeString(char *s) {
     Value_String *retVal = (Value_String *)newValue();
     int l = strlen(s);
     retVal->header.tag = STRING_TAG;
@@ -166,16 +147,14 @@ Value_String *makeString(char *s)
     return retVal;
 }
 
-Value_Pointer *makePointer(void *ptr_Raw)
-{
+Value_Pointer *makePointer(void *ptr_Raw) {
     Value_Pointer *p = (Value_Pointer *)newValue();
     p->header.tag = POINTER_TAG;
     p->p = ptr_Raw;
     return p;
 }
 
-Value_GCPointer *makeGCPointer(void *ptr_Raw, Value_Closure *onCollectFct)
-{
+Value_GCPointer *makeGCPointer(void *ptr_Raw, Value_Closure *onCollectFct) {
     Value_GCPointer *p = (Value_GCPointer *)newValue();
     p->header.tag = GC_POINTER_TAG;
     p->p = makePointer(ptr_Raw);
@@ -183,16 +162,14 @@ Value_GCPointer *makeGCPointer(void *ptr_Raw, Value_Closure *onCollectFct)
     return p;
 }
 
-Value_Buffer *makeBuffer(void *buf)
-{
+Value_Buffer *makeBuffer(void *buf) {
     Value_Buffer *b = (Value_Buffer *)newValue();
     b->header.tag = BUFFER_TAG;
     b->buffer = buf;
     return b;
 }
 
-Value_Array *makeArray(int length)
-{
+Value_Array *makeArray(int length) {
     Value_Array *a = (Value_Array *)newValue();
     a->header.tag = ARRAY_TAG;
     a->capacity = length;
@@ -201,28 +178,23 @@ Value_Array *makeArray(int length)
     return a;
 }
 
-Value_World *makeWorld()
-{
+Value_World *makeWorld() {
     Value_World *retVal = (Value_World *)newValue();
     retVal->header.tag = WORLD_TAG;
     retVal->listIORefs = NULL;
     return retVal;
 }
 
-Value *newReference(Value *source)
-{
+Value *newReference(Value *source) {
     // note that we explicitly allow NULL as source (for erased arguments)
-    if (source)
-    {
+    if (source) {
         source->header.refCounter++;
     }
     return source;
 }
 
-void removeReference(Value *elem)
-{
-    if (!elem)
-    {
+void removeReference(Value *elem) {
+    if (!elem) {
         return;
     }
     // remove reference counter
@@ -230,8 +202,7 @@ void removeReference(Value *elem)
     if (elem->header.refCounter == 0)
     // recursively remove all references to all children
     {
-        switch (elem->header.tag)
-        {
+        switch (elem->header.tag) {
         case BITS8_TAG:
         case BITS16_TAG:
         case BITS32_TAG:
@@ -242,8 +213,7 @@ void removeReference(Value *elem)
         case INT64_TAG:
             /* nothing to delete, added for sake of completeness */
             break;
-        case INTEGER_TAG:
-        {
+        case INTEGER_TAG: {
             mpz_clear(((Value_Integer *)elem)->i);
             break;
         }
@@ -257,39 +227,32 @@ void removeReference(Value *elem)
             free(((Value_String *)elem)->str);
             break;
 
-        case CLOSURE_TAG:
-        {
+        case CLOSURE_TAG: {
             Value_Closure *cl = (Value_Closure *)elem;
             Value_Arglist *al = cl->arglist;
             removeReference((Value *)al);
             break;
         }
-        case COMPLETE_CLOSURE_TAG:
-        {
+        case COMPLETE_CLOSURE_TAG: {
             Value_Closure *cl = (Value_Closure *)elem;
             Value_Arglist *al = cl->arglist;
             removeReference((Value *)al);
             break;
         }
-        case ARGLIST_TAG:
-        {
+        case ARGLIST_TAG: {
             Value_Arglist *al = (Value_Arglist *)elem;
-            for (int i = 0; i < al->filled; i++)
-            {
+            for (int i = 0; i < al->filled; i++) {
                 removeReference(al->args[i]);
             }
             free(al->args);
             break;
         }
-        case CONSTRUCTOR_TAG:
-        {
+        case CONSTRUCTOR_TAG: {
             Value_Constructor *constr = (Value_Constructor *)elem;
-            for (int i = 0; i < constr->total; i++)
-            {
+            for (int i = 0; i < constr->total; i++) {
                 removeReference(constr->args[i]);
             }
-            if (constr->name)
-            {
+            if (constr->name) {
                 free(constr->name);
             }
             free(constr->args);
@@ -299,18 +262,15 @@ void removeReference(Value *elem)
             /* nothing to delete, added for sake of completeness */
             break;
 
-        case BUFFER_TAG:
-        {
+        case BUFFER_TAG: {
             Value_Buffer *b = (Value_Buffer *)elem;
             free(b->buffer);
             break;
         }
 
-        case ARRAY_TAG:
-        {
+        case ARRAY_TAG: {
             Value_Array *a = (Value_Array *)elem;
-            for (int i = 0; i < a->capacity; i++)
-            {
+            for (int i = 0; i < a->capacity; i++) {
                 removeReference(a->arr[i]);
             }
             free(a->arr);
@@ -320,24 +280,21 @@ void removeReference(Value *elem)
             /* nothing to delete, added for sake of completeness */
             break;
 
-        case GC_POINTER_TAG:
-        {
+        case GC_POINTER_TAG: {
             /* maybe here we need to invoke onCollectAny */
             Value_GCPointer *vPtr = (Value_GCPointer *)elem;
-            Value *closure1 = apply_closure((Value *)vPtr->onCollectFct, (Value *)vPtr->p);
+            Value *closure1 =
+                apply_closure((Value *)vPtr->onCollectFct, (Value *)vPtr->p);
             apply_closure(closure1, NULL);
             removeReference(closure1);
             removeReference((Value *)vPtr->onCollectFct);
             removeReference((Value *)vPtr->p);
             break;
         }
-        case WORLD_TAG:
-        {
+        case WORLD_TAG: {
             Value_World *w = (Value_World *)elem;
-            if (w->listIORefs)
-            {
-                for (int i = 0; i < w->listIORefs->filled; i++)
-                {
+            if (w->listIORefs) {
+                for (int i = 0; i < w->listIORefs->filled; i++) {
                     removeReference(w->listIORefs->refs[i]);
                 }
                 free(w->listIORefs->refs);

--- a/support/refc/prim.h
+++ b/support/refc/prim.h
@@ -2,8 +2,6 @@
 
 #include "cBackend.h"
 
-
-
 // IORef
 
 Value *newIORef(Value *, Value *, Value *);
@@ -13,7 +11,7 @@ Value *writeIORef(Value *, Value *, Value *, Value *);
 // Sys
 
 Value *sysOS(void);
-Value* idris2_crash(Value* msg);
+Value *idris2_crash(Value *msg);
 
 // Array
 
@@ -38,7 +36,8 @@ Value *System_Concurrency_Raw_prim__makeCondition(Value *);
 
 Value *System_Concurrency_Raw_prim__conditionWait(Value *, Value *, Value *);
 
-Value *System_Concurrency_Raw_prim__conditionWaitTimeout(Value *, Value *, Value *, Value *);
+Value *System_Concurrency_Raw_prim__conditionWaitTimeout(Value *, Value *,
+                                                         Value *, Value *);
 
 Value *System_Concurrency_Raw_prim__conditionSignal(Value *, Value *);
 

--- a/support/refc/runtime.c
+++ b/support/refc/runtime.c
@@ -1,144 +1,120 @@
 #include "runtime.h"
 
-void missing_ffi()
-{
-  fprintf(
-    stderr,
-    "Foreign function declared, but not defined.\n"
-    "Cannot call missing FFI - aborting.\n"
-  );
-  exit(1);
-}
-
-void push_Arglist(Value_Arglist *arglist, Value *arg)
-{
-  if (arglist->filled >= arglist->total)
-  {
-    fprintf(stderr, "unable to add more arguments to arglist\n");
+void missing_ffi() {
+    fprintf(stderr, "Foreign function declared, but not defined.\n"
+                    "Cannot call missing FFI - aborting.\n");
     exit(1);
-  }
-
-  arglist->args[arglist->filled] = newReference(arg);
-  arglist->filled++;
 }
 
-Value *apply_closure(Value *_clos, Value *arg)
-{
-  // create a new arg list
-  Value_Arglist *oldArgs = ((Value_Closure *)_clos)->arglist;
-  Value_Arglist *newArgs = newArglist(0, oldArgs->total);
-  newArgs->filled = oldArgs->filled + 1;
-  // add argument to new arglist
-  for (int i = 0; i < oldArgs->filled; i++)
-  {
-    newArgs->args[i] = newReference(oldArgs->args[i]);
-  }
-  newArgs->args[oldArgs->filled] = newReference(arg);
-
-  Value_Closure *clos = (Value_Closure *)_clos;
-
-  // check if enough arguments exist
-  if (newArgs->filled >= newArgs->total)
-  {
-    fun_ptr_t f = clos->f;
-    while (1)
-    {
-      Value *retVal = f(newArgs);
-      removeReference((Value *)newArgs);
-      if (!retVal || retVal->header.tag != COMPLETE_CLOSURE_TAG)
-      {
-        return retVal;
-      }
-      f = ((Value_Closure *)retVal)->f;
-      newArgs = ((Value_Closure *)retVal)->arglist;
-      newArgs = (Value_Arglist *)newReference((Value *)newArgs);
-      removeReference(retVal);
+void push_Arglist(Value_Arglist *arglist, Value *arg) {
+    if (arglist->filled >= arglist->total) {
+        fprintf(stderr, "unable to add more arguments to arglist\n");
+        exit(1);
     }
-  }
 
-  return (Value *)makeClosureFromArglist(clos->f, newArgs);
+    arglist->args[arglist->filled] = newReference(arg);
+    arglist->filled++;
 }
 
-Value *tailcall_apply_closure(Value *_clos, Value *arg)
-{
-  // create a new arg list
-  Value_Arglist *oldArgs = ((Value_Closure *)_clos)->arglist;
-  Value_Arglist *newArgs = newArglist(0, oldArgs->total);
-  newArgs->filled = oldArgs->filled + 1;
-  // add argument to new arglist
-  for (int i = 0; i < oldArgs->filled; i++)
-  {
-    newArgs->args[i] = newReference(oldArgs->args[i]);
-  }
-  newArgs->args[oldArgs->filled] = newReference(arg);
+Value *apply_closure(Value *_clos, Value *arg) {
+    // create a new arg list
+    Value_Arglist *oldArgs = ((Value_Closure *)_clos)->arglist;
+    Value_Arglist *newArgs = newArglist(0, oldArgs->total);
+    newArgs->filled = oldArgs->filled + 1;
+    // add argument to new arglist
+    for (int i = 0; i < oldArgs->filled; i++) {
+        newArgs->args[i] = newReference(oldArgs->args[i]);
+    }
+    newArgs->args[oldArgs->filled] = newReference(arg);
 
-  Value_Closure *clos = (Value_Closure *)_clos;
+    Value_Closure *clos = (Value_Closure *)_clos;
 
-  // check if enough arguments exist
-  if (newArgs->filled >= newArgs->total)
+    // check if enough arguments exist
+    if (newArgs->filled >= newArgs->total) {
+        fun_ptr_t f = clos->f;
+        while (1) {
+            Value *retVal = f(newArgs);
+            removeReference((Value *)newArgs);
+            if (!retVal || retVal->header.tag != COMPLETE_CLOSURE_TAG) {
+                return retVal;
+            }
+            f = ((Value_Closure *)retVal)->f;
+            newArgs = ((Value_Closure *)retVal)->arglist;
+            newArgs = (Value_Arglist *)newReference((Value *)newArgs);
+            removeReference(retVal);
+        }
+    }
+
     return (Value *)makeClosureFromArglist(clos->f, newArgs);
-
-  return (Value *)makeClosureFromArglist(clos->f, newArgs);
 }
 
-int extractInt(Value *v)
-{
-  if (v->header.tag == INTEGER_TAG)
-  {
-    return (int)mpz_get_si(((Value_Integer *)v)->i);
-  }
-
-  if (v->header.tag == INT8_TAG)
-  {
-    return (int)((Value_Int8 *)v)->i8;
-  }
-
-  if (v->header.tag == INT16_TAG)
-  {
-    return (int)((Value_Int16 *)v)->i16;
-  }
-
-  if (v->header.tag == INT32_TAG)
-  {
-    return (int)((Value_Int32 *)v)->i32;
-  }
-
-  if (v->header.tag == INT64_TAG)
-  {
-    return (int)((Value_Int64 *)v)->i64;
-  }
-
-  if (v->header.tag == DOUBLE_TAG)
-  {
-    return (int)((Value_Double *)v)->d;
-  }
-
-  if (v->header.tag == CHAR_TAG)
-  {
-    return (int)((Value_Char *)v)->c;
-  }
-
-  return -1;
-}
-
-Value *trampoline(Value *closure)
-{
-  fun_ptr_t f = ((Value_Closure *)closure)->f;
-  Value_Arglist *_arglist = ((Value_Closure *)closure)->arglist;
-  Value_Arglist *arglist = (Value_Arglist *)newReference((Value *)_arglist);
-  removeReference(closure);
-  while (1)
-  {
-    Value *retVal = f(arglist);
-    removeReference((Value *)arglist);
-    if (!retVal || retVal->header.tag != COMPLETE_CLOSURE_TAG)
-    {
-      return retVal;
+Value *tailcall_apply_closure(Value *_clos, Value *arg) {
+    // create a new arg list
+    Value_Arglist *oldArgs = ((Value_Closure *)_clos)->arglist;
+    Value_Arglist *newArgs = newArglist(0, oldArgs->total);
+    newArgs->filled = oldArgs->filled + 1;
+    // add argument to new arglist
+    for (int i = 0; i < oldArgs->filled; i++) {
+        newArgs->args[i] = newReference(oldArgs->args[i]);
     }
-    f = ((Value_Closure *)retVal)->f;
-    arglist = ((Value_Closure *)retVal)->arglist;
-    arglist = (Value_Arglist *)newReference((Value *)arglist);
-    removeReference(retVal);
-  }
-  return NULL;
+    newArgs->args[oldArgs->filled] = newReference(arg);
+
+    Value_Closure *clos = (Value_Closure *)_clos;
+
+    // check if enough arguments exist
+    if (newArgs->filled >= newArgs->total)
+        return (Value *)makeClosureFromArglist(clos->f, newArgs);
+
+    return (Value *)makeClosureFromArglist(clos->f, newArgs);
+}
+
+int extractInt(Value *v) {
+    if (v->header.tag == INTEGER_TAG) {
+        return (int)mpz_get_si(((Value_Integer *)v)->i);
+    }
+
+    if (v->header.tag == INT8_TAG) {
+        return (int)((Value_Int8 *)v)->i8;
+    }
+
+    if (v->header.tag == INT16_TAG) {
+        return (int)((Value_Int16 *)v)->i16;
+    }
+
+    if (v->header.tag == INT32_TAG) {
+        return (int)((Value_Int32 *)v)->i32;
+    }
+
+    if (v->header.tag == INT64_TAG) {
+        return (int)((Value_Int64 *)v)->i64;
+    }
+
+    if (v->header.tag == DOUBLE_TAG) {
+        return (int)((Value_Double *)v)->d;
+    }
+
+    if (v->header.tag == CHAR_TAG) {
+        return (int)((Value_Char *)v)->c;
+    }
+
+    return -1;
+}
+
+Value *trampoline(Value *closure) {
+    fun_ptr_t f = ((Value_Closure *)closure)->f;
+    Value_Arglist *_arglist = ((Value_Closure *)closure)->arglist;
+    Value_Arglist *arglist = (Value_Arglist *)newReference((Value *)_arglist);
+    removeReference(closure);
+    while (1) {
+        Value *retVal = f(arglist);
+        removeReference((Value *)arglist);
+        if (!retVal || retVal->header.tag != COMPLETE_CLOSURE_TAG) {
+            return retVal;
+        }
+        f = ((Value_Closure *)retVal)->f;
+        arglist = ((Value_Closure *)retVal)->arglist;
+        arglist = (Value_Arglist *)newReference((Value *)arglist);
+        removeReference(retVal);
+    }
+    return NULL;
 }

--- a/support/refc/stringOps.c
+++ b/support/refc/stringOps.c
@@ -1,42 +1,35 @@
 #include "stringOps.h"
 
-Value *stringLength(Value *s)
-{
+Value *stringLength(Value *s) {
     int length = strlen(((Value_String *)s)->str);
     return (Value *)makeInt64(length);
 }
 
-Value *head(Value *str)
-{
+Value *head(Value *str) {
     Value_Char *c = (Value_Char *)newValue();
     c->header.tag = CHAR_TAG;
     c->c = ((Value_String *)str)->str[0];
     return (Value *)c;
 }
 
-Value *tail(Value *input)
-{
+Value *tail(Value *input) {
     Value_String *tailStr = (Value_String *)newValue();
     tailStr->header.tag = STRING_TAG;
     Value_String *s = (Value_String *)input;
     int l = strlen(s->str);
-    if(l != 0)
-    {
+    if (l != 0) {
         tailStr->str = malloc(l);
         memset(tailStr->str, 0, l);
         memcpy(tailStr->str, s->str + 1, l - 1);
         return (Value *)tailStr;
-    }
-    else
-    {
+    } else {
         tailStr->str = malloc(1);
         tailStr->str[0] = '\0';
         return (Value *)tailStr;
     }
 }
 
-Value *reverse(Value *str)
-{
+Value *reverse(Value *str) {
     Value_String *retVal = (Value_String *)newValue();
     retVal->header.tag = STRING_TAG;
     Value_String *input = (Value_String *)str;
@@ -45,22 +38,19 @@ Value *reverse(Value *str)
     memset(retVal->str, 0, l + 1);
     char *p = retVal->str;
     char *q = input->str + (l - 1);
-    for (int i = 0; i < l; i++)
-    {
+    for (int i = 0; i < l; i++) {
         *p++ = *q--;
     }
     return (Value *)retVal;
 }
 
-Value *strIndex(Value *str, Value *i)
-{
+Value *strIndex(Value *str, Value *i) {
     char *s = ((Value_String *)str)->str;
     int idx = ((Value_Int64 *)i)->i64;
     return (Value *)makeChar(s[idx]);
 }
 
-Value *strCons(Value *c, Value *str)
-{
+Value *strCons(Value *c, Value *str) {
     int l = strlen(((Value_String *)str)->str);
     Value_String *retVal = makeEmptyString(l + 2);
     retVal->str[0] = ((Value_Char *)c)->c;
@@ -68,8 +58,7 @@ Value *strCons(Value *c, Value *str)
     return (Value *)retVal;
 }
 
-Value *strAppend(Value *a, Value *b)
-{
+Value *strAppend(Value *a, Value *b) {
     int la = strlen(((Value_String *)a)->str);
     int lb = strlen(((Value_String *)b)->str);
     Value_String *retVal = makeEmptyString(la + lb + 1);
@@ -78,15 +67,13 @@ Value *strAppend(Value *a, Value *b)
     return (Value *)retVal;
 }
 
-Value *strSubstr(Value *start, Value *len, Value *s)
-{
+Value *strSubstr(Value *start, Value *len, Value *s) {
     char *input = ((Value_String *)s)->str;
     int offset = extractInt(start);
     int l = extractInt(len);
 
     int tailLen = strlen(input);
-    if (tailLen < l)
-    {
+    if (tailLen < l) {
         l = tailLen;
     }
 
@@ -96,15 +83,13 @@ Value *strSubstr(Value *start, Value *len, Value *s)
     return (Value *)retVal;
 }
 
-char *fastPack(Value *charList)
-{
+char *fastPack(Value *charList) {
     Value_Constructor *current;
 
     int l = 0;
     current = (Value_Constructor *)charList;
-    while (current->total == 2)
-    {
-        l ++;
+    while (current->total == 2) {
+        l++;
         current = (Value_Constructor *)current->args[1];
     }
 
@@ -113,8 +98,7 @@ char *fastPack(Value *charList)
 
     int i = 0;
     current = (Value_Constructor *)charList;
-    while (current->total == 2)
-    {
+    while (current->total == 2) {
         retVal[i++] = ((Value_Char *)current->args[0])->c;
         current = (Value_Constructor *)current->args[1];
     }
@@ -122,13 +106,13 @@ char *fastPack(Value *charList)
     return retVal;
 }
 
-Value *fastUnpack(char *str)
-{
+Value *fastUnpack(char *str) {
     if (str[0] == '\0') {
         return (Value *)newConstructor(0, 0, "Prelude_Types_Nil");
     }
 
-    Value_Constructor *retVal = newConstructor(2, 1, "Prelude_Types__colon_colon");
+    Value_Constructor *retVal =
+        newConstructor(2, 1, "Prelude_Types__colon_colon");
     retVal->args[0] = (Value *)makeChar(str[0]);
 
     int i = 1;
@@ -139,7 +123,7 @@ Value *fastUnpack(char *str)
         next->args[0] = (Value *)makeChar(str[i]);
         current->args[1] = (Value *)next;
 
-        i ++;
+        i++;
         current = next;
     }
     current->args[1] = (Value *)newConstructor(0, 0, "Prelude_Types_Nil");
@@ -147,14 +131,12 @@ Value *fastUnpack(char *str)
     return (Value *)retVal;
 }
 
-char *fastConcat(Value *strList)
-{
+char *fastConcat(Value *strList) {
     Value_Constructor *current;
 
     int totalLength = 0;
     current = (Value_Constructor *)strList;
-    while (current->total == 2)
-    {
+    while (current->total == 2) {
         totalLength += strlen(((Value_String *)current->args[0])->str);
         current = (Value_Constructor *)current->args[1];
     }
@@ -166,8 +148,7 @@ char *fastConcat(Value *strList)
     int currentStrLen;
     int offset = 0;
     current = (Value_Constructor *)strList;
-    while (current->total == 2)
-    {
+    while (current->total == 2) {
         currentStr = ((Value_String *)current->args[0])->str;
         currentStrLen = strlen(currentStr);
         memcpy(retVal + offset, currentStr, currentStrLen);
@@ -179,14 +160,12 @@ char *fastConcat(Value *strList)
     return retVal;
 }
 
-typedef struct
-{
+typedef struct {
     char *str;
     int pos;
 } String_Iterator;
 
-Value *stringIteratorNew(char *str)
-{
+Value *stringIteratorNew(char *str) {
     int l = strlen(str);
 
     String_Iterator *it = (String_Iterator *)malloc(sizeof(String_Iterator));
@@ -195,36 +174,31 @@ Value *stringIteratorNew(char *str)
     memcpy(it->str, str, l + 1); // Take a copy of str, in case it gets GCed
 
     Value_Arglist *arglist = newArglist(2, 2);
-    Value *(*onCollectRaw)(Value_Arglist*) = onCollectStringIterator_arglist;
+    Value *(*onCollectRaw)(Value_Arglist *) = onCollectStringIterator_arglist;
     Value_Closure *onCollect = makeClosureFromArglist(onCollectRaw, arglist);
 
     return (Value *)makeGCPointer(it, onCollect);
 }
 
-Value *onCollectStringIterator(Value_Pointer *ptr, void *null)
-{
+Value *onCollectStringIterator(Value_Pointer *ptr, void *null) {
     String_Iterator *it = (String_Iterator *)ptr->p;
     free(it->str);
     free(it);
     return NULL;
 }
 
-Value *onCollectStringIterator_arglist(Value_Arglist *arglist)
-{
-    return onCollectStringIterator(
-        (Value_Pointer *)arglist->args[0],
-        arglist->args[1]
-    );
+Value *onCollectStringIterator_arglist(Value_Arglist *arglist) {
+    return onCollectStringIterator((Value_Pointer *)arglist->args[0],
+                                   arglist->args[1]);
 }
 
-Value *stringIteratorToString(void *a, char *str, Value *it_p, Value_Closure *f)
-{
+Value *stringIteratorToString(void *a, char *str, Value *it_p,
+                              Value_Closure *f) {
     String_Iterator *it = ((Value_GCPointer *)it_p)->p->p;
     return apply_closure((Value *)f, (Value *)makeString(it->str + it->pos));
 }
 
-Value *stringIteratorNext(char *s, Value *it_p)
-{
+Value *stringIteratorNext(char *s, Value *it_p) {
     String_Iterator *it = (String_Iterator *)((Value_GCPointer *)it_p)->p->p;
     char c = it->str[it->pos];
 
@@ -232,9 +206,10 @@ Value *stringIteratorNext(char *s, Value *it_p)
         return (Value *)newConstructor(0, 0, "Data_String_Iterator_EOF");
     }
 
-    it->pos ++; // Ok to do this as StringIterator linear
+    it->pos++; // Ok to do this as StringIterator linear
 
-    Value_Constructor *retVal = newConstructor(2, 1, "Data_String_Iterator_Character");
+    Value_Constructor *retVal =
+        newConstructor(2, 1, "Data_String_Iterator_Character");
     retVal->args[0] = (Value *)makeChar(c);
     retVal->args[1] = newReference(it_p);
 

--- a/support/refc/stringOps.h
+++ b/support/refc/stringOps.h
@@ -17,5 +17,6 @@ char *fastConcat(Value *strList);
 Value *stringIteratorNew(char *str);
 Value *onCollectStringIterator(Value_Pointer *ptr, void *null);
 Value *onCollectStringIterator_arglist(Value_Arglist *arglist);
-Value *stringIteratorToString(void *a, char *str, Value *it_p, Value_Closure *f);
+Value *stringIteratorToString(void *a, char *str, Value *it_p,
+                              Value_Closure *f);
 Value *stringIteratorNext(char *s, Value *it_p);

--- a/tests/chez/chez010/cblib.c
+++ b/tests/chez/chez010/cblib.c
@@ -1,10 +1,10 @@
 #include <stdio.h>
 
-typedef int(*IntFn)(int, int);
-typedef char(*CharFn)(char, int);
+typedef int (*IntFn)(int, int);
+typedef char (*CharFn)(char, int);
 
 int add(int x, int y) {
-    return x+y;
+    return x + y;
 }
 
 int applyIntFn(int x, int y, IntFn f) {

--- a/tests/chez/chez013/struct.c
+++ b/tests/chez/chez013/struct.c
@@ -1,24 +1,24 @@
-#include <stdlib.h>
-#include <stdio.h>
 #include "struct.h"
+#include <stdio.h>
+#include <stdlib.h>
 
-char* getString(void *p) {
-    return (char*)p;
+char *getString(void *p) {
+    return (char *)p;
 }
 
-point* mkPoint(int x, int y) {
-    point* pt = malloc(sizeof(point));
+point *mkPoint(int x, int y) {
+    point *pt = malloc(sizeof(point));
     pt->x = x;
     pt->y = y;
     return pt;
 }
 
-void freePoint(point* pt) {
+void freePoint(point *pt) {
     free(pt);
 }
 
-namedpoint* mkNamedPoint(char* str, point* p) {
-    namedpoint* np = malloc(sizeof(namedpoint));
+namedpoint *mkNamedPoint(char *str, point *p) {
+    namedpoint *np = malloc(sizeof(namedpoint));
     np->name = str;
     np->pt = p;
     printf("Made it!\n");
@@ -26,6 +26,6 @@ namedpoint* mkNamedPoint(char* str, point* p) {
     return np;
 }
 
-void freeNamedPoint(namedpoint* np) {
+void freeNamedPoint(namedpoint *np) {
     free(np);
 }

--- a/tests/chez/chez013/struct.h
+++ b/tests/chez/chez013/struct.h
@@ -6,14 +6,14 @@ typedef struct {
 } point;
 
 typedef struct {
-    char* name;
-    point* pt;
+    char *name;
+    point *pt;
 } namedpoint;
 
-point* mkPoint(int x, int y);
-void freePoint(point* pt);
+point *mkPoint(int x, int y);
+void freePoint(point *pt);
 
-namedpoint* mkNamedPoint(char* str, point* p);
-void freeNamedPoint(namedpoint* np);
+namedpoint *mkNamedPoint(char *str, point *p);
+void freeNamedPoint(namedpoint *np);
 
-char* getString(void *p);
+char *getString(void *p);

--- a/tests/chez/chez022/mkalloc.c
+++ b/tests/chez/chez022/mkalloc.c
@@ -1,26 +1,26 @@
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 typedef struct {
     int val;
-    char* str;
+    char *str;
 } Stuff;
 
-Stuff* mkThing() {
+Stuff *mkThing() {
     static int num = 0;
-    Stuff* x = malloc(sizeof(Stuff));
+    Stuff *x = malloc(sizeof(Stuff));
     x->val = num++;
     x->str = malloc(20);
-    strcpy(x->str,"Hello");
+    strcpy(x->str, "Hello");
     return x;
 }
 
-char* getStr(Stuff* x) {
+char *getStr(Stuff *x) {
     return x->str;
 }
 
-void freeThing(Stuff* x) {
+void freeThing(Stuff *x) {
     printf("Freeing %d %s\n", x->val, x->str);
     free(x->str);
     free(x);


### PR DESCRIPTION
* Add `.clang-format` with some meaningful values
* There's no single style in C code, so any options will cause reformatting
* Run it

`clang-format` seems to be not supported by super-linter out of the
box, so the correctness of the style won't be checked.

One possible option is to add
[clang-format lint action](https://github.com/marketplace/actions/clang-format-lint).