### PR TITLE
Move rm -rf to the beginning of the test

### DIFF
--- a/tests/allbackends/basic048/run
+++ b/tests/allbackends/basic048/run
@@ -1,5 +1,6 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 "Module'.idr" < input
 $1 --exec main "Module'.idr"
 EDITOR=true $1 --no-banner --no-color --console-width 0 "Module'.idr" < input-ed
 
-rm -rf build

--- a/tests/allbackends/evaluator004/run
+++ b/tests/allbackends/evaluator004/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 Issue735.idr < input
 $1 --exec main Issue735.idr
 
-rm -rf build

--- a/tests/allbackends/evaluator005/run
+++ b/tests/allbackends/evaluator005/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --exec main Issue1200.idr
 
-rm -rf build

--- a/tests/allbackends/perf006/run
+++ b/tests/allbackends/perf006/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --exec main Issue775.idr
 
-rm -rf build

--- a/tests/base/control_app001/run
+++ b/tests/base/control_app001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner TestException.idr < input
 
-rm -rf build

--- a/tests/base/data_bits001/run
+++ b/tests/base/data_bits001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 BitOps.idr < input
 
-rm -rf build

--- a/tests/base/system_errno/run
+++ b/tests/base/system_errno/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 Test.idr < input
 
-rm -rf build

--- a/tests/base/system_file001/run
+++ b/tests/base/system_file001/run
@@ -1,3 +1,5 @@
+rm -rf build
+
 # @readFilePage@ uses primitive functions with definitions for both
 # C (supported by most backends) and Node.
 $1 --cg chez --no-color --console-width 0 --no-banner ReadFilePage.idr < input
@@ -12,4 +14,3 @@ $1 --cg node --no-color --console-width 0 --no-banner ReadFilePage.idr < input
 # GAMBIT hung seemingly indefinitely
 # $1 --cg gambit --no-color --console-width 0 --no-banner ReadFilePage.idr < input
 
-rm -rf build

--- a/tests/base/system_info001/run
+++ b/tests/base/system_info001/run
@@ -1,3 +1,5 @@
+rm -rf build
+
 rm -f expected
 
 if ! NProcs=$(nproc || sysctl -n hw.ncpu) 2>/dev/null; then
@@ -9,4 +11,3 @@ echo "$NProcs processors" > expected
 
 $1 --no-banner --no-color --console-width 0 NumProcessors.idr --exec main
 
-rm -rf build

--- a/tests/base/system_info_os001/run
+++ b/tests/base/system_info_os001/run
@@ -1,3 +1,5 @@
+rm -rf build
+
 case "$(uname)" in
   Linux*) EXPECTED_OS=unix ;;
   Darwin*) EXPECTED_OS=darwin ;;
@@ -9,4 +11,3 @@ export EXPECTED_OS
 
 $1 --no-banner --no-color --console-width 0 Os.idr --exec main
 
-rm -rf build

--- a/tests/base/system_signal001/run
+++ b/tests/base/system_signal001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner IgnoreSignal.idr < input
 
-rm -rf build

--- a/tests/base/system_signal002/run
+++ b/tests/base/system_signal002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner HandleSignal.idr < input
 
-rm -rf build

--- a/tests/base/system_signal003/run
+++ b/tests/base/system_signal003/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner DefaultSignal.idr < input 2> /dev/null
 
-rm -rf build

--- a/tests/base/system_signal004/run
+++ b/tests/base/system_signal004/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner HandleManySignals.idr < input
 
-rm -rf build

--- a/tests/base/system_system/run
+++ b/tests/base/system_system/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Test.idr < input
 
-rm -rf build

--- a/tests/chez/bitops/run
+++ b/tests/chez/bitops/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 BitOps.idr < input
 
-rm -rf build

--- a/tests/chez/casts/run
+++ b/tests/chez/casts/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 Casts.idr < input
 
-rm -rf build

--- a/tests/chez/channels001/run
+++ b/tests/chez/channels001/run
@@ -1,2 +1,3 @@
-$1 --no-banner --no-color --console-width 0 --cg chez Main.idr --exec main
 rm -rf build
+
+$1 --no-banner --no-color --console-width 0 --cg chez Main.idr --exec main

--- a/tests/chez/channels002/run
+++ b/tests/chez/channels002/run
@@ -1,2 +1,3 @@
-$1 --no-banner --no-color --console-width 0 --cg chez Main.idr --exec main
 rm -rf build
+
+$1 --no-banner --no-color --console-width 0 --cg chez Main.idr --exec main

--- a/tests/chez/channels003/run
+++ b/tests/chez/channels003/run
@@ -1,2 +1,3 @@
-$1 --no-banner --no-color --console-width 0 --cg chez Main.idr --exec main
 rm -rf build
+
+$1 --no-banner --no-color --console-width 0 --cg chez Main.idr --exec main

--- a/tests/chez/channels004/run
+++ b/tests/chez/channels004/run
@@ -1,2 +1,3 @@
-$1 --no-banner --no-color --console-width 0 --cg chez Main.idr --exec main
 rm -rf build
+
+$1 --no-banner --no-color --console-width 0 --cg chez Main.idr --exec main

--- a/tests/chez/channels005/run
+++ b/tests/chez/channels005/run
@@ -1,2 +1,3 @@
-$1 --no-banner --no-color --console-width 0 --cg chez Main.idr --exec main
 rm -rf build
+
+$1 --no-banner --no-color --console-width 0 --cg chez Main.idr --exec main

--- a/tests/chez/chez001/run
+++ b/tests/chez/chez001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Total.idr < input
 
-rm -rf build

--- a/tests/chez/chez002/run
+++ b/tests/chez/chez002/run
@@ -1,2 +1,3 @@
-$1 --no-color --console-width 0 --no-banner Pythag.idr < input
 rm -rf build
+
+$1 --no-color --console-width 0 --no-banner Pythag.idr < input

--- a/tests/chez/chez003/run
+++ b/tests/chez/chez003/run
@@ -1,2 +1,3 @@
-$1 --no-color --console-width 0 --no-banner IORef.idr < input
 rm -rf build
+
+$1 --no-color --console-width 0 --no-banner IORef.idr < input

--- a/tests/chez/chez005/run
+++ b/tests/chez/chez005/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Filter.idr < input
 
-rm -rf build

--- a/tests/chez/chez006/run
+++ b/tests/chez/chez006/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner TypeCase.idr < input
 $1 --no-color --console-width 0 --no-banner TypeCase2.idr --check
 
-rm -rf build

--- a/tests/chez/chez007/run
+++ b/tests/chez/chez007/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner TypeCase.idr < input
 
-rm -rf build

--- a/tests/chez/chez008/run
+++ b/tests/chez/chez008/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Nat.idr < input
 
-rm -rf build

--- a/tests/chez/chez009/run
+++ b/tests/chez/chez009/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner uni.idr < input
 
-rm -rf build

--- a/tests/chez/chez011/run
+++ b/tests/chez/chez011/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner bangs.idr < input
 
-rm -rf build

--- a/tests/chez/chez012/run
+++ b/tests/chez/chez012/run
@@ -1,2 +1,3 @@
-$1 --no-color --console-width 0 --no-banner array.idr < input
 rm -rf build
+
+$1 --no-color --console-width 0 --no-banner array.idr < input

--- a/tests/chez/chez014/run
+++ b/tests/chez/chez014/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner -p network Echo.idr < input
 
-rm -rf build

--- a/tests/chez/chez015/run
+++ b/tests/chez/chez015/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Numbers.idr < input
 
-rm -rf build

--- a/tests/chez/chez016/run
+++ b/tests/chez/chez016/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 cd "folder with spaces" || exit
 
 $1 --no-color --console-width 0 --no-banner Main.idr < ../input
-rm -rf build

--- a/tests/chez/chez020/run
+++ b/tests/chez/chez020/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 POPEN_CMD="$1 --version" $1 --no-color --console-width 0 --no-banner Popen.idr < input
 
-rm -rf build

--- a/tests/chez/chez021/run
+++ b/tests/chez/chez021/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Bits.idr < input
 
-rm -rf build

--- a/tests/chez/chez024/run
+++ b/tests/chez/chez024/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Envy.idr < input
 
-rm -rf build

--- a/tests/chez/chez025/run
+++ b/tests/chez/chez025/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner runst.idr < input
 
-rm -rf build

--- a/tests/chez/chez027/run
+++ b/tests/chez/chez027/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner -p contrib StringParser.idr < input
 
-rm -rf build

--- a/tests/chez/chez028/run
+++ b/tests/chez/chez028/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 -p contrib ExpressionParser.idr < input
 
-rm -rf build

--- a/tests/chez/chez029/run
+++ b/tests/chez/chez029/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 BitCasts.idr < input
 
-rm -rf build

--- a/tests/chez/chez030/run
+++ b/tests/chez/chez030/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 --directive extraRuntime=extensions.scm -o chez030 ExtraRuntime.idr
 ./build/exec/chez030
 
-rm -rf build

--- a/tests/chez/chez031/run
+++ b/tests/chez/chez031/run
@@ -1,5 +1,6 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 --cg chez Specifiers.idr --exec main
 $1 --no-banner --no-color --console-width 0 --cg chez Specifiers.idr -o build/foo
 $1 --no-banner --no-color --console-width 0 --cg chez < input
 
-rm -rf build

--- a/tests/chez/chez032/run
+++ b/tests/chez/chez032/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 BitOps.idr < input
 
-rm -rf build

