### PR TITLE
[ backends ] always assign tag to constructors

### DIFF
--- a/src/Compiler/ANF.idr
+++ b/src/Compiler/ANF.idr
@@ -29,7 +29,7 @@ mutual
     AUnderApp : FC -> Name -> (missing : Nat) -> (args : List AVar) -> ANF
     AApp : FC -> (lazy : Maybe LazyReason) -> (closure : AVar) -> (arg : AVar) -> ANF
     ALet : FC -> (var : Int) -> ANF -> ANF -> ANF
-    ACon : FC -> Name -> ConInfo -> (tag : Maybe Int) -> List AVar -> ANF
+    ACon : FC -> Name -> ConInfo -> (tag : Int) -> List AVar -> ANF
     AOp : {0 arity : Nat} -> FC -> (lazy : Maybe LazyReason) -> PrimFn arity -> Vect arity AVar -> ANF
         -- ^ we explicitly bind arity here to silence the warning that it shadows
         --   existing functions called arity.
@@ -42,7 +42,7 @@ mutual
 
   public export
   data AConAlt : Type where
-       MkAConAlt : Name -> ConInfo -> (tag : Maybe Int) -> (args : List Int) ->
+       MkAConAlt : Name -> ConInfo -> (tag : Int) -> (args : List Int) ->
                    ANF -> AConAlt
 
   public export
@@ -52,7 +52,7 @@ mutual
 public export
 data ANFDef : Type where
      MkAFun : (args : List Int) -> ANF -> ANFDef
-     MkACon : (tag : Maybe Int) -> (arity : Nat) -> (nt : Maybe Nat) -> ANFDef
+     MkACon : (tag : Int) -> (arity : Nat) -> (nt : Maybe Nat) -> ANFDef
      MkAForeign : (ccs : List String) -> (fargs : List CFType) ->
                   CFType -> ANFDef
      MkAError : ANF -> ANFDef

--- a/src/Compiler/ES/Ast.idr
+++ b/src/Compiler/ES/Ast.idr
@@ -86,7 +86,7 @@ mutual
     ||| The tag either represents the name of a type constructor
     ||| (when we are pattern matching on types) or the index
     ||| of a data constructor.
-    ECon      : (tag : Either Int Name) -> ConInfo -> List Exp -> Exp
+    ECon      : (tag : Int) -> ConInfo -> List Exp -> Exp
 
     ||| Primitive operation
     EOp       : {0 arity : Nat} -> PrimFn arity -> Vect arity Exp -> Exp
@@ -167,7 +167,7 @@ mutual
   public export
   record EConAlt (e : Effect) where
     constructor MkEConAlt
-    tag     : Either Int Name
+    tag     : Int
     conInfo : ConInfo
     body    : Stmt (Just e)
 

--- a/src/Compiler/ES/Codegen.idr
+++ b/src/Compiler/ES/Codegen.idr
@@ -114,9 +114,9 @@ minimal : Minimal -> Doc
 minimal (MVar v)          = var v
 minimal (MProjection n v) = minimal v <+> ".a" <+> shown n
 
-tag2es : Either Int Name -> Doc
-tag2es (Left x)  = shown x
-tag2es (Right x) = jsStringDoc $ show x
+%inline
+tag2es : Int -> Doc
+tag2es x = shown x
 
 constant : Doc -> Doc -> Doc
 constant n d = "const" <++> n <+> softEq <+> d <+> ";"
@@ -139,7 +139,7 @@ applyObj = applyList "{" "}" softComma
 -- Exceptions based on the given `ConInfo`:
 -- `NIL` and `NOTHING`-like data constructors are represented as `{h: 0}`,
 -- while `CONS`, `JUST`, and `RECORD` come without the header field.
-applyCon : ConInfo -> (tag : Either Int Name) -> (args : List Doc) -> Doc
+applyCon : ConInfo -> (tag : Int) -> (args : List Doc) -> Doc
 applyCon NIL     _ [] = "{h" <+> softColon <+> "0}"
 applyCon NOTHING _ [] = "{h" <+> softColon <+> "0}"
 applyCon CONS    _ as = applyObj (conTags as)

