### PR TITLE
Properly compute length of string in stringByteLength

### DIFF
--- a/libs/base/Data/Buffer.idr
+++ b/libs/base/Data/Buffer.idr
@@ -195,7 +195,8 @@ getDouble buf loc
 
 -- Get the length of a string in bytes, rather than characters
 export
-%foreign "C:strlen,libc 6"
+%foreign "scheme:blodwen-stringbytelen"
+         "RefC:strlen"
 stringByteLength : String -> Int
 
 %foreign "scheme:blodwen-buffer-setstring"


### PR DESCRIPTION
String may contain `\0` characters, these cannot be counted with
`strlen`.

The definition of `blodwen-stringbytelen` is:

```
(define (blodwen-stringbytelen str)
  (bytevector-length (string->utf8 str)))
```

so it allocates a bytevector to compute length. But calling FFI
function with `char*` argument should perform the same conversion,
so the change should have no perf effect.

I have not found Chez API to find string UTF-8 length without
converting it into a buffer explicitly or implicitly.

Note RefC assumes string is nul-terminated, this can be fixed too,
but not in this PR.