### PR TITLE
Implement test discovery

### DIFF
--- a/libs/base/System/Directory.idr
+++ b/libs/base/System/Directory.idr
@@ -105,7 +105,10 @@ nextDirEntry (MkDir d)
             then if !(getErrno) /= 0
                     then returnError
                     else pure $ Right Nothing
-            else pure $ Right (Just (prim__getString res))
+            else do let n = prim__getString res
+                    if n == "." || n == ".."
+                       then assert_total $ nextDirEntry (MkDir d)
+                       else pure $ Right (Just n)
 
 -- This function is deprecated; to be removed after the next version bump
 export

--- a/support/c/idris_directory.c
+++ b/support/c/idris_directory.c
@@ -60,6 +60,10 @@ int idris2_removeDir(char* path) {
 
 char* idris2_nextDirEntry(void* d) {
     DirInfo* di = (DirInfo*)d;
+    // `readdir` keeps `errno` unchanged on end of stream
+    // so we need to reset `errno` to distinguish between
+    // end of stream and failure.
+    errno = 0;
     struct dirent* de = readdir(di->dirptr);
 
     if (de == NULL) {

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -298,6 +298,7 @@ baseLibraryTests = MkTestPool "Base library" [Chez, Node] Nothing
   , "data_bits001"
   , "data_string_lines001"
   , "data_string_unlines001"
+  , "system_directory"
   , "system_errno"
   , "system_info001"
   , "system_signal001", "system_signal002", "system_signal003", "system_signal004"

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -1,5 +1,9 @@
 module Main
 
+import System
+import System.Directory
+import System.File
+
 import Test.Golden
 
 %default covering
@@ -199,12 +203,8 @@ idrisTests = MkTestPool "Misc" [] Nothing
        -- golden file testing
        "golden001"]
 
-typeddTests : TestPool
-typeddTests = MkTestPool "Type Driven Development" [] Nothing
-     [ "chapter01", "chapter02", "chapter03", "chapter04", "chapter05"
-     , "chapter06", "chapter07", "chapter08", "chapter09", "chapter10"
-     , "chapter11", "chapter12", "chapter13", "chapter14"
-     ]
+typeddTests : IO TestPool
+typeddTests = testsInDir "typedd-book" (const True) "Type Driven Development" [] Nothing
 
 chezTests : TestPool
 chezTests = MkTestPool "Chez backend" [] (Just Chez)
@@ -226,12 +226,8 @@ chezTests = MkTestPool "Chez backend" [] (Just Chez)
     , "channels001", "channels002", "channels003", "channels004", "channels005"
     ]
 
-refcTests : TestPool
-refcTests = MkTestPool "Reference counting C backend" [] (Just C)
-    [ "refc001" , "refc002"
-    , "strings", "integers", "doubles"
-    , "buffer", "clock", "args"
-    ]
+refcTests : IO TestPool
+refcTests = testsInDir "refc" (const True) "Reference counting C backend" [] (Just C)
 
 racketTests : TestPool
 racketTests = MkTestPool "Racket backend" [] (Just Racket)
@@ -264,57 +260,32 @@ nodeTests = MkTestPool "Node backend" [] (Just Node)
     , "integers"
     ]
 
-vmcodeInterpTests : TestPool
-vmcodeInterpTests = MkTestPool "VMCode interpreter" [] Nothing
-    [ "basic001"
-    ]
+vmcodeInterpTests : IO TestPool
+vmcodeInterpTests = testsInDir "vmcode" (const True) "VMCode interpreter" [] Nothing
 
-ideModeTests : TestPool
-ideModeTests = MkTestPool "IDE mode" [] Nothing
-  [ "ideMode001", "ideMode002", "ideMode003", "ideMode004", "ideMode005"
-  ]
+ideModeTests : IO TestPool
+ideModeTests = testsInDir "ideMode" (const True) "IDE mode" [] Nothing
 
-preludeTests : TestPool
-preludeTests = MkTestPool "Prelude library" [] Nothing
-  [ "reg001"
-  ]
+preludeTests : IO TestPool
+preludeTests = testsInDir "prelude" (const True) "Prelude library" [] Nothing
 
-templateTests : TestPool
-templateTests = MkTestPool "Test templates" [] Nothing
-  [ "simple-test", "ttimp", "with-ipkg"
-  ]
+templateTests : IO TestPool
+templateTests = testsInDir "templates" (const True) "Test templates" [] Nothing
 
 -- base library tests are run against
 -- each codegen supported and to keep
 -- things simple it's all one test group
 -- that only runs if all backends are
 -- available.
-baseLibraryTests : TestPool
-baseLibraryTests = MkTestPool "Base library" [Chez, Node] Nothing
-  [ "control_app001"
-  , "system_file001"
-  , "system_info_os001"
-  , "system_system"
-  , "data_bits001"
-  , "data_string_lines001"
-  , "data_string_unlines001"
-  , "system_directory"
-  , "system_errno"
-  , "system_info001"
-  , "system_signal001", "system_signal002", "system_signal003", "system_signal004"
-  ]
+baseLibraryTests : IO TestPool
+baseLibraryTests = testsInDir "base" (const True) "Base library" [Chez, Node] Nothing
 
 -- same behavior as `baseLibraryTests`
