### PR TITLE
[ fix ] `Name` in `Language.Reflection.TT`

### DIFF
--- a/libs/base/Language/Reflection/TT.idr
+++ b/libs/base/Language/Reflection/TT.idr
@@ -103,8 +103,8 @@ data Name = UN String -- user defined name
           | DN String Name -- a name and how to display it
           | RF String -- record field name
           | Nested (Int, Int) Name -- nested function name
-          | CaseBlock Int Int -- case block nested in (resolved) name
-          | WithBlock Int Int -- with block nested in (resolved) name
+          | CaseBlock String Int -- case block nested in (resolved) name
+          | WithBlock String Int -- with block nested in (resolved) name
 
 export
 Show Name where


### PR DESCRIPTION
This was different to `Name` in `Core.Name`
Specifically `CaseBlock` and `WithBlock` had an `Int` instead of a `String`