### PR TITLE
[ refactor, breaking ] Redesign Functor interface hierarchy as suggested in #1325

### DIFF
--- a/libs/base/Control/App.idr
+++ b/libs/base/Control/App.idr
@@ -186,14 +186,20 @@ Functor (App {l} es) where
   map f ap = bindApp ap $ \ap' => pureApp (f ap')
 
 export
+Apply (App {l} es) where
+  (<*>) f a = bindApp f $ \f' =>
+              bindApp a $ \a' => pureApp (f' a')
+
+export
 Applicative (App {l} es) where
   pure = pureApp
-  (<*>) f a = bindApp f $ \f' =>
-              bindApp a $ \a' => pure (f' a')
+
+export
+Bind (App es) where
+  (>>=) = bindApp -- won't get used, but handy to have the instance
 
 export
 Monad (App es) where
-  (>>=) = bindApp -- won't get used, but handy to have the instance
 
 export
 (>>=) : SafeBind l l' =>

--- a/libs/base/Control/Applicative/Const.idr
+++ b/libs/base/Control/Applicative/Const.idr
@@ -85,9 +85,12 @@ Contravariant (Const a) where
   contramap _ (MkConst v) = MkConst v
 
 public export
+Semigroup a => Apply (Const a) where
+  MkConst x <*> MkConst y = MkConst (x <+> y)
+
+public export
 Monoid a => Applicative (Const a) where
   pure _ = MkConst neutral
-  MkConst x <*> MkConst y = MkConst (x <+> y)
 
 public export
 Foldable (Const a) where

--- a/libs/base/Control/Monad/Error/Either.idr
+++ b/libs/base/Control/Monad/Error/Either.idr
@@ -117,25 +117,34 @@ Traversable m => Traversable (EitherT e m) where
     = MkEitherT <$> traverse (either (pure . Left) (map Right . f)) x
 
 public export
+Apply m => Apply (EitherT e m) where
+  f <*> x = MkEitherT $ (<*>) <$> runEitherT f <*> runEitherT x
+
+public export
 Applicative m => Applicative (EitherT e m) where
   pure = MkEitherT . pure . Right
-  f <*> x = MkEitherT [| runEitherT f <*> runEitherT x |]
+
+public export
+Monad m => Bind (EitherT e m) where
+  x >>= k = MkEitherT $ runEitherT x >>= either (pure . Left) (runEitherT . k)
 
 public export
 Monad m => Monad (EitherT e m) where
-  x >>= k = MkEitherT $ runEitherT x >>= either (pure . Left) (runEitherT . k)
 
-||| Alternative instance that collects left results, allowing you to try
-||| multiple possibilities and combine failures.
 public export
