### PR TITLE
Fixed wrong reflection of records and parameters

### DIFF
--- a/libs/base/Language/Reflection/TT.idr
+++ b/libs/base/Language/Reflection/TT.idr
@@ -161,3 +161,6 @@ data TotalReq = Total | CoveringOnly | PartialOK
 
 public export
 data Visibility = Private | Export | Public
+
+public export
+data BuiltinType = BuiltinNatural | NaturalToInteger | IntegerToNatural

--- a/libs/base/Language/Reflection/TTImp.idr
+++ b/libs/base/Language/Reflection/TTImp.idr
@@ -66,7 +66,7 @@ mutual
        -- Quasiquotation
        IQuote : FC -> TTImp -> TTImp
        IQuoteName : FC -> Name -> TTImp
-       IQuoteDecl : FC -> TTImp -> TTImp
+       IQuoteDecl : FC -> List Decl -> TTImp
        IUnquote : FC -> TTImp -> TTImp
 
        IPrimVal : FC -> (c : Constant) -> TTImp
@@ -116,9 +116,9 @@ mutual
   data DataOpt : Type where
        SearchBy : List Name -> DataOpt -- determining arguments
        NoHints : DataOpt -- Don't generate search hints for constructors
-       UniqueSearch : DataOpt
-       External : DataOpt
-       NoNewtype : DataOpt
+       UniqueSearch : DataOpt -- auto implicit search must check result is unique
+       External : DataOpt -- implemented externally
+       NoNewtype : DataOpt -- don't apply newtype optimisation
 
   public export
   data Data : Type where
@@ -135,15 +135,19 @@ mutual
   public export
   data Record : Type where
        MkRecord : FC -> (n : Name) ->
-                  (params : List (Name, TTImp)) ->
+                  (params : List (Name, Count, PiInfo TTImp, TTImp)) ->
                   (conName : Name) ->
                   (fields : List IField) ->
                   Record
 
   public export
+  data WithFlag = Syntactic
+
+  public export
   data Clause : Type where
        PatClause : FC -> (lhs : TTImp) -> (rhs : TTImp) -> Clause
        WithClause : FC -> (lhs : TTImp) -> (wval : TTImp) ->
+                    (prf : Maybe Name) -> (flags : List WithFlag) ->
                     List Clause -> Clause
        ImpossibleClause : FC -> (lhs : TTImp) -> Clause
 
@@ -153,9 +157,13 @@ mutual
                 ITy -> Decl
        IData : FC -> Visibility -> Data -> Decl
        IDef : FC -> Name -> List Clause -> Decl
-       IParameters : FC -> List (Name, TTImp) ->
+       IParameters : FC -> List (Name, Count, PiInfo TTImp, TTImp) ->
                      List Decl -> Decl
-       IRecord : FC -> Visibility -> Record -> Decl
+       IRecord : FC ->
+                 Maybe String -> -- nested namespace
+                 Visibility -> Record -> Decl
        INamespace : FC -> Namespace -> List Decl -> Decl
        ITransform : FC -> Name -> TTImp -> TTImp -> Decl
-       ILog : Nat -> Decl
+       IRunElabDecl : FC -> TTImp -> Decl
+       ILog : Maybe (List String, Nat) -> Decl
+       IBuiltin : FC -> BuiltinType -> Name -> Decl

--- a/src/Core/Reflect.idr
+++ b/src/Core/Reflect.idr
@@ -627,6 +627,28 @@ Reify VirtualIdent where
   reify defs val = cantReify val "VirtualIdent"
 
 export
+Reflect BuiltinType where
+  reflect fc defs lhs env BuiltinNatural
+      = getCon fc defs (reflectiontt "BuiltinNatural")
+  reflect fc defs lhs env NaturalToInteger
+      = getCon fc defs (reflectiontt "NaturalToInteger")
+  reflect fc defs lhs env IntegerToNatural
+      = getCon fc defs (reflectiontt "IntegerToNatural")
+
+export
+Reify BuiltinType where
+  reify defs val@(NDCon _ n _ _ args)
+      = case (!(full (gamma defs) n), args) of
+             (NS _ (UN "BuiltinNatural"), [])
+                   => pure BuiltinNatural
+             (NS _ (UN "NaturalToInteger"), [])
+                   => pure NaturalToInteger
+             (NS _ (UN "IntegerToNatural"), [])
+                   => pure IntegerToNatural
+             _ => cantReify val "BuiltinType"
+  reify defs val = cantReify val "BuiltinType"
+
+export
 Reflect VirtualIdent where
   reflect fc defs lhs env Interactive
       = getCon fc defs (reflectiontt "Interactive")

