### PR TITLE
Fix 'with' under implicit parameters

### DIFF
--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -512,6 +512,13 @@ checkClause {vars} mult vis totreq hashit n opts nest env
                                  (weakenNs (mkSizeOf wargs) notreqty))
          let bNotReq = binder wtyScope
 
+         -- The environment has some implicit and some explcit args, potentially,
+         -- which is inconvenient since we have to know which is which when
+         -- elaborating the application of the rhs function. So it's easier
+         -- if we just make them all explicit - this type isn't visible to
+         -- users anyway!
+         let env' = mkExplicit env'
+
          let Just (reqns, envns, wtype) = bindReq vfc env' withSub [] bNotReq
              | Nothing => throw (InternalError "Impossible happened: With abstraction failure #4")
 
@@ -564,6 +571,11 @@ checkClause {vars} mult vis totreq hashit n opts nest env
   where
     vfc : FC
     vfc = virtualiseFC ifc
+
+    mkExplicit : forall vs . Env Term vs -> Env Term vs
+    mkExplicit [] = []
+    mkExplicit (Pi fc c _ ty :: env) = Pi fc c Explicit ty :: mkExplicit env
+    mkExplicit (b :: env) = b :: mkExplicit env
 
     bindWithArgs :
        (wvalTy : Term xs) -> Maybe (Name, Term xs) ->

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -124,7 +124,7 @@ idrisTestsRegression = MkTestPool "Various regressions" [] Nothing
        "reg022", "reg023", "reg024", "reg025", "reg026", "reg027", "reg028",
        "reg029", "reg030", "reg031", "reg032", "reg033", "reg034", "reg035",
        "reg036", "reg037", "reg038", "reg039", "reg040", "reg041", "reg042",
-       "reg043", "reg044"]
+       "reg043", "reg044", "reg045"]
 
 idrisTestsData : TestPool
 idrisTestsData = MkTestPool "Data and record types" [] Nothing

--- a/tests/idris2/reg045/expected
+++ b/tests/idris2/reg045/expected
@@ -1,0 +1,1 @@
+1/1: Building withparams (withparams.idr)

--- a/tests/idris2/reg045/run
+++ b/tests/idris2/reg045/run
@@ -1,0 +1,3 @@
+$1 --no-color --console-width 0 --check withparams.idr
+
+rm -rf build

--- a/tests/idris2/reg045/withparams.idr
+++ b/tests/idris2/reg045/withparams.idr
@@ -1,0 +1,11 @@
+-- Testing that 'with' works under parameters that are implicits
+parameters {0 A : Type} (pred : A -> Bool)
+  foo : A -> Bool
+  foo x = case pred x of
+    True  => False
+    False => True
+
+  bar : (x : A) -> not (pred x) = foo x
+  bar  a with (pred a)
+   bar a | True  = Refl
+   bar a | False = Refl


### PR DESCRIPTION
The 'with' type and application need to treat the parameters with the same plicity, but the application has just always treated them as explicit since it never looked. It's easiest just to make them all explicit, since this isn't a user visible type. Fixes #1695.