### PR TITLE
[fix] refc backend broken with msys2

### DIFF
--- a/src/Compiler/RefC/CC.idr
+++ b/src/Compiler/RefC/CC.idr
@@ -60,7 +60,7 @@ compileCFile {asShared} objectFile outFile =
 
      let runcc = cc ++ " -Werror " ++ sharedFlag ++ objectFile ++
                        " -o " ++ outFile ++ " " ++
-                       fullprefix_dir dirs "lib" </> "libidris2_support.a" ++ " " ++
+                       fullprefix_dir dirs ("lib" </> "libidris2_support.a") ++ " " ++
                        "-lidris2_refc " ++
                        "-L" ++ fullprefix_dir dirs "refc " ++
                        clibdirs (lib_dirs dirs) ++

--- a/src/Compiler/RefC/CC.idr
+++ b/src/Compiler/RefC/CC.idr
@@ -60,7 +60,7 @@ compileCFile {asShared} objectFile outFile =
 
      let runcc = cc ++ " -Werror " ++ sharedFlag ++ objectFile ++
                        " -o " ++ outFile ++ " " ++
-                       fullprefix_dir dirs ("lib" </> "libidris2_support.a") ++ " " ++
+                       (fullprefix_dir dirs "lib" </> "libidris2_support.a") ++ " " ++
                        "-lidris2_refc " ++
                        "-L" ++ fullprefix_dir dirs "refc " ++
                        clibdirs (lib_dirs dirs) ++


### PR DESCRIPTION
I was getting "The system cannot find the drive specified" when compiling any code with "--cg refc", with msys2, no additional environment variables set.
Tried two different PCs both with Windows 10 + fresh msys2 install.

The problem is that operator `</>` is infix 5 so we're regarding the concatenation of everything (including `cc`) on the left side of `</>` a path, which is not valid (when CC is not set to an absolute path), so we end up with an invalid path.