### PR TITLE
Replace per signal counter with per signal flag

### DIFF
--- a/support/c/idris_signal.c
+++ b/support/c/idris_signal.c
@@ -5,7 +5,9 @@
 #include <limits.h>
 #include <signal.h>
 #include <stdatomic.h>
+#include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "idris_util.h"
@@ -14,13 +16,12 @@ static_assert(ATOMIC_LONG_LOCK_FREE == 2,
   "when not lock free, atomic functions are not async-signal-safe");
 
 #define N_SIGNALS 32
-static atomic_long signal_count[N_SIGNALS];
+static atomic_uint_fast32_t signals;
 
 void _collect_signal(int signum) {
   IDRIS2_VERIFY(signum >= 0 && signum < N_SIGNALS, "signal number out of range: %d", signum);
 
-  long prev = atomic_fetch_add(&signal_count[signum], 1);
-  IDRIS2_VERIFY(prev != LONG_MAX, "signal count overflow");
+  atomic_fetch_or(&signals, (uint32_t) 1 << signum);
 
 #ifdef _WIN32
   //re-instate signal handler
@@ -68,19 +69,18 @@ int collect_signal(int signum) {
 }
 
 int handle_next_collected_signal() {
-  for (int signum = 0; signum != N_SIGNALS; ++signum) {
-    for (;;) {
-      long count = atomic_load(&signal_count[signum]);
-      if (count == 0) {
-        break;
-      }
-      IDRIS2_VERIFY(count >= 0, "signal count overflow");
-      if (atomic_compare_exchange_strong(&signal_count[signum], &count, count - 1)) {
-        return signum;
-      }
+  uint32_t signals_snapshot = atomic_load(&signals);
+  if (signals_snapshot == 0) {
+    return -1;
+  }
+  for (uint32_t signum = 0; signum != N_SIGNALS; ++signum) {
+    uint32_t mask = (uint32_t) 1 << signum;
+    if ((signals_snapshot & mask) != 0) {
+      atomic_fetch_and(&signals, ~mask);
+      return signum;
     }
   }
-  return -1;
+  abort();
 }
 
 int raise_signal(int signum) {

--- a/tests/base/system_signal004/HandleManySignals.idr
+++ b/tests/base/system_signal004/HandleManySignals.idr
@@ -7,12 +7,16 @@ main : IO ()
 main = do
   Right () <- collectSignal SigABRT
     | Left (Error code) => putStrLn $ "error " ++ (show code)
+  Right () <- collectSignal SigILL
+    | Left (Error code) => putStrLn $ "error " ++ (show code)
   putStrLn "before"
   [Right (), Right (), Right ()] <- sequence $ replicate 3 (raiseSignal SigABRT)
     | _ => putStrLn $ "got non-zero exit from a system call"
+  [Right (), Right (), Right ()] <- sequence $ replicate 3 (raiseSignal SigILL)
+    | _ => putStrLn $ "got non-zero exit from a system call"
   sleep 1
-  [SigABRT, SigABRT, SigABRT] <- handleManyCollectedSignals (limit 4)
-    | (_ :: _ :: _ :: [])  => putStrLn "received the wrong signals."
+  [SigILL, SigABRT] <- handleManyCollectedSignals (limit 4)
+    | (_ :: _ :: [])  => putStrLn "received the wrong signals."
     | _ => putStrLn "did not receive expected number of signals."
   putStrLn "after"
   Right () <- defaultSignal SigABRT


### PR DESCRIPTION
Operating system counter stores signals as flag set without counter.
So sending two signals to a process may result to one or two signal
handler invocation. Queueing signals inside Idris could give users
false sense of signals being are queue, while they are not.

In particular, test for signal could not work reliably for that
reason.

Also, practically we usually don't need have more than once signal
event.

This is follow-up to #1660. CC @mattpolzin