--- a/src/Compiler/ES/TailRec.idr
+++ b/src/Compiler/ES/TailRec.idr
@@ -257,21 +257,21 @@ tcDoneName gi = MN "TcDone" gi
 conAlt : TcGroup -> TcFunction -> NamedConAlt
 conAlt (MkTcGroup tcIx funs) (MkTcFunction n ix args exp) =
   let name = tcContinueName tcIx ix
-   in MkNConAlt name DATACON (Just ix) args (toTc exp)
+   in MkNConAlt name DATACON ix args (toTc exp)
 
    where mutual
      -- this is returned in case we arrived at a result
      -- (an expression not corresponding to a recursive
      -- call in tail position).
      tcDone : NamedCExp -> NamedCExp
-     tcDone x = NmCon EmptyFC (tcDoneName tcIx) DATACON (Just 0) [x]
+     tcDone x = NmCon EmptyFC (tcDoneName tcIx) DATACON 0 [x]
 
      -- this is returned in case we arrived at a resursive call
      -- in tail position. The index indicates the next "function"
      -- to call, the list of expressions are the function's
      -- arguments.
      tcContinue : (index : Int) -> List NamedCExp -> NamedCExp
-     tcContinue ix = NmCon EmptyFC (tcContinueName tcIx ix) DATACON (Just ix)
+     tcContinue ix = NmCon EmptyFC (tcContinueName tcIx ix) DATACON ix
 
      -- recursively converts an expression. Only the `NmApp` case is
      -- interesting, the rest is pretty much boiler plate.
@@ -314,7 +314,7 @@ convertTcGroup loop g@(MkTcGroup gindex fs) =
         toFun (MkTcFunction n ix args x) =
           let exps  = map local args
               tcArg = NmCon EmptyFC (tcContinueName gindex ix)
-                        DATACON (Just ix) exps
+                        DATACON ix exps
               tcFun = NmRef EmptyFC tcFun
               body  = NmApp EmptyFC (NmRef EmptyFC loop) [tcFun,tcArg]
            in MkFunction n args body

--- a/src/Compiler/ES/ToAst.idr
+++ b/src/Compiler/ES/ToAst.idr
@@ -160,7 +160,7 @@ mutual
 
   stmt e (NmCon _ n ci tg xs) = do
     (mbxs, args) <- liftArgs xs
-    pure . prepend mbxs $ assign e (ECon (tag n tg) ci args)
+    pure . prepend mbxs $ assign e (ECon tg ci args)
 
   stmt e o@(NmOp _ x xs) =
     case integerArith o of
@@ -228,7 +228,7 @@ mutual
     -- data projections (field accessors). They'll
     -- be then properly inlined when converting `x`.
     projections sc args
-    MkEConAlt (tag n tg) ci <$> stmt e x
+    MkEConAlt tg ci <$> stmt e x
 
   -- a single branch in a pattern match on a constant
   constAlt :  { auto c : Ref ESs ESSt }

