### PR TITLE
In RefC, allocate the exact size of value subtype

### DIFF
--- a/support/refc/casts.c
+++ b/support/refc/casts.c
@@ -520,7 +520,7 @@ Value *cast_string_to_Integer(Value *input)
 
 Value *cast_string_to_double(Value *input)
 {
-    Value_Double *retVal = (Value_Double *)newValue();
+    Value_Double *retVal = IDRIS2_NEW_VALUE(Value_Double);
     retVal->header.tag = DOUBLE_TAG;
     Value_String *from = (Value_String *)input;
     retVal->d = atof(from->str);
@@ -530,7 +530,7 @@ Value *cast_string_to_double(Value *input)
 
 Value *cast_string_to_char(Value *input)
 {
-    Value_Char *retVal = (Value_Char *)newValue();
+    Value_Char *retVal = IDRIS2_NEW_VALUE(Value_Char);
     retVal->header.tag = CHAR_TAG;
     Value_String *from = (Value_String *)input;
     retVal->c = from->str[0];
@@ -917,7 +917,7 @@ Value *cast_Integer_to_string(Value *input)
 {
     Value_Integer *from = (Value_Integer *)input;
 
-    Value_String *retVal = (Value_String *)newValue();
+    Value_String *retVal = IDRIS2_NEW_VALUE(Value_String);
     retVal->header.tag = STRING_TAG;
     retVal->str = mpz_get_str(NULL, 10, from->i);
 

--- a/support/refc/datatypes.h
+++ b/support/refc/datatypes.h
@@ -46,7 +46,9 @@ typedef struct
 typedef struct
 {
     Value_header header;
-    char payload[25];
+    // `Value` is an "abstract" struct,
+    // `Value_Xxx` structs have the same header
+    // followed by type-specific payload.
 } Value;
 
 typedef struct

--- a/support/refc/memoryManagement.c
+++ b/support/refc/memoryManagement.c
@@ -1,8 +1,8 @@
 #include "runtime.h"
 
-Value *newValue()
+Value *newValue(size_t size)
 {
-    Value *retVal = (Value *)malloc(sizeof(Value));
+    Value *retVal = (Value *)malloc(size);
     retVal->header.refCounter = 1;
     retVal->header.tag = NO_TAG;
     return retVal;
@@ -10,7 +10,7 @@ Value *newValue()
 
 Value_Arglist *newArglist(int missing, int total)
 {
-    Value_Arglist *retVal = (Value_Arglist *)newValue();
+    Value_Arglist *retVal = IDRIS2_NEW_VALUE(Value_Arglist);
     retVal->header.tag = ARGLIST_TAG;
     retVal->total = total;
     retVal->filled = total - missing;
@@ -21,7 +21,7 @@ Value_Arglist *newArglist(int missing, int total)
 
 Value_Constructor *newConstructor(int total, int tag, const char *name)
 {
-    Value_Constructor *retVal = (Value_Constructor *)newValue();
+    Value_Constructor *retVal = IDRIS2_NEW_VALUE(Value_Constructor);
     retVal->header.tag = CONSTRUCTOR_TAG;
     retVal->total = total;
     retVal->tag = tag;
@@ -35,7 +35,7 @@ Value_Constructor *newConstructor(int total, int tag, const char *name)
 
 Value_Closure *makeClosureFromArglist(fun_ptr_t f, Value_Arglist *arglist)
 {
-    Value_Closure *retVal = (Value_Closure *)newValue();
+    Value_Closure *retVal = IDRIS2_NEW_VALUE(Value_Closure);
     retVal->header.tag = CLOSURE_TAG;
     retVal->arglist = arglist; // (Value_Arglist *)newReference((Value*)arglist);
     retVal->f = f;
@@ -48,7 +48,7 @@ Value_Closure *makeClosureFromArglist(fun_ptr_t f, Value_Arglist *arglist)
 
 Value_Double *makeDouble(double d)
 {
-    Value_Double *retVal = (Value_Double *)newValue();
+    Value_Double *retVal = IDRIS2_NEW_VALUE(Value_Double);
     retVal->header.tag = DOUBLE_TAG;
     retVal->d = d;
     return retVal;
@@ -56,7 +56,7 @@ Value_Double *makeDouble(double d)
 
 Value_Char *makeChar(char c)
 {
-    Value_Char *retVal = (Value_Char *)newValue();
+    Value_Char *retVal = IDRIS2_NEW_VALUE(Value_Char);
     retVal->header.tag = CHAR_TAG;
     retVal->c = c;
     return retVal;
@@ -64,7 +64,7 @@ Value_Char *makeChar(char c)
 
 Value_Bits8 *makeBits8(uint8_t i)
 {
-    Value_Bits8 *retVal = (Value_Bits8 *)newValue();
+    Value_Bits8 *retVal = IDRIS2_NEW_VALUE(Value_Bits8);
     retVal->header.tag = BITS8_TAG;
     retVal->ui8 = i;
     return retVal;
@@ -72,7 +72,7 @@ Value_Bits8 *makeBits8(uint8_t i)
 
 Value_Bits16 *makeBits16(uint16_t i)
 {
-    Value_Bits16 *retVal = (Value_Bits16 *)newValue();
+    Value_Bits16 *retVal = IDRIS2_NEW_VALUE(Value_Bits16);
     retVal->header.tag = BITS16_TAG;
     retVal->ui16 = i;
     return retVal;
@@ -80,7 +80,7 @@ Value_Bits16 *makeBits16(uint16_t i)
 
 Value_Bits32 *makeBits32(uint32_t i)
 {
-    Value_Bits32 *retVal = (Value_Bits32 *)newValue();
+    Value_Bits32 *retVal = IDRIS2_NEW_VALUE(Value_Bits32);
     retVal->header.tag = BITS32_TAG;
     retVal->ui32 = i;
     return retVal;
@@ -88,7 +88,7 @@ Value_Bits32 *makeBits32(uint32_t i)
 
 Value_Bits64 *makeBits64(uint64_t i)
 {
-    Value_Bits64 *retVal = (Value_Bits64 *)newValue();
+    Value_Bits64 *retVal = IDRIS2_NEW_VALUE(Value_Bits64);
     retVal->header.tag = BITS64_TAG;
     retVal->ui64 = i;
     return retVal;
@@ -96,7 +96,7 @@ Value_Bits64 *makeBits64(uint64_t i)
 
 Value_Int8 *makeInt8(int8_t i)
 {
-    Value_Int8 *retVal = (Value_Int8 *)newValue();
+    Value_Int8 *retVal = IDRIS2_NEW_VALUE(Value_Int8);
     retVal->header.tag = INT8_TAG;
     retVal->i8 = i;
     return retVal;
@@ -104,7 +104,7 @@ Value_Int8 *makeInt8(int8_t i)
 
 Value_Int16 *makeInt16(int16_t i)
 {
-    Value_Int16 *retVal = (Value_Int16 *)newValue();
+    Value_Int16 *retVal = IDRIS2_NEW_VALUE(Value_Int16);
     retVal->header.tag = INT16_TAG;
     retVal->i16 = i;
     return retVal;
@@ -112,7 +112,7 @@ Value_Int16 *makeInt16(int16_t i)
 
 Value_Int32 *makeInt32(int32_t i)
 {
-    Value_Int32 *retVal = (Value_Int32 *)newValue();
+    Value_Int32 *retVal = IDRIS2_NEW_VALUE(Value_Int32);
     retVal->header.tag = INT32_TAG;
     retVal->i32 = i;
     return retVal;
@@ -120,7 +120,7 @@ Value_Int32 *makeInt32(int32_t i)
 
 Value_Int64 *makeInt64(int64_t i)
 {
-    Value_Int64 *retVal = (Value_Int64 *)newValue();
+    Value_Int64 *retVal = IDRIS2_NEW_VALUE(Value_Int64);
     retVal->header.tag = INT64_TAG;
     retVal->i64 = i;
     return retVal;
@@ -133,7 +133,7 @@ Value_Int8 *makeBool(int p)
 
 Value_Integer *makeInteger()
 {
-    Value_Integer *retVal = (Value_Integer *)newValue();
+    Value_Integer *retVal = IDRIS2_NEW_VALUE(Value_Integer);
     retVal->header.tag = INTEGER_TAG;
     mpz_init(retVal->i);
     return retVal;
@@ -148,7 +148,7 @@ Value_Integer *makeIntegerLiteral(char *i)
 
 Value_String *makeEmptyString(size_t l)
 {
-    Value_String *retVal = (Value_String *)newValue();
+    Value_String *retVal = IDRIS2_NEW_VALUE(Value_String);
     retVal->header.tag = STRING_TAG;
     retVal->str = malloc(l);
     memset(retVal->str, 0, l);
@@ -157,7 +157,7 @@ Value_String *makeEmptyString(size_t l)
 
 Value_String *makeString(char *s)
 {
-    Value_String *retVal = (Value_String *)newValue();
+    Value_String *retVal = IDRIS2_NEW_VALUE(Value_String);
     int l = strlen(s);
     retVal->header.tag = STRING_TAG;
     retVal->str = malloc(l + 1);
@@ -168,7 +168,7 @@ Value_String *makeString(char *s)
 
 Value_Pointer *makePointer(void *ptr_Raw)
 {
-    Value_Pointer *p = (Value_Pointer *)newValue();
+    Value_Pointer *p = IDRIS2_NEW_VALUE(Value_Pointer);
     p->header.tag = POINTER_TAG;
     p->p = ptr_Raw;
     return p;
@@ -176,7 +176,7 @@ Value_Pointer *makePointer(void *ptr_Raw)
 
 Value_GCPointer *makeGCPointer(void *ptr_Raw, Value_Closure *onCollectFct)
 {
-    Value_GCPointer *p = (Value_GCPointer *)newValue();
+    Value_GCPointer *p = IDRIS2_NEW_VALUE(Value_GCPointer);
     p->header.tag = GC_POINTER_TAG;
     p->p = makePointer(ptr_Raw);
     p->onCollectFct = onCollectFct;
@@ -185,7 +185,7 @@ Value_GCPointer *makeGCPointer(void *ptr_Raw, Value_Closure *onCollectFct)
 
 Value_Buffer *makeBuffer(void *buf)
 {
-    Value_Buffer *b = (Value_Buffer *)newValue();
+    Value_Buffer *b = IDRIS2_NEW_VALUE(Value_Buffer);
     b->header.tag = BUFFER_TAG;
     b->buffer = buf;
     return b;
@@ -193,7 +193,7 @@ Value_Buffer *makeBuffer(void *buf)
 
 Value_Array *makeArray(int length)
 {
-    Value_Array *a = (Value_Array *)newValue();
+    Value_Array *a = IDRIS2_NEW_VALUE(Value_Array);
     a->header.tag = ARRAY_TAG;
     a->capacity = length;
     a->arr = (Value **)malloc(sizeof(Value *) * length);
@@ -203,7 +203,7 @@ Value_Array *makeArray(int length)
 
 Value_World *makeWorld()
 {
-    Value_World *retVal = (Value_World *)newValue();
+    Value_World *retVal = IDRIS2_NEW_VALUE(Value_World);
     retVal->header.tag = WORLD_TAG;
     retVal->listIORefs = NULL;
     return retVal;

--- a/support/refc/memoryManagement.h
+++ b/support/refc/memoryManagement.h
@@ -2,9 +2,11 @@
 
 #include "cBackend.h"
 
-Value *newValue(void);
+Value *newValue(size_t size);
 Value *newReference(Value *source);
 void removeReference(Value *source);
+
+#define IDRIS2_NEW_VALUE(t) ((t*) newValue(sizeof(t)))
 
 Value_Arglist *newArglist(int missing, int total);
 Value_Constructor *newConstructor(int total, int tag, const char *name);

--- a/support/refc/prim.c
+++ b/support/refc/prim.c
@@ -39,7 +39,7 @@ Value *newIORef(Value *erased, Value *input_value, Value *_world)
     }
 
     // store value
-    Value_IORef *ioRef = (Value_IORef *)newValue();
+    Value_IORef *ioRef = IDRIS2_NEW_VALUE(Value_IORef);
     ioRef->header.tag = IOREF_TAG;
     ioRef->index = world->listIORefs->filled;
     world->listIORefs->refs[world->listIORefs->filled] = newReference(input_value);
@@ -142,7 +142,7 @@ Value *arraySet(Value *erased, Value *_array, Value *_index, Value *v, Value *_w
 Value *onCollect(Value *_erased, Value *_anyPtr, Value *_freeingFunction, Value *_world)
 {
     printf("onCollect called\n");
-    Value_GCPointer *retVal = (Value_GCPointer *)newValue();
+    Value_GCPointer *retVal = IDRIS2_NEW_VALUE(Value_GCPointer);
     retVal->header.tag = GC_POINTER_TAG;
     retVal->p = (Value_Pointer *)newReference(_anyPtr);
     retVal->onCollectFct = (Value_Closure *)newReference(_freeingFunction);
@@ -152,7 +152,7 @@ Value *onCollect(Value *_erased, Value *_anyPtr, Value *_freeingFunction, Value 
 Value *onCollectAny(Value *_erased, Value *_anyPtr, Value *_freeingFunction, Value *_world)
 {
     printf("onCollectAny called\n");
-    Value_GCPointer *retVal = (Value_GCPointer *)newValue();
+    Value_GCPointer *retVal = IDRIS2_NEW_VALUE(Value_GCPointer);
     retVal->header.tag = GC_POINTER_TAG;
     retVal->p = (Value_Pointer *)_anyPtr;
     retVal->onCollectFct = (Value_Closure *)_freeingFunction;
@@ -171,7 +171,7 @@ Value *voidElim(Value *erased1, Value *erased2)
 // using pthread_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr)
 Value *System_Concurrency_Raw_prim__makeMutex(Value *_world)
 {
-    Value_Mutex *mut = (Value_Mutex *)newValue();
+    Value_Mutex *mut = IDRIS2_NEW_VALUE(Value_Mutex);
     mut->header.tag = MUTEX_TAG;
     mut->mutex = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
     if (pthread_mutex_init(mut->mutex, NULL))
@@ -219,7 +219,7 @@ Value *System_Concurrency_Raw_prim__makeCondition(Value *_world)
     //     pthread_cond_t *cond;
     // }Value_Condition;
 
-    Value_Condition *c = (Value_Condition *)newValue();
+    Value_Condition *c = IDRIS2_NEW_VALUE(Value_Condition);
     c->header.tag = CONDITION_TAG;
     c->cond = (pthread_cond_t *)malloc(sizeof(pthread_cond_t));
     if (pthread_cond_init(c->cond, NULL))

--- a/support/refc/stringOps.c
+++ b/support/refc/stringOps.c
@@ -8,7 +8,7 @@ Value *stringLength(Value *s)
 
 Value *head(Value *str)
 {
-    Value_Char *c = (Value_Char *)newValue();
+    Value_Char *c = IDRIS2_NEW_VALUE(Value_Char);
     c->header.tag = CHAR_TAG;
     c->c = ((Value_String *)str)->str[0];
     return (Value *)c;
@@ -16,7 +16,7 @@ Value *head(Value *str)
 
 Value *tail(Value *input)
 {
-    Value_String *tailStr = (Value_String *)newValue();
+    Value_String *tailStr = IDRIS2_NEW_VALUE(Value_String);
     tailStr->header.tag = STRING_TAG;
     Value_String *s = (Value_String *)input;
     int l = strlen(s->str);
@@ -37,7 +37,7 @@ Value *tail(Value *input)
 
 Value *reverse(Value *str)
 {
-    Value_String *retVal = (Value_String *)newValue();
+    Value_String *retVal = IDRIS2_NEW_VALUE(Value_String);
     retVal->header.tag = STRING_TAG;
     Value_String *input = (Value_String *)str;
     int l = strlen(input->str);


### PR DESCRIPTION
* remove `Value.payload` field
* `IDRIS2_NEW_VALUE` macro now allocates the size needed for the struct