### PR TITLE
RefC string functions refactoring

### DIFF
--- a/support/refc/casts.c
+++ b/support/refc/casts.c
@@ -70,9 +70,7 @@ Value *cast_Int8_to_string(Value *input)
 {
     Value_Int8 *from = (Value_Int8 *)input;
 
-    int l = snprintf(NULL, 0, "%" PRId8 "", from->i8);
-    Value_String *retVal = makeEmptyString(l + 1);
-    sprintf(retVal->str, "%" PRId8 "", from->i8);
+    Value_String *retVal = makeStringPrintf("%" PRId8 "", from->i8);
 
     return (Value *)retVal;
 }
@@ -146,9 +144,7 @@ Value *cast_Int16_to_string(Value *input)
 {
     Value_Int16 *from = (Value_Int16 *)input;
 
-    int l = snprintf(NULL, 0, "%" PRId16 "", from->i16);
-    Value_String *retVal = makeEmptyString(l + 1);
-    sprintf(retVal->str, "%" PRId16 "", from->i16);
+    Value_String *retVal = makeStringPrintf("%" PRId16 "", from->i16);
 
     return (Value *)retVal;
 }
@@ -222,9 +218,7 @@ Value *cast_Int32_to_string(Value *input)
 {
     Value_Int32 *from = (Value_Int32 *)input;
 
-    int l = snprintf(NULL, 0, "%" PRId32 "", from->i32);
-    Value_String *retVal = makeEmptyString(l + 1);
-    sprintf(retVal->str, "%" PRId32 "", from->i32);
+    Value_String *retVal = makeStringPrintf("%" PRId32 "", from->i32);
 
     return (Value *)retVal;
 }
@@ -304,9 +298,7 @@ Value *cast_Int64_to_string(Value *input)
 {
     Value_Int64 *from = (Value_Int64 *)input;
 
-    int l = snprintf(NULL, 0, "%" PRId64 "", from->i64);
-    Value_String *retVal = makeEmptyString(l + 1);
-    sprintf(retVal->str, "%" PRId64 "", from->i64);
+    Value_String *retVal = makeStringPrintf("%" PRId64 "", from->i64);
 
     return (Value *)retVal;
 }
@@ -379,9 +371,7 @@ Value *cast_double_to_string(Value *input)
 {
     Value_Double *from = (Value_Double *)input;
 
-    int l = snprintf(NULL, 0, "%f", from->d);
-    Value_String *retVal = makeEmptyString(l + 1);
-    sprintf(retVal->str, "%f", from->d);
+    Value_String *retVal = makeStringPrintf("%f", from->d);
 
     return (Value *)retVal;
 }
@@ -454,8 +444,8 @@ Value *cast_char_to_string(Value *input)
 {
     Value_Char *from = (Value_Char *)input;
 
-    Value_String *retVal = makeEmptyString(2);
-    retVal->str[0] = from->c;
+    char c = from->c;
+    Value_String *retVal = makeStringWithLength(&c, 1);
 
     return (Value *)retVal;
 }
@@ -607,9 +597,7 @@ Value *cast_Bits8_to_string(Value *input)
 {
     Value_Bits8 *from = (Value_Bits8 *)input;
 
-    int l = snprintf(NULL, 0, "%" PRIu8 "", from->ui8);
-    Value_String *retVal = makeEmptyString(l + 1);
-    sprintf(retVal->str, "%" PRIu8 "", from->ui8);
+    Value_String *retVal = makeStringPrintf("%" PRIu8 "", from->ui8);
 
     return (Value *)retVal;
 }
@@ -683,9 +671,7 @@ Value *cast_Bits16_to_string(Value *input)
 {
     Value_Bits16 *from = (Value_Bits16 *)input;
 
-    int l = snprintf(NULL, 0, "%" PRIu16 "", from->ui16);
-    Value_String *retVal = makeEmptyString(l + 1);
-    sprintf(retVal->str, "%" PRIu16 "", from->ui16);
+    Value_String *retVal = makeStringPrintf("%" PRIu16 "", from->ui16);
 
     return (Value *)retVal;
 }
@@ -759,9 +745,7 @@ Value *cast_Bits32_to_string(Value *input)
 {
     Value_Bits32 *from = (Value_Bits32 *)input;
 
-    int l = snprintf(NULL, 0, "%" PRIu32 "", from->ui32);
-    Value_String *retVal = makeEmptyString(l + 1);
-    sprintf(retVal->str, "%" PRIu32 "", from->ui32);
+    Value_String *retVal = makeStringPrintf("%" PRIu32 "", from->ui32);
 
     return (Value *)retVal;
 }
@@ -835,9 +819,7 @@ Value *cast_Bits64_to_string(Value *input)
 {
     Value_Bits64 *from = (Value_Bits64 *)input;
 
-    int l = snprintf(NULL, 0, "%" PRIu64 "", from->ui64);
-    Value_String *retVal = makeEmptyString(l + 1);
-    sprintf(retVal->str, "%" PRIu64 "", from->ui64);
+    Value_String *retVal = makeStringPrintf("%" PRIu64 "", from->ui64);
 
     return (Value *)retVal;
 }

--- a/support/refc/memoryManagement.c
+++ b/support/refc/memoryManagement.c
@@ -1,5 +1,7 @@
 #include "runtime.h"
 
+#include <stdarg.h>
+
 Value *newValue()
 {
     Value *retVal = (Value *)malloc(sizeof(Value));
@@ -146,23 +148,40 @@ Value_Integer *makeIntegerLiteral(char *i)
     return retVal;
 }
 
