### PR TITLE
[ Test ] allow 'N' as an acceptable response

### DIFF
--- a/libs/test/Test/Golden.idr
+++ b/libs/test/Test/Golden.idr
@@ -246,6 +246,7 @@ runTest opts testPath = forkIO $ do
       case str of
         "y" => pure True
         "n" => pure False
+        "N" => pure False
         ""  => pure False
         _   => do putStrLn "Invalid answer."
                   getAnswer


### PR DESCRIPTION
Situation I just ran into that I found confusing:
```
Golden value differs from actual value.
Accept actual value as new golden value? [y/N]
N
Invalid answer.
```