### PR TITLE
System.Directory.nextDirEntry

### DIFF
--- a/support/c/idris_directory.c
+++ b/support/c/idris_directory.c
@@ -60,6 +60,10 @@ int idris2_removeDir(char* path) {
 
 char* idris2_nextDirEntry(void* d) {
     DirInfo* di = (DirInfo*)d;
+    // `readdir` keeps `errno` unchanged on end of stream
+    // so we need to reset `errno` to distinguish between
+    // end of stream and failure.
+    errno = 0;
     struct dirent* de = readdir(di->dirptr);
 
     if (de == NULL) {

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -298,6 +298,7 @@ baseLibraryTests = MkTestPool "Base library" [Chez, Node] Nothing
   , "data_bits001"
   , "data_string_lines001"
   , "data_string_unlines001"
+  , "system_directory"
   , "system_errno"
   , "system_info001"
   , "system_signal001", "system_signal002", "system_signal003", "system_signal004"

--- a/tests/base/system_directory/ReadDir.idr
+++ b/tests/base/system_directory/ReadDir.idr
@@ -1,0 +1,22 @@
+import System
+import System.Directory
+
+panic : String -> IO a
+panic s = do putStrLn s
+             exitFailure
+
+collectEntries : Directory -> IO (List String)
+collectEntries d = do Right (Just n) <- nextDirEntry d
+                        | Right Nothing => pure []
+                        | Left e        => panic (show e)
+                      ns <- collectEntries d
+                      if n == "." || n == ".."
+                         then pure ns
+                         else pure (n :: ns)
+
+main : IO ()
+main = do Right d <- openDir "dir"
+            | Left e => panic (show e)
+          ["a"] <- collectEntries d
+            | x => panic ("wrong entries: " ++ (show x))
+          pure ()

--- a/tests/base/system_directory/expected
+++ b/tests/base/system_directory/expected
@@ -1,0 +1,2 @@
+1/1: Building ReadDir (ReadDir.idr)
+Main> Main> Bye for now!

--- a/tests/base/system_directory/input
+++ b/tests/base/system_directory/input
@@ -1,0 +1,2 @@
+:exec main
+:q

--- a/tests/base/system_directory/run
+++ b/tests/base/system_directory/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --no-banner ReadDir.idr < input


### PR DESCRIPTION
* add `nextDirEntry` which returns `Maybe String`, so `Nothing` on
  the end of directory unlike `dirEntry` which returns unspecified error
  on the end of directory
* `dirEntry` is deprecated now, but not removed because compiler depends on it
* native implementation of `dirEntry` is patched to explicitly reset `errno`
  before the `readdir` call: without it end of directory and error were
  indistinguishable
* test added