--- a/tests/chez/chez033/run
+++ b/tests/chez/chez033/run
@@ -1,2 +1,3 @@
-$1 --no-banner --no-color --console-width 0 Main.idr --inc chez < input
 rm -rf build
+
+$1 --no-banner --no-color --console-width 0 Main.idr --inc chez < input

--- a/tests/chez/integers/run
+++ b/tests/chez/integers/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 -o integers TestIntegers.idr > /dev/null
 ./build/exec/integers
 
-rm -rf build

--- a/tests/chez/newints/run
+++ b/tests/chez/newints/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 IntOps.idr < input
 
-rm -rf build

--- a/tests/chez/perf001/run
+++ b/tests/chez/perf001/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 -c Fact.idr -o fact
 ./build/exec/fact
 
-rm -rf build

--- a/tests/chez/reg001/run
+++ b/tests/chez/reg001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 numbers.idr -x main
 
-rm -rf build

--- a/tests/contrib/json_001/run
+++ b/tests/contrib/json_001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 -p contrib CharEncoding.idr < input
 
-rm -rf build

--- a/tests/ideMode/ideMode001/run
+++ b/tests/ideMode/ideMode001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --ide-mode < input
 
-rm -rf build

--- a/tests/ideMode/ideMode002/run
+++ b/tests/ideMode/ideMode002/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --version | awk '{print $4}' | ./gen_expected.sh
 $1 --no-color --console-width 0 --ide-mode < input
 
-rm -rf build

--- a/tests/ideMode/ideMode003/run
+++ b/tests/ideMode/ideMode003/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --ide-mode < input
 
-rm -rf build

--- a/tests/ideMode/ideMode004/run
+++ b/tests/ideMode/ideMode004/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --ide-mode < input
 
-rm -rf build

--- a/tests/ideMode/ideMode005/run
+++ b/tests/ideMode/ideMode005/run
@@ -1,3 +1,5 @@
+rm -rf build
+
 rm -f output*
 
 $1 --no-color --console-width 0 --ide-mode < input1 > output1
@@ -51,4 +53,3 @@ diff expectedG outputG >> output
 $1 --no-color --console-width 0 --ide-mode < inputH > outputH
 diff expectedH outputH >> output
 
-rm -rf build

--- a/tests/idris2/basic001/run
+++ b/tests/idris2/basic001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --no-prelude Vect.idr < input
 
-rm -rf build

--- a/tests/idris2/basic002/run
+++ b/tests/idris2/basic002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --no-prelude Do.idr < input
 
-rm -rf build

--- a/tests/idris2/basic003/run
+++ b/tests/idris2/basic003/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 echo ':q' | $1 --no-color --console-width 0 --no-banner --no-prelude Ambig1.idr
 echo ':q' | $1 --no-color --console-width 0 --no-banner --no-prelude Ambig2.idr
 
-rm -rf build

--- a/tests/idris2/basic004/run
+++ b/tests/idris2/basic004/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --no-prelude Wheres.idr < input
 
-rm -rf build

--- a/tests/idris2/basic005/run
+++ b/tests/idris2/basic005/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 echo ':q' | $1 --no-color --console-width 0 --no-banner --no-prelude NoInfer.idr
 
-rm -rf build

--- a/tests/idris2/basic006/run
+++ b/tests/idris2/basic006/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --no-prelude PMLet.idr < input
 
-rm -rf build

--- a/tests/idris2/basic007/run
+++ b/tests/idris2/basic007/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --no-prelude DoLocal.idr < input
 
-rm -rf build

--- a/tests/idris2/basic008/run
+++ b/tests/idris2/basic008/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --no-prelude If.idr < input
 
-rm -rf build

--- a/tests/idris2/basic009/run
+++ b/tests/idris2/basic009/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --no-prelude LetCase.idr < input
 
-rm -rf build

--- a/tests/idris2/basic010/run
+++ b/tests/idris2/basic010/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --no-prelude Comp.idr < input
 
-rm -rf build

--- a/tests/idris2/basic011/run
+++ b/tests/idris2/basic011/run
@@ -1,5 +1,6 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Dots1.idr
 $1 --no-color --console-width 0 --check Dots2.idr
 $1 --no-color --console-width 0 --check Dots3.idr
 
-rm -rf build

--- a/tests/idris2/basic012/run
+++ b/tests/idris2/basic012/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check VIndex.idr
 
-rm -rf build

--- a/tests/idris2/basic013/run
+++ b/tests/idris2/basic013/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Implicits.idr
 
-rm -rf build

--- a/tests/idris2/basic014/run
+++ b/tests/idris2/basic014/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Rewrite.idr
 
-rm -rf build

--- a/tests/idris2/basic015/run
+++ b/tests/idris2/basic015/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check George.idr
 
-rm -rf build

--- a/tests/idris2/basic016/run
+++ b/tests/idris2/basic016/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Eta.idr
 $1 --no-color --console-width 0 --check Eta2.idr
 
-rm -rf build

--- a/tests/idris2/basic017/run
+++ b/tests/idris2/basic017/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner CaseInf.idr < input
 
-rm -rf build

--- a/tests/idris2/basic018/run
+++ b/tests/idris2/basic018/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Fin.idr
 
-rm -rf build

--- a/tests/idris2/basic019/run
+++ b/tests/idris2/basic019/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner CaseBlock.idr < input
 
-rm -rf build

--- a/tests/idris2/basic020/run
+++ b/tests/idris2/basic020/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Mut.idr < input
 
-rm -rf build

--- a/tests/idris2/basic021/run
+++ b/tests/idris2/basic021/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner CaseDep.idr < input
 
-rm -rf build

--- a/tests/idris2/basic022/run
+++ b/tests/idris2/basic022/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Erase.idr < input
 
-rm -rf build

--- a/tests/idris2/basic023/run
+++ b/tests/idris2/basic023/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Params.idr < input
 
-rm -rf build

--- a/tests/idris2/basic024/run
+++ b/tests/idris2/basic024/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner PatLam.idr < input
 
-rm -rf build

--- a/tests/idris2/basic025/run
+++ b/tests/idris2/basic025/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner < input
 
-rm -rf build

--- a/tests/idris2/basic026/run
+++ b/tests/idris2/basic026/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Erl.idr
 
-rm -rf build

--- a/tests/idris2/basic027/run
+++ b/tests/idris2/basic027/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Temp.idr
 
-rm -rf build

--- a/tests/idris2/basic028/run
+++ b/tests/idris2/basic028/run
@@ -1,5 +1,6 @@
+rm -rf build
+
 unset IDRIS2_PATH
 
 $1 --no-color --console-width 0 --no-banner --no-prelude < input
 
-rm -rf build

--- a/tests/idris2/basic029/run
+++ b/tests/idris2/basic029/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Params.idr < input
 
-rm -rf build

--- a/tests/idris2/basic030/run
+++ b/tests/idris2/basic030/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check arity.idr
 
-rm -rf build

--- a/tests/idris2/basic031/run
+++ b/tests/idris2/basic031/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check erased.idr
 
-rm -rf build

--- a/tests/idris2/basic032/run
+++ b/tests/idris2/basic032/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Idiom.idr < input
 $1 --no-color --console-width 0 --no-banner Idiom2.idr --check
 
-rm -rf build

--- a/tests/idris2/basic033/run
+++ b/tests/idris2/basic033/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check unboundimps.idr
 
-rm -rf build

--- a/tests/idris2/basic034/run
+++ b/tests/idris2/basic034/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check lets.idr
 
-rm -rf build

--- a/tests/idris2/basic035/run
+++ b/tests/idris2/basic035/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner using.idr < input
 
-rm -rf build

--- a/tests/idris2/basic036/run
+++ b/tests/idris2/basic036/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner defimp.idr < input
 
-rm -rf build

--- a/tests/idris2/basic037/run
+++ b/tests/idris2/basic037/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 echo ':q' | $1 --no-color --console-width 0 --no-banner --no-prelude Comments.idr
 echo ':q' | $1 --no-color --console-width 0 --no-banner Issue279.idr
 
-rm -rf build

--- a/tests/idris2/basic038/run
+++ b/tests/idris2/basic038/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Resugar.idr < input
 
-rm -rf build

--- a/tests/idris2/basic039/run
+++ b/tests/idris2/basic039/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Main.idr < input
 
-rm -rf build

--- a/tests/idris2/basic040/run
+++ b/tests/idris2/basic040/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 echo ":q" | $1 --no-color --console-width 0 --no-banner Default.idr
 
-rm -rf build

--- a/tests/idris2/basic041/run
+++ b/tests/idris2/basic041/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check QDo.idr
 
-rm -rf build

--- a/tests/idris2/basic042/run
+++ b/tests/idris2/basic042/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 LiteralsString.idr < input
 $1 --no-banner --no-color --console-width 0 LiteralsInteger.idr < input2
 
-rm -rf build

--- a/tests/idris2/basic043/run
+++ b/tests/idris2/basic043/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 BitCasts.idr < input
 
-rm -rf build

--- a/tests/idris2/basic044/run
+++ b/tests/idris2/basic044/run
@@ -1,3 +1,5 @@
+rm -rf build
+
 echo ":q" | $1 --no-banner --no-color --console-width 0 --log unify.equal:10 --log unify:5 Term.idr \
   | sed -E "s/[0-9]+}/N}/g" | sed -E "s/resolved([0-9]+)/resolvedN/g" \
   | sed -E "s/case in ([0-9]+)/case in N/g" | sed -E "s/[0-9]+:[0-9]+/L:C/g"