--- a/src/Compiler/Inline.idr
+++ b/src/Compiler/Inline.idr
@@ -273,7 +273,7 @@ mutual
   pickAlt rec env stk (CCon fc n ci t args) [] def
       = traverseOpt (eval rec env stk) def
   pickAlt {vars} {free} rec env stk con@(CCon fc n ci t args) (MkConAlt n' _ t' args' sc :: alts) def
-      = if matches n t n' t'
+      = if t == t'
            then case checkLengthMatch args args' of
                      Nothing => pure Nothing
                      Just m =>
@@ -283,11 +283,6 @@ mutual
                                     (rewrite sym (appendAssociative args' vars free) in
                                              sc))
            else pickAlt rec env stk con alts def
-    where
-      matches : Name -> Maybe Int -> Name -> Maybe Int -> Bool
-      matches _ (Just t) _ (Just t') = t == t'
-      matches n Nothing n' Nothing = n == n'
-      matches _ _ _ _ = False
   pickAlt rec env stk _ _ _ = pure Nothing
 
   pickConstAlt : {vars, free : _} ->

--- a/src/Compiler/Interpreter/VMCode.idr
+++ b/src/Compiler/Interpreter/VMCode.idr
@@ -17,7 +17,7 @@ import Data.Vect
 public export
 data Object : Type where
     Closure : (predMissing : Nat) -> (args : SnocList Object) -> Name -> Object
-    Constructor : (tag : Either Int Name) -> (args : List Object) -> Object
+    Constructor : (tag : Int) -> (args : List Object) -> Object
     Const : Constant -> Object
     Null : Object
 
@@ -35,7 +35,7 @@ mutual
 
     showDepth : Nat -> Object -> String
     showDepth (S k) (Closure mis args fn) = show fn ++ "-" ++ show mis ++ "(" ++ showSep k (args <>> []) ++ ")"
-    showDepth (S k) (Constructor (Left t) args) = "tag" ++ show t ++ "(" ++ showSep k args ++ ")"
+    showDepth (S k) (Constructor t args) = "tag" ++ show t ++ "(" ++ showSep k args ++ ")"
     showDepth (S k) (Const c) = show c
     showDepth _ obj = showType obj
 
@@ -129,7 +129,7 @@ unit : Object
 unit = Const (I 0)
 
 ioRes : Object -> Object
-ioRes obj = Constructor (Left 0) [Const WorldVal, obj]
+ioRes obj = Constructor 0 [Const WorldVal, obj]
 
 -- TODO: add more?
 knownForeign : NameMap (ar ** (Ref State InterpState => Stack -> Vect ar Object -> Core Object))
@@ -212,7 +212,7 @@ parameters {auto c : Ref Ctxt Defs}
             Constructor tag _ => matchCon stk tag alts def
             _ => interpError stk $ "CASE: Expected Constructor, found " ++ showType scObj
       where
-        matchCon : Stack -> Either Int Name -> List (Either Int Name, List VMInst) -> Maybe (List VMInst) -> Core ()
+        matchCon : Stack -> Int -> List (Int, List VMInst) -> Maybe (List VMInst) -> Core ()
         matchCon stk tag [] Nothing = interpError stk "CASE: Missing matching alternative or default"
         matchCon stk tag [] (Just is) = traverse_ (step stk) is
         matchCon stk tag ((t, is) :: alts) def =

--- a/src/Compiler/LambdaLift.idr
+++ b/src/Compiler/LambdaLift.idr
@@ -31,7 +31,7 @@ mutual
        LApp : FC -> (lazy : Maybe LazyReason) -> (closure : Lifted vars) -> (arg : Lifted vars) -> Lifted vars
        LLet : FC -> (x : Name) -> Lifted vars ->
               Lifted (x :: vars) -> Lifted vars
-       LCon : FC -> Name -> ConInfo -> (tag : Maybe Int) ->
+       LCon : FC -> Name -> ConInfo -> (tag : Int) ->
               List (Lifted vars) -> Lifted vars
        LOp : {arity : _} ->
              FC -> (lazy : Maybe LazyReason) -> PrimFn arity -> Vect arity (Lifted vars) -> Lifted vars
@@ -48,7 +48,7 @@ mutual
 
   public export
   data LiftedConAlt : List Name -> Type where
-       MkLConAlt : Name -> ConInfo -> (tag : Maybe Int) -> (args : List Name) ->
+       MkLConAlt : Name -> ConInfo -> (tag : Int) -> (args : List Name) ->
                    Lifted (args ++ vars) -> LiftedConAlt vars
 
   public export
@@ -67,7 +67,7 @@ data LiftedDef : Type where
      MkLFun : (args : List Name) -> -- function arguments
               (scope : List Name) -> -- outer scope
               Lifted (scope ++ args) -> LiftedDef
-     MkLCon : (tag : Maybe Int) -> (arity : Nat) -> (nt : Maybe Nat) -> LiftedDef
+     MkLCon : (tag : Int) -> (arity : Nat) -> (nt : Maybe Nat) -> LiftedDef
      MkLForeign : (ccs : List String) ->
                   (fargs : List CFType) ->
                   CFType ->

--- a/src/Compiler/RefC/RefC.idr
+++ b/src/Compiler/RefC/RefC.idr
@@ -467,15 +467,10 @@ mutual
                     -> Nat
                     -> Core $ ()
     copyConstructors _ [] _ _ _ = pure ()
-    copyConstructors sc ((MkAConAlt n _ mTag args body) :: xs) constrFieldVar retValVar k = do
-        (tag', name') <- getNameTag mTag n
-        emit EmptyFC $ constrFieldVar ++ "[" ++ show k ++ "].tag = " ++ tag' ++ ";"
-        emit EmptyFC $ constrFieldVar ++ "[" ++ show k ++ "].name = " ++ name' ++ ";"
+    copyConstructors sc ((MkAConAlt _ _ tag args body) :: xs) constrFieldVar retValVar k = do
+        emit EmptyFC $ constrFieldVar ++ "[" ++ show k ++ "].tag = " ++ show tag ++ ";"
+        emit EmptyFC $ constrFieldVar ++ "[" ++ show k ++ "].name = " ++ "NULL" ++ ";"
         copyConstructors sc xs constrFieldVar retValVar (S k)
-    where
-        getNameTag : {auto a : Ref ArgCounter Nat} -> Maybe Int -> Name -> Core (String, String)
-        getNameTag Nothing n = pure ("-1", "\"" ++ cName n ++ "\"")
-        getNameTag (Just t) _ = pure (show t, "NULL")
 
 
     conBlocks : {auto a : Ref ArgCounter Nat}
@@ -585,11 +580,6 @@ mutual
         makeNonIntSwitchStatementConst alts (k+1) constantArray compareFct
 
 
-    checkTags : List AConAlt -> Core Bool
-    checkTags [] = pure False
-    checkTags ((MkAConAlt n _ Nothing args sc) :: xs) = pure False
-    checkTags _ = pure True
-
 
     cStatementsFromANF : {auto a : Ref ArgCounter Nat}
                       -> {auto t : Ref TemporaryVariableTracker (List (List String))}
@@ -639,8 +629,8 @@ mutual
         emit fc $ "Value_Constructor* "
                 ++ constr ++ " = newConstructor("
                 ++ (show (length args))
-                ++ ", "  ++ showTag tag  ++ ", "
-                ++ "\"" ++ cName n ++ "\""
+                ++ ", "  ++ show tag ++ ", "
+                ++ "NULL"
                 ++ ");"
         emit fc $ " // constructor " ++ cName n
 

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -129,12 +129,12 @@ chezString cs = strCons '"' (showChezString (unpack cs) "\"")
 
 mutual
   handleRet : String -> String -> String
-  handleRet "void" op = op ++ " " ++ mkWorld (schConstructor chezString (UN "") (Just 0) [])
+  handleRet "void" op = op ++ " " ++ mkWorld (schConstructor 0 [])
   handleRet _ op = mkWorld op
 
   getFArgs : NamedCExp -> Core (List (NamedCExp, NamedCExp))
-  getFArgs (NmCon fc _ _ (Just 0) _) = pure []
-  getFArgs (NmCon fc _ _ (Just 1) [ty, val, rest]) = pure $ (ty, val) :: !(getFArgs rest)
+  getFArgs (NmCon fc _ _ 0 _) = pure []
+  getFArgs (NmCon fc _ _ 1 [ty, val, rest]) = pure $ (ty, val) :: !(getFArgs rest)
   getFArgs arg = throw (GenericMsg (getFC arg) ("Badly formed c call argument list " ++ show arg))
 
   export

--- a/src/Compiler/Scheme/Common.idr
+++ b/src/Compiler/Scheme/Common.idr
@@ -43,15 +43,13 @@ schName (WithBlock x y) = "with--" ++ schString x ++ "-" ++ show y
 schName (Resolved i) = "fn--" ++ show i
 
 export
-schConstructor : (String -> String) -> Name -> Maybe Int -> List String -> String
-schConstructor _ _ (Just t) args
+schConstructor : Int -> List String -> String
+schConstructor t args
     = "(vector " ++ show t ++ " " ++ showSep " " args ++ ")"
-schConstructor schString n Nothing args
-    = "(vector " ++ schString (show n) ++ " " ++ showSep " " args ++ ")"
 
 export
-schRecordCon : (String -> String) -> Name -> List String -> String
-schRecordCon _ _ args = "(vector " ++ showSep " " args ++ ")"
+schRecordCon : List String -> String
+schRecordCon args = "(vector " ++ showSep " " args ++ ")"
 
 ||| Generate scheme for a plain function.
 op : String -> List String -> String
@@ -319,14 +317,11 @@ var _ = False
 
 parameters (schExtPrim : Int -> ExtPrim -> List NamedCExp -> Core String,
             schString : String -> String)
-  showTag : Name -> Maybe Int -> String
-  showTag n (Just i) = show i
-  showTag n Nothing = schString (show n)
 
   mutual
     schConAlt : Int -> String -> NamedConAlt -> Core String
     schConAlt i target (MkNConAlt n ci tag args sc)
-        = pure $ "((" ++ showTag n tag ++ ") "
+        = pure $ "((" ++ show tag ++ ") "
                       ++ bindArgs 1 args !(schExp i sc) ++ ")"
       where
         bindArgs : Int -> (ns : List Name) -> String -> String
@@ -558,9 +553,9 @@ parameters (schExtPrim : Int -> ExtPrim -> List NamedCExp -> Core String,
              pure $ "(box " ++ x' ++ ")"
     schExp i (NmCon fc _ JUST tag _) = throw (InternalError "Bad JUST")
     schExp i (NmCon fc x RECORD tag args)
-        = pure $ schRecordCon schString x !(traverse (schExp i) args)
+        = pure $ schRecordCon !(traverse (schExp i) args)
     schExp i (NmCon fc x ci tag args)
-        = pure $ schConstructor schString x tag !(traverse (schExp i) args)
+        = pure $ schConstructor tag !(traverse (schExp i) args)
     schExp i (NmOp fc op args)
         = schOp op !(schArgs i args)
     schExp i (NmExtPrim fc p args)

--- a/src/Compiler/Scheme/Gambit.idr
+++ b/src/Compiler/Scheme/Gambit.idr
@@ -75,12 +75,12 @@ gambitString cs = strCons '"' (showGambitString (unpack cs) "\"")
 
 mutual
   handleRet : String -> String -> String
-  handleRet "void" op = op ++ " " ++ mkWorld (schConstructor gambitString (UN "") (Just 0) [])
+  handleRet "void" op = op ++ " " ++ mkWorld (schConstructor 0 [])
   handleRet _ op = mkWorld op
 
   getFArgs : NamedCExp -> Core (List (NamedCExp, NamedCExp))
-  getFArgs (NmCon fc _ _ (Just 0) _) = pure []
-  getFArgs (NmCon fc _ _ (Just 1) [ty, val, rest]) = pure $ (ty, val) :: !(getFArgs rest)
+  getFArgs (NmCon fc _ _ 0 _) = pure []
+  getFArgs (NmCon fc _ _ 1 [ty, val, rest]) = pure $ (ty, val) :: !(getFArgs rest)
   getFArgs arg = throw (GenericMsg (getFC arg) ("Badly formed c call argument list " ++ show arg))
 
   gambitPrim : Int -> ExtPrim -> List NamedCExp -> Core String

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -173,7 +173,7 @@ rktToC CFChar op = "(char->integer " ++ op ++ ")"
 rktToC _ op = op
 
 handleRet : CFType -> String -> String
-handleRet CFUnit op = op ++ " " ++ mkWorld (schConstructor racketString (UN "") (Just 0) [])
+handleRet CFUnit op = op ++ " " ++ mkWorld (schConstructor 0 [])
 handleRet ret op = mkWorld (cToRkt ret op)
 
 cCall : {auto f : Ref Done (List String) } ->

--- a/src/Compiler/Separate.idr
+++ b/src/Compiler/Separate.idr
@@ -133,7 +133,7 @@ HasNamespaces VMInst where
   nsRefs (DECLARE x) = empty
   nsRefs START = empty
   nsRefs (ASSIGN x y) = empty
-  nsRefs (MKCON x tag args) = either (const empty) (singleton . getNS) tag
+  nsRefs (MKCON x tag args) = empty
   nsRefs (MKCLOSURE x n missing args) = singleton $ getNS n
   nsRefs (MKCONSTANT x y) = empty
   nsRefs (APPLY x f a) = empty
@@ -142,8 +142,7 @@ HasNamespaces VMInst where
   nsRefs (EXTPRIM x n xs) = singleton $ getNS n
   nsRefs (CASE x alts def) =
     maybe empty (concatMap nsRefs) def <+>
-    concatMap ((concatMap nsRefs) . snd) alts <+>
-    concatMap ((either (const empty) (singleton . getNS)) . fst) alts
+    concatMap ((concatMap nsRefs) . snd) alts
   nsRefs (CONSTCASE x alts def) =
     maybe empty (concatMap nsRefs) def <+>
     concatMap ((concatMap nsRefs) . snd) alts

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -31,7 +31,7 @@ import public Libraries.Utils.Binary
 ||| (Increment this when changing anything in the data format)
 export
 ttcVersion : Int
-ttcVersion = 57
+ttcVersion = 58
 
 export
 checkTTCVersion : String -> Int -> Int -> Core ()

--- a/src/Core/CompileExpr.idr
+++ b/src/Core/CompileExpr.idr
@@ -66,7 +66,7 @@ mutual
        -- A saturated constructor application
        -- 'ConInfo' gives additional information about the constructor that
        -- a back end might be able to use. It is ignorable.
-       CCon : FC -> Name -> ConInfo -> (tag : Maybe Int) ->
+       CCon : FC -> Name -> ConInfo -> (tag : Int) ->
               List (CExp vars) -> CExp vars
        -- Internally defined primitive operations
        COp : {arity : _} ->
@@ -91,7 +91,7 @@ mutual
   data CConAlt : List Name -> Type where
        -- If no tag, then match by constructor name. Back ends might want to
        -- convert names to a unique integer for performance.
-       MkConAlt : Name -> ConInfo -> (tag : Maybe Int) -> (args : List Name) ->
+       MkConAlt : Name -> ConInfo -> (tag : Int) -> (args : List Name) ->
                   CExp (args ++ vars) -> CConAlt vars
 
   public export
@@ -119,7 +119,7 @@ mutual
        -- A saturated constructor application
        -- 'ConInfo' gives additional information about the constructor that
        -- a back end might be able to use. It is ignoreable.
-       NmCon : FC -> Name -> ConInfo -> (tag : Maybe Int) ->
+       NmCon : FC -> Name -> ConInfo -> (tag : Int) ->
                List NamedCExp -> NamedCExp
        -- Internally defined primitive operations
        NmOp : {arity : _ } -> FC -> PrimFn arity -> Vect arity NamedCExp -> NamedCExp
@@ -141,7 +141,7 @@ mutual
 
   public export
   data NamedConAlt : Type where
-       MkNConAlt : Name -> ConInfo -> (tag : Maybe Int) -> (args : List Name) ->
+       MkNConAlt : Name -> ConInfo -> (tag : Int) -> (args : List Name) ->
                    NamedCExp -> NamedConAlt
 
   public export
@@ -178,7 +178,7 @@ data CDef : Type where
      -- Normal function definition
      MkFun : (args : List Name) -> CExp args -> CDef
      -- Constructor
-     MkCon : (tag : Maybe Int) -> (arity : Nat) -> (nt : Maybe Nat) -> CDef
+     MkCon : (tag : Int) -> (arity : Nat) -> (nt : Maybe Nat) -> CDef
      -- Foreign definition
      MkForeign : (ccs : List String) ->
                  (fargs : List CFType) ->
@@ -193,7 +193,7 @@ data NamedDef : Type where
      -- Normal function definition
      MkNmFun : (args : List Name) -> NamedCExp -> NamedDef
      -- Constructor
-     MkNmCon : (tag : Maybe Int) -> (arity : Nat) -> (nt : Maybe Nat) -> NamedDef
+     MkNmCon : (tag : Int) -> (arity : Nat) -> (nt : Maybe Nat) -> NamedDef
      -- Foreign definition
      MkNmForeign : (ccs : List String) ->
                    (fargs : List CFType) ->

--- a/tests/codegen/con001/expected
+++ b/tests/codegen/con001/expected
@@ -1,12 +1,12 @@
 Dumping case trees to Main.cases
-Prelude.Basics.Nil = Constructor tag Just 0 arity 0
-Prelude.Basics.:: = Constructor tag Just 1 arity 2
-Builtin.MkPair = Constructor tag Just 0 arity 2
-Prelude.Types.Stream.:: = Constructor tag Just 0 arity 2
-Prelude.Num.MkNum = Constructor tag Just 0 arity 3
-Prelude.Num.MkNeg = Constructor tag Just 0 arity 3
-Prelude.Num.MkIntegral = Constructor tag Just 0 arity 3
-Prelude.EqOrd.MkOrd = Constructor tag Just 0 arity 8
-Prelude.EqOrd.MkEq = Constructor tag Just 0 arity 2
-Prelude.Interfaces.MkMonoid = Constructor tag Just 0 arity 2
-Prelude.Interfaces.MkFoldable = Constructor tag Just 0 arity 6
+Prelude.Basics.Nil = Constructor tag 0 arity 0
+Prelude.Basics.:: = Constructor tag 1 arity 2
+Builtin.MkPair = Constructor tag 0 arity 2
+Prelude.Types.Stream.:: = Constructor tag 0 arity 2
+Prelude.Num.MkNum = Constructor tag 0 arity 3
+Prelude.Num.MkNeg = Constructor tag 0 arity 3
+Prelude.Num.MkIntegral = Constructor tag 0 arity 3
+Prelude.EqOrd.MkOrd = Constructor tag 0 arity 8
+Prelude.EqOrd.MkEq = Constructor tag 0 arity 2
+Prelude.Interfaces.MkMonoid = Constructor tag 0 arity 2
+Prelude.Interfaces.MkFoldable = Constructor tag 0 arity 6

--- a/tests/idris2/basic039/expected
+++ b/tests/idris2/basic039/expected
@@ -5,7 +5,7 @@ Erasable args: []
 Detaggable arg types: []
 Specialise args: []
 Inferrable args: []
-Compiled: Constructor tag Just 0 arity 1 (newtype by 0)
+Compiled: Constructor tag 0 arity 1 (newtype by 0)
 Refers to: []
 Refers to (runtime): []
 Flags: [contype [record]]
@@ -15,7 +15,7 @@ Erasable args: []
 Detaggable arg types: []
 Specialise args: []
 Inferrable args: []
-Compiled: Constructor tag Just 0 arity 1
+Compiled: Constructor tag 0 arity 1
 Refers to: []
 Refers to (runtime): []
 Flags: [contype [record]]


### PR DESCRIPTION
This is a cleaned-up second approach to #1608.
This uses a polynomial rolling hash to get tags for types, which should minimise chance of collisions
The refc backend is broken by this, I'd appreciate some help.