-Value_String *makeEmptyString(size_t l)
+Value_String *makeString(const char *s)
+{
+    return makeStringWithLength(s, strlen(s));
+}
+
+Value_String *makeStringWithLength(const char *s, size_t len)
+{
+    return makeStringConcat(s, len, "", 0);
+}
+
+Value_String *makeStringConcat(const char *a, size_t a_len, const char *b, size_t b_len)
 {
     Value_String *retVal = (Value_String *)newValue();
     retVal->header.tag = STRING_TAG;
-    retVal->str = malloc(l);
-    memset(retVal->str, 0, l);
+    retVal->str = malloc(a_len + b_len + 1);
+    memcpy(retVal->str, a, a_len);
+    memcpy(retVal->str + a_len, b, b_len);
+    retVal->str[a_len + b_len] = 0;
     return retVal;
 }
 
-Value_String *makeString(char *s)
+Value_String* makeStringPrintf(const char* fmt, ...)
 {
     Value_String *retVal = (Value_String *)newValue();
-    int l = strlen(s);
+
+    va_list ap;
+    va_start(ap, fmt);
+    size_t len = vsnprintf(NULL, 0, fmt, ap);
+    va_end(ap);
     retVal->header.tag = STRING_TAG;
-    retVal->str = malloc(l + 1);
-    memset(retVal->str, 0, l + 1);
-    memcpy(retVal->str, s, l);
+    retVal->str = malloc(len + 1);
+    va_start(ap, fmt);
+    vsnprintf(retVal->str, len + 1, fmt, ap);
+    va_end(ap);
     return retVal;
 }
 

--- a/support/refc/memoryManagement.h
+++ b/support/refc/memoryManagement.h
@@ -25,8 +25,14 @@ Value_Int64 *makeInt64(int64_t i);
 Value_Int8 *makeBool(int p);
 Value_Integer *makeInteger();
 Value_Integer *makeIntegerLiteral(char *i);
-Value_String *makeEmptyString(size_t l);
-Value_String *makeString(char *);
+Value_String *makeString(const char *);
+Value_String *makeStringWithLength(const char *, size_t);
+Value_String *makeStringConcat(const char *a, size_t a_len, const char *b, size_t b_len);
+Value_String *makeStringPrintf(const char* fmt, ...)
+#if defined(__clang__) || defined(__GNUC__)
+__attribute__ ((format(printf, 1, 2)))
+#endif
+;
 
 Value_Pointer *makePointer(void *);
 Value_GCPointer *makeGCPointer(void *ptr_Raw, Value_Closure *onCollectFct);

--- a/support/refc/stringOps.c
+++ b/support/refc/stringOps.c
@@ -16,22 +16,15 @@ Value *head(Value *str)
 
 Value *tail(Value *input)
 {
-    Value_String *tailStr = (Value_String *)newValue();
-    tailStr->header.tag = STRING_TAG;
     Value_String *s = (Value_String *)input;
-    int l = strlen(s->str);
+    size_t l = strlen(s->str);
     if(l != 0)
     {
-        tailStr->str = malloc(l);
-        memset(tailStr->str, 0, l);
-        memcpy(tailStr->str, s->str + 1, l - 1);
-        return (Value *)tailStr;
+        return (Value *)makeStringWithLength(s->str + 1, l - 1);
     }
     else
     {
-        tailStr->str = malloc(1);
-        tailStr->str[0] = '\0';
-        return (Value *)tailStr;
+        return (Value *)makeStringWithLength("", 0);
     }
 }
 
@@ -61,21 +54,16 @@ Value *strIndex(Value *str, Value *i)
 
 Value *strCons(Value *c, Value *str)
 {
-    int l = strlen(((Value_String *)str)->str);
-    Value_String *retVal = makeEmptyString(l + 2);
-    retVal->str[0] = ((Value_Char *)c)->c;
-    memcpy(retVal->str + 1, ((Value_String *)str)->str, l);
-    return (Value *)retVal;
+    char c_char = ((Value_Char *)c)->c;
+    char *str_s = ((Value_String *)str)->str;
+    return (Value *)makeStringConcat(&c_char, 1, str_s, strlen(str_s));
 }
 
 Value *strAppend(Value *a, Value *b)
 {
-    int la = strlen(((Value_String *)a)->str);
-    int lb = strlen(((Value_String *)b)->str);
-    Value_String *retVal = makeEmptyString(la + lb + 1);
-    memcpy(retVal->str, ((Value_String *)a)->str, la);
-    memcpy(retVal->str + la, ((Value_String *)b)->str, lb);
-    return (Value *)retVal;
+    char *a_s = ((Value_String *)a)->str;
+    char *b_s = ((Value_String *)b)->str;
+    return (Value *)makeStringConcat(a_s, strlen(a_s), b_s, strlen(b_s));
 }
 
 Value *strSubstr(Value *start, Value *len, Value *s)
@@ -90,8 +78,7 @@ Value *strSubstr(Value *start, Value *len, Value *s)
         l = tailLen;
     }
 
-    Value_String *retVal = makeEmptyString(l + 1);
-    memcpy(retVal->str, input + offset, l);
+    Value_String *retVal = makeStringWithLength(input + offset, l);
 
     return (Value *)retVal;
 }


### PR DESCRIPTION
* remove `makeEmptyString` function, it's safer when `Value_String`
  is not modified after creation, especially in non-string impl code
* add `makeStringWithLength` funtion which accepts string length
  and does not require a string to be NUL-terminated
* add `makeStringConcat` to construct a string by concatenating two strings
* add `makeStringPrintf` to create a string with `sprintf`

This is a preparation to change `String` implementation in RefC:
* store string length in `Value_String`
* possibly do not require a string to be NUL-terminated