### PR TITLE
Data.IOArray.Prims.prim__newUninitArray

### DIFF
--- a/libs/base/Data/IOArray/Prims.idr
+++ b/libs/base/Data/IOArray/Prims.idr
@@ -8,6 +8,8 @@ data ArrayData : Type -> Type where [external]
 -- 'unsafe' primitive access, backend dependent
 -- get and set assume that the bounds have been checked. Behaviour is undefined
 -- otherwise.
-export %extern prim__newArray : forall a . Int -> a -> PrimIO (ArrayData a)
-export %extern prim__arrayGet : forall a . ArrayData a -> Int -> PrimIO a
-export %extern prim__arraySet : forall a . ArrayData a -> Int -> a -> PrimIO ()
+export %extern prim__newArray       : forall a . Int -> a -> PrimIO (ArrayData a)
+partial
+export %extern prim__newUninitArray : forall a . Int -> PrimIO (ArrayData a)
+export %extern prim__arrayGet       : forall a . ArrayData a -> Int -> PrimIO a
+export %extern prim__arraySet       : forall a . ArrayData a -> Int -> a -> PrimIO ()

--- a/src/Compiler/ES/Codegen.idr
+++ b/src/Compiler/ES/Codegen.idr
@@ -516,6 +516,7 @@ jsPrim (NS _ (UN "prim__newIORef")) [_,v,_] = pure $ hcat ["({value:", v, "})"]
 jsPrim (NS _ (UN "prim__readIORef")) [_,r,_] = pure $ hcat ["(", r, ".value)"]
 jsPrim (NS _ (UN "prim__writeIORef")) [_,r,v,_] = pure $ hcat ["(", r, ".value=", v, ")"]
 jsPrim (NS _ (UN "prim__newArray")) [_,s,v,_] = pure $ hcat ["(Array(", s, ").fill(", v, "))"]
+jsPrim (NS _ (UN "prim__newUninitArray")) [_,s,_] = pure $ hcat ["(Array(", s, "))"]
 jsPrim (NS _ (UN "prim__arrayGet")) [_,x,p,_] = pure $ hcat ["(", x, "[", p, "])"]
 jsPrim (NS _ (UN "prim__arraySet")) [_,x,p,v,_] = pure $ hcat ["(", x, "[", p, "]=", v, ")"]
 jsPrim (NS _ (UN "prim__os")) [] = pure $ Text $ esName "sysos"

--- a/src/Compiler/RefC/RefC.idr
+++ b/src/Compiler/RefC/RefC.idr
@@ -200,7 +200,7 @@ cOp fn args = plainOp (show fn) (toList args)
 
 
 data ExtPrim = NewIORef | ReadIORef | WriteIORef
-             | NewArray | ArrayGet | ArraySet
+             | NewArray | NewUninitArray | ArrayGet | ArraySet
              | GetField | SetField
              | VoidElim
              | SysOS | SysCodegen
@@ -214,6 +214,7 @@ Show ExtPrim where
   show ReadIORef = "readIORef"
   show WriteIORef = "writeIORef"
   show NewArray = "newArray"
+  show NewUninitArray = "newUninitArray"
   show ArrayGet = "arrayGet"
   show ArraySet = "arraySet"
   show GetField = "getField"
@@ -232,6 +233,7 @@ toPrim pn@(NS _ n)
             (n == UN "prim__readIORef", ReadIORef),
             (n == UN "prim__writeIORef", WriteIORef),
             (n == UN "prim__newArray", NewArray),
+            (n == UN "prim__newUninitArray", NewUninitArray),
             (n == UN "prim__arrayGet", ArrayGet),
             (n == UN "prim__arraySet", ArraySet),
             (n == UN "prim__getField", GetField),

--- a/src/Compiler/Scheme/Common.idr
+++ b/src/Compiler/Scheme/Common.idr
@@ -192,7 +192,7 @@ schOp Crash [_,msg] = pure $ "(blodwen-error-quit (string-append \"ERROR: \" " +
 ||| Extended primitives for the scheme backend, outside the standard set of primFn
 public export
 data ExtPrim = NewIORef | ReadIORef | WriteIORef
-             | NewArray | ArrayGet | ArraySet
+             | NewArray | NewUninitArray | ArrayGet | ArraySet
              | GetField | SetField
              | VoidElim
              | SysOS | SysCodegen
@@ -207,6 +207,7 @@ Show ExtPrim where
   show ReadIORef = "ReadIORef"
   show WriteIORef = "WriteIORef"
   show NewArray = "NewArray"
