### PR TITLE
IDRIS2_VERIFY macro

### DIFF
--- a/support/c/idris_directory.c
+++ b/support/c/idris_directory.c
@@ -1,13 +1,18 @@
 #include "idris_directory.h"
 
+#include <dirent.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <dirent.h>
-#include <stdlib.h>
 #include <unistd.h>
+
+#include "idris_util.h"
 
 char* idris2_currentDirectory() {
    char* cwd = malloc(1024); // probably ought to deal with the unlikely event of this being too small
+   IDRIS2_VERIFY(cwd, "malloc failed");
    return getcwd(cwd, 1024); // Freed by RTS
 }
 
@@ -34,6 +39,7 @@ void* idris2_openDir(char* dir) {
         return NULL;
     } else {
         DirInfo* di = malloc(sizeof(DirInfo));
+        IDRIS2_VERIFY(di, "malloc failed");
         di->dirptr = d;
         di->error = 0;
 
@@ -44,7 +50,7 @@ void* idris2_openDir(char* dir) {
 void idris2_closeDir(void* d) {
     DirInfo* di = (DirInfo*)d;
 
-    closedir(di->dirptr);
+    IDRIS2_VERIFY(closedir(di->dirptr) == 0, "closedir failed: %s", strerror(errno));
     free(di);
 }
 

--- a/support/c/idris_file.c
+++ b/support/c/idris_file.c
@@ -1,12 +1,13 @@
 #include "getline.h"
 #include "idris_file.h"
 
-#include <fcntl.h>
-#include <errno.h>
-#include <sys/stat.h>
-#include <time.h>
-#include <sys/time.h>
 #include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <time.h>
 #include <unistd.h>
 
 #ifdef _WIN32
@@ -14,6 +15,8 @@
 #else
 #include <sys/select.h>
 #endif
+
+#include "idris_util.h"
 
 FILE* idris2_openFile(char* name, char* mode) {
 #ifdef _WIN32
@@ -25,7 +28,7 @@ FILE* idris2_openFile(char* name, char* mode) {
 }
 
 void idris2_closeFile(FILE* f) {
-    fclose(f);
+    IDRIS2_VERIFY(fclose(f) == 0, "fclose failed: %s", strerror(errno));
 }
 
 int idris2_fileError(FILE* f) {
@@ -90,10 +93,11 @@ void *idris2_popen(const char *cmd, const char *mode) {
 
 void idris2_pclose(void *stream) {
 #ifdef _WIN32
-    _pclose(stream);
+    int r = _pclose(stream);
 #else
-    pclose(stream);
+    int r = pclose(stream);
 #endif
+    IDRIS2_VERIFY(r != -1, "pclose failed");
 }
 
 // seek through the next newline, consuming and

--- a/support/c/idris_memory.c
+++ b/support/c/idris_memory.c
@@ -1,15 +1,13 @@
 #include "idris_memory.h"
 
 #include <errno.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
+#include "idris_util.h"
+
 void* idris2_malloc(int size) {
-    if (size < 0) {
-        fprintf(stderr, "malloc negative argument: %d\n", size);
-        abort();
-    }
+    IDRIS2_VERIFY(size >= 0, "malloc negative argument: %d", size);
 
     if (size == 0) {
         // Do not depend on platform-speific behavior of malloc.
@@ -17,10 +15,7 @@ void* idris2_malloc(int size) {
     }
 
     void* ptr = malloc(size);
-    if (!ptr) {
-        fprintf(stderr, "malloc failed: %s\n", strerror(errno));
-        abort();
-    }
+    IDRIS2_VERIFY(ptr, "malloc failed: %s", strerror(errno));
     return ptr;
 }
 

--- a/support/c/idris_net.c
+++ b/support/c/idris_net.c
@@ -8,6 +8,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "idris_util.h"
+
 #ifndef _WIN32
 #include <netinet/in.h>
 #include <arpa/inet.h>

--- a/support/c/idris_support.c
+++ b/support/c/idris_support.c
@@ -68,6 +68,8 @@ void idris2_sleep(int sec) {
     t.tv_sec = sec;
     t.tv_nsec = 0;
 
+    // TODO: `nanosleep` can fail
+    // TODO: `nanosleep` can return early due to interrupt
     nanosleep(&t, NULL);
 #endif
 }

--- a/support/c/idris_util.c
+++ b/support/c/idris_util.c
@@ -1,0 +1,16 @@
+#include "idris_util.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+void idris2_verify_failed(const char* file, int line, const char* cond, const char* fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+
+    char message[1000];
+    snprintf(message, sizeof(message), fmt, ap);
+
+    fprintf(stderr, "assertion failed in %s:%d: %s: %s\n", file, line, cond, message);
+    abort();
+}

--- a/support/c/idris_util.h
+++ b/support/c/idris_util.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <stdnoreturn.h>
+
+// Utilities used by FFI code.
+
+// Crash is the condition is false.
+#define IDRIS2_VERIFY(cond, ...) \
+    do { \
+        if (!(cond)) { \
+            idris2_verify_failed(__FILE__, __LINE__, #cond, __VA_ARGS__); \
+        } \
+    } while (0)
+
+// Used by `IDRIS2_VERIFY`, do not use directly.
+noreturn void idris2_verify_failed(const char* file, int line, const char* cond, const char* fmt, ...)
+#if defined(__clang__) || defined(__GNUC__)
+__attribute__ ((format(printf, 4, 5)))
+#endif
+;


### PR DESCRIPTION
```
IDRIS2_VERIFY(cond, message_format, ...)
```

When condition is false, crash.

Used in native functions where correct error handling is hard or
not impossible.

For example, `malloc` rarely fails, but if it fails, better crash
with clear error message than spend time debugging null pointer
dereference.