-(Monad m, Monoid e) => Alternative (EitherT e m) where
-  empty = left neutral
+(Monad m, Semigroup e) => Alt (EitherT e m) where
   MkEitherT x <|> MkEitherT y = MkEitherT $ do
     Left l <- x
       | Right r => pure (Right r)
     Left l' <- y
       | Right r => pure (Right r)
     pure (Left (l <+> l'))
+
+||| Alternative instance that collects left results, allowing you to try
+||| multiple possibilities and combine failures.
+public export
+(Monad m, Monoid e) => Alternative (EitherT e m) where
+  empty = left neutral
 
 public export
 MonadTrans (EitherT e) where

--- a/libs/base/Control/Monad/Identity.idr
+++ b/libs/base/Control/Monad/Identity.idr
@@ -14,13 +14,19 @@ Functor Identity where
     map fn (Id a) = Id (fn a)
 
 public export
-Applicative Identity where
-    pure x = Id x
+Apply Identity where
     (Id f) <*> (Id g) = Id (f g)
 
 public export
-Monad Identity where
+Applicative Identity where
+    pure x = Id x
+
+public export
+Bind Identity where
     (Id x) >>= k = k x
+
+public export
+Monad Identity where
 
 public export
 Show a => Show (Identity a) where

--- a/libs/base/Control/Monad/Maybe.idr
+++ b/libs/base/Control/Monad/Maybe.idr
@@ -118,19 +118,29 @@ Traversable m => Traversable (MaybeT m) where
     = MkMaybeT <$> traverse (maybe (pure Nothing) (map Just . f)) x
 
 public export
+Apply m => Apply (MaybeT m) where
+  MkMaybeT f <*> MkMaybeT x = MkMaybeT $ (<*>) <$> f <*> x
+
+public export
 Applicative m => Applicative (MaybeT m) where
   pure = just
-  MkMaybeT f <*> MkMaybeT x = MkMaybeT [| f <*> x |]
+
+public export
+Monad m => Bind (MaybeT m) where
+  MkMaybeT x >>= k = MkMaybeT $ x >>= maybe (pure Nothing) (runMaybeT . k)
 
 public export
 Monad m => Monad (MaybeT m) where
-  MkMaybeT x >>= k = MkMaybeT $ x >>= maybe (pure Nothing) (runMaybeT . k)
+
+||| See note about Monad prerequisite on Semigroup instance.
+public export
+Monad m => Alt (MaybeT m) where
+  a <|> b = a <+> b
 
 ||| See note about Monad prerequisite on Semigroup instance.
 public export
 Monad m => Alternative (MaybeT m) where
   empty = nothing
-  a <|> b = a <+> b
 
 public export
 MonadTrans MaybeT where

--- a/libs/base/Control/Monad/RWS/CPS.idr
+++ b/libs/base/Control/Monad/RWS/CPS.idr
@@ -109,22 +109,31 @@ Functor m => Functor (RWST r w s m) where
   map f m = MkRWST \r,s,w => (\(a,s',w') => (f a,s',w')) <$> unRWST m r s w
 
 public export %inline
-Monad m => Applicative (RWST r w s m) where
-  pure a = MkRWST \_,s,w => pure (a,s,w)
+Monad m => Apply (RWST r w s m) where
   MkRWST mf <*> MkRWST mx =
     MkRWST \r,s,w => do (f,s1,w1) <- mf r s w
                         (a,s2,w2) <- mx r s1 w1
                         pure (f a,s2,w2)
 
 public export %inline
-(Monad m, Alternative m) => Alternative (RWST r w s m) where
-  empty = MkRWST \_,_,_ => empty
+Monad m => Applicative (RWST r w s m) where
+  pure a = MkRWST \_,s,w => pure (a,s,w)
+
+public export %inline
+(Monad m, Alt m) => Alt (RWST r w s m) where
   MkRWST m <|> MkRWST n = MkRWST \r,s,w => m r s w <|> n r s w
 
 public export %inline
-Monad m => Monad (RWST r w s m) where
+(Monad m, Alternative m) => Alternative (RWST r w s m) where
+  empty = MkRWST \_,_,_ => empty
+
+public export %inline
+Monad m => Bind (RWST r w s m) where
   m >>= k = MkRWST \r,s,w => do (a,s1,w1) <- unRWST m r s w
                                 unRWST (k a) r s1 w1
+
+public export %inline
+Monad m => Monad (RWST r w s m) where
 
 public export %inline
 MonadTrans (RWST r w s) where

--- a/libs/base/Control/Monad/Reader/Reader.idr
+++ b/libs/base/Control/Monad/Reader/Reader.idr
@@ -45,9 +45,7 @@ implementation Functor f => Functor (ReaderT stateType f) where
   map f (MkReaderT g) = MkReaderT (\st => map f (g st))
 
 public export
-implementation Applicative f => Applicative (ReaderT stateType f) where
-  pure x = MkReaderT (\st => pure x)
-
+implementation Apply f => Apply (ReaderT stateType f) where
   (MkReaderT f) <*> (MkReaderT a) =
     MkReaderT (\st =>
       let f' = f st in
@@ -55,11 +53,18 @@ implementation Applicative f => Applicative (ReaderT stateType f) where
       f' <*> a')
 
 public export
-implementation Monad m => Monad (ReaderT stateType m) where
+implementation Applicative f => Applicative (ReaderT stateType f) where
+  pure x = MkReaderT (\st => pure x)
+
+public export
+implementation Bind m => Bind (ReaderT stateType m) where
   (MkReaderT f) >>= k =
     MkReaderT (\st => do v <- f st
                          let MkReaderT kv = k v
                          kv st)
+
+public export
+implementation Monad m => Monad (ReaderT stateType m) where
 
 public export
 implementation MonadTrans (ReaderT stateType) where
@@ -70,7 +75,9 @@ implementation HasIO m => HasIO (ReaderT stateType m) where
   liftIO f = MkReaderT (\_ => liftIO f)
 
 public export
+implementation Alt f => Alt (ReaderT stateType f) where
+  (MkReaderT f) <|> (MkReaderT g) = MkReaderT (\st => f st <|> g st)
+
+public export
 implementation (Monad f, Alternative f) => Alternative (ReaderT stateType f) where
   empty = lift empty
-
-  (MkReaderT f) <|> (MkReaderT g) = MkReaderT (\st => f st <|> g st)

--- a/libs/base/Control/Monad/ST.idr
+++ b/libs/base/Control/Monad/ST.idr
@@ -23,16 +23,22 @@ Functor (ST s) where
   map fn (MkST st) = MkST $ fn <$> st
 
 export
-Applicative (ST s) where
-  pure = MkST . pure
+Apply (ST s) where
   MkST f <*> MkST a = MkST $ f <*> a
 
 export
-Monad (ST s) where
+Applicative (ST s) where
+  pure = MkST . pure
+
+export
+Bind (ST s) where
   MkST p >>= k
       = MkST $ do p' <- p
                   let MkST kp = k p'
                   kp
+
+export
+Monad (ST s) where
 
 export
 newSTRef : a -> ST s (STRef s a)

--- a/libs/base/Control/Monad/State/State.idr
+++ b/libs/base/Control/Monad/State/State.idr
@@ -72,9 +72,7 @@ implementation Functor f => Functor (StateT stateType f) where
     map f (ST g) = ST (\st => map (map f) (g st)) where
 
 public export
-implementation Monad f => Applicative (StateT stateType f) where
-    pure x = ST (\st => pure (st, x))
-
+implementation Monad f => Apply (StateT stateType f) where
     (ST f) <*> (ST a)
         = ST (\st =>
                 do (r, g) <- f st
@@ -82,12 +80,19 @@ implementation Monad f => Applicative (StateT stateType f) where
                    pure (t, g b))
 
 public export
-implementation Monad m => Monad (StateT stateType m) where
+implementation Monad f => Applicative (StateT stateType f) where
+    pure x = ST (\st => pure (st, x))
+
+public export
+implementation Monad m => Bind (StateT stateType m) where
     (ST f) >>= k
         = ST (\st =>
                 do (st', v) <- f st
                    let ST kv = k v
                    kv st')
+
+public export
+implementation Monad m => Monad (StateT stateType m) where
 
 public export
 implementation MonadTrans (StateT stateType) where
@@ -97,9 +102,12 @@ implementation MonadTrans (StateT stateType) where
                    pure (st, r))
 
 public export
+implementation Monad f => Alt f => Alt (StateT st f) where
+    (ST f) <|> (ST g) = ST (\st => f st <|> g st)
+
+public export
 implementation (Monad f, Alternative f) => Alternative (StateT st f) where
     empty = lift empty
-    (ST f) <|> (ST g) = ST (\st => f st <|> g st)
 
 public export
 implementation HasIO m => HasIO (StateT stateType m) where

--- a/libs/base/Control/Monad/Writer/CPS.idr
+++ b/libs/base/Control/Monad/Writer/CPS.idr
@@ -83,22 +83,31 @@ Functor m => Functor (WriterT w m) where
   map f m = MkWriterT \w => (\(a,w') => (f a,w')) <$> unWriterT m w
 
 public export %inline
-Monad m => Applicative (WriterT w m) where
-  pure a = MkWriterT \w => pure (a,w)
+Monad m => Apply (WriterT w m) where
   MkWriterT mf <*> MkWriterT mx =
     MkWriterT \w => do (f,w1) <- mf w
                        (a,w2) <- mx w1
                        pure (f a,w2)
 
 public export %inline
-(Monad m, Alternative m) => Alternative (WriterT w m) where
-  empty = MkWriterT \_ => empty
+Monad m => Applicative (WriterT w m) where
+  pure a = MkWriterT \w => pure (a,w)
+
+public export %inline
+(Monad m, Alt m) => Alt (WriterT w m) where
   MkWriterT m <|> MkWriterT n = MkWriterT \w => m w <|> n w
 
 public export %inline
-Monad m => Monad (WriterT w m) where
+(Monad m, Alternative m) => Alternative (WriterT w m) where
+  empty = MkWriterT \_ => empty
+
+public export %inline
+Monad m => Bind (WriterT w m) where
   m >>= k = MkWriterT \w => do (a,w1) <- unWriterT m w
                                unWriterT (k a) w1
+
+public export %inline
+Monad m => Monad (WriterT w m) where
 
 public export %inline
 MonadTrans (WriterT w) where

--- a/libs/base/Data/Colist.idr
+++ b/libs/base/Data/Colist.idr
@@ -243,12 +243,14 @@ Functor Colist where
   map f (x :: xs) = f x :: map f xs
 
 public export
-Applicative Colist where
-  pure = repeat
-
+Apply Colist where
   [] <*> _  = []
   _  <*> [] = []
   f :: fs <*> a :: as = f a :: (fs <*> as)
+
+public export
+Applicative Colist where
+  pure = repeat
 
 public export
 Zippable Colist where

--- a/libs/base/Data/Colist1.idr
+++ b/libs/base/Data/Colist1.idr
@@ -185,10 +185,12 @@ Functor Colist1 where
   map f (x ::: xs) = f x ::: map f xs
 
 public export
+Apply Colist1 where
+  (f ::: fs) <*> (a ::: as) = f a ::: (fs <*> as)
+
+public export
 Applicative Colist1 where
   pure = repeat
-
-  (f ::: fs) <*> (a ::: as) = f a ::: (fs <*> as)
 
 public export
 Zippable Colist1 where

--- a/libs/base/Data/List1.idr
+++ b/libs/base/Data/List1.idr
@@ -123,13 +123,23 @@ Functor List1 where
   map f (x ::: xs) = f x ::: map f xs
 
 public export
+Apply List1 where
+  f ::: fs <*> xs = appendl (map f xs) (fs <*> forget xs)
+
+public export
 Applicative List1 where
   pure x = singleton x
-  f ::: fs <*> xs = appendl (map f xs) (fs <*> forget xs)
+
+export
+Bind List1 where
+  (x ::: xs) >>= f = appendl (f x) (xs >>= forget . f)
 
 export
 Monad List1 where
-  (x ::: xs) >>= f = appendl (f x) (xs >>= forget . f)
+
+public export
+Alt List1 where
+  a <|> b = a ++ b
 
 export
 Foldable List1 where
@@ -140,8 +150,18 @@ Foldable List1 where
   foldMap f (x ::: xs) = f x <+> foldMap f xs
 
 export
+Foldable1 List1 where
+  foldMap1 f (x ::: xs) = foldl (\a,e => a <+> f e) (f x) xs
+
+export
 Traversable List1 where
   traverse f (x ::: xs) = [| f x ::: traverse f xs |]
+
+export
+Traversable1 List1 where
+  traverse1 f (x ::: []) = (::: []) <$> f x
+  traverse1 f l@(x ::: (h :: t)) =
+    cons <$> f x <*> traverse1 f (assert_smaller l (h ::: t))
 
 export
 Show a => Show (List1 a) where

--- a/libs/base/Data/Morphisms.idr
+++ b/libs/base/Data/Morphisms.idr
@@ -35,13 +35,19 @@ Functor (Morphism r) where
   map f (Mor a) = Mor $ f . a
 
 export
-Applicative (Morphism r) where
-  pure a = Mor $ const a
+Apply (Morphism r) where
   (Mor f) <*> (Mor a) = Mor $ \r => f r $ a r
 
 export
-Monad (Morphism r) where
+Applicative (Morphism r) where
+  pure a = Mor $ const a
+
+export
+Bind (Morphism r) where
   (Mor h) >>= f = Mor $ \r => applyMor (f $ h r) r
+
+export
+Monad (Morphism r) where
 
 export
 Semigroup a => Semigroup (Morphism r a) where
@@ -64,15 +70,21 @@ Functor f => Functor (Kleislimorphism f a) where
   map f (Kleisli g) = Kleisli (map f . g)
 
 export
-Applicative f => Applicative (Kleislimorphism f a) where
-  pure a = Kleisli $ const $ pure a
+Apply f => Apply (Kleislimorphism f a) where
   (Kleisli f) <*> (Kleisli a) = Kleisli $ \r => f r <*> a r
 
 export
-Monad f => Monad (Kleislimorphism f a) where
+Applicative f => Applicative (Kleislimorphism f a) where
+  pure a = Kleisli $ const $ pure a
+
+export
+Bind f => Bind (Kleislimorphism f a) where
   (Kleisli f) >>= g = Kleisli $ \r => do
     k1 <- f r
     applyKleisli (g k1) r
+
+export
+Monad f => Monad (Kleislimorphism f a) where
 
 public export
 Contravariant (Op b) where

--- a/libs/base/Data/SnocList.idr
+++ b/libs/base/Data/SnocList.idr
@@ -111,13 +111,19 @@ Foldable SnocList where
   foldMap f = foldl (\xs, x => xs <+> f x) neutral
 
 public export
-Applicative SnocList where
-  pure = (:<) Lin
+Apply SnocList where
   fs <*> xs = concatMap (flip map xs) fs
 
 public export
-Monad SnocList where
+Applicative SnocList where
+  pure = (:<) Lin
+
+public export
+Bind SnocList where
   xs >>= k = concatMap k xs
+
+public export
+Monad SnocList where
 
 public export
 Traversable SnocList where
@@ -125,9 +131,12 @@ Traversable SnocList where
   traverse f (xs :< x) = [| traverse f xs :< f x |]
 
 public export
+Alt SnocList where
+  xs <|> ys = xs ++ ys
+
+public export
 Alternative SnocList where
   empty = Lin
-  xs <|> ys = xs ++ ys
 
 ||| Check if something is a member of a snoc-list using the default Boolean equality.
 public export

--- a/libs/base/Data/Stream.idr
+++ b/libs/base/Data/Stream.idr
@@ -168,13 +168,19 @@ namespace Pair
 --------------------------------------------------------------------------------
 
 export
-Applicative Stream where
-  pure = repeat
+Apply Stream where
   (<*>) = zipWith apply
 
 export
-Monad Stream where
+Applicative Stream where
+  pure = repeat
+
+export
+Bind Stream where
   s >>= f = diag (map f s)
+
+export
+Monad Stream where
 
 --------------------------------------------------------------------------------
 -- Properties

--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -850,14 +850,20 @@ transpose (x :: xs) = zipWith (::) x (transpose xs) -- = [| x :: xs |]
 -- These only work if the length is known at run time!
 
 public export
+implementation Apply (Vect k) where
+    fs <*> vs = zipWith apply fs vs
+
+public export
+implementation Bind (Vect k) where
+    m >>= f = diag (map f m)
+
+public export
 implementation {k : Nat} -> Applicative (Vect k) where
     pure = replicate _
-    fs <*> vs = zipWith apply fs vs
 
 -- ||| This monad is different from the List monad, (>>=)
 -- ||| uses the diagonal.
 implementation {k : Nat} -> Monad (Vect k) where
-    m >>= f = diag (map f m)
 
 public export
 implementation Traversable (Vect k) where

--- a/libs/base/Language/Reflection.idr
+++ b/libs/base/Language/Reflection.idr
@@ -52,13 +52,19 @@ Functor Elab where
   map f e = Bind e $ Pure . f
 
 export
-Applicative Elab where
-  pure = Pure
+Apply Elab where
   f <*> a = Bind f (<$> a)
 
 export
-Monad Elab where
+Applicative Elab where
+  pure = Pure
+
+export
+Bind Elab where
   (>>=) = Bind
+
+export
+Monad Elab where
 
 ||| Report an error in elaboration
 export

--- a/libs/base/System/File.idr
+++ b/libs/base/System/File.idr
@@ -330,8 +330,8 @@ readLinesOnto acc offset (More fuel) h
   = do False <- fEOF h
          | True => pure $ Right (True, reverse acc)
        case offset of
-            (S offset') => (fSeekLine h *> readLinesOnto acc offset' (More fuel) h) @{Applicative.Compose}
-            0           => (fGetLine h >>= \str => readLinesOnto (str :: acc) 0 fuel h) @{Monad.Compose}
+            (S offset') => (fSeekLine h *> readLinesOnto acc offset' (More fuel) h) @{Apply.Compose}
+            0           => (fGetLine h >>= \str => readLinesOnto (str :: acc) 0 fuel h) @{Monad.ComposeBind}
 
 ||| Read a chunk of a file in a line-delimited fashion.
 ||| You can use this function to read an entire file

--- a/libs/contrib/Control/Arrow.idr
+++ b/libs/contrib/Control/Arrow.idr
@@ -113,14 +113,20 @@ implementation Arrow a => Functor (ArrowMonad a) where
   map f (MkArrowMonad m) = MkArrowMonad $ m >>> arrow f
 
 public export
-implementation Arrow a => Applicative (ArrowMonad a) where
-  pure x = MkArrowMonad $ arrow $ \_ => x
+implementation Arrow a => Apply (ArrowMonad a) where
   (MkArrowMonad f) <*> (MkArrowMonad x) = MkArrowMonad $ f &&& x >>> arrow (uncurry id)
 
 public export
-implementation ArrowApply a => Monad (ArrowMonad a) where
+implementation Arrow a => Applicative (ArrowMonad a) where
+  pure x = MkArrowMonad $ arrow $ \_ => x
+
+public export
+implementation ArrowApply a => Bind (ArrowMonad a) where
   (MkArrowMonad m) >>= f =
     MkArrowMonad $ m >>> (arrow $ \x => (runArrowMonad (f x), ())) >>> app
+
+public export
+implementation ArrowApply a => Monad (ArrowMonad a) where
 
 public export
 interface Arrow arr => ArrowLoop (0 arr : Type -> Type -> Type) where

--- a/libs/contrib/Control/Category.idr
+++ b/libs/contrib/Control/Category.idr
@@ -4,24 +4,33 @@ import Data.Morphisms
 
 
 public export
-interface Category (0 cat : obj -> obj -> Type) | cat where
-  id  : cat a a
+interface Semigroupoid (0 cat : obj -> obj -> Type) | cat where
   (.) : cat b c -> cat a b -> cat a c
 
 public export
-Category Morphism where
-  id                = Mor id
+interface Semigroupoid cat => Category (0 cat : obj -> obj -> Type) where
+  id  : cat a a
+
+public export
+Semigroupoid Morphism where
   -- disambiguation needed below, because unification can now get further
   -- here with Category.(.) and it's only interface resolution that fails!
   (Mor f) . (Mor g) = Mor $ Basics.(.) f g
 
 public export
+Category Morphism where
+  id                = Mor id
+
+public export
+Bind m => Semigroupoid (Kleislimorphism m) where
+  (Kleisli f) . (Kleisli g) = Kleisli $ \a => g a >>= f
+
+public export
 Monad m => Category (Kleislimorphism m) where
   id                        = Kleisli (pure . id)
-  (Kleisli f) . (Kleisli g) = Kleisli $ \a => g a >>= f
 
 infixr 1 >>>
 
 public export
-(>>>) : Category cat => cat a b -> cat b c -> cat a c
+(>>>) : Semigroupoid cat => cat a b -> cat b c -> cat a c
 f >>> g = g . f

--- a/libs/contrib/Control/Linear/LIO.idr
+++ b/libs/contrib/Control/Linear/LIO.idr
@@ -94,16 +94,22 @@ Functor io => Functor (L io) where
   map fn act = Bind act \a' => PureW (fn a')
 
 export
-Applicative io => Applicative (L io) where
-  pure = PureW
+Apply io => Apply (L io) where
   (<*>) f a
       = f `Bind` \f' =>
         a `Bind` \a' =>
         PureW (f' a')
 
 export
-(Applicative m, LinearBind m) => Monad (L m) where
+Applicative io => Applicative (L io) where
+  pure = PureW
+
+export
+(Applicative m, LinearBind m) => Bind (L m) where
   (>>=) a k = Bind a k
+
+export
+(Applicative m, LinearBind m) => Monad (L m) where
 
 -- prioritise this one for concrete LIO, so we get the most useful
 -- linearity annotations.

--- a/libs/contrib/Control/Validation.idr
+++ b/libs/contrib/Control/Validation.idr
@@ -66,15 +66,21 @@ Functor m => Functor (ValidatorT m a) where
     map f v = MkValidator (map f . validateT v)
 
 export
-Monad m => Applicative (ValidatorT m a) where
-    pure a = MkValidator (const $ pure a)
+Monad m => Apply (ValidatorT m a) where
     f <*> a = MkValidator (\x => validateT f x <*> validateT a x)
 
 export
-Monad m => Monad (ValidatorT m a) where
+Monad m => Applicative (ValidatorT m a) where
+    pure a = MkValidator (const $ pure a)
+
+export
+Monad m => Bind (ValidatorT m a) where
     v >>= f = MkValidator $ \x => do
         r <- validateT v x
         validateT (f r) x
+
+export
+Monad m => Monad (ValidatorT m a) where
 
 ||| Plug a property validator into the chain of other validators. The value
 ||| under validation will be ignored and the value whose property is going to
@@ -103,7 +109,7 @@ export
 (>>>) : Monad m => ValidatorT m a b -> ValidatorT m b c -> ValidatorT m a c
 left >>> right = MkValidator (validateT left >=> validateT right)
 
-Monad m => Alternative (ValidatorT m a) where
+Monad m => Alt (ValidatorT m a) where
     left <|> right = MkValidator \x => MkEitherT $ do
         case !(runEitherT $ validateT left x) of
             (Right r) => pure $ Right r
@@ -111,6 +117,7 @@ Monad m => Alternative (ValidatorT m a) where
                 (Right r) => pure $ Right r
                 (Left e') => pure $ Left (e <+> " / " <+> e')
 
+Monad m => Alternative (ValidatorT m a) where
     empty = MkValidator \x => MkEitherT $ pure (Left "invalid")
 
 ||| Alter the input before validation using given function.

--- a/libs/contrib/Data/IMaybe.idr
+++ b/libs/contrib/Data/IMaybe.idr
@@ -18,6 +18,9 @@ Functor (IMaybe b) where
   map f Nothing = Nothing
 
 public export
+Apply (IMaybe True) where
+  Just f <*> Just x = Just (f x)
+
+public export
 Applicative (IMaybe True) where
   pure = Just
-  Just f <*> Just x = Just (f x)

--- a/libs/contrib/Data/InductionRecursion/DybjerSetzer.idr
+++ b/libs/contrib/Data/InductionRecursion/DybjerSetzer.idr
@@ -56,10 +56,16 @@ Functor (Code i) where
   map f v = bind v (Yield . f)
 
 public export
-Applicative (Code i) where
-  pure = Yield
+Apply (Code i) where
   cf <*> co = bind cf (\ f => map (f $) co)
 
 public export
-Monad (Code i) where
+Applicative (Code i) where
+  pure = Yield
+
+public export
+Bind (Code i) where
   (>>=) = bind
+
+public export
+Monad (Code i) where

--- a/libs/contrib/Data/Late.idr
+++ b/libs/contrib/Data/Late.idr
@@ -72,10 +72,16 @@ Functor Late where
   map f d = bind d (Now . f)
 
 public export
-Applicative Late where
-  pure = Now
+Apply Late where
   df <*> dx = bind df (\ f => map (f $) dx)
 
 public export
-Monad Late where
+Applicative Late where
+  pure = Now
+
+public export
+Bind Late where
   (>>=) = bind
+
+public export
+Monad Late where

--- a/libs/contrib/Data/List/Lazy.idr
+++ b/libs/contrib/Data/List/Lazy.idr
@@ -107,18 +107,27 @@ Functor LazyList where
   map f (x :: xs) = f x :: map f xs
 
 public export
+Apply LazyList where
+  fs <*> vs = bindLazy (\f => map f vs) fs
+
+public export
 Applicative LazyList where
   pure x = [x]
-  fs <*> vs = bindLazy (\f => map f vs) fs
+
+public export
+Alt LazyList where
+  (<|>) = (++)
 
 public export
 Alternative LazyList where
   empty = []
-  (<|>) = (++)
+
+public export
+Bind LazyList where
+  m >>= f = bindLazy f m
 
 public export
 Monad LazyList where
-  m >>= f = bindLazy f m
 
 -- There is no Traversable instance for lazy lists.
 -- The result of a traversal will be a non-lazy list in general

--- a/libs/contrib/Data/Recursion/Free.idr
+++ b/libs/contrib/Data/Recursion/Free.idr
@@ -69,13 +69,19 @@ Functor (General a b) where
   map f = fold (Tell . f) Ask
 
 public export
-Applicative (General a b) where
-  pure = Tell
+Apply (General a b) where
   gf <*> gv = bind gf (\ f => map (f $) gv)
 
 public export
-Monad (General a b) where
+Applicative (General a b) where
+  pure = Tell
+
+public export
+Bind (General a b) where
   (>>=) = bind
+
+public export
+Monad (General a b) where
 
 ------------------------------------------------------------------------
 -- Fuel-based (partial) evaluation

--- a/libs/contrib/Data/String/Parser.idr
+++ b/libs/contrib/Data/String/Parser.idr
@@ -44,24 +44,33 @@ Functor m => Functor (ParseT m) where
     map f p = P $ \s => map (map f) (p.runParser s)
 
 public export
-Monad m => Applicative (ParseT m) where
-    pure x = P $ \s => pure $ OK x s
+Monad m => Apply (ParseT m) where
     f <*> x = P $ \s => case !(f.runParser s) of
                             OK f' s' => map (map f') (x.runParser s')
                             Fail i err => pure $ Fail i err
 
 public export
-Monad m => Alternative (ParseT m) where
-    empty = P $ \s => pure $ Fail s.pos "no alternative left"
+Monad m => Applicative (ParseT m) where
+    pure x = P $ \s => pure $ OK x s
+
+public export
+Monad m => Alt (ParseT m) where
     a <|> b = P $ \s => case !(a.runParser s) of
                             OK r s' => pure $ OK r s'
                             Fail _ _ => b.runParser s
 
 public export
-Monad m => Monad (ParseT m) where
+Monad m => Alternative (ParseT m) where
+    empty = P $ \s => pure $ Fail s.pos "no alternative left"
+
+public export
+Monad m => Bind (ParseT m) where
     m >>= k = P $ \s => case !(m.runParser s) of
                              OK a s' => (k a).runParser s'
                              Fail i err => pure $ Fail i err
+
+public export
+Monad m => Monad (ParseT m) where
 
 public export
 MonadTrans ParseT where

--- a/libs/contrib/Data/Tree/Perfect.idr
+++ b/libs/contrib/Data/Tree/Perfect.idr
@@ -33,11 +33,13 @@ replicate Z a = Leaf a
 replicate (S n) a = let t = replicate n a in Node t t
 
 public export
-{n : _} -> Applicative (Tree n) where
-  pure = replicate n
-
+Apply (Tree n) where
   Leaf f <*> Leaf a = Leaf (f a)
   Node fl fr <*> Node xl xr = Node (fl <*> xl) (fr <*> xr)
+
+public export
+{n : _} -> Applicative (Tree n) where
+  pure = replicate n
 
 public export
 data Path : Nat -> Type where

--- a/libs/contrib/Data/Validated.idr
+++ b/libs/contrib/Data/Validated.idr
@@ -50,13 +50,16 @@ Bitraversable Validated where
 
 ||| Applicative composition preserves invalidity sequentially accumulating all errors.
 public export
-Semigroup e => Applicative (Validated e) where
-  pure = Valid
-
+Semigroup e => Apply (Validated e) where
   Valid f    <*> Valid x    = Valid $ f x
   Invalid e1 <*> Invalid e2 = Invalid $ e1 <+> e2
   Invalid e  <*> Valid _    = Invalid e
   Valid _    <*> Invalid e  = Invalid e
+
+||| Applicative composition preserves invalidity sequentially accumulating all errors.
+public export
+Semigroup e => Applicative (Validated e) where
+  pure = Valid
 
 -- There is no `Monad` implementation because it can't be coherent with the accumulating `Applicative` one.
 
@@ -75,11 +78,16 @@ Monoid e => Monoid (Validated e a) where
 ||| Alternative composition preserves validity selecting the leftmost valid value.
 ||| If both sides are invalid, errors are accumulated.
 public export
-Monoid e => Alternative (Validated e) where
-  empty = neutral
+Semigroup e => Alt (Validated e) where
   l@(Valid _) <|> _           = l
   _           <|> r@(Valid _) = r
   Invalid e1  <|> Invalid e2  = Invalid $ e1 <+> e2
+
+||| Alternative composition preserves validity selecting the leftmost valid value.
+||| If both sides are invalid, errors are accumulated.
+public export
+Monoid e => Alternative (Validated e) where
+  empty = neutral
 
 public export
 Foldable (Validated e) where

--- a/libs/contrib/Search/HDecidable.idr
+++ b/libs/contrib/Search/HDecidable.idr
@@ -67,24 +67,34 @@ Functor HDec where
   map f (MkHDec b prf) = MkHDec b (f . prf)
 
 public export
-Applicative HDec where
-  pure = yes
+Apply HDec where
   MkHDec False prff <*> _ = MkHDec False absurd
   _ <*> MkHDec False _ = MkHDec False absurd
   MkHDec True prff <*> MkHDec True prfx
     = yes (prff Oh (prfx Oh))
 
+public export
+Applicative HDec where
+  pure = yes
+
+||| Lazy in the second argument
+public export
+Alt HDec where
+  p@(MkHDec True _) <|> _ = p
+  _ <|> q = q
+
 ||| Lazy in the second argument
 public export
 Alternative HDec where
   empty = no
-  p@(MkHDec True _) <|> _ = p
-  _ <|> q = q
+
+public export
+Bind HDec where
+  MkHDec True x >>= f = f (x Oh)
+  _ >>= _ = no
 
 public export
 Monad HDec where
-  MkHDec True x >>= f = f (x Oh)
-  _ >>= _ = no
 
 public export
 Show f => Show (HDec f) where

--- a/libs/contrib/System/Future.idr
+++ b/libs/contrib/System/Future.idr
@@ -25,14 +25,20 @@ Functor Future where
   map func future = fork $ func (await future)
 
 public export
-Applicative Future where
-  pure v = fork v
+Apply Future where
   funcF <*> v = fork $ (await funcF) (await v)
 
 public export
-Monad Future where
+Applicative Future where
+  pure v = fork v
+
+public export
+Bind Future where
   join = map await
   v >>= func = join . fork $ func (await v)
+
+public export
+Monad Future where
 
 export
 performFutureIO : HasIO io => Future (IO a) -> io (Future a)

--- a/libs/prelude/Prelude/IO.idr
+++ b/libs/prelude/Prelude/IO.idr
@@ -18,8 +18,7 @@ Functor IO where
 
 %inline
 public export
-Applicative IO where
-  pure x = io_pure x
+Apply IO where
   f <*> a
       = io_bind f (\f' =>
           io_bind a (\a' =>
@@ -27,8 +26,17 @@ Applicative IO where
 
 %inline
 public export
-Monad IO where
+Applicative IO where
+  pure x = io_pure x
+
+%inline
+public export
+Bind IO where
   b >>= k = io_bind b k
+
+%inline
+public export
+Monad IO where
 
 public export
 interface Monad io => HasIO io where

--- a/libs/prelude/Prelude/Types.idr
+++ b/libs/prelude/Prelude/Types.idr
@@ -132,14 +132,22 @@ Functor (Pair a) where
 
 %inline
 public export
-Monoid a => Applicative (Pair a) where
-  pure = (neutral,)
+Semigroup a => Apply (Pair a) where
   (a1,f) <*> (a2,v) = (a1 <+> a2, f v)
 
 %inline
 public export
-Monoid a => Monad (Pair a) where
+Monoid a => Applicative (Pair a) where
+  pure = (neutral,)
+
+%inline
+public export
+Monoid a => Bind (Pair a) where
   (a1,a) >>= f = let (a2,b) = f a in (a1 <+> a2, b)
+
+%inline
+public export
+Monoid a => Monad (Pair a) where
 
 -----------
 -- MAYBE --
@@ -203,23 +211,30 @@ Functor Maybe where
   map f Nothing  = Nothing
 
 public export
+Apply Maybe where
+  Just f <*> Just a = Just (f a)
+  _      <*> _      = Nothing
+
+public export
 Applicative Maybe where
   pure = Just
 
-  Just f <*> Just a = Just (f a)
-  _      <*> _      = Nothing
+public export
+Alt Maybe where
+  (Just x) <|> _ = Just x
+  Nothing  <|> v = v
 
 public export
 Alternative Maybe where
   empty = Nothing
 
-  (Just x) <|> _ = Just x
-  Nothing  <|> v = v
+public export
+Bind Maybe where
+  Nothing  >>= k = Nothing
+  (Just x) >>= k = k x
 
 public export
 Monad Maybe where
-  Nothing  >>= k = Nothing
-  (Just x) >>= k = k x
 
 public export
 Foldable Maybe where
@@ -330,17 +345,28 @@ Bitraversable Either where
 
 %inline
 public export
-Applicative (Either e) where
-  pure = Right
-
+Apply (Either e) where
   (Left a) <*> _          = Left a
   (Right f) <*> (Right r) = Right (f r)
   (Right _) <*> (Left l)  = Left l
 
+%inline
 public export
-Monad (Either e) where
+Applicative (Either e) where
+  pure = Right
+
+public export
+Bind (Either e) where
   (Left n) >>= _ = Left n
   (Right r) >>= f = f r
+
+public export
+Monad (Either e) where
+
+public export
+Alt (Either e) where
+  (Right x) <|> _ = Right x
+  (Left _)  <|> v = v
 
 public export
 Foldable (Either e) where
@@ -414,18 +440,27 @@ Foldable List where
   foldMap f = foldl (\acc, elem => acc <+> f elem) neutral
 
 public export
+Apply List where
+  fs <*> vs = concatMap (\f => map f vs) fs
+
+public export
 Applicative List where
   pure x = [x]
-  fs <*> vs = concatMap (\f => map f vs) fs
+
+public export
+Alt List where
+  xs <|> ys = xs ++ ys
 
 public export
 Alternative List where
   empty = []
-  xs <|> ys = xs ++ ys
+
+public export
+Bind List where
+  m >>= f = concatMap f m
 
 public export
 Monad List where
-  m >>= f = concatMap f m
 
 public export
 Traversable List where

--- a/src/Libraries/Data/List/Lazy.idr
+++ b/src/Libraries/Data/List/Lazy.idr
@@ -42,20 +42,6 @@ Functor LazyList where
   map f [] = []
   map f (x :: xs) = f x :: map f xs
 
-public export
-Applicative LazyList where
-  pure x = [x]
-  fs <*> vs = concatMap (\f => map f vs) fs
-
-public export
-Alternative LazyList where
-  empty = []
-  xs <|> ys = xs ++ ys
-
-public export
-Monad LazyList where
-  m >>= f = concatMap f m
-
 -- There is no Traversable instance for lazy lists.
 -- The result of a traversal will be a non-lazy list in general
 -- (you can't delay the "effect" of an applicative functor).

--- a/tests/idris2/basic020/Mut.idr
+++ b/tests/idris2/basic020/Mut.idr
@@ -30,15 +30,19 @@ mutual
         = do b' <- b
              pure (f b')
 
-  Applicative Box where
+  Apply Box where
     (<*>) f a
         = do f' <- f
              a' <- a
              pure (f' a')
+
+  Applicative Box where
     pure = MkBox
 
-  Monad Box where
+  Bind Box where
     (>>=) (MkBox val) k = k val
+
+  Monad Box where
 
 boxy : Box Integer
 boxy = map (*2) (MkBox 20)

--- a/tests/idris2/docs001/expected
+++ b/tests/idris2/docs001/expected
@@ -68,12 +68,7 @@ Main> Prelude.show : Show ty => ty -> String
   Totality: total
 Main> Prelude.Monad : (Type -> Type) -> Type
   Parameters: m
-  Constraints: Applicative m
-  Methods:
-    (>>=) : m a -> (a -> m b) -> m b
-      Also called `bind`.
-    join : m (m a) -> m a
-      Also called `flatten` or mu.
+  Constraints: Applicative m, Bind m
   Implementations:
     Monad IO
     Monoid a => Monad (Pair a)

--- a/tests/idris2/interactive030/expected
+++ b/tests/idris2/interactive030/expected
@@ -20,12 +20,7 @@ Main> Prelude.<$> : Functor f => (a -> b) -> f a -> f b
   Fixity Declaration: infixr operator, level 4
 Main> Prelude.Monad : (Type -> Type) -> Type
   Parameters: m
-  Constraints: Applicative m
-  Methods:
-    (>>=) : m a -> (a -> m b) -> m b
-      Also called `bind`.
-    join : m (m a) -> m a
-      Also called `flatten` or mu.
+  Constraints: Applicative m, Bind m
   Implementations:
     Monad IO
     Monoid a => Monad (Pair a)
@@ -35,11 +30,11 @@ Main> Prelude.Monad : (Type -> Type) -> Type
 Main> Prelude.div : Integral ty => ty -> ty -> ty
   Totality: total
   Fixity Declaration: infixl operator, level 9
-Main> Prelude.>>= : Monad m => m a -> (a -> m b) -> m b
+Main> Prelude.>>= : Bind m => m a -> (a -> m b) -> m b
   Also called `bind`.
   Totality: total
   Fixity Declaration: infixl operator, level 1
-Main> Prelude.>> : Monad m => m () -> Lazy (m b) -> m b
+Main> Prelude.>> : Bind m => m () -> Lazy (m b) -> m b
   Sequencing of effectful composition
   Totality: total
   Fixity Declaration: infixl operator, level 1

--- a/tests/idris2/interface023/AppComp.idr
+++ b/tests/idris2/interface023/AppComp.idr
@@ -19,7 +19,7 @@ c1 : Monad m => m (Either String Int)
 c1 = f1 1 *> f2 1
 
 c2 : Monad m => m (Either String Int)
-c2 = (f1 1 *> f2 1) @{Applicative.Compose}
+c2 = (f1 1 *> f2 1) @{Apply.Compose}
 
 c3 : Monad m => m (Either String Int)
 c3 = runEitherT $ MkEitherT {m} (f1 1) *> MkEitherT {m} (f2 1)

--- a/tests/idris2/real002/Control/App.idr
+++ b/tests/idris2/real002/Control/App.idr
@@ -185,14 +185,20 @@ Functor (App {l} es) where
   map f ap = bindApp ap $ \ap' => pureApp (f ap')
 
 export
+Apply (App {l} es) where
+  (<*>) f a = bindApp f $ \f' =>
+              bindApp a $ \a' => pureApp (f' a')
+
+export
 Applicative (App {l} es) where
   pure = pureApp
-  (<*>) f a = bindApp f $ \f' =>
-              bindApp a $ \a' => pure (f' a')
+
+export
+Bind (App es) where
+  (>>=) = bindApp -- won't get used, but handy to have the instance
 
 export
 Monad (App es) where
-  (>>=) = bindApp -- won't get used, but handy to have the instance
 
 export
 (>>=) : SafeBind l l' =>

--- a/tests/typedd-book/chapter12/StateMonad.idr
+++ b/tests/typedd-book/chapter12/StateMonad.idr
@@ -19,14 +19,18 @@ mutual
       map func x = do val <- x
                       pure (func val)
 
-  Applicative (State stateType) where
-      pure = Pure
+  Apply (State stateType) where
       (<*>) f a = do f' <- f
                      a' <- a
                      pure (f' a')
 
-  Monad (State stateType) where
+  Applicative (State stateType) where
+      pure = Pure
+
+  Bind (State stateType) where
       (>>=) = Bind
+
+  Monad (State stateType) where
 
 {-
 (>>=) : State stateType a -> (a -> State stateType b) ->

--- a/tests/typedd-book/chapter12/TreeLabelType.idr
+++ b/tests/typedd-book/chapter12/TreeLabelType.idr
@@ -29,14 +29,18 @@ mutual
       map func x = do val <- x
                       Pure (func val)
 
-  Applicative (State stateType) where
-      pure x = Pure x
+  Apply (State stateType) where
       (<*>) f a = do func <- f
                      arg <- a
                      pure (func arg)
 
-  Monad (State stateType) where
+  Applicative (State stateType) where
+      pure x = Pure x
+
+  Bind (State stateType) where
       (>>=) = Bind
+
+  Monad (State stateType) where
 
 runState : State stateType a -> (st : stateType) -> (a, stateType)
 runState Get st = (st, st)


### PR DESCRIPTION
This was much less painful than I thought it would be (though, I should probably wait until CI had its say). Luckily, there was only one `Monad` in the compiler libs (Data.List.Lazy) and the interface was actually never used so I just removed the implementation. Some instances of `Apply`, `Alt`, or `Bind` might still be missing, and I'll need to add some additional docstrings.

@buzden: You mentioned that `Control.Arrow` should also be split up. I didn't do this so far, since there is also talk on discord about adding `Profunctor` and related interfaces to contrib. This will allow us to move some stuff from `Arrow` to `Profunctor`-related interfaces anyway.