@@ -5,4 +7,3 @@ echo ":q" | $1 --no-banner --no-color --console-width 0 --log unify:3 --log elab
   | sed -E "s/[0-9]+}/N}/g" | sed -E "s/resolved([0-9]+)/resolvedN/g" \
   | sed -E "s/case in ([0-9]+)/case in N/g" | sed -E "s/[0-9]+:[0-9]+/L:C/g"
 
-rm -rf build

--- a/tests/idris2/basic045/run
+++ b/tests/idris2/basic045/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 Main.idr --check
 
-rm -rf build

--- a/tests/idris2/basic046/run
+++ b/tests/idris2/basic046/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 TupleSections.idr < input
 
-rm -rf build

--- a/tests/idris2/basic047/run
+++ b/tests/idris2/basic047/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 InterleavingLets.idr < input
 
-rm -rf build

--- a/tests/idris2/basic049/run
+++ b/tests/idris2/basic049/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Fld.idr < input
 
-rm -rf build

--- a/tests/idris2/basic050/run
+++ b/tests/idris2/basic050/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Ilc.idr < input
 
-rm -rf build

--- a/tests/idris2/basic051/run
+++ b/tests/idris2/basic051/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --check Issue833.idr
 
-rm -rf build

--- a/tests/idris2/basic052/run
+++ b/tests/idris2/basic052/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner DoubleClBrace.idr < input
 
-rm -rf build

--- a/tests/idris2/basic053/run
+++ b/tests/idris2/basic053/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --exec test StringLiteral.idr
 
-rm -rf build

--- a/tests/idris2/basic054/run
+++ b/tests/idris2/basic054/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Issue1023.idr --exec main
 
-rm -rf build

--- a/tests/idris2/basic055/run
+++ b/tests/idris2/basic055/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 BitOps.idr < input
 
-rm -rf build

--- a/tests/idris2/basic056/run
+++ b/tests/idris2/basic056/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 DoubleLit.idr < input
 
-rm -rf build

--- a/tests/idris2/basic057/run
+++ b/tests/idris2/basic057/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 --check LetIn.idr
 
-rm -rf build

--- a/tests/idris2/basic058/run
+++ b/tests/idris2/basic058/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 --check DataTypeOp.idr
 $1 --no-banner --no-color --console-width 0 --check DataTypeProj.idr
 
-rm -rf build

--- a/tests/idris2/basic059/run
+++ b/tests/idris2/basic059/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 --check MultiClaim.idr
 
-rm -rf build

--- a/tests/idris2/basic060/run
+++ b/tests/idris2/basic060/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Snoc.idr < input
 
-rm -rf build

--- a/tests/idris2/basic061/run
+++ b/tests/idris2/basic061/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner UnderscoredIntegerLiterals.idr < input
 
-rm -rf build

--- a/tests/idris2/builtin001/run
+++ b/tests/idris2/builtin001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Test.idr < input
 
-rm -rf build

--- a/tests/idris2/builtin002/run
+++ b/tests/idris2/builtin002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Test.idr < input
 
-rm -rf build

--- a/tests/idris2/builtin003/run
+++ b/tests/idris2/builtin003/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Test.idr < input
 
-rm -rf build

--- a/tests/idris2/builtin004/run
+++ b/tests/idris2/builtin004/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Test.idr < input
 
-rm -rf build

--- a/tests/idris2/builtin005/run
+++ b/tests/idris2/builtin005/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Test.idr < input
 
-rm -rf build

--- a/tests/idris2/builtin006/run
+++ b/tests/idris2/builtin006/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Test.idr < input
 
-rm -rf build

--- a/tests/idris2/builtin007/run
+++ b/tests/idris2/builtin007/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Test.idr < input
 
-rm -rf build

--- a/tests/idris2/builtin008/run
+++ b/tests/idris2/builtin008/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Test.idr < input
 
-rm -rf build

--- a/tests/idris2/builtin009/run
+++ b/tests/idris2/builtin009/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --exec main Test.idr
 
-rm -rf build

--- a/tests/idris2/builtin010/run
+++ b/tests/idris2/builtin010/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Test.idr < input
 
-rm -rf build

--- a/tests/idris2/builtin011/run
+++ b/tests/idris2/builtin011/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --exec main Test.idr
 
-rm -rf build

--- a/tests/idris2/casetree001/run
+++ b/tests/idris2/casetree001/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --check Issue762.idr
 $1 --no-color --console-width 0 --no-banner --check IsS.idr
 
-rm -rf build/

--- a/tests/idris2/coverage001/run
+++ b/tests/idris2/coverage001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Vect.idr < input
 
-rm -rf build

--- a/tests/idris2/coverage002/run
+++ b/tests/idris2/coverage002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Vect.idr < input
 
-rm -rf build

--- a/tests/idris2/coverage003/run
+++ b/tests/idris2/coverage003/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Cover.idr < input
 
-rm -rf build

--- a/tests/idris2/coverage004/run
+++ b/tests/idris2/coverage004/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Cover.idr < input
 
-rm -rf build

--- a/tests/idris2/coverage005/run
+++ b/tests/idris2/coverage005/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Cover.idr < input
 
-rm -rf build

--- a/tests/idris2/coverage006/run
+++ b/tests/idris2/coverage006/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner foobar.idr < input
 
-rm -rf build

--- a/tests/idris2/coverage007/run
+++ b/tests/idris2/coverage007/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner eq.idr --check
 
-rm -rf build

--- a/tests/idris2/coverage008/run
+++ b/tests/idris2/coverage008/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner wcov.idr < input
 
-rm -rf build

--- a/tests/idris2/coverage009/run
+++ b/tests/idris2/coverage009/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check unreachable.idr
 
-rm -rf build

--- a/tests/idris2/coverage010/run
+++ b/tests/idris2/coverage010/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check casetot.idr
 
-rm -rf build

--- a/tests/idris2/coverage011/run
+++ b/tests/idris2/coverage011/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Sing.idr
 
-rm -rf build

--- a/tests/idris2/coverage012/run
+++ b/tests/idris2/coverage012/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Issue899.idr
 $1 --no-color --console-width 0 --check Issue484.idr
 
-rm -rf build

--- a/tests/idris2/coverage013/run
+++ b/tests/idris2/coverage013/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Issue1022.idr
 $1 --no-color --console-width 0 --check Issue1022-Refl.idr
 
-rm -rf build

--- a/tests/idris2/coverage014/run
+++ b/tests/idris2/coverage014/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Issue794.idr
 
-rm -rf build

--- a/tests/idris2/coverage015/run
+++ b/tests/idris2/coverage015/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Issue1169.idr
 $1 --no-color --console-width 0 --check Issue1366.idr
 
-rm -rf build

--- a/tests/idris2/coverage016/run
+++ b/tests/idris2/coverage016/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Issue633.idr
 $1 --no-color --console-width 0 --check Issue633-2.idr
 
-rm -rf build

--- a/tests/idris2/coverage017/run
+++ b/tests/idris2/coverage017/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Issue1421.idr
 
-rm -rf build

--- a/tests/idris2/data001/run
+++ b/tests/idris2/data001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --check TestImpl.idr
 
-rm -rf build

--- a/tests/idris2/docs001/run
+++ b/tests/idris2/docs001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner < input
 
-rm -rf build

--- a/tests/idris2/docs002/run
+++ b/tests/idris2/docs002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Doc.idr < input
 
-rm -rf build

--- a/tests/idris2/docs003/run
+++ b/tests/idris2/docs003/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner RecordDoc.idr < input
 
-rm -rf build

--- a/tests/idris2/error001/run
+++ b/tests/idris2/error001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Error.idr
 
-rm -rf build

--- a/tests/idris2/error002/run
+++ b/tests/idris2/error002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Error.idr
 
-rm -rf build

--- a/tests/idris2/error003/run
+++ b/tests/idris2/error003/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Error.idr
 
-rm -rf build

--- a/tests/idris2/error004/run
+++ b/tests/idris2/error004/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Error1.idr
 $1 --no-color --console-width 0 --check Error2.idr
 
-rm -rf build

--- a/tests/idris2/error005/run
+++ b/tests/idris2/error005/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check IfErr.idr
 
-rm -rf build

--- a/tests/idris2/error006/run
+++ b/tests/idris2/error006/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check IfErr.idr
 
-rm -rf build

--- a/tests/idris2/error007/run
+++ b/tests/idris2/error007/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check CongErr.idr
 
-rm -rf build

--- a/tests/idris2/error008/run
+++ b/tests/idris2/error008/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner DoesntExist.idr < input
 
-rm -rf build

--- a/tests/idris2/error009/run
+++ b/tests/idris2/error009/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Exists.idr < input
 
-rm -rf build

--- a/tests/idris2/error010/run
+++ b/tests/idris2/error010/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 Loop.idr --check
 
-rm -rf build

--- a/tests/idris2/error011/run
+++ b/tests/idris2/error011/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 ConstructorDuplicate.idr --check
 
-rm -rf build

--- a/tests/idris2/error013/run
+++ b/tests/idris2/error013/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 Issue361.idr --check
 
-rm -rf build/

--- a/tests/idris2/error014/run
+++ b/tests/idris2/error014/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 Issue735.idr --check
 
-rm -rf build/

--- a/tests/idris2/error015/run
+++ b/tests/idris2/error015/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 Issue110.idr --check
 
-rm -rf build/

--- a/tests/idris2/error016/run
+++ b/tests/idris2/error016/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --check Issue1230.idr
 $1 --no-color --console-width 0 --no-banner < input
 