-contribLibraryTests : TestPool
-contribLibraryTests = MkTestPool "Contrib library" [Chez, Node] Nothing
-  [ "json_001"
-  ]
+contribLibraryTests : IO TestPool
+contribLibraryTests = testsInDir "contrib" (const True) "Contrib library" [Chez, Node] Nothing
 
-codegenTests : TestPool
-codegenTests = MkTestPool "Code generation" [] Nothing
-  [ "con001"
-  , "builtin001"
-  ]
+codegenTests : IO TestPool
+codegenTests = testsInDir "codegen" (const True) "Code generation" [] Nothing
 
 main : IO ()
 main = runner $
@@ -334,18 +305,18 @@ main = runner $
   , testPaths "idris2" idrisTestsBuiltin
   , testPaths "idris2" idrisTestsEvaluator
   , testPaths "idris2" idrisTests
-  , testPaths "typedd-book" typeddTests
-  , testPaths "ideMode" ideModeTests
-  , testPaths "prelude" preludeTests
-  , testPaths "base" baseLibraryTests
-  , testPaths "contrib" contribLibraryTests
+  , !typeddTests
+  , !ideModeTests
+  , !preludeTests
+  , !baseLibraryTests
+  , !contribLibraryTests
   , testPaths "chez" chezTests
-  , testPaths "refc" refcTests
+  , !refcTests
   , testPaths "racket" racketTests
   , testPaths "node" nodeTests
-  , testPaths "vmcode" vmcodeInterpTests
-  , testPaths "templates" templateTests
-  , testPaths "codegen" codegenTests
+  , !vmcodeInterpTests
+  , !templateTests
+  , !codegenTests
   ]
   ++ map (testPaths "allbackends" . idrisTestsAllBackends) [Chez, Node, Racket]
 

--- a/tests/base/system_directory/ReadDir.idr
+++ b/tests/base/system_directory/ReadDir.idr
@@ -1,0 +1,22 @@
+import System
+import System.Directory
+
+panic : String -> IO a
+panic s = do putStrLn s
+             exitFailure
+
+collectEntries : Directory -> IO (List String)
+collectEntries d = do Right (Just n) <- nextDirEntry d
+                        | Right Nothing => pure []
+                        | Left e        => panic (show e)
+                      ns <- collectEntries d
+                      if n == "." || n == ".."
+                         then pure ns
+                         else pure (n :: ns)
+
+main : IO ()
+main = do Right d <- openDir "dir"
+            | Left e => panic (show e)
+          ["a"] <- collectEntries d
+            | x => panic ("wrong entries: " ++ (show x))
+          pure ()

--- a/tests/base/system_directory/ReadDir.idr
+++ b/tests/base/system_directory/ReadDir.idr
@@ -10,9 +10,7 @@ collectEntries d = do Right (Just n) <- nextDirEntry d
                         | Right Nothing => pure []
                         | Left e        => panic (show e)
                       ns <- collectEntries d
-                      if n == "." || n == ".."
-                         then pure ns
-                         else pure (n :: ns)
+                      pure (n :: ns)
 
 main : IO ()
 main = do Right d <- openDir "dir"

--- a/tests/base/system_directory/ReadDir.idr
+++ b/tests/base/system_directory/ReadDir.idr
@@ -5,16 +5,8 @@ panic : String -> IO a
 panic s = do putStrLn s
              exitFailure
 
-collectEntries : Directory -> IO (List String)
-collectEntries d = do Right (Just n) <- nextDirEntry d
-                        | Right Nothing => pure []
-                        | Left e        => panic (show e)
-                      ns <- collectEntries d
-                      pure (n :: ns)
-
 main : IO ()
-main = do Right d <- openDir "dir"
+main = do Right ["a"] <- listDir "dir"
             | Left e => panic (show e)
-          ["a"] <- collectEntries d
-            | x => panic ("wrong entries: " ++ (show x))
+            | Right x => panic ("wrong entries: " ++ (show x))
           pure ()

--- a/tests/base/system_directory/expected
+++ b/tests/base/system_directory/expected
@@ -1,0 +1,2 @@
+1/1: Building ReadDir (ReadDir.idr)
+Main> Main> Bye for now!

--- a/tests/base/system_directory/input
+++ b/tests/base/system_directory/input
@@ -1,0 +1,2 @@
+:exec main
+:q

--- a/tests/base/system_directory/run
+++ b/tests/base/system_directory/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --no-banner ReadDir.idr < input


### PR DESCRIPTION
`testInDir dir ...` lists all directories in `dir` which contains
`run` files, and such directories are considered tests.

This is done to make test addition/maintenance cheaper.

Convert some test directories to `testInDir`, but not all of them
because
* some directories are listed in several test groups
* other directories are have some tests disabled

This is on top of #1733.