--- a/src/TTImp/Reflect.idr
+++ b/src/TTImp/Reflect.idr
@@ -370,6 +370,15 @@ mutual
     reify defs val = cantReify val "Record"
 
   export
+  Reify WithFlag where
+    reify defs val@(NDCon _ n _ _ args)
+        = case (!(full (gamma defs) n), map snd args) of
+               (NS _ (UN "Syntactic"), [])
+                    => pure Syntactic
+               _ => cantReify val "WithFlag"
+    reify defs val = cantReify val "WithFlag"
+
+  export
   Reify ImpClause where
     reify defs val@(NDCon _ n _ _ args)
         = case (!(full (gamma defs) n), map snd args) of
@@ -378,13 +387,14 @@ mutual
                           y' <- reify defs !(evalClosure defs y)
                           z' <- reify defs !(evalClosure defs z)
                           pure (PatClause x' y' z')
-               (NS _ (UN "WithClause"), [v,w,x,y,z])
-                    => do v' <- reify defs !(evalClosure defs v)
+               (NS _ (UN "WithClause"), [u,v,w,x,y,z])
+                    => do u' <- reify defs !(evalClosure defs u)
+                          v' <- reify defs !(evalClosure defs v)
                           w' <- reify defs !(evalClosure defs w)
                           x' <- reify defs !(evalClosure defs x)
                           y' <- reify defs !(evalClosure defs y)
                           z' <- reify defs !(evalClosure defs z)
-                          pure (WithClause v' w' x' y' [] z')
+                          pure (WithClause u' v' w' x' y' z')
                (NS _ (UN "ImpossibleClause"), [x,y])
                     => do x' <- reify defs !(evalClosure defs x)
                           y' <- reify defs !(evalClosure defs y)
@@ -418,11 +428,12 @@ mutual
                           y' <- reify defs !(evalClosure defs y)
                           z' <- reify defs !(evalClosure defs z)
                           pure (IParameters x' y' z')
-               (NS _ (UN "IRecord"), [x,y,z])
-                    => do x' <- reify defs !(evalClosure defs x)
+               (NS _ (UN "IRecord"), [w, x,y,z])
+                    => do w' <- reify defs !(evalClosure defs w)
+                          x' <- reify defs !(evalClosure defs x)
                           y' <- reify defs !(evalClosure defs y)
                           z' <- reify defs !(evalClosure defs z)
-                          pure (IRecord x' Nothing y' z')
+                          pure (IRecord w' x' y' z')
                (NS _ (UN "INamespace"), [w,x,y])
                     => do w' <- reify defs !(evalClosure defs w)
                           x' <- reify defs !(evalClosure defs x)
@@ -700,6 +711,11 @@ mutual
              appCon fc defs (reflectionttimp "MkRecord") [v', w', x', y', z']
 
   export
+  Reflect WithFlag where
+    reflect fc defs lhs env Syntactic
+        = getCon fc defs (reflectionttimp "Syntactic")
+
+  export
   Reflect ImpClause where
     reflect fc defs lhs env (PatClause x y z)
         = do x' <- reflect fc defs lhs env x
@@ -711,8 +727,9 @@ mutual
              v' <- reflect fc defs lhs env v
              w' <- reflect fc defs lhs env w
              x' <- reflect fc defs lhs env x
+             y' <- reflect fc defs lhs env y
              z' <- reflect fc defs lhs env z
-             appCon fc defs (reflectionttimp "WithClause") [u', v', w', x', z']
+             appCon fc defs (reflectionttimp "WithClause") [u', v', w', x', y', z']
     reflect fc defs lhs env (ImpossibleClause x y)
         = do x' <- reflect fc defs lhs env x
              y' <- reflect fc defs lhs env y
@@ -742,11 +759,12 @@ mutual
              y' <- reflect fc defs lhs env y
              z' <- reflect fc defs lhs env z
              appCon fc defs (reflectionttimp "IParameters") [x', y', z']
-    reflect fc defs lhs env (IRecord x _ y z)
-        = do x' <- reflect fc defs lhs env x
+    reflect fc defs lhs env (IRecord w x y z)
+        = do w' <- reflect fc defs lhs env w
+             x' <- reflect fc defs lhs env x
              y' <- reflect fc defs lhs env y
              z' <- reflect fc defs lhs env z
-             appCon fc defs (reflectionttimp "IRecord") [x', y', z']
+             appCon fc defs (reflectionttimp "IRecord") [w', x', y', z']
     reflect fc defs lhs env (INamespace x y z)
         = do x' <- reflect fc defs lhs env x
              y' <- reflect fc defs lhs env y

--- a/tests/idris2/reflection004/refdecl.idr
+++ b/tests/idris2/reflection004/refdecl.idr
@@ -20,7 +20,7 @@ axes (S (S (S (S (S _))))) {lte} = absurd lte
 mkPoint : (n : Nat) -> {auto gt : GT n 0} -> {auto lte : LTE n 4} -> Decl
 mkPoint n
     = let type = "Point" ++ show n ++ "D" in
-      IRecord emptyFC Public
+      IRecord emptyFC Nothing Public
       (MkRecord emptyFC (NS (MkNS ["Main"]) (UN type)) [] (NS (MkNS ["Main"]) (UN ("Mk" ++ type)))
         (toList $ map (\axis => MkIField emptyFC MW ExplicitArg (RF axis) `(Double)) (axes n)))
 

--- a/tests/idris2/reflection010/expected
+++ b/tests/idris2/reflection010/expected
@@ -1,10 +1,10 @@
 1/1: Building Name (Name.idr)
 LOG declare.data:1: Processing Main.Identity
 LOG declare.type:1: Processing Main.nested
-LOG declare.type:1: Processing Main.2971:747:foo
+LOG declare.type:1: Processing Main.N:N:foo
 LOG declare.type:1: Processing Main.cased
 LOG declare.type:1: Processing Main.test
-LOG 1: nested: ((Main.MkIdentity [a = Int]) Main.2971:747:foo)
+LOG 1: nested: ((Main.MkIdentity [a = Int]) Main.N:N:foo)
 LOG 1: True
 LOG 1: cased: (%lam RigW Explicit (Just {lamc:0}) (Main.Identity Int) (Main.case block in cased {lamc:0}))
 LOG 1: 10

--- a/tests/idris2/reflection010/expected
+++ b/tests/idris2/reflection010/expected
@@ -1,10 +1,10 @@
 1/1: Building Name (Name.idr)
 LOG declare.data:1: Processing Main.Identity
 LOG declare.type:1: Processing Main.nested
-LOG declare.type:1: Processing Main.2964:747:foo
+LOG declare.type:1: Processing Main.2971:747:foo
 LOG declare.type:1: Processing Main.cased
 LOG declare.type:1: Processing Main.test
-LOG 1: nested: ((Main.MkIdentity [a = Int]) Main.2964:747:foo)
+LOG 1: nested: ((Main.MkIdentity [a = Int]) Main.2971:747:foo)
 LOG 1: True
 LOG 1: cased: (%lam RigW Explicit (Just {lamc:0}) (Main.Identity Int) (Main.case block in cased {lamc:0}))
 LOG 1: 10

--- a/tests/idris2/reflection010/run
+++ b/tests/idris2/reflection010/run
@@ -1,3 +1,3 @@
-$1 --no-color --console-width 0 --no-banner --check Name.idr
+$1 --no-color --console-width 0 --no-banner --check Name.idr | sed -E "s/\.[0-9]+:[0-9]+/\.N:N/"
 
 rm -rf build


### PR DESCRIPTION
Due to recent changes, the reflected version of records and parameters block got out of sync with the compiler internals. Thanks to @Z-snails for finding the issue.