-rm -rf build/

--- a/tests/idris2/error017/run
+++ b/tests/idris2/error017/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --check Issue962.idr
 $1 --no-color --console-width 0 --no-banner --check Issue962-case.idr
 
-rm -rf build/

--- a/tests/idris2/error018/run
+++ b/tests/idris2/error018/run
@@ -1,6 +1,7 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --check Issue1031.idr
 $1 --no-color --console-width 0 --no-banner --check Issue1031-2.idr
 $1 --no-color --console-width 0 --no-banner --check Issue1031-3.idr
 $1 --no-color --console-width 0 --no-banner --check Issue1031-4.idr
 
-rm -rf build/

--- a/tests/idris2/error019/run
+++ b/tests/idris2/error019/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner -Werror --check Error.idr
 
-rm -rf build/

--- a/tests/idris2/eta001/run
+++ b/tests/idris2/eta001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --check Issue1370.idr
 
-rm -rf build

--- a/tests/idris2/evaluator001/run
+++ b/tests/idris2/evaluator001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --check Issue650.idr
 
-rm -rf build/

--- a/tests/idris2/evaluator002/run
+++ b/tests/idris2/evaluator002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 --log eval.stuck:5 Main.idr < input
 
-rm -rf build

--- a/tests/idris2/evaluator003/run
+++ b/tests/idris2/evaluator003/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 Issue705.idr < input
 
-rm -rf build

--- a/tests/idris2/golden001/run
+++ b/tests/idris2/golden001/run
@@ -1,7 +1,8 @@
+rm -rf build
+
 $1 --build hello.ipkg
 $1 --build test.ipkg
 
 ./build/exec/runtests ../build/exec/hello --no-colour
 
 
-rm -rf build

--- a/tests/idris2/import001/run
+++ b/tests/idris2/import001/run
@@ -1,3 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --no-prelude Test.idr < input
 sleep 1
 touch Mult.idr
@@ -6,4 +8,3 @@ sleep 1
 touch Mult.idr
 $1 --no-color --console-width 0 --no-banner --no-prelude -Xcheck-hashes Test.idr < input
 
-rm -rf build

--- a/tests/idris2/import002/run
+++ b/tests/idris2/import002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 echo ':q' | $1 --no-color --console-width 0 --no-banner --no-prelude Test.idr
 
-rm -rf build

--- a/tests/idris2/import003/run
+++ b/tests/idris2/import003/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner B.idr < input
 $1 --no-color --console-width 0 --no-banner C.idr < input
 
-rm -rf build

--- a/tests/idris2/import004/run
+++ b/tests/idris2/import004/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Cycle1.idr
 $1 --no-color --console-width 0 --no-banner Loop.idr
 
-rm -rf build

--- a/tests/idris2/import005/run
+++ b/tests/idris2/import005/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner As.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive001/run
+++ b/tests/idris2/interactive001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner LocType.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive002/run
+++ b/tests/idris2/interactive002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner IEdit.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive003/run
+++ b/tests/idris2/interactive003/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner IEdit.idr < input
 $1 --no-color --console-width 0 --no-banner IEdit2.idr < input2
 
-rm -rf build

--- a/tests/idris2/interactive004/run
+++ b/tests/idris2/interactive004/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner IEdit.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive005/run
+++ b/tests/idris2/interactive005/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner IEdit.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive006/run
+++ b/tests/idris2/interactive006/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner IEdit.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive007/run
+++ b/tests/idris2/interactive007/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner IEdit.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive008/run
+++ b/tests/idris2/interactive008/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner IEdit.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive009/run
+++ b/tests/idris2/interactive009/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Door.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive010/run
+++ b/tests/idris2/interactive010/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner IEdit.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive011/run
+++ b/tests/idris2/interactive011/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner IEdit.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive012/run
+++ b/tests/idris2/interactive012/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner WithLift.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive013/run
+++ b/tests/idris2/interactive013/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Spacing.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive014/run
+++ b/tests/idris2/interactive014/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner case.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive015/run
+++ b/tests/idris2/interactive015/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner IEdit.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive016/run
+++ b/tests/idris2/interactive016/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 Cont.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive017/run
+++ b/tests/idris2/interactive017/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner RLE.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive018/run
+++ b/tests/idris2/interactive018/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 PlusPrf.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive019/run
+++ b/tests/idris2/interactive019/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 TypeSearch.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive020/run
+++ b/tests/idris2/interactive020/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 Issue835.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive021/run
+++ b/tests/idris2/interactive021/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner TypeAtDoNotation.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive022/run
+++ b/tests/idris2/interactive022/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner TypeAtBangSyntax.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive023/run
+++ b/tests/idris2/interactive023/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner TypeAtLambda.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive024/run
+++ b/tests/idris2/interactive024/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner TypeAtAsPatterns.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive025/run
+++ b/tests/idris2/interactive025/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner TypeAtInterfaces.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive026/run
+++ b/tests/idris2/interactive026/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner TypeAtRecords.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive027/run
+++ b/tests/idris2/interactive027/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner TypeAtLocalVars.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive028/run
+++ b/tests/idris2/interactive028/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner < input
 
-rm -rf build

--- a/tests/idris2/interactive029/run
+++ b/tests/idris2/interactive029/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Issue834.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive030/run
+++ b/tests/idris2/interactive030/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner < input
 
-rm -rf build

--- a/tests/idris2/interactive031/run
+++ b/tests/idris2/interactive031/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Signatures.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive032/run
+++ b/tests/idris2/interactive032/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Uninh.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive033/run
+++ b/tests/idris2/interactive033/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner UninhIndent.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive034/run
+++ b/tests/idris2/interactive034/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner timeout.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive035/run
+++ b/tests/idris2/interactive035/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner unify.idr < input
 
-rm -rf build

--- a/tests/idris2/interactive036/run
+++ b/tests/idris2/interactive036/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner casefn.idr < input
 
-rm -rf build

--- a/tests/idris2/interface001/run
+++ b/tests/idris2/interface001/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --no-prelude IFace.idr < input
 $1 --no-color --console-width 0 --no-banner --no-prelude IFace1.idr < input1
 
-rm -rf build

--- a/tests/idris2/interface002/run
+++ b/tests/idris2/interface002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --no-prelude Functor.idr < input
 
-rm -rf build

--- a/tests/idris2/interface003/run
+++ b/tests/idris2/interface003/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Do.idr < input
 
-rm -rf build

--- a/tests/idris2/interface004/run
+++ b/tests/idris2/interface004/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Do.idr < input
 
-rm -rf build

--- a/tests/idris2/interface005/run
+++ b/tests/idris2/interface005/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Deps.idr
 
-rm -rf build

--- a/tests/idris2/interface006/run
+++ b/tests/idris2/interface006/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Bimonad.idr
 
-rm -rf build

--- a/tests/idris2/interface007/run
+++ b/tests/idris2/interface007/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --debug-elab-check --check A.idr
 
-rm -rf build

--- a/tests/idris2/interface008/run
+++ b/tests/idris2/interface008/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Deps.idr
 
-rm -rf build

--- a/tests/idris2/interface009/run
+++ b/tests/idris2/interface009/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Odd.idr < input
 
-rm -rf build

--- a/tests/idris2/interface010/run
+++ b/tests/idris2/interface010/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 Dep.idr --check
 
-rm -rf build

--- a/tests/idris2/interface011/run
+++ b/tests/idris2/interface011/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 FuncImpl.idr --check
 
-rm -rf build

--- a/tests/idris2/interface012/run
+++ b/tests/idris2/interface012/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 Defmeth.idr --check
 
-rm -rf build

--- a/tests/idris2/interface013/run
+++ b/tests/idris2/interface013/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 TypeInt.idr --check
 
-rm -rf build

--- a/tests/idris2/interface014/run
+++ b/tests/idris2/interface014/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 DepInt.idr --check
 
-rm -rf build

--- a/tests/idris2/interface015/run
+++ b/tests/idris2/interface015/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 gnu.idr --check
 
-rm -rf build

--- a/tests/idris2/interface016/run
+++ b/tests/idris2/interface016/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 TwoNum.idr --check
 
-rm -rf build

--- a/tests/idris2/interface017/run
+++ b/tests/idris2/interface017/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 Tricho.idr --check
 
-rm -rf build

--- a/tests/idris2/interface018/run
+++ b/tests/idris2/interface018/run
@@ -1,5 +1,6 @@
+rm -rf build
+
 $1 --no-color --no-banner --console-width 0 Sized.idr < input
 $1 --no-color --console-width 0 Sized2.idr --check
 $1 --no-color --console-width 0 Sized3.idr --check
 
-rm -rf build

--- a/tests/idris2/interface019/run
+++ b/tests/idris2/interface019/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 LocalHints.idr --check
 
-rm -rf build

--- a/tests/idris2/interface020/run
+++ b/tests/idris2/interface020/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 LocalInterface.idr --check
 
-rm -rf build

--- a/tests/idris2/interface021/run
+++ b/tests/idris2/interface021/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 LocalHint.idr --check
 
-rm -rf build

--- a/tests/idris2/interface022/run
+++ b/tests/idris2/interface022/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --no-banner --console-width 0 DotMethod.idr < input
 
-rm -rf build

--- a/tests/idris2/interface023/run
+++ b/tests/idris2/interface023/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 AppComp.idr < input
 
