### PR TITLE
Folk Test.Golden as IdrisGolden

### DIFF
--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -1,6 +1,6 @@
 module Main
 
-import Test.Golden
+import IdrisGolden
 
 %default covering
 

--- a/tests/tests.ipkg
+++ b/tests/tests.ipkg
@@ -3,4 +3,4 @@ package runtests
 main = Main
 executable = runtests
 
-depends = contrib, test
+depends = contrib


### PR DESCRIPTION
To be able to freely modify golden testing of Idris compiler and
standard library without affecting users of generic `Test.Golden`.

Possible extensions to now forked `IdrisGolden` test:

* remove `build` directory in the test framework instead of in each test
* support specifying list of codegens per `.idr` file instead of per set of tests
* support test autodiscovery (without having to list them in `Main.idr`)
* use default `run` file if no run file provider
* support different test types from instructions inside `.idr` test

I imagine test framework could support something like this: a folder with
only `.idr` file with content:

```
-- specify codegens per file instead of per test set
-- @idris-test-codegen: chez, refc
-- specify test type: file must be compiled and executed with zero exit code,
-- stdin is not used, stdout and stderr is ignored
-- @idris-test-type: execute-expect-zero-return

main : IO () = ...
```

I argue that when tests are easier to write, it encourages people
to write more tests. And currently Idris is undertested, and that
can be attributed to the relative high cost of writing a new test.