### PR TITLE
Set the stage for renaming the `master` branch to `main`.

### DIFF
--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -8,7 +8,6 @@ on:
       - '*'
   pull_request:
     branches:
-      - master
       - main
 
 env:

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - master
+      - main
 
 jobs:
   build:

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -7,7 +7,6 @@ on:
       - '*'
   pull_request:
     branches:
-      - master
       - main
 
 jobs:

--- a/.github/workflows/ci-sphinx.yml
+++ b/.github/workflows/ci-sphinx.yml
@@ -8,7 +8,6 @@ on:
       - '*'
   pull_request:
     branches:
-      - master
       - main
 jobs:
 

--- a/.github/workflows/ci-super-linter.yml
+++ b/.github/workflows/ci-super-linter.yml
@@ -19,7 +19,6 @@ on:
       - '*'
   pull_request:
     branches:
-      - master
       - main
 
 ###############

--- a/.github/workflows/ci-super-linter.yml
+++ b/.github/workflows/ci-super-linter.yml
@@ -20,6 +20,7 @@ on:
   pull_request:
     branches:
       - master
+      - main
 
 ###############
 # Set the Job #
@@ -54,7 +55,7 @@ jobs:
           VALIDATE_CPP: false # C files predate linting
           VALIDATE_JSCPD: false  # erroneously complains about docs/requirements.txt
           VALIDATE_JAVASCRIPT_STANDARD: false #requires camel-casing
-          DEFAULT_BRANCH: master
+          DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IGNORE_GENERATED_FILES: true
 


### PR DESCRIPTION
Partially addresses https://github.com/idris-lang/Idris2/issues/1682.

This PR updates the only inward-facing references to `master` branches in this repository: those found in the CI configurations. Additionally, see the bottom of the PR description for a bit more context on this branch renaming (in addition to the above-linked Issue).

Until the `master` branch is renamed `main`, the super-linter will fail on this PR due to the fact that this PR changes the `DEFAULT_BRANCH` to `main` which is not a branch yet.

We _could_ create the `main` branch before deleting the `master` branch to sidestep the awkwardness of this PR being broken until the `main` branch is created, but I suggest we use GitHub's built-in branch renaming, as described below, because it will automatically update all PRs from pointing at `master` to pointing at `main` and it will draw attention to the branch rename the next time each user visits the repository in GitHub.

So, either quickly before or quickly after merging this PR, an admin of the Idris 2 project should follow the below steps to rename `master` to `main`:
1. Click into the project's Settings tab.
2. Switch to the "Branches" section.
3. To the right of `master`, click the pencil.
4. Type `main` in at the branch rename dialog and click "Rename branch".
<img width="827" alt="Screen Shot 2021-07-16 at 10 55 00 PM" src="https://user-images.githubusercontent.com/2075353/126027394-adcedd2b-9974-4a04-a04b-7a73ffb1d87f.png">
<img width="389" alt="Screen Shot 2021-07-16 at 10 55 23 PM" src="https://user-images.githubusercontent.com/2075353/126027409-bf1a55ac-f6c3-47a5-830a-a90d3cd2cc3d.png">

At this point, GitHub will take care of "swapping out" `master` for `main` (like pointing all PRs at `main` instead of `master`) in addition to renaming the branch.

Developers with forks of the repository can follow the above instructions to rename the `master` branch of their forks as well, although that is not required for them to continue to contribute because PRs can be opened from any of their branches back to the new `main` branch of the Idris 2 parent repository.

The next time users visit the repository on GitHub, they will see the following instructions to perform in their local environments:
<img width="425" alt="Screen Shot 2021-07-16 at 10 46 37 PM" src="https://user-images.githubusercontent.com/2075353/126027259-060a1a6e-a61d-4890-b66d-f6fd192ca1e1.png">

To list those same instructions here in plaintext, each developer will want to do the following in their local copies of the repository:
1. `git branch -m master main`
2. `git fetch origin` (or whatever name has been given to the upstream Idris 2 repository).
3. `git branch -u origin/main main`
4. `git remote set-head origin -a`

## Motivation
The following statement is not expressly the view of the broader Idris 2 community, its maintainers, or its creator, but it is my personal view on why renaming the `master` branch to `main` is fitting for the Idris 2 project. The pitch for this change was well received, so I do believe the sentiment below to be a reasonable approximation of how the community at large feels.

------------
The Idris 2 project and the community that maintains and enjoys using Idris 2 aim to be inclusive and welcoming to all contributors and users. Just as the broader open source community has begun to recognize that not everyone feels comfortable with the branch name "master," the Idris 2 community wishes to embrace a move that will hurt no one and at the same time make it clear that everyone should feel comfortable and welcome in all of the spaces where we meet or collaborate.