### PR TITLE
Remove Value_Buffer.len field

### DIFF
--- a/support/refc/datatypes.h
+++ b/support/refc/datatypes.h
@@ -176,8 +176,7 @@ typedef struct
 typedef struct
 {
     Value_header header;
-    size_t len;
-    char *buffer;
+    void *buffer; // *Buffer
 } Value_Buffer;
 
 typedef struct


### PR DESCRIPTION
It is not used.

Also change `buffer` field type to avoid confusion.