-rm -rf build

--- a/tests/idris2/interface024/run
+++ b/tests/idris2/interface024/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --check EH.idr -p contrib
 
-rm -rf build

--- a/tests/idris2/interface025/run
+++ b/tests/idris2/interface025/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 AutoSearchHide2.idr < input
 
-rm -rf build

--- a/tests/idris2/interface026/run
+++ b/tests/idris2/interface026/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 UninhabitedRec.idr < input
 
-rm -rf build

--- a/tests/idris2/interface027/run
+++ b/tests/idris2/interface027/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 params.idr < input
 
-rm -rf build

--- a/tests/idris2/interpreter002/run
+++ b/tests/idris2/interpreter002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --no-prelude < input
 
-rm -rf build

--- a/tests/idris2/interpreter005/run
+++ b/tests/idris2/interpreter005/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 Issue37.lidr < input
 
-rm -rf build

--- a/tests/idris2/lazy001/run
+++ b/tests/idris2/lazy001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --no-prelude Lazy.idr < input
 
-rm -rf build

--- a/tests/idris2/lazy002/run
+++ b/tests/idris2/lazy002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner -p contrib LazyFoldlM.idr < input
 
-rm -rf build

--- a/tests/idris2/linear001/run
+++ b/tests/idris2/linear001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 echo ':q' | $1 --no-color --console-width 0 --no-banner --no-prelude Door.idr
 
-rm -rf build

--- a/tests/idris2/linear002/run
+++ b/tests/idris2/linear002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --no-prelude Door.idr < input
 
-rm -rf build

--- a/tests/idris2/linear003/run
+++ b/tests/idris2/linear003/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --no-prelude Linear.idr < input
 
-rm -rf build

--- a/tests/idris2/linear004/run
+++ b/tests/idris2/linear004/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --no-prelude Erase.idr < input
 
-rm -rf build

--- a/tests/idris2/linear005/run
+++ b/tests/idris2/linear005/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Door.idr < input
 
-rm -rf build

--- a/tests/idris2/linear006/run
+++ b/tests/idris2/linear006/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner ZFun.idr < input
 
-rm -rf build

--- a/tests/idris2/linear007/run
+++ b/tests/idris2/linear007/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check LCase.idr
 
-rm -rf build

--- a/tests/idris2/linear008/run
+++ b/tests/idris2/linear008/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Door.idr
 
-rm -rf build

--- a/tests/idris2/linear009/run
+++ b/tests/idris2/linear009/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner qtt.idr < input
 
-rm -rf build

--- a/tests/idris2/linear010/run
+++ b/tests/idris2/linear010/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Door.idr -p contrib
 
-rm -rf build

--- a/tests/idris2/linear011/run
+++ b/tests/idris2/linear011/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Network.idr -p contrib -p network < input
 
-rm -rf build

--- a/tests/idris2/linear012/run
+++ b/tests/idris2/linear012/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner linholes.idr < input
 
-rm -rf build

--- a/tests/idris2/linear013/run
+++ b/tests/idris2/linear013/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Issue758.idr < input
 
-rm -rf build

--- a/tests/idris2/literate001/run
+++ b/tests/idris2/literate001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner IEdit.lidr < input
 
-rm -rf build

--- a/tests/idris2/literate002/run
+++ b/tests/idris2/literate002/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner IEdit.lidr < input
 $1 --no-color --console-width 0 --no-banner IEdit2.lidr < input2
 
-rm -rf build

--- a/tests/idris2/literate003/run
+++ b/tests/idris2/literate003/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner IEdit.lidr < input
 
-rm -rf build

--- a/tests/idris2/literate004/run
+++ b/tests/idris2/literate004/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner IEdit.lidr < input
 
-rm -rf build

--- a/tests/idris2/literate005/run
+++ b/tests/idris2/literate005/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner IEdit.lidr < input
 
-rm -rf build

--- a/tests/idris2/literate006/run
+++ b/tests/idris2/literate006/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Door.lidr < input
 
-rm -rf build

--- a/tests/idris2/literate007/run
+++ b/tests/idris2/literate007/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner IEdit.lidr < input
 $1 --no-color --console-width 0 --no-banner IEditOrg.org < input2
 
-rm -rf build

--- a/tests/idris2/literate008/run
+++ b/tests/idris2/literate008/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner IEdit.lidr < input
 
-rm -rf build

--- a/tests/idris2/literate009/run
+++ b/tests/idris2/literate009/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner WithLift.lidr < input
 
-rm -rf build

--- a/tests/idris2/literate010/run
+++ b/tests/idris2/literate010/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check --no-banner MyFirstIdrisProgram.org
 
-rm -rf build

--- a/tests/idris2/literate011/run
+++ b/tests/idris2/literate011/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner IEdit.md < input
 
-rm -rf build

--- a/tests/idris2/literate012/run
+++ b/tests/idris2/literate012/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner IEdit.org < input
 
-rm -rf build

--- a/tests/idris2/literate013/run
+++ b/tests/idris2/literate013/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --check Lit.lidr
 $1 --no-color --console-width 0 --no-banner --check LitTeX.tex
-rm -rf build

--- a/tests/idris2/literate014/run
+++ b/tests/idris2/literate014/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner with.lidr < input
 
-rm -rf build

--- a/tests/idris2/literate015/run
+++ b/tests/idris2/literate015/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner case.lidr < input
 
-rm -rf build

--- a/tests/idris2/literate016/run
+++ b/tests/idris2/literate016/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner IEdit.org < input
 
-rm -rf build

--- a/tests/idris2/namespace001/run
+++ b/tests/idris2/namespace001/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 echo ':q' | $1 --no-color --console-width 0 --no-banner Dup.idr
 echo ':t Test' | $1 --no-color --console-width 0 --no-banner Scope.idr
 
-rm -rf build

--- a/tests/idris2/params001/run
+++ b/tests/idris2/params001/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --check param.idr
 $1 --no-color --console-width 0 --no-banner --check parambad.idr
 
-rm -rf build

--- a/tests/idris2/params002/run
+++ b/tests/idris2/params002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner ParamsPrint.idr < input
 
-rm -rf build

--- a/tests/idris2/params003/run
+++ b/tests/idris2/params003/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner casesplit.idr < input
 
-rm -rf build

--- a/tests/idris2/perf001/run
+++ b/tests/idris2/perf001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Big.idr
 
-rm -rf build

--- a/tests/idris2/perf002/run
+++ b/tests/idris2/perf002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Big.idr
 
-rm -rf build

--- a/tests/idris2/perf003/run
+++ b/tests/idris2/perf003/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Auto.idr
 
-rm -rf build

--- a/tests/idris2/perf004/run
+++ b/tests/idris2/perf004/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check bigdpair.idr
 
-rm -rf build

--- a/tests/idris2/perf005/run
+++ b/tests/idris2/perf005/run
@@ -1,3 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Lambda.idr
 
 $1 --no-color --console-width 0 --check Bad1.idr
@@ -6,4 +8,3 @@ $1 --no-color --console-width 0 --check Bad2.idr
 
 $1 --no-color --console-width 0 --check Bad3.idr
 
-rm -rf build

--- a/tests/idris2/perf007/run
+++ b/tests/idris2/perf007/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --check Slooow.idr
 
-rm -rf build

--- a/tests/idris2/perf008/run
+++ b/tests/idris2/perf008/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 FinPerf.idr --exec main
 
-rm -rf build/

--- a/tests/idris2/perror001/run
+++ b/tests/idris2/perror001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check PError.idr
 
-rm -rf build

--- a/tests/idris2/perror002/run
+++ b/tests/idris2/perror002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check PError.idr
 
-rm -rf build

--- a/tests/idris2/perror003/run
+++ b/tests/idris2/perror003/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check PError.idr
 $1 --no-color --console-width 0 --check PError2.idr
 
-rm -rf build

--- a/tests/idris2/perror004/run
+++ b/tests/idris2/perror004/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check PError.idr
 
-rm -rf build

--- a/tests/idris2/perror005/run
+++ b/tests/idris2/perror005/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check PError.idr
 
-rm -rf build

--- a/tests/idris2/perror006/run
+++ b/tests/idris2/perror006/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check PError.idr
 
-rm -rf build

--- a/tests/idris2/perror007/run
+++ b/tests/idris2/perror007/run
@@ -1,3 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check StrError1.idr || true
 $1 --no-color --console-width 0 --check StrError2.idr || true
 $1 --no-color --console-width 0 --check StrError3.idr || true
@@ -11,4 +13,3 @@ $1 --no-color --console-width 0 --check StrError10.idr || true
 $1 --no-color --console-width 0 --check StrError11.idr || true
 $1 --no-color --console-width 0 --check StrError12.idr || true
 
-rm -rf build

--- a/tests/idris2/perror008/run
+++ b/tests/idris2/perror008/run
@@ -1,3 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Issue710a.idr || true
 $1 --no-color --console-width 0 --check Issue710b.idr || true
 $1 --no-color --console-width 0 --check Issue710c.idr || true
@@ -8,4 +10,3 @@ $1 --no-color --console-width 0 --check Issue710f.idr || true
 $1 --no-color --console-width 0 --check Issue1224a.idr || true
 $1 --no-color --console-width 0 --check Issue1224b.idr || true
 
-rm -rf build

--- a/tests/idris2/pkg001/run
+++ b/tests/idris2/pkg001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --build dummy.ipkg
 
-rm -rf build

