### PR TITLE
[ cosmetic ] use the whole range when underlining the problem

### DIFF
--- a/src/Libraries/Text/Parser/Core.idr
+++ b/src/Libraries/Text/Parser/Core.idr
@@ -278,7 +278,8 @@ doParse : Semigroup state => state -> (commit : Bool) ->
           (xs : List (WithBounds tok)) ->
           ParseResult state tok ty
 doParse s com (Empty val) xs = Res s com (irrelevantBounds val) xs
-doParse s com (Fail location fatal str) xs = Failure com fatal str (maybe (bounds <$> head' xs) Just location)
+doParse s com (Fail location fatal str) xs
+  = Failure com fatal str (location <|> (bounds <$> head' xs))
 doParse s com (Try g) xs = case doParse s com g xs of
   -- recover from fatal match but still propagate the 'commit'
   Failure com _ msg ts => Failure com False msg ts

--- a/src/Parser/Support.idr
+++ b/src/Parser/Support.idr
@@ -34,9 +34,11 @@ fromParsingError : (Show token, Pretty token) =>
 fromParsingError origin (Error msg Nothing)
     = ParseFail (MkFC origin (0, 0) (0, 0)) (msg +> '.')
 fromParsingError origin (Error msg (Just t))
-    = let l = t.startLine
-          c = t.startCol in
-          ParseFail (MkFC origin (l, c) (l, c + 1)) (msg +> '.')
+    = let start = startBounds t; end = endBounds t in
+      let fc = if start == end
+                then MkFC origin start (mapSnd (+1) start)
+                else MkFC origin start end
+      in ParseFail fc (msg +> '.')
 
 export
 hex : Char -> Maybe Int

--- a/tests/idris2/interactive028/expected
+++ b/tests/idris2/interactive028/expected
@@ -6,15 +6,15 @@ Main> Expected 'case', 'if', 'do', application or operator expression.
 
 Main> Expected string begin.
 
-(Interactive):1:5--1:6
+(Interactive):1:5--1:7
  1 | :cd ..
-         ^
+         ^^
 
 Main> Expected string begin.
 
-(Interactive):1:7--1:8
+(Interactive):1:7--1:15
  1 | :load expected
-           ^
+           ^^^^^^^^
 
 Main> 
 Bye for now!

--- a/tests/idris2/perf005/expected
+++ b/tests/idris2/perf005/expected
@@ -14,11 +14,11 @@ Lambda:62:3--88:9
 1/1: Building Bad1 (Bad1.idr)
 Error: Couldn't parse declaration.
 
-Bad1:3:1--3:2
+Bad1:3:1--3:5
  1 | module Bad1
  2 | 
  3 | data Bad = BadDCon (x : Nat)
-     ^
+     ^^^^
 
 1/1: Building Bad2 (Bad2.idr)
 Error: Expected 'case', 'if', 'do', application or operator expression.
@@ -32,10 +32,10 @@ Bad2:3:13--3:14
 1/1: Building Bad3 (Bad3.idr)
 Error: Couldn't parse declaration.
 
-Bad3:4:1--4:2
+Bad3:4:1--4:8
  1 | module Bad3
  2 | 
  3 | badExpr : ()
  4 | badExpr (whatever : ())
-     ^
+     ^^^^^^^
 

--- a/tests/idris2/perror005/expected
+++ b/tests/idris2/perror005/expected
@@ -1,11 +1,11 @@
 1/1: Building PError (PError.idr)
 Error: Expected 'in'.
 
-PError:7:1--7:2
+PError:7:1--7:4
  3 | 
  4 | bar : Int -> Int
  5 | bar x = let y = 42
  6 | 
  7 | baz : Int -> Int
-     ^
+     ^^^
 

--- a/tests/idris2/perror006/expected
+++ b/tests/idris2/perror006/expected
@@ -1,11 +1,11 @@
 1/1: Building PError (PError.idr)
 Error: Expected 'else'.
 
-PError:7:1--7:2
+PError:7:1--7:4
  3 | 
  4 | bar : Int -> Int
  5 | bar x = if x == 95 then 0
  6 | 
  7 | baz : Int -> Int
-     ^
+     ^^^
 

--- a/tests/idris2/perror008/expected
+++ b/tests/idris2/perror008/expected
@@ -19,21 +19,21 @@ Issue710b:3:6--3:7
 1/1: Building Issue710c (Issue710c.idr)
 Error: Expected a capitalised identifier, got: leaf.
 
-Issue710c:5:3--5:4
+Issue710c:5:3--5:7
  1 | infix 3 #
  2 | 
  3 | data T : Type where
  4 |   (#) : T -> T -> T
  5 |   leaf : T
-       ^
+       ^^^^
 
 1/1: Building Issue710d (Issue710d.idr)
 Error: Expected a capitalised identifier, got: mkT.
 
-Issue710d:2:15--2:16
+Issue710d:2:15--2:18
  1 | record T where
  2 |   constructor mkT
-                   ^
+                   ^^^
 
 1/1: Building Issue710e (Issue710e.idr)
 Error: Expected a capitalised identifier, got: a.
@@ -47,20 +47,20 @@ Issue710e:3:11--3:12
 1/1: Building Issue710f (Issue710f.idr)
 Error: Expected a capitalised identifier, got: cons.
 
-Issue710f:2:15--2:16
+Issue710f:2:15--2:19
  1 | interface Lalala where
  2 |   constructor cons
-                   ^
+                   ^^^^
 
 Uncaught error: Error: Expected a capitalised identifier, got: ggg.
 
-Issue1224a:1:8--1:9
+Issue1224a:1:8--1:11
  1 | module ggg
-            ^
+            ^^^
 
 Uncaught error: Error: Expected a capitalised identifier, got: ggg.
 
-Issue1224b:1:8--1:9
+Issue1224b:1:8--1:11
  1 | import ggg
-            ^
+            ^^^
 

--- a/tests/idris2/with003/expected
+++ b/tests/idris2/with003/expected
@@ -33,8 +33,8 @@ Mismatch between: Vect 0 ?elem and List ?a.
 Main> the (Maybe Integer) (pure 4) : Maybe Integer
 Main> Expected 'case', 'if', 'do', application or operator expression.
 
-(Interactive):1:4--1:5
+(Interactive):1:4--1:8
  1 | :t with [] 4
-        ^
+        ^^^^
 
 Main> Bye for now!

--- a/tests/idris2/with004/expected
+++ b/tests/idris2/with004/expected
@@ -5,20 +5,20 @@ Bye for now!
 1/1: Building Issue637-2 (Issue637-2.idr)
 Error: Expected an indented non-empty block.
 
-Issue637-2:5:3--5:4
+Issue637-2:5:3--5:7
  1 | namespace A
  2 |   export
  3 |   foo3 : Int -> Int
  4 |   foo3 x with (x + 1)
  5 |   foo3 x | y = y + x
-       ^
+       ^^^^
 
 1/1: Building Issue637-3 (Issue637-3.idr)
 Error: Expected an indented non-empty block.
 
-Issue637-3:3:1--3:2
+Issue637-3:3:1--3:5
  1 | foo5 : Int -> Int
  2 | foo5 x with (x + 1)
  3 | foo5 x | y = y + x
-     ^
+     ^^^^
 


### PR DESCRIPTION
I was generating good error ranges in #1703 only to see them thrown away
by the reporting mechanism!