### PR TITLE
Enable incremental compilation on Windows.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,16 @@ libdocs:
 	${MAKE} -C libs/network docs IDRIS2=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 	${MAKE} -C libs/test docs IDRIS2=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 
+
+ifeq ($(OS), windows)
+${TEST_PREFIX}/${NAME_VERSION} :
+	${MAKE} install-support PREFIX=${TEST_PREFIX}
+	cp -rf ${IDRIS2_CURDIR}/libs/prelude/build/ttc ${TEST_PREFIX}/${NAME_VERSION}/prelude-${IDRIS2_VERSION}
+	cp -rf ${IDRIS2_CURDIR}/libs/base/build/ttc    ${TEST_PREFIX}/${NAME_VERSION}/base-${IDRIS2_VERSION}
+	cp -rf ${IDRIS2_CURDIR}/libs/test/build/ttc    ${TEST_PREFIX}/${NAME_VERSION}/test-${IDRIS2_VERSION}
+	cp -rf ${IDRIS2_CURDIR}/libs/contrib/build/ttc ${TEST_PREFIX}/${NAME_VERSION}/contrib-${IDRIS2_VERSION}
+	cp -rf ${IDRIS2_CURDIR}/libs/network/build/ttc ${TEST_PREFIX}/${NAME_VERSION}/network-${IDRIS2_VERSION}
+else
 ${TEST_PREFIX}/${NAME_VERSION} :
 	${MAKE} install-support PREFIX=${TEST_PREFIX}
 	ln -s ${IDRIS2_CURDIR}/libs/prelude/build/ttc ${TEST_PREFIX}/${NAME_VERSION}/prelude-${IDRIS2_VERSION}
@@ -102,6 +112,7 @@ ${TEST_PREFIX}/${NAME_VERSION} :
 	ln -s ${IDRIS2_CURDIR}/libs/test/build/ttc    ${TEST_PREFIX}/${NAME_VERSION}/test-${IDRIS2_VERSION}
 	ln -s ${IDRIS2_CURDIR}/libs/contrib/build/ttc ${TEST_PREFIX}/${NAME_VERSION}/contrib-${IDRIS2_VERSION}
 	ln -s ${IDRIS2_CURDIR}/libs/network/build/ttc ${TEST_PREFIX}/${NAME_VERSION}/network-${IDRIS2_VERSION}
+endif
 
 testenv:
 	@${MAKE} ${TEST_PREFIX}/${NAME_VERSION}

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -100,7 +100,7 @@ schHeader chez libs whole
     showSep "\n" (map (\x => "(load-shared-object \"" ++ escapeStringChez x ++ "\")") libs) ++ "\n\n" ++
     if whole
        then "(let ()\n"
-       else "(source-directories (list (getenv \"IDRIS2_INC_SRC\") \".\"))\n"
+       else "(source-directories (cons (getenv \"IDRIS2_INC_SRC\") (source-directories)))\n"
 
 schFooter : Bool -> Bool -> String
 schFooter prof whole

--- a/tests/chez/chez033/run
+++ b/tests/chez/chez033/run
@@ -1,9 +1,2 @@
-if [ "$OS" = "windows" ]; then
-    # incremental builds don't work on windows so we get lots of warnings,
-    # but we still need the test output to be correct
-    $1 --no-banner --no-color --console-width 0 Main.idr < input
-else
-    $1 --no-banner --no-color --console-width 0 Main.idr --inc chez < input
-fi
-
+$1 --no-banner --no-color --console-width 0 Main.idr --inc chez < input
 rm -rf build


### PR DESCRIPTION
Update Windows launch script.

Add back the current directory to source-directories (not needed for
this, but it's the default and it's better to keep load working as usual,
there's no risk as the new dir has priority).

Copy libs instead of linking when testing (linking has bad interactions
with admin privileges).