--- a/tests/idris2/pkg002/run
+++ b/tests/idris2/pkg002/run
@@ -1,5 +1,6 @@
+rm -rf build
+
 cd src/Top
 $1 --find-ipkg --check Dummy.idr
 cd ../..
 
-rm -rf build

--- a/tests/idris2/pkg004/run
+++ b/tests/idris2/pkg004/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --repl dummy.ipkg < input
 
-rm -rf build

--- a/tests/idris2/pkg005/run
+++ b/tests/idris2/pkg005/run
@@ -1,5 +1,6 @@
+rm -rf build
+
 $1 --clean foo.ipkg
 $1 --repl foo.ipkg < input
 $1 --repl foo.ipkg < input
 
-rm -rf build

--- a/tests/idris2/pkg006/run
+++ b/tests/idris2/pkg006/run
@@ -1,7 +1,8 @@
+rm -rf build
+
 $1 --build test1.ipkg
 $1 --build test2.ipkg
 $1 --build test3.ipkg
 $1 --build test4.ipkg
 $1 --build test5.ipkg
 
-rm -rf build

--- a/tests/idris2/positivity001/run
+++ b/tests/idris2/positivity001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 Issue660.idr --check
 
-rm -rf build

--- a/tests/idris2/positivity002/run
+++ b/tests/idris2/positivity002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 Issue660.idr --check
 
-rm -rf build

--- a/tests/idris2/positivity003/run
+++ b/tests/idris2/positivity003/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 Issue660.idr --check
 
-rm -rf build

--- a/tests/idris2/positivity004/run
+++ b/tests/idris2/positivity004/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 Issue524.idr --check
 
-rm -rf build

--- a/tests/idris2/pretty001/run
+++ b/tests/idris2/pretty001/run
@@ -1,2 +1,3 @@
-$1 --no-color --console-width 0 --no-banner Issue1328A.idr < input
 rm -rf build
+
+$1 --no-color --console-width 0 --no-banner Issue1328A.idr < input

--- a/tests/idris2/real001/run
+++ b/tests/idris2/real001/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check TestProto.idr
 #$1 --no-color --console-width 0 --check MakeChans.idr
 
-rm -rf build

--- a/tests/idris2/real002/run
+++ b/tests/idris2/real002/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Store.idr
 $1 --no-color --console-width 0 --check StoreL.idr
 
-rm -rf build

--- a/tests/idris2/record001/run
+++ b/tests/idris2/record001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Record.idr < input
 
-rm -rf build

--- a/tests/idris2/record002/run
+++ b/tests/idris2/record002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Record.idr < input
 
-rm -rf build

--- a/tests/idris2/record003/run
+++ b/tests/idris2/record003/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 -c --no-color --console-width 0 --no-banner Record.idr
 
-rm -rf build

--- a/tests/idris2/record004/run
+++ b/tests/idris2/record004/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Main.idr < input
 
-rm -rf build

--- a/tests/idris2/record005/run
+++ b/tests/idris2/record005/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Fld.idr < input
 
-rm -rf build

--- a/tests/idris2/record006/run
+++ b/tests/idris2/record006/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Fld.idr < input
 
-rm -rf build

--- a/tests/idris2/record007/run
+++ b/tests/idris2/record007/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Bond.idr < input
 
-rm -rf build

--- a/tests/idris2/record008/run
+++ b/tests/idris2/record008/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Postfix.idr < input
 
-rm -rf build

--- a/tests/idris2/record009/run
+++ b/tests/idris2/record009/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner record.idr < input
 
-rm -rf build

--- a/tests/idris2/reflection001/run
+++ b/tests/idris2/reflection001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner quote.idr < input
 
-rm -rf build

--- a/tests/idris2/reflection002/run
+++ b/tests/idris2/reflection002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner power.idr < input
 
-rm -rf build

--- a/tests/idris2/reflection003/run
+++ b/tests/idris2/reflection003/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 refprims.idr --check
 
-rm -rf build

--- a/tests/idris2/reflection004/run
+++ b/tests/idris2/reflection004/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner refdecl.idr < input
 
-rm -rf build

--- a/tests/idris2/reflection005/run
+++ b/tests/idris2/reflection005/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner refdecl.idr < input
 
-rm -rf build

--- a/tests/idris2/reflection006/run
+++ b/tests/idris2/reflection006/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check refleq.idr
 
-rm -rf build

--- a/tests/idris2/reflection007/run
+++ b/tests/idris2/reflection007/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner NatExpr.idr < input
 
-rm -rf build

--- a/tests/idris2/reflection008/run
+++ b/tests/idris2/reflection008/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Interp.idr < input
 
-rm -rf build

--- a/tests/idris2/reflection009/run
+++ b/tests/idris2/reflection009/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check perf.idr
 
-rm -rf build

--- a/tests/idris2/reg001/run
+++ b/tests/idris2/reg001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check D.idr
 
-rm -rf build

--- a/tests/idris2/reg002/run
+++ b/tests/idris2/reg002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check linm.idr
 
-rm -rf build

--- a/tests/idris2/reg003/run
+++ b/tests/idris2/reg003/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --no-prelude Holes.idr < input
 
-rm -rf build

--- a/tests/idris2/reg004/run
+++ b/tests/idris2/reg004/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check ambig.idr
 
-rm -rf build

--- a/tests/idris2/reg005/run
+++ b/tests/idris2/reg005/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check iftype.idr
 
-rm -rf build

--- a/tests/idris2/reg006/run
+++ b/tests/idris2/reg006/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Cmd.idr
 
-rm -rf build

--- a/tests/idris2/reg007/run
+++ b/tests/idris2/reg007/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Main.idr
 
-rm -rf build

--- a/tests/idris2/reg008/run
+++ b/tests/idris2/reg008/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 Vending.idr --no-banner --debug-elab-check < input
 
-rm -rf build

--- a/tests/idris2/reg009/run
+++ b/tests/idris2/reg009/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 Case.idr --check
 
-rm -rf build

--- a/tests/idris2/reg010/run
+++ b/tests/idris2/reg010/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 Recordname.idr --check
 
-rm -rf build

--- a/tests/idris2/reg011/run
+++ b/tests/idris2/reg011/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 mut.idr --check
 
-rm -rf build

--- a/tests/idris2/reg012/run
+++ b/tests/idris2/reg012/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 Foo.idr --check
 
-rm -rf build

--- a/tests/idris2/reg013/run
+++ b/tests/idris2/reg013/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 UnboundImplicits.idr --check
 
-rm -rf build

--- a/tests/idris2/reg014/run
+++ b/tests/idris2/reg014/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 casecase.idr --check --debug-elab-check
 
-rm -rf build

--- a/tests/idris2/reg015/run
+++ b/tests/idris2/reg015/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 anyfail.idr --check
 
-rm -rf build

--- a/tests/idris2/reg016/run
+++ b/tests/idris2/reg016/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 Using.idr --check
 
-rm -rf build

--- a/tests/idris2/reg017/run
+++ b/tests/idris2/reg017/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 lammult.idr --check
 
-rm -rf build

--- a/tests/idris2/reg018/run
+++ b/tests/idris2/reg018/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 cycle.idr --check
 
-rm -rf build

--- a/tests/idris2/reg019/run
+++ b/tests/idris2/reg019/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 lazybug.idr --check
 
-rm -rf build

--- a/tests/idris2/reg020/run
+++ b/tests/idris2/reg020/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 matchlits.idr --no-banner < input
 
-rm -rf build

--- a/tests/idris2/reg021/run
+++ b/tests/idris2/reg021/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check case.idr
 
-rm -rf build

--- a/tests/idris2/reg022/run
+++ b/tests/idris2/reg022/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check case.idr
 
-rm -rf build

--- a/tests/idris2/reg023/run
+++ b/tests/idris2/reg023/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check boom.idr
 
-rm -rf build

--- a/tests/idris2/reg024/run
+++ b/tests/idris2/reg024/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner split.idr < input
 
-rm -rf build

--- a/tests/idris2/reg025/run
+++ b/tests/idris2/reg025/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner lift.idr < input
 
-rm -rf build

--- a/tests/idris2/reg026/run
+++ b/tests/idris2/reg026/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Meh.idr
 
-rm -rf build

--- a/tests/idris2/reg027/run
+++ b/tests/idris2/reg027/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check pwhere.idr
 
-rm -rf build

--- a/tests/idris2/reg028/run
+++ b/tests/idris2/reg028/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Test.idr
 
-rm -rf build

--- a/tests/idris2/reg029/run
+++ b/tests/idris2/reg029/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check lqueue.idr
 
-rm -rf build

--- a/tests/idris2/reg030/run
+++ b/tests/idris2/reg030/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check A.idr
 
-rm -rf build

--- a/tests/idris2/reg031/run
+++ b/tests/idris2/reg031/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check dpair.idr
 
-rm -rf build

--- a/tests/idris2/reg032/run
+++ b/tests/idris2/reg032/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check recupdate.idr
 
-rm -rf build

--- a/tests/idris2/reg033/run
+++ b/tests/idris2/reg033/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check test.idr
 
-rm -rf build

--- a/tests/idris2/reg034/run
+++ b/tests/idris2/reg034/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check void.idr
 
-rm -rf build

--- a/tests/idris2/reg035/run
+++ b/tests/idris2/reg035/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 Implicit.idr --check
 
-rm -rf build

--- a/tests/idris2/reg036/run
+++ b/tests/idris2/reg036/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 Test.idr --check
 
-rm -rf build

