### PR TITLE
[ improvement ] VMCode

### DIFF
--- a/idris2api.ipkg
+++ b/idris2api.ipkg
@@ -23,6 +23,8 @@ modules =
     Compiler.ES.Node,
     Compiler.ES.TailRec,
 
+    Compiler.Interpreter.VMCode,
+
     Compiler.RefC,
     Compiler.RefC.CC,
     Compiler.RefC.RefC,

--- a/src/Compiler/Interpreter/VMCode.idr
+++ b/src/Compiler/Interpreter/VMCode.idr
@@ -1,0 +1,282 @@
+module Compiler.Interpreter.VMCode
+
+
+import Core.Core
+import Core.Context
+import Core.Context.Log
+import Core.Primitives
+import Core.Value
+import Compiler.Common
+import Compiler.VMCode
+import Data.IOArray
+import Libraries.Data.NameMap
+import Data.Nat
+import Data.Vect
+
+public export
+data Object : Type where
+    Closure : (predMissing : Nat) -> (args : List Object) -> Name -> Object
+    Constructor : (tag : Either Int Name) -> (args : List Object) -> Object
+    Const : Constant -> Object
+    Null : Object
+
+showType : Object -> String
+showType (Closure _ _ _) = "Closure"
+showType (Constructor _ _) = "Constructor"
+showType (Const _) = "Constant"
+showType Null = "Null"
+
+mutual
+    showSep : Nat -> List Object -> String
+    showSep k [] = ""
+    showSep k [o] = showDepth k o
+    showSep k (o :: os) = showDepth k o ++ ", " ++ showSep k os
+
+    showDepth : Nat -> Object -> String
+    showDepth (S k) (Closure mis args fn) = show fn ++ "-" ++ show mis ++ "(" ++ showSep k args ++ ")"
+    showDepth (S k) (Constructor (Left t) args) = "tag" ++ show t ++ "(" ++ showSep k args ++ ")"
+    showDepth (S k) (Const c) = show c
+    showDepth _ obj = showType obj
+
+Show Object where
+    show = showDepth 5
+
+data State : Type where
+record InterpState where
+    constructor MkInterpState
+    defs : NameMap VMDef
+    locals : IOArray Object
+    return : Maybe Object
+
+initInterpState : List (Name, VMDef) -> Core InterpState
+initInterpState defsList = do
+    let defs = fromList defsList
+    locals <- coreLift $ newArray 0
+    let return = Nothing
+    pure $ MkInterpState defs locals return
+
+0
+Stack : Type
+Stack = List Name
+
+interpError : Ref State InterpState => Stack -> String -> Core a
+interpError stk msg = do
+    MkInterpState _ ls ret <- get State
+    lsList <- coreLift $ toList ls
+    throw $ InternalError $ "Interpreter Error in " ++ show (take 10 stk) ++ ":\n" ++ msg
+        ++ "\n\nlocals:\n" ++ showWithIndex lsList
+        ++ "\nreturn:\n  " ++ show ret
+  where
+    showWithIndex : forall a. {default 0 idx : Nat} -> Show a => List a -> String
+    showWithIndex {idx} [] = ""
+    showWithIndex {idx} (x :: xs) = "  " ++ show idx ++ ": " ++ show x ++ "\n" ++ showWithIndex {idx = S idx} xs
+
+getReg : Ref State InterpState => Stack -> Reg -> Core Object
+getReg stk (Loc i) = do
+    ls <- locals <$> get State
+    objm <- coreLift $ readArray ls i
+    case objm of
+        Just obj => pure obj
+        Nothing =>
+            interpError stk $ "Missing local " ++ show i
+getReg stk RVal = do
+    objm <- return <$> get State
+    case objm of
+        Just obj => pure obj
+        Nothing => interpError stk "Missing return val"
+getReg stk Discard = pure Null
+
+setReg : Ref State InterpState => Stack -> Reg -> Object -> Core ()
+setReg stk RVal obj = update State $ record { return = Just obj }
+setReg stk (Loc i) obj = do
+    ls <- locals <$> get State
+    when (i >= max ls) $ interpError stk $ "Attempt to set register: " ++ show i ++ ", size of locals: " ++ show (max ls)
+    coreLift $ writeArray ls i obj
+setReg stk Discard _ = pure ()
+
+saveLocals : Ref State InterpState => Core a -> Core a
+saveLocals act = do
+    st <- get State
+    x <- act
+    put State st
+    pure x
+
+total
+indexMaybe : List a -> Int -> Maybe a
+indexMaybe [] _ = Nothing
+indexMaybe (x :: xs) idx = if idx <= 0 then Just x else indexMaybe xs (idx - 1)
+
+callPrim : Ref State InterpState => Stack -> PrimFn ar -> Vect ar Object -> Core Object
+callPrim stk BelieveMe [_, _, obj] = pure obj
+callPrim stk fn args = case the (Either Object (Vect ar Constant)) $ traverse getConst args of
+    Right args' => case getOp {vars=[]} fn (NPrimVal EmptyFC <$> args') of
+        Just (NPrimVal _ res) => pure $ Const res
+        _ => interpError stk $ "OP: Error calling " ++ show (opName fn) ++ " with operands: " ++ show args'
+    Left obj => interpError stk $ "OP: Expected Constant, found " ++ showType obj
+  where
+    getConst : Object -> Either Object Constant
+    getConst (Const c) = Right c
+    getConst o = Left o
+
+NS_UN : Namespace -> String -> Name
+NS_UN ns un = NS ns (UN un)
+
+argError : Ref State InterpState => Stack -> Vect h Object -> Core a
+argError stk obj = interpError stk $ "Unexpected arguments: " ++ foldMap ((" " ++) . showType) obj
+
+unit : Object
+unit = Const (I 0)
+
+ioRes : Object -> Object
+ioRes obj = Constructor (Left 0) [Const WorldVal, obj]
+
+-- TODO: add more?
+knownForeign : NameMap (ar ** (Ref State InterpState => Stack -> Vect ar Object -> Core Object))
+knownForeign = fromList
+    [ (NS_UN ioNS "prim__putChar", (2 ** prim_putChar))
+    , (NS_UN ioNS "prim__getChar", (1 ** prim_getChar))
+    , (NS_UN ioNS "prim__getStr", (1 ** prim_getStr))
+    , (NS_UN ioNS "prim__putStr", (2 ** prim_putStr))
+    ]
+  where
+    prim_putChar : Ref State InterpState => Stack -> Vect 2 Object -> Core Object
+    prim_putChar _ [Const (Ch c), Const WorldVal] = ioRes unit <$ coreLift_ (putChar c)
+    prim_putChar stk as = argError stk as
+    prim_getChar : Ref State InterpState => Stack -> Vect 1 Object -> Core Object
+    prim_getChar _ [Const WorldVal] = ioRes . Const . Ch <$> coreLift getChar
+    prim_getChar stk as = argError stk as
+    prim_getStr : Ref State InterpState => Stack -> Vect 1 Object -> Core Object
+    prim_getStr _ [Const WorldVal] = Const . Str <$> coreLift getLine
+    prim_getStr stk as = argError stk as
+    prim_putStr : Ref State InterpState => Stack -> Vect 2 Object -> Core Object
+    prim_putStr _ [Const (Str s), Const WorldVal] = ioRes unit <$ coreLift_ (putStr s)
+    prim_putStr stk as = argError stk as
+
+knownExtern : NameMap (ar ** (Ref State InterpState => Stack -> Vect ar Object -> Core Object))
+knownExtern = empty
+
+beginFunction : Ref State InterpState => List (Int, Object) -> List VMInst -> Int -> Core (List VMInst)
+beginFunction args (DECLARE (Loc i) :: is) maxLoc = beginFunction args is (Prelude.max i maxLoc)
+beginFunction args (DECLARE _ :: is) maxLoc = beginFunction args is maxLoc
+beginFunction args (START :: is) maxLoc = do
+    locals <- coreLift $ newArray (maxLoc + 1)
+    ignore $ traverse (\(idx, arg) => coreLift $ writeArray locals idx arg) args
+    update State $ record { locals = locals, return = Nothing }
+    pure is
+beginFunction args is maxLoc = pure is
+
+parameters {auto c : Ref Ctxt Defs}
+  mutual
+    step : Stack -> Ref State InterpState => VMInst -> Core ()
+    step stk (DECLARE _) = pure ()
+    step stk START = pure ()
+    step stk (ASSIGN target val) = do
+        valObj <- getReg stk val
+        setReg stk target valObj
+    step stk (MKCON target tag args) = do
+        argObjs <- traverse (getReg stk) args
+        setReg stk target $ Constructor tag argObjs
+    step stk (MKCLOSURE target fn missing args) = do
+        argObjs <- traverse (getReg stk) args
+        setReg stk target $ Closure (pred missing) argObjs fn
+    step stk (MKCONSTANT target c) = setReg stk target $ Const c
+    step stk (APPLY target fn arg) = do
+        fnObj <- getReg stk fn
+        argObj <- getReg stk arg
+        case fnObj of
+            Closure Z args fn => do
+                res <- callFunc stk fn (args ++ [argObj])
+                setReg stk target res
+            Closure (S k) args fn => setReg stk target $ Closure k (args ++ [argObj]) fn
+            obj => interpError stk $ "APPLY: While applying " ++ show fn ++ ", expected closure, found: " ++ show obj
+    step stk (CALL target _ fn args) = do
+        argObjs <- traverse (getReg stk) args
+        res <- callFunc stk fn argObjs
+        setReg stk target res
+    step stk (OP target fn args) = do
+        argObjs <- traverseVect (getReg stk) args
+        res <- callPrim stk fn argObjs
+        setReg stk target res
+    step stk (EXTPRIM target fn args) = case lookup fn knownExtern of
+        Nothing => interpError stk $ "EXTPRIM: Unkown foreign function: " ++ show fn
+        Just (ar ** op) => case toVect ar args of
+            Nothing => interpError stk $ "EXTPRIM: Wrong number of arguments, found: " ++ show (length args) ++ ", expected: " ++ show ar
+            Just argsVect => do
+                argObjs <- traverseVect (getReg stk) argsVect
+                res <- op stk argObjs
+                setReg stk target res
+    step stk (CASE sc alts def) = do
+        scObj <- getReg stk sc
+        case scObj of
+            Constructor tag _ => matchCon stk tag alts def
+            _ => interpError stk $ "CASE: Expected Constructor, found " ++ showType scObj
+      where
+        matchCon : Stack -> Either Int Name -> List (Either Int Name, List VMInst) -> Maybe (List VMInst) -> Core ()
+        matchCon stk tag [] Nothing = interpError stk "CASE: Missing matching alternative or default"
+        matchCon stk tag [] (Just is) = traverse_ (step stk) is
+        matchCon stk tag ((t, is) :: alts) def =
+            if tag == t
+                then traverse_ (step stk) is
+                else matchCon stk tag alts def
+    step stk (CONSTCASE sc alts def) = do
+        scObj <- getReg stk sc
+        case scObj of
+            Const c => matchConst stk c alts def
+            _ => interpError stk $ "CONSTCASE: Expected Constant, found " ++ showType scObj
+      where
+        matchConst : Stack -> Constant -> List (Constant, List VMInst) -> Maybe (List VMInst) -> Core ()
+        matchConst stk c [] Nothing = interpError stk "CONSTCASE: Missing matching alternative or default"
+        matchConst stk c [] (Just is) = traverse_ (step stk) is
+        matchConst stk c ((c', is) :: alts) def =
+            if c == c'
+                then traverse_ (step stk) is
+                else matchConst stk c alts def
+    step stk (PROJECT target val idx) = do
+        valObj <- getReg stk val
+        case valObj of
+            Constructor _ args => case indexMaybe args idx of
+                Nothing => interpError stk
+                    $ "PROJECT: Unable to project index " ++ show idx
+                    ++ ", missing arguments for constructor:\n" ++ show valObj
+                Just arg => setReg stk target arg
+            _ => interpError stk $ "PROJECT: Expected Constructor, found " ++ showType valObj
+    step stk (NULL reg) = setReg stk reg Null
+    step stk (ERROR msg) = interpError stk $ "ERROR: " ++ msg
+        
+    callFunc : Ref State InterpState => Stack -> Name -> List Object -> Core Object
+    callFunc stk fn args = saveLocals $ do
+        let ind = pack $ '|' <$ stk
+        logCallStack <- logging "compiler.interpreter" 25
+        when logCallStack $ coreLift $ putStrLn $ ind ++ "Calling " ++ show fn ++ " with args: " ++ show args
+        let stk' = fn :: stk
+        defs <- defs <$> get State
+        res <- case lookup fn defs of
+            Nothing => interpError stk $ "Undefined function: " ++ show fn
+            Just (MkVMFun as is) => do
+                is' <- beginFunction (zip as args) is (foldl max (-1) as)
+                traverse_ (step stk') is'
+                getReg stk' RVal
+            Just (MkVMForeign _ _ _) => case lookup fn knownForeign of
+                Nothing => interpError stk $ "Unkown foreign function: " ++ show fn
+                Just (ar ** op) => case toVect ar args of
+                    Nothing => interpError stk $ "Wrong number of arguments, found: " ++ show (length args) ++ ", expected: " ++ show ar
+                    Just argsVect => op stk argsVect
+            Just (MkVMError is) => do
+                traverse_ (step stk') is
+                getReg stk' RVal
+        when logCallStack $ coreLift $ putStrLn $ ind ++ "Result: " ++ show res
+        pure res
+
+compileExpr : Ref Ctxt Defs -> String -> String -> ClosedTerm -> String -> Core (Maybe String)
+compileExpr _ _ _ _ _ = Nothing <$ throw {a=()} (InternalError "compile not implemeted for vmcode-interp")
+
+executeExpr : Ref Ctxt Defs -> String -> ClosedTerm -> Core ()
+executeExpr c _ tm = do
+    cdata <- getCompileData False VMCode tm
+    st <- newRef State !(initInterpState cdata.vmcode)
+    ignore $ callFunc [] (MN "__mainExpression" 0) []
+
+export
+codegenVMCodeInterp : Codegen
+codegenVMCodeInterp = MkCG compileExpr executeExpr Nothing Nothing
+

--- a/src/Compiler/Interpreter/VMCode.idr
+++ b/src/Compiler/Interpreter/VMCode.idr
@@ -242,7 +242,7 @@ parameters {auto c : Ref Ctxt Defs}
             _ => interpError stk $ "PROJECT: Expected Constructor, found " ++ showType valObj
     step stk (NULL reg) = setReg stk reg Null
     step stk (ERROR msg) = interpError stk $ "ERROR: " ++ msg
-        
+
     callFunc : Ref State InterpState => Stack -> Name -> List Object -> Core Object
     callFunc stk fn args = saveLocals $ do
         let ind = pack $ '|' <$ stk
@@ -279,4 +279,3 @@ executeExpr c _ tm = do
 export
 codegenVMCodeInterp : Codegen
 codegenVMCodeInterp = MkCG compileExpr executeExpr Nothing Nothing
-

--- a/src/Compiler/Separate.idr
+++ b/src/Compiler/Separate.idr
@@ -154,6 +154,7 @@ HasNamespaces VMInst where
 export
 HasNamespaces VMDef where
   nsRefs (MkVMFun args is) = concatMap nsRefs is
+  nsRefs (MkVMForeign _ _ _) = empty
   nsRefs (MkVMError is) = concatMap nsRefs is
 
 

--- a/src/Compiler/VMCode.idr
+++ b/src/Compiler/VMCode.idr
@@ -7,6 +7,7 @@ import Core.Context
 import Core.Core
 import Core.TT
 
+import Libraries.Data.IntMap
 import Data.List
 import Data.Maybe
 import Data.Vect
@@ -57,6 +58,8 @@ data VMInst : Type where
 public export
 data VMDef : Type where
      MkVMFun : (args : List Int) -> List VMInst -> VMDef
+     MkVMForeign : (ccs : List String) -> (fargs : List CFType) ->
+                   CFType -> VMDef
      MkVMError : List VMInst -> VMDef
 
 export
@@ -101,11 +104,46 @@ Show VMInst where
 export
 Show VMDef where
   show (MkVMFun args body) = show args ++ ": " ++ show body
+  show (MkVMForeign ccs args ret)
+      = "Foreign call " ++ show ccs ++ " " ++
+        show args ++ " " ++ show ret
   show (MkVMError err) = "Error: " ++ show err
 
 toReg : AVar -> Reg
 toReg (ALocal i) = Loc i
 toReg ANull = Discard
+
+projectArgs : Int -> Int -> (used : IntMap ()) -> (args : List Int) -> List VMInst
+projectArgs scr i used [] = []
+projectArgs scr i used (arg :: args)
+    = case lookup arg used of
+           Just _ => PROJECT (Loc arg) (Loc scr) i :: projectArgs scr (i + 1) used args
+           Nothing => projectArgs scr (i + 1) used args
+
+collectReg : Reg -> IntMap ()
+collectReg (Loc i) = singleton i ()
+collectReg _ = empty
+
+collectUsed : VMInst -> IntMap ()
+collectUsed (DECLARE reg) = collectReg reg
+collectUsed START = empty
+collectUsed (ASSIGN _ val) = collectReg val
+collectUsed (MKCON _ _ args) = foldMap collectReg args
+collectUsed (MKCLOSURE _ _ _ args) = foldMap collectReg args
+collectUsed (MKCONSTANT _ _) = empty
+collectUsed (APPLY _ fn arg) = collectReg fn <+> collectReg arg
+collectUsed (CALL _ _ _ args) = foldMap collectReg args
+collectUsed (OP _ _ args) = foldMap collectReg args
+collectUsed (EXTPRIM _ _ args) = foldMap collectReg args
+collectUsed (CASE _ is mdef)
+    = foldMap (foldMap collectUsed . snd) is
+      <+> maybe empty (foldMap collectUsed) mdef
+collectUsed (CONSTCASE _ is mdef)
+    = foldMap (foldMap collectUsed . snd) is
+      <+> maybe empty (foldMap collectUsed) mdef
+collectUsed (PROJECT _ val _) = collectReg val
+collectUsed (NULL _) = empty
+collectUsed (ERROR _) = empty
 
 toVM : (tailpos : Bool) -> (target : Reg) -> ANF -> List VMInst
 toVM t Discard _ = []
@@ -127,19 +165,18 @@ toVM t res (AOp fc _ op args)
     = [OP res op (map toReg args)]
 toVM t res (AExtPrim fc _ p args)
     = [EXTPRIM res p (map toReg args)]
+toVM t res (AConCase fc (ALocal scr) [MkAConAlt n ci mt args code] Nothing) -- exactly one alternative, so skip matching
+    = let body = toVM t res code
+          used = foldMap collectUsed body
+       in projectArgs scr 0 used args ++ body
 toVM t res (AConCase fc (ALocal scr) alts def)
     = [CASE (Loc scr) (map toVMConAlt alts) (map (toVM t res) def)]
   where
-    projectArgs : Int -> List Int -> List VMInst
-    projectArgs i [] = []
-    projectArgs i (arg :: args)
-        = PROJECT (Loc arg) (Loc scr) i :: projectArgs (i + 1) args
-
     toVMConAlt : AConAlt -> (Either Int Name, List VMInst)
-    toVMConAlt (MkAConAlt n ci (Just tag) args code)
-        = (Left tag, projectArgs 0 args ++ toVM t res code)
-    toVMConAlt (MkAConAlt n ci Nothing args code)
-        = (Right n, projectArgs 0 args ++ toVM t res code)
+    toVMConAlt (MkAConAlt n ci tag args code)
+       = let body = toVM t res code
+             used = foldMap collectUsed body
+          in (maybe (Right n) Left tag, projectArgs scr 0 used args ++ body)
 toVM t res (AConstCase fc (ALocal scr) alts def)
     = [CONSTCASE (Loc scr) (map toVMConstAlt alts) (map (toVM t res) def)]
   where
@@ -165,21 +202,21 @@ findVars (CALL (Loc r) _ _ _) = [r]
 findVars (OP (Loc r) _ _) = [r]
 findVars (EXTPRIM (Loc r) _ _) = [r]
 findVars (CASE _ alts d)
-    = concatMap findVarAlt alts ++ fromMaybe [] (map (concatMap findVars) d)
+    = foldMap findVarAlt alts ++ fromMaybe [] (map (foldMap findVars) d)
   where
     findVarAlt : (Either Int Name, List VMInst) -> List Int
-    findVarAlt (t, code) = concatMap findVars code
+    findVarAlt (t, code) = foldMap findVars code
 findVars (CONSTCASE _ alts d)
-    = concatMap findConstVarAlt alts ++ fromMaybe [] (map (concatMap findVars) d)
+    = foldMap findConstVarAlt alts ++ fromMaybe [] (map (foldMap findVars) d)
   where
     findConstVarAlt : (Constant, List VMInst) -> List Int
-    findConstVarAlt (t, code) = concatMap findVars code
+    findConstVarAlt (t, code) = foldMap findVars code
 findVars (PROJECT (Loc r) _ _) = [r]
 findVars _ = []
 
 declareVars : List Int -> List VMInst -> List VMInst
 declareVars got code
-    = let vs = concatMap findVars code in
+    = let vs = foldMap findVars code in
           declareAll got vs
   where
     declareAll : List Int -> List Int -> List VMInst
@@ -193,6 +230,8 @@ export
 toVMDef : ANFDef -> Maybe VMDef
 toVMDef (MkAFun args body)
     = Just $ MkVMFun args (declareVars args (toVM True RVal body))
+toVMDef (MkAForeign ccs cargs ret)
+    = Just $ MkVMForeign ccs cargs ret
 toVMDef (MkAError body)
     = Just $ MkVMError (declareVars [] (toVM True RVal body))
 toVMDef _ = Nothing

--- a/src/Compiler/VMCode.idr
+++ b/src/Compiler/VMCode.idr
@@ -135,11 +135,13 @@ collectUsed (APPLY _ fn arg) = collectReg fn <+> collectReg arg
 collectUsed (CALL _ _ _ args) = foldMap collectReg args
 collectUsed (OP _ _ args) = foldMap collectReg args
 collectUsed (EXTPRIM _ _ args) = foldMap collectReg args
-collectUsed (CASE _ is mdef)
-    = foldMap (foldMap collectUsed . snd) is
+collectUsed (CASE sc is mdef)
+    = collectReg sc
+      <+> foldMap (foldMap collectUsed . snd) is
       <+> maybe empty (foldMap collectUsed) mdef
-collectUsed (CONSTCASE _ is mdef)
-    = foldMap (foldMap collectUsed . snd) is
+collectUsed (CONSTCASE sc is mdef)
+    = collectReg sc
+      <+> foldMap (foldMap collectUsed . snd) is
       <+> maybe empty (foldMap collectUsed) mdef
 collectUsed (PROJECT _ val _) = collectReg val
 collectUsed (NULL _) = empty

--- a/src/Core/Name/Namespace.idr
+++ b/src/Core/Name/Namespace.idr
@@ -266,6 +266,10 @@ primIONS : Namespace
 primIONS = mkNamespace "PrimIO"
 
 export
+ioNS : Namespace
+ioNS = mkNamespace "Prelude.IO"
+
+export
 reflectionNS : Namespace
 reflectionNS = mkNamespace "Language.Reflection"
 

--- a/src/Core/Options.idr
+++ b/src/Core/Options.idr
@@ -59,6 +59,7 @@ data CG = Chez
         | Node
         | Javascript
         | RefC
+        | VMCodeInterp
         | Other String
 
 export
@@ -70,6 +71,7 @@ Eq CG where
   Node == Node = True
   Javascript == Javascript = True
   RefC == RefC = True
+  VMCodeInterp == VMCodeInterp = True
   Other s == Other t = s == t
   _ == _ = False
 
@@ -82,6 +84,7 @@ Show CG where
   show Node = "node"
   show Javascript = "javascript"
   show RefC = "refc"
+  show VMCodeInterp = "vmcode-interp"
   show (Other s) = s
 
 public export
@@ -200,7 +203,8 @@ availableCGs o
        ("node", Node),
        ("javascript", Javascript),
        ("refc", RefC),
-       ("gambit", Gambit)] ++ additionalCGs o
+       ("gambit", Gambit),
+       ("vmcode-interp", VMCodeInterp)] ++ additionalCGs o
 
 export
 getCG : Options -> String -> Maybe CG

--- a/src/Core/Options/Log.idr
+++ b/src/Core/Options/Log.idr
@@ -53,6 +53,7 @@ knownTopics = [
     ("compile.casetree.pick", Nothing),
     ("compile.casetree.partition", Nothing),
     ("compiler.inline.eval", Nothing),
+    ("compiler.interpreter", Nothing),
     ("compiler.refc", Nothing),
     ("compiler.refc.cc", Nothing),
     ("compiler.scheme.chez", Nothing),

--- a/src/Core/TTC.idr
+++ b/src/Core/TTC.idr
@@ -838,6 +838,7 @@ TTC CG where
   toBuf b Node = tag 5
   toBuf b Javascript = tag 6
   toBuf b RefC = tag 7
+  toBuf b VMCodeInterp = tag 8
 
   fromBuf b
       = case !getTag of
@@ -850,6 +851,7 @@ TTC CG where
              5 => pure Node
              6 => pure Javascript
              7 => pure RefC
+             8 => pure VMCodeInterp
              _ => corrupt "CG"
 
 export

--- a/src/Idris/ProcessIdr.idr
+++ b/src/Idris/ProcessIdr.idr
@@ -9,6 +9,7 @@ import Compiler.ES.Node
 import Compiler.ES.Javascript
 import Compiler.Common
 import Compiler.Inline
+import Compiler.Interpreter.VMCode
 
 import Core.Binary
 import Core.Context
@@ -247,6 +248,7 @@ getCG Gambit = pure $ Just codegenGambit
 getCG Node = pure $ Just codegenNode
 getCG Javascript = pure $ Just codegenJavascript
 getCG RefC = pure $ Just codegenRefC
+getCG VMCodeInterp = pure $ Just codegenVMCodeInterp
 getCG (Other s) = getCodegen s
 
 export

--- a/src/Libraries/Data/IntMap.idr
+++ b/src/Libraries/Data/IntMap.idr
@@ -224,6 +224,10 @@ insert k v (M _ t) =
     Right t' => (M _ t')
 
 export
+singleton : Int -> v -> IntMap v
+singleton k v = insert k v empty
+
+export
 insertFrom : List (Int, v) -> IntMap v -> IntMap v
 insertFrom = flip $ foldl $ flip $ uncurry insert
 

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -264,6 +264,11 @@ nodeTests = MkTestPool "Node backend" [] (Just Node)
     , "integers"
     ]
 
+vmcodeInterpTests : TestPool
+vmcodeInterpTests = MkTestPool "VMCode interpreter" [] Nothing
+    [ "basic001"
+    ]
+
 ideModeTests : TestPool
 ideModeTests = MkTestPool "IDE mode" [] Nothing
   [ "ideMode001", "ideMode002", "ideMode003", "ideMode004", "ideMode005"
@@ -332,6 +337,7 @@ main = runner $
   , testPaths "refc" refcTests
   , testPaths "racket" racketTests
   , testPaths "node" nodeTests
+  , testPaths "vmcode" vmcodeInterpTests
   , testPaths "templates" templateTests
   , testPaths "codegen" codegenTests
   ]

--- a/tests/chez/chez031/expected
+++ b/tests/chez/chez031/expected
@@ -1,5 +1,5 @@
 Error: The given specifier '["scheme,racket:+"]' was not accepted by any backend. Available backends:
-  chez, chez-sep, racket, node, javascript, refc, gambit
+  chez, chez-sep, racket, node, javascript, refc, gambit, vmcode-interp
 Some backends have additional specifier rules, refer to their documentation.
 
 Specifiers:29:1--30:35
@@ -7,7 +7,7 @@ Specifiers:29:1--30:35
  30 | plusRacketFail : Int -> Int -> Int
 
 Error: The given specifier '["scheme,racket:+"]' was not accepted by any backend. Available backends:
-  chez, chez-sep, racket, node, javascript, refc, gambit
+  chez, chez-sep, racket, node, javascript, refc, gambit, vmcode-interp
 Some backends have additional specifier rules, refer to their documentation.
 
 Specifiers:29:1--30:35
@@ -16,13 +16,13 @@ Specifiers:29:1--30:35
 
 Main> Loaded file Specifiers.idr
 Specifiers> Error: The given specifier '["scheme,racket:+"]' was not accepted by any backend. Available backends:
-  chez, chez-sep, racket, node, javascript, refc, gambit
+  chez, chez-sep, racket, node, javascript, refc, gambit, vmcode-interp
 Some backends have additional specifier rules, refer to their documentation.
 
 Specifiers:29:1--30:35
 
 Specifiers> [exec] Specifiers> Error: The given specifier '["scheme,racket:+"]' was not accepted by any backend. Available backends:
-  chez, chez-sep, racket, node, javascript, refc, gambit
+  chez, chez-sep, racket, node, javascript, refc, gambit, vmcode-interp
 Some backends have additional specifier rules, refer to their documentation.
 
 Specifiers:29:1--30:35

--- a/tests/vmcode/basic001/Test.idr
+++ b/tests/vmcode/basic001/Test.idr
@@ -25,7 +25,7 @@ main = do
     putStrLn $ foo $ Left (Right ())
 
     -- recursion
-    printLn $ bah [0 .. 10] 
+    printLn $ bah [0 .. 10]
     printLn $ bah [11, 2]
 
     -- primitive pattern matching

--- a/tests/vmcode/basic001/Test.idr
+++ b/tests/vmcode/basic001/Test.idr
@@ -1,0 +1,33 @@
+
+foo : Either (Either () ()) () -> String
+foo (Left (Left ())) = "Left Left"
+foo (Left (Right ())) = "Left Right"
+foo (Right ()) = "Right"
+
+bah : List Nat -> Nat
+bah [] = 0
+bah (x :: xs) = x + bah xs
+
+baz : Int -> Int
+baz 10 = -1
+baz _ = -2
+
+main : IO ()
+main = do
+    -- primitives
+    printLn $ the Int $ 10 + 11 * 92
+    printLn $ the Bits32 $ 8 * 9 * 10
+    printLn $ the Integer $ 19 * 19
+
+    -- pattern matching
+    putStrLn $ foo $ Left (Left ())
+    putStrLn $ foo $ Right ()
+    putStrLn $ foo $ Left (Right ())
+
+    -- recursion
+    printLn $ bah [0 .. 10] 
+    printLn $ bah [11, 2]
+
+    -- primitive pattern matching
+    printLn $ baz 10
+    printLn $ baz (-100)

--- a/tests/vmcode/basic001/expected
+++ b/tests/vmcode/basic001/expected
@@ -1,0 +1,10 @@
+1022
+720
+361
+Left Left
+Right
+Left Right
+55
+13
+-1
+-2

--- a/tests/vmcode/basic001/run
+++ b/tests/vmcode/basic001/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 --no-banner Test.idr -x main --cg vmcode-interp
+
+rm -rf build


### PR DESCRIPTION
See #1608 for context.

This PR includes the improvements to `VMCode`, namely:
- Include Foreign definitions in `VMDef`
- Only project arguments to constructors when they are used
- If a case statement has exactly one alternative and no default, then skip CASE instruction (speeds up record projections).
