### PR TITLE
Fork Data.IOArray into the compiler

### DIFF
--- a/idris2api.ipkg
+++ b/idris2api.ipkg
@@ -125,6 +125,7 @@ modules =
     Libraries.Data.Graph,
     Libraries.Data.IMaybe,
     Libraries.Data.IntMap,
+    Libraries.Data.IOArray,
     Libraries.Data.IOMatrix,
     Libraries.Data.LengthMatch,
     Libraries.Data.List.Extra,

--- a/src/Compiler/Common.idr
+++ b/src/Compiler/Common.idr
@@ -13,10 +13,10 @@ import Core.Directory
 import Core.Options
 import Core.TT
 import Core.TTC
+import Libraries.Data.IOArray
 import Libraries.Utils.Binary
 import Libraries.Utils.Path
 
-import Data.IOArray
 import Data.List
 import Data.List1
 import Libraries.Data.NameMap

--- a/src/Compiler/Interpreter/VMCode.idr
+++ b/src/Compiler/Interpreter/VMCode.idr
@@ -8,7 +8,7 @@ import Core.Primitives
 import Core.Value
 import Compiler.Common
 import Compiler.VMCode
-import Data.IOArray
+import Libraries.Data.IOArray
 import Libraries.Data.NameMap
 import Data.Nat
 import Data.SnocList

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -13,8 +13,8 @@ import public Core.TT
 import Libraries.Utils.Binary
 
 import Data.Fin
+import Libraries.Data.IOArray
 import Libraries.Data.IntMap
-import Data.IOArray
 import Data.List
 import Data.List1
 import Data.Maybe

--- a/src/Libraries/Data/IOArray.idr
+++ b/src/Libraries/Data/IOArray.idr
@@ -1,0 +1,81 @@
+module Libraries.Data.IOArray
+
+import Data.IOArray.Prims
+import Data.List
+
+%default total
+
+export
+record IOArray a where
+  constructor MkIOArray
+  maxSize : Int
+  content : ArrayData (Maybe a)
+
+export
+max : IOArray a -> Int
+max = maxSize
+
+export
+newArray : HasIO io => Int -> io (IOArray a)
+newArray size
+    = pure (MkIOArray size !(primIO (prim__newArray size Nothing)))
+
+export
+writeArray : HasIO io => IOArray a -> Int -> a -> io ()
+writeArray arr pos el
+    = if pos < 0 || pos >= max arr
+         then pure ()
+         else primIO (prim__arraySet (content arr) pos (Just el))
+
+export
+readArray : HasIO io => IOArray a -> Int -> io (Maybe a)
+readArray arr pos
+    = if pos < 0 || pos >= max arr
+         then pure Nothing
+         else primIO (prim__arrayGet (content arr) pos)
+
+-- Make a new array of the given size with the elements copied from the
+-- other array
+export
+newArrayCopy : HasIO io =>
+               (newsize : Int) -> IOArray a -> io (IOArray a)
+newArrayCopy newsize arr
+    = do let newsize' = if newsize < max arr then max arr else newsize
+         arr' <- newArray newsize'
+         copyFrom (content arr) (content arr') (max arr - 1)
+         pure arr'
+  where
+    copyFrom : ArrayData (Maybe a) ->
+               ArrayData (Maybe a) ->
+               Int -> io ()
+    copyFrom old new pos
+        = if pos < 0
+             then pure ()
+             else do el <- primIO $ prim__arrayGet old pos
+                     primIO $ prim__arraySet new pos el
+                     copyFrom old new $ assert_smaller pos (pos - 1)
+
+export
+toList : HasIO io => IOArray a -> io (List (Maybe a))
+toList arr = iter 0 (max arr) []
+  where
+    iter : Int -> Int -> List (Maybe a) -> io (List (Maybe a))
+    iter pos end acc
+         = if pos >= end
+              then pure (reverse acc)
+              else do el <- readArray arr pos
+                      assert_total (iter (pos + 1) end (el :: acc))
+
+export
+fromList : HasIO io => List (Maybe a) -> io (IOArray a)
+fromList ns
+    = do arr <- newArray (cast (length ns))
+         addToArray 0 ns arr
+         pure arr
+  where
+    addToArray : Int -> List (Maybe a) -> IOArray a -> io ()
+    addToArray loc [] arr = pure ()
+    addToArray loc (Nothing :: ns) arr = addToArray (loc + 1) ns arr
+    addToArray loc (Just el :: ns) arr
+        = do primIO $ prim__arraySet (content arr) loc (Just el)
+             addToArray (loc + 1) ns arr

--- a/src/Libraries/Utils/Binary.idr
+++ b/src/Libraries/Utils/Binary.idr
@@ -17,7 +17,7 @@ import System.File
 import Libraries.Data.PosMap
 import Libraries.Utils.String
 
-import public Data.IOArray
+import public Libraries.Data.IOArray
 
 -- Serialising data as binary. Provides an interface TTC which allows
 -- reading and writing to chunks of memory, "Binary", which can be written


### PR DESCRIPTION
To be able to modify `Data.IOArray` as proposed in #1677.

Currently `Data.IOArray` cannot be modified because compiler need
to be built with previous compiler. This PR removes compiler
dependency on `Data.IOArray`.