--- a/tests/idris2/reg037/run
+++ b/tests/idris2/reg037/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 Test.idr --check
 
-rm -rf build

--- a/tests/idris2/reg038/run
+++ b/tests/idris2/reg038/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 Test1.idr --check
 $1 --no-color --console-width 0 Test2.idr --check
 
-rm -rf build

--- a/tests/idris2/reg039/run
+++ b/tests/idris2/reg039/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check dupdup.idr
 
-rm -rf build

--- a/tests/idris2/reg040/run
+++ b/tests/idris2/reg040/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check CoverBug.idr
 
-rm -rf build

--- a/tests/idris2/reg041/run
+++ b/tests/idris2/reg041/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check tuple.idr
 
-rm -rf build

--- a/tests/idris2/reg042/run
+++ b/tests/idris2/reg042/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner NatOpts.idr < input
 
-rm -rf build

--- a/tests/idris2/reg043/run
+++ b/tests/idris2/reg043/run
@@ -1,6 +1,7 @@
+rm -rf build
+
 mkdir -p build/ttc
 echo "TT2This Is A Fake TTC" > build/ttc/Fake.ttc
 
 $1 --no-color --console-width 0 --check TestFake.idr
 
-rm -rf build

--- a/tests/idris2/reg044/run
+++ b/tests/idris2/reg044/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Methods.idr
 
-rm -rf build

--- a/tests/idris2/total001/run
+++ b/tests/idris2/total001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Total.idr < input
 
-rm -rf build

--- a/tests/idris2/total002/run
+++ b/tests/idris2/total002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Total.idr < input
 
-rm -rf build

--- a/tests/idris2/total003/run
+++ b/tests/idris2/total003/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Total.idr < input
 
-rm -rf build

--- a/tests/idris2/total004/run
+++ b/tests/idris2/total004/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Total.idr < input
 
-rm -rf build

--- a/tests/idris2/total005/run
+++ b/tests/idris2/total005/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Total.idr < input
 
-rm -rf build

--- a/tests/idris2/total006/run
+++ b/tests/idris2/total006/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Total.idr < input
 
-rm -rf build

--- a/tests/idris2/total007/run
+++ b/tests/idris2/total007/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner partial.idr --check
 
-rm -rf build

--- a/tests/idris2/total008/run
+++ b/tests/idris2/total008/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner partial.idr --check
 
-rm -rf build

--- a/tests/idris2/total009/run
+++ b/tests/idris2/total009/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 tree.idr --check
 
-rm -rf build

--- a/tests/idris2/total010/run
+++ b/tests/idris2/total010/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 PartialWith.idr --check
 
-rm -rf build

--- a/tests/idris2/warning001/run
+++ b/tests/idris2/warning001/run
@@ -1,7 +1,8 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Issue539.idr
 $1 --no-color --console-width 0 --check Issue621.idr
 $1 --no-color --console-width 0 --check Issue1401.idr
 $1 --no-color --console-width 0 --check PR1407.idr
 $1 --no-color --console-width 0 --check Holes.idr
 
-rm -rf build

--- a/tests/idris2/with001/run
+++ b/tests/idris2/with001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Temp.idr
 
-rm -rf build

--- a/tests/idris2/with002/run
+++ b/tests/idris2/with002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --check Temp.idr
 
-rm -rf build

--- a/tests/idris2/with003/run
+++ b/tests/idris2/with003/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Main.idr < input
 
-rm -rf build

--- a/tests/idris2/with004/run
+++ b/tests/idris2/with004/run
@@ -1,5 +1,6 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Issue637.idr < input
 $1 --no-color --console-width 0 --no-banner --check Issue637-2.idr
 $1 --no-color --console-width 0 --no-banner --check Issue637-3.idr
 
-rm -rf build

--- a/tests/idris2/with005/run
+++ b/tests/idris2/with005/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner --check WithProof.idr
 $1 --no-color --console-width 0 --no-banner --check Issue893.idr
 
-rm -rf build

--- a/tests/node/args/run
+++ b/tests/node/args/run
@@ -1,5 +1,6 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 --cg node -o node_args TestArgs.idr > /dev/null
 node ./build/exec/node_args a b
 node ./build/exec/node_args c
 
-rm -rf build

--- a/tests/node/bitops/run
+++ b/tests/node/bitops/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --cg node --no-banner --no-color --console-width 0 BitOps.idr < input
 
-rm -rf build

--- a/tests/node/casts/run
+++ b/tests/node/casts/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --cg node --no-banner --no-color --console-width 0 Casts.idr < input
 
-rm -rf build

--- a/tests/node/idiom001/run
+++ b/tests/node/idiom001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --cg node --no-banner Main.idr < input
 
-rm -rf build

--- a/tests/node/integers/run
+++ b/tests/node/integers/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 --cg node -o node_integers.js TestIntegers.idr > /dev/null
 node build/exec/node_integers.js
 
-rm -rf build

--- a/tests/node/newints/run
+++ b/tests/node/newints/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --cg node --no-banner --no-color --console-width 0 IntOps.idr < input
 
-rm -rf build

--- a/tests/node/node001/run
+++ b/tests/node/node001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --cg node --no-banner Total.idr < input
 
-rm -rf build

--- a/tests/node/node002/run
+++ b/tests/node/node002/run
@@ -1,2 +1,3 @@
-$1 --no-color --console-width 0 --cg node --no-banner Pythag.idr < input
 rm -rf build
+
+$1 --no-color --console-width 0 --cg node --no-banner Pythag.idr < input

--- a/tests/node/node003/run
+++ b/tests/node/node003/run
@@ -1,2 +1,3 @@
-$1 --no-color --console-width 0 --cg node --no-banner IORef.idr < input
 rm -rf build
+
+$1 --no-color --console-width 0 --cg node --no-banner IORef.idr < input

--- a/tests/node/node005/run
+++ b/tests/node/node005/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --cg node --no-banner Filter.idr < input
 
-rm -rf build

--- a/tests/node/node006/run
+++ b/tests/node/node006/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --cg node --no-banner TypeCase.idr < input
 $1 --no-color --console-width 0 --cg node --no-banner TypeCase2.idr --check
 
-rm -rf build

--- a/tests/node/node007/run
+++ b/tests/node/node007/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --cg node --no-banner TypeCase.idr < input
 
-rm -rf build

--- a/tests/node/node008/run
+++ b/tests/node/node008/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --cg node --no-banner Nat.idr < input
 
-rm -rf build

--- a/tests/node/node009/run
+++ b/tests/node/node009/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --cg node --no-banner uni.idr < input
 
-rm -rf build

--- a/tests/node/node011/run
+++ b/tests/node/node011/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --cg node --no-banner bangs.idr < input
 
-rm -rf build

--- a/tests/node/node012/run
+++ b/tests/node/node012/run
@@ -1,2 +1,3 @@
-$1 --no-color --console-width 0 --cg node --no-banner array.idr < input
 rm -rf build
+
+$1 --no-color --console-width 0 --cg node --no-banner array.idr < input

--- a/tests/node/node014/run
+++ b/tests/node/node014/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --cg node --no-banner -p network Echo.idr < input
 
-rm -rf build

--- a/tests/node/node015/run
+++ b/tests/node/node015/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --cg node --no-banner Numbers.idr < input
 
-rm -rf build

--- a/tests/node/node019/run
+++ b/tests/node/node019/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --cg node --no-banner partial.idr < input
 
-rm -rf build

--- a/tests/node/node020/run
+++ b/tests/node/node020/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 POPEN_CMD="$1 --version" $1 --no-color --console-width 0 --cg node --no-banner Popen.idr < input
 
-rm -rf build

--- a/tests/node/node021/run
+++ b/tests/node/node021/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --cg node --no-banner Bits.idr < input
 
-rm -rf build

--- a/tests/node/node022/run
+++ b/tests/node/node022/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --cg node --no-banner --no-color --console-width 0 BitCasts.idr < input
 
-rm -rf build

--- a/tests/node/node023/run
+++ b/tests/node/node023/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --cg node --no-banner --no-color --console-width 0 Casts.idr < input
 
-rm -rf build

--- a/tests/node/node024/run
+++ b/tests/node/node024/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --cg node --no-banner --no-color --console-width 0 BitOps.idr < input
 
-rm -rf build

--- a/tests/node/node025/run
+++ b/tests/node/node025/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --cg node --no-banner --no-color --console-width 0 Fix1037.idr < input
 
-rm -rf build

--- a/tests/node/perf001/run
+++ b/tests/node/perf001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --cg node --no-banner --no-color --console-width 0 Span.idr < input
 
-rm -rf build

--- a/tests/node/reg001/run
+++ b/tests/node/reg001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --cg node numbers.idr -x main
 
-rm -rf build

--- a/tests/node/syntax001/run
+++ b/tests/node/syntax001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --cg node caseBlock.idr -x main
 
-rm -rf build

--- a/tests/node/tailrec001/run
+++ b/tests/node/tailrec001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --cg node tailrec.idr -x main
 
-rm -rf build

--- a/tests/prelude/reg001/run
+++ b/tests/prelude/reg001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --check fixity.idr
 
-rm -rf build

--- a/tests/refc/args/run
+++ b/tests/refc/args/run
@@ -1,5 +1,6 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 --cg refc -o refc_args TestArgs.idr > /dev/null
 ./build/exec/refc_args a b
 ./build/exec/refc_args c
 
-rm -rf build

