### PR TITLE
Rename C__collect_safe call convention to C__blocking

### DIFF
--- a/libs/network/Network/FFI.idr
+++ b/libs/network/Network/FFI.idr
@@ -57,7 +57,7 @@ prim__idrnet_sockaddr_port : (sockfd : SocketDescriptor) -> PrimIO Int
 export
 prim__idrnet_create_sockaddr : PrimIO AnyPtr
 
-%foreign "C__collect_safe:idrnet_accept, libidris2_support, idris_net.h"
+%foreign "C__blocking:idrnet_accept, libidris2_support, idris_net.h"
          "C:idrnet_accept, libidris2_support, idris_net.h"
 export
 prim__idrnet_accept : (sockfd : SocketDescriptor) -> (sockaddr : AnyPtr) -> PrimIO Int
@@ -71,12 +71,12 @@ export
 prim__idrnet_send_buf : (sockfd : SocketDescriptor) -> (dataBuffer : AnyPtr) -> (len : Int) -> PrimIO Int
 
 
-%foreign "C__collect_safe:idrnet_recv, libidris2_support, idris_net.h"
+%foreign "C__blocking:idrnet_recv, libidris2_support, idris_net.h"
          "C:idrnet_recv, libidris2_support, idris_net.h"
 export
 prim__idrnet_recv : (sockfd : SocketDescriptor) -> (len : Int) -> PrimIO AnyPtr
 
-%foreign "C__collect_safe:idrnet_recv_buf, libidris2_support, idris_net.h"
+%foreign "C__blocking:idrnet_recv_buf, libidris2_support, idris_net.h"
          "C:idrnet_recv_buf, libidris2_support, idris_net.h"
 export
 prim__idrnet_recv_buf : (sockfd : SocketDescriptor) -> (buf : AnyPtr) -> (len : Int) -> PrimIO Int
@@ -92,12 +92,12 @@ prim__idrnet_sendto_buf : (sockfd : SocketDescriptor) -> (dataBuf : AnyPtr) ->
                           (buf_len : Int) -> (host : String) -> (port : Port) ->
                           (family : Int) -> PrimIO Int
 
-%foreign "C__collect_safe:idrnet_recvfrom, libidris2_support, idris_net.h"
+%foreign "C__blocking:idrnet_recvfrom, libidris2_support, idris_net.h"
          "C:idrnet_recvfrom, libidris2_support, idris_net.h"
 export
 prim__idrnet_recvfrom : (sockfd : SocketDescriptor) -> (len : Int) -> PrimIO AnyPtr
 
-%foreign "C__collect_safe:idrnet_recvfrom_buf, libidris2_support, idris_net.h"
+%foreign "C__blocking:idrnet_recvfrom_buf, libidris2_support, idris_net.h"
          "C:idrnet_recvfrom_buf, libidris2_support, idris_net.h"
 export
 prim__idrnet_recvfrom_buf : (sockfd : SocketDescriptor) -> (buf : AnyPtr) -> (len : Int) -> PrimIO AnyPtr

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -317,14 +317,14 @@ useCC : {auto c : Ref Ctxt Defs} ->
         FC -> List String -> List (Name, CFType) -> CFType ->
         Maybe Version -> Core (Maybe String, String)
 useCC fc ccs args ret version
-    = case parseCC ["scheme,chez", "scheme", "C__collect_safe", "C"] ccs of
+    = case parseCC ["scheme,chez", "scheme", "C__blocking", "C"] ccs of
            Just ("scheme,chez", [sfn]) =>
                do body <- schemeCall fc sfn (map fst args) ret
                   pure (Nothing, body)
            Just ("scheme", [sfn]) =>
                do body <- schemeCall fc sfn (map fst args) ret
                   pure (Nothing, body)
-           Just ("C__collect_safe", (cfn :: clib :: _)) => do
+           Just ("C__blocking", (cfn :: clib :: _)) => do
              if unsupportedCallingConvention version
                then cCall fc cfn clib args ret False
                else cCall fc cfn clib args ret True


### PR DESCRIPTION
The idea is this. RefC codegen might need to support threading.
The obvious way to suport threading is to implement GIL (as Python
does).

To make GIL useful, we need to unlock it sometimes. As in Python,
we can unlock GIL when we are performing blocking native calls.

Thus `C__blocking` convention can be used in RefC codegen to emit
code similar to `C` convention with addition of unlocking/locking
GIL.