+  show NewUninitArray = "NewUninitArray"
   show ArrayGet = "ArrayGet"
   show ArraySet = "ArraySet"
   show GetField = "GetField"
@@ -226,6 +227,7 @@ toPrim pn@(NS _ n)
             (n == UN "prim__readIORef", ReadIORef),
             (n == UN "prim__writeIORef", WriteIORef),
             (n == UN "prim__newArray", NewArray),
+            (n == UN "prim__newUninitArray", NewUninitArray),
             (n == UN "prim__arrayGet", ArrayGet),
             (n == UN "prim__arraySet", ArraySet),
             (n == UN "prim__getField", GetField),
@@ -640,6 +642,8 @@ parameters (schExtPrim : Int -> ExtPrim -> List NamedCExp -> Core String,
   schExtCommon i NewArray [_, size, val, world]
       = pure $ mkWorld $ "(make-vector " ++ !(schExp i size) ++ " "
                                          ++ !(schExp i val) ++ ")"
+  schExtCommon i NewUninitArray [_, size, world]
+      = pure $ mkWorld $ "(make-vector " ++ !(schExp i size) ++ ")"
   schExtCommon i ArrayGet [_, arr, pos, world]
       = pure $ mkWorld $ "(vector-ref " ++ !(schExp i arr) ++ " "
                                         ++ !(schExp i pos) ++ ")"

--- a/support/refc/prim.c
+++ b/support/refc/prim.c
@@ -120,6 +120,13 @@ Value *newArray(Value *erased, Value *_length, Value *v, Value *_word)
     return (Value *)a;
 }
 
+Value *newUninitArray(Value *erased, Value *cap, Value *_word)
+{
+    int cap_int = extractInt(cap);
+    Value_Array *a = makeArray(cap_int);
+    return (Value *)a;
+}
+
 Value *arrayGet(Value *erased, Value *_array, Value *_index, Value *_word)
 {
     Value_Array *a = (Value_Array *)_array;

--- a/support/refc/prim.h
+++ b/support/refc/prim.h
@@ -18,6 +18,7 @@ Value* idris2_crash(Value* msg);
 // Array
 
 Value *newArray(Value *, Value *, Value *, Value *);
+Value *newUninitArray(Value *, Value *, Value *);
 Value *arrayGet(Value *, Value *, Value *, Value *);
 Value *arraySet(Value *, Value *, Value *, Value *, Value *);
 

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -158,6 +158,7 @@ idrisTestsAllBackends cg = MkTestPool
        -- Unfortunately the behaviour of Double is platform dependent so the
        -- following test is turned off.
        -- "evaluator005",
+       "base_data_ioarray_prims",
        "basic048",
        "perf006"]
 

--- a/tests/allbackends/base_data_ioarray_prims/Arr.idr
+++ b/tests/allbackends/base_data_ioarray_prims/Arr.idr
@@ -1,0 +1,13 @@
+module Arr
+
+import System
+import Data.IOArray.Prims
+
+main : IO ()
+main = do
+  array <- primIO $ prim__newUninitArray 23 {a = String}
+  primIO $ prim__arraySet array 17 "x"
+  "x" <- primIO $ prim__arrayGet array 17
+     | x => do putStrLn (show x)
+               exitFailure
+  putStrLn "good"

--- a/tests/allbackends/base_data_ioarray_prims/expected
+++ b/tests/allbackends/base_data_ioarray_prims/expected
@@ -1,0 +1,3 @@
+1/1: Building Arr (Arr.idr)
+Arr> good
+Arr> Bye for now!

--- a/tests/allbackends/base_data_ioarray_prims/input
+++ b/tests/allbackends/base_data_ioarray_prims/input
@@ -1,0 +1,2 @@
+:exec main
+:q

--- a/tests/allbackends/base_data_ioarray_prims/run
+++ b/tests/allbackends/base_data_ioarray_prims/run
@@ -1,0 +1,3 @@
+$1 --no-banner --no-color --console-width 0 Arr.idr < input
+
+rm -rf build


### PR DESCRIPTION
`prim__newArray` requires an element to fill in the array.

Consider we want to implement an `IOArray` without `Maybe` wrapper
(like in #1677).

To implement `fromList` we need to create an array. When the list
is not empty we can implement call `prim__newArray` taking a first
element from the list.  But when the list is empty, we need to this
`prim__newEmptyArray` function.

Additionally this function might be needed for more efficient
implementation of functions like `fromList`: no need to initialize
array if the array will be immediately overwritten.

This PR includes a change to `IOArray` to use this function for
faster initialization of array in `fromList`.