--- a/tests/refc/buffer/run
+++ b/tests/refc/buffer/run
@@ -1,6 +1,7 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 --cg refc -o refc_buffer TestBuffer.idr > /dev/null
 ./build/exec/refc_buffer
 base64 testWrite.buf
 
 rm testWrite.buf
-rm -rf build

--- a/tests/refc/clock/run
+++ b/tests/refc/clock/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 --cg refc -o refc_clock TestClock.idr > /dev/null
 ./build/exec/refc_clock
 
-rm -rf build

--- a/tests/refc/doubles/run
+++ b/tests/refc/doubles/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 --cg refc -o refc_doubles TestDoubles.idr > /dev/null
 ./build/exec/refc_doubles
 
-rm -rf build

--- a/tests/refc/integers/run
+++ b/tests/refc/integers/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 --cg refc -o refc_integers TestIntegers.idr > /dev/null
 ./build/exec/refc_integers
 
-rm -rf build

--- a/tests/refc/refc001/run
+++ b/tests/refc/refc001/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 --cg refc -o refc001 Tail.idr > /dev/null
 ./build/exec/refc001
 
-rm -rf build

--- a/tests/refc/refc002/run
+++ b/tests/refc/refc002/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 --cg refc -o refc002 RecordProjection.idr > /dev/null
 ./build/exec/refc002
 
-rm -rf build

--- a/tests/refc/strings/run
+++ b/tests/refc/strings/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-banner --no-color --console-width 0 --cg refc -p contrib -o refc_strings TestStrings.idr > /dev/null
 ./build/exec/refc_strings
 
-rm -rf build

--- a/tests/templates/simple-test/run
+++ b/tests/templates/simple-test/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Test.idr < input
 
-rm -rf build

--- a/tests/templates/ttimp/run
+++ b/tests/templates/ttimp/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --yaffle Interp.yaff < input
 $1 --yaffle build/ttc/Interp.ttc < input
 
-rm -rf build

--- a/tests/templates/with-ipkg/run
+++ b/tests/templates/with-ipkg/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --build dummy.ipkg
 
-rm -rf build

--- a/tests/ttimp/basic001/run
+++ b/tests/ttimp/basic001/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --yaffle Interp.yaff < input
 $1 --yaffle build/ttc/Interp.ttc < input
 
-rm -rf build

--- a/tests/ttimp/basic002/run
+++ b/tests/ttimp/basic002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --yaffle Adder.yaff < input
 
-rm -rf build

--- a/tests/ttimp/basic003/run
+++ b/tests/ttimp/basic003/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --yaffle Hole.yaff < input
 $1 --yaffle build/ttc/Hole.ttc < input
 
-rm -rf build

--- a/tests/ttimp/basic004/run
+++ b/tests/ttimp/basic004/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --yaffle AsPat.yaff < input
 
-rm -rf build

--- a/tests/ttimp/basic005/run
+++ b/tests/ttimp/basic005/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --yaffle Ambig.yaff < input
 
-rm -rf build

--- a/tests/ttimp/basic006/run
+++ b/tests/ttimp/basic006/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --yaffle Ambig.yaff < input
 
-rm -rf build

--- a/tests/ttimp/coverage001/run
+++ b/tests/ttimp/coverage001/run
@@ -1,5 +1,6 @@
+rm -rf build
+
 echo ':q' | $1 --yaffle Vect.yaff
 echo ':q' | $1 --yaffle Vect2.yaff
 echo ':q' | $1 --yaffle Vect3.yaff
 
-rm -rf build

--- a/tests/ttimp/coverage002/run
+++ b/tests/ttimp/coverage002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --yaffle Vect.yaff < input
 
-rm -rf build

--- a/tests/ttimp/dot001/run
+++ b/tests/ttimp/dot001/run
@@ -1,6 +1,7 @@
+rm -rf build
+
 echo ':q' | $1 --yaffle Dot.yaff
 echo ':q' | $1 --yaffle Dot2.yaff
 echo ':q' | $1 --yaffle Dot3.yaff
 echo ':q' | $1 --yaffle Dot4.yaff
 
-rm -rf build

--- a/tests/ttimp/eta001/run
+++ b/tests/ttimp/eta001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --yaffle Eta.yaff < input
 
-rm -rf build

--- a/tests/ttimp/eta002/run
+++ b/tests/ttimp/eta002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 echo ':q' | $1 --yaffle Eta.yaff
 
-rm -rf build

--- a/tests/ttimp/lazy001/run
+++ b/tests/ttimp/lazy001/run
@@ -1,5 +1,6 @@
+rm -rf build
+
 $1 --yaffle Lazy.yaff < input
 $1 --yaffle LazyInf.yaff < input
 $1 --yaffle build/ttc/LazyInf.ttc < input
 
-rm -rf build

--- a/tests/ttimp/nest001/run
+++ b/tests/ttimp/nest001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --yaffle Let.yaff < input
 
-rm -rf build

--- a/tests/ttimp/nest002/run
+++ b/tests/ttimp/nest002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --yaffle Case.yaff < input
 
-rm -rf build

--- a/tests/ttimp/perf001/run
+++ b/tests/ttimp/perf001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 echo ':q' | $1 --yaffle bigsuc.yaff
 
-rm -rf build

--- a/tests/ttimp/perf002/run
+++ b/tests/ttimp/perf002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --yaffle BigVect.yaff < input
 
-rm -rf build

--- a/tests/ttimp/perf003/run
+++ b/tests/ttimp/perf003/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --yaffle Id.yaff < input
 
-rm -rf build

--- a/tests/ttimp/qtt001/run
+++ b/tests/ttimp/qtt001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --yaffle QTT.yaff < input
 
-rm -rf build

--- a/tests/ttimp/qtt003/run
+++ b/tests/ttimp/qtt003/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --yaffle QTTEq.yaff < input
 
-rm -rf build

--- a/tests/ttimp/record001/run
+++ b/tests/ttimp/record001/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --yaffle Record.yaff < input
 $1 --yaffle build/ttc/Record.ttc < input
 
-rm -rf build

--- a/tests/ttimp/record002/run
+++ b/tests/ttimp/record002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --yaffle Record.yaff < input
 
-rm -rf build

--- a/tests/ttimp/record003/run
+++ b/tests/ttimp/record003/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --yaffle Record.yaff          < input
 $1 --yaffle build/ttc/Record.ttc < input
 
-rm -rf build

--- a/tests/ttimp/total001/run
+++ b/tests/ttimp/total001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --yaffle Vect.yaff < input
 
-rm -rf build

--- a/tests/ttimp/total002/run
+++ b/tests/ttimp/total002/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --yaffle Total.yaff < input
 
-rm -rf build

--- a/tests/ttimp/total003/run
+++ b/tests/ttimp/total003/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --yaffle Bad.yaff < input
 
-rm -rf build

--- a/tests/typedd-book/chapter01/run
+++ b/tests/typedd-book/chapter01/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 All.idr --check
 $1 --no-color --console-width 0 --no-banner HoleFix.idr < input
 
-rm -rf build

--- a/tests/typedd-book/chapter02/run
+++ b/tests/typedd-book/chapter02/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 All.idr --check
 
-rm -rf build

--- a/tests/typedd-book/chapter03/run
+++ b/tests/typedd-book/chapter03/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 All.idr --check
 
-rm -rf build

--- a/tests/typedd-book/chapter04/run
+++ b/tests/typedd-book/chapter04/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 All.idr --check
 
-rm -rf build

--- a/tests/typedd-book/chapter05/run
+++ b/tests/typedd-book/chapter05/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 All.idr --check
 
-rm -rf build

--- a/tests/typedd-book/chapter06/run
+++ b/tests/typedd-book/chapter06/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 All.idr --check
 
-rm -rf build

--- a/tests/typedd-book/chapter07/run
+++ b/tests/typedd-book/chapter07/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 All.idr --check
 
-rm -rf build

--- a/tests/typedd-book/chapter08/run
+++ b/tests/typedd-book/chapter08/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 All.idr --check
 
-rm -rf build

--- a/tests/typedd-book/chapter09/run
+++ b/tests/typedd-book/chapter09/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 All.idr --check
 
-rm -rf build

--- a/tests/typedd-book/chapter10/run
+++ b/tests/typedd-book/chapter10/run
@@ -1,4 +1,5 @@
+rm -rf build
+
 $1 --no-color --console-width 0 DLFail.idr --check
 $1 --no-color --console-width 0 All.idr --check
 
-rm -rf build

--- a/tests/typedd-book/chapter11/run
+++ b/tests/typedd-book/chapter11/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 All.idr --check
 
-rm -rf build

--- a/tests/typedd-book/chapter12/run
+++ b/tests/typedd-book/chapter12/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 All.idr --check
 
-rm -rf build

--- a/tests/typedd-book/chapter13/run
+++ b/tests/typedd-book/chapter13/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 All.idr --check
 
-rm -rf build

--- a/tests/typedd-book/chapter14/run
+++ b/tests/typedd-book/chapter14/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 All.idr --check
 
-rm -rf build

--- a/tests/vmcode/basic001/run
+++ b/tests/vmcode/basic001/run
@@ -1,3 +1,4 @@
+rm -rf build
+
 $1 --no-color --console-width 0 --no-banner Test.idr -x main --cg vmcode-interp
 
-rm -rf build


### PR DESCRIPTION
While the discussion about how to refactor test framework is not
finished (#1654), make this change: move `rm -rf build` in the
beginning of the test. For these reasons:

* it is useful to inspect the contents of the `build` directory
  especially after the test failure
* if build crashes mid-test (e.g. process killed), next run should
  not be affected by the `build` directory from the previous run