### PR TITLE
Update issue template for proposals

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-requests-and-proposals.md
+++ b/.github/ISSUE_TEMPLATE/feature-requests-and-proposals.md
@@ -7,8 +7,48 @@ assignees: ''
 
 ---
 
-Experience with Idris 1 suggests that feature requests and proposals tend to get buried among the bug reports in the issue tracker, even if we tag them effectively. Partly this is because there's not many people working on Idris full time (it's approximately one person at the moment).
+<!---
+Before submitting your proposal, read the https://github.com/idris-lang/Idris2/blob/master/CONTRIBUTING.md page , it should give you an idea of what kind of proposal is likely to be accepted. Additionally, you can talk about your idea on the idris community discord server https://discord.gg/UX68fDs2jc or on the mailing list. Also check that your idea hasn't already been proposed or isn't already being worked on, make use of the Github search feature, someone is sure to tell you if you participate in the mailing list or discord. There is a checklist to remind you to do this before submitting your proposal :)
 
-We might be able to implement small suggestions fairly easily, but for larger features, please add the details on the wiki, at https://github.com/idris-lang/Idris2/wiki/Contributions-wanted, which I hope will be more discoverable. It's also a good idea to suggest it on the mailing list and/or the IRC channel. And if you're looking for inspiration for places to contribute, this is a good place to look too!
+If you are confident in your idea, please follow the following template to describe your proposal. Follow the directive for each section, you have some liberty to update the “Proposal” section to better match your idea but leave the rest unchanged to keep the format uniform.
 
-Please be as precise as you can about how your suggestion might work. For example, try to explain how it might impact other language features, give some ideas about how it might be implemented, and describe some things that will become possible if it is implemented. Remember that things can be more complicated than they might seem!
+We cannot guarantee your proposal will be implemented in a timely manner (or at all) given how few people work on Idris2. Similarly with comments, few people have the time to read through and ingest a complex proposal. Try to be as clear and concise as you can so that it’s easy for the community to understand and comment on your idea.
+
+--->
+
+- [ ] I have read [CONTRIBUTING.md](../../CONTRIBUTING.md).
+- [ ] I have checked that there is no existing PR/issue about my proposal.
+
+## Summary
+
+<!---
+Describe your proposal in slightly more detail than the title, it should be easy to understand and pique the interest of the reader.
+--->
+
+## Motivation
+
+<!---
+Explain why this change is necessary and why the existing solutions are unsuitable.
+--->
+
+## The proposal
+
+<!---
+Explain your solution in detail, provide examples and highlight breaking changes, if any. Expose as many examples are you need to properly showcase the solution and help readers build a mental model of how and why it would work. This section can benefit from additional subsections about different aspects of the design of your solution (typically how does your proposal fit in the type theory, or how it can benefit from linearity). By default, we have 2 subsections: Examples and Technical implementation but feel free to restructure them, if you want the examples inlined for example.
+--->
+
+### Examples
+
+### Technical implementation
+
+## Alternatives considered
+
+<!---
+Show the research you conducted and the other alternatives that could have also solved the problem. Explain why you picked the one you presented and attempt to answer all the questions you already know you’re going to get. It’s a good idea to look at other programming languages and see how they solved similar problems and see if their rationale can be ported to Idris or not.
+--->
+
+## Conclusion
+
+<!---
+End your proposal with why you expect the community to accept this proposal. This is a good time to also highlight future work, potential new research avenues and longer-term benefits.
+--->


### PR DESCRIPTION
In concert with  #1722 I think it's time we update the template for creating new proposals and feature requests. 

The new template has the following formal:

- Summary
- Motivation
- Proposal
  - Subsections about the proposal
- Alternatives
- Conclusion

This aims to reach three goals:
 - Encourage more thoroughly researched proposals
 - Impose a uniform format for proposal and new features
 - Ease the access to information about new features

