### PR TITLE
Make foreign calls collect_safe by default

### DIFF
--- a/libs/network/Network/FFI.idr
+++ b/libs/network/Network/FFI.idr
@@ -57,8 +57,7 @@ prim__idrnet_sockaddr_port : (sockfd : SocketDescriptor) -> PrimIO Int
 export
 prim__idrnet_create_sockaddr : PrimIO AnyPtr
 
-%foreign "C__collect_safe:idrnet_accept, libidris2_support, idris_net.h"
-         "C:idrnet_accept, libidris2_support, idris_net.h"
+%foreign "C:idrnet_accept, libidris2_support, idris_net.h"
 export
 prim__idrnet_accept : (sockfd : SocketDescriptor) -> (sockaddr : AnyPtr) -> PrimIO Int
 
@@ -71,13 +70,11 @@ export
 prim__idrnet_send_buf : (sockfd : SocketDescriptor) -> (dataBuffer : AnyPtr) -> (len : Int) -> PrimIO Int
 
 
-%foreign "C__collect_safe:idrnet_recv, libidris2_support, idris_net.h"
-         "C:idrnet_recv, libidris2_support, idris_net.h"
+%foreign "C:idrnet_recv, libidris2_support, idris_net.h"
 export
 prim__idrnet_recv : (sockfd : SocketDescriptor) -> (len : Int) -> PrimIO AnyPtr
 
-%foreign "C__collect_safe:idrnet_recv_buf, libidris2_support, idris_net.h"
-         "C:idrnet_recv_buf, libidris2_support, idris_net.h"
+%foreign "C:idrnet_recv_buf, libidris2_support, idris_net.h"
 export
 prim__idrnet_recv_buf : (sockfd : SocketDescriptor) -> (buf : AnyPtr) -> (len : Int) -> PrimIO Int
 
@@ -92,13 +89,11 @@ prim__idrnet_sendto_buf : (sockfd : SocketDescriptor) -> (dataBuf : AnyPtr) ->
                           (buf_len : Int) -> (host : String) -> (port : Port) ->
                           (family : Int) -> PrimIO Int
 
-%foreign "C__collect_safe:idrnet_recvfrom, libidris2_support, idris_net.h"
-         "C:idrnet_recvfrom, libidris2_support, idris_net.h"
+%foreign "C:idrnet_recvfrom, libidris2_support, idris_net.h"
 export
 prim__idrnet_recvfrom : (sockfd : SocketDescriptor) -> (len : Int) -> PrimIO AnyPtr
 
-%foreign "C__collect_safe:idrnet_recvfrom_buf, libidris2_support, idris_net.h"
-         "C:idrnet_recvfrom_buf, libidris2_support, idris_net.h"
+%foreign "C:idrnet_recvfrom_buf, libidris2_support, idris_net.h"
 export
 prim__idrnet_recvfrom_buf : (sockfd : SocketDescriptor) -> (buf : AnyPtr) -> (len : Int) -> PrimIO AnyPtr
 


### PR DESCRIPTION
__collect_safe in Chez allows C functions to run without worrying about
scheme memory management. The only reason a function wouldn't be collect
safe is if it has access to some scheme managed memory, which with the
FFI as it stands, is only Buffers, and we can spot those.
This means we don't need to have a special C calling convention just for
Chez, and we don't need to expect users to flag potentially blocking
foreign functions.
By the way: __collect_safe only works on Chez >= 9.5.1 anyway, so using
earlier versions may lead to blocking in concurrent programs. We should
document this!