### PR TITLE
Delayed elaborator tweaks

### DIFF
--- a/docs/source/faq/faq.rst
+++ b/docs/source/faq/faq.rst
@@ -43,19 +43,25 @@ from the generated Scheme code, as described in Section :ref:`sect-starting`.
 Why does Idris 2 target Scheme? Surely a dynamically typed target language is going to be slow?
 ===============================================================================================
 
-You may be surprised at how fast Chez Scheme is :). `Racket <https://download.racket-lang.org/>`_,
+You may be surprised at how fast Chez Scheme is! `Racket <https://download.racket-lang.org/>`_,
 as an alternative target, also performs well. Both perform better than the
 Idris 1 back end, which is written in C but has not had the decades of
 engineering effort by run time system specialists that Chez and Racket have.
 Chez Scheme also allows us to turn off run time checks, which we do.
 
-As anecdotal evidence of the performance improvement, as of 23rd May 2020, on a
-Dell XPS 13 running Ubuntu, the performance is:
+As anecdotal evidence of the performance improvement, we compared the
+performance of the Idris 2 runtime with the Idris 1 runtime, using a version of
+the compiler built with the Chez runtime and the same version built with the
+bootstrapping Idris 2.  On a Dell XPS 13 running Ubuntu, with the versions of
+23rd May 2020, the performance was:
 
-* Idris 2 (with the Chez Scheme runtime) checks its own source in 93 seconds.
-* The bootstrapping Idris 2 (compiled with Idris 1) checks the same source in 125s.
-* Idris 1 checks the bootstrapping Idris 2's source (the same as the above,
+* Idris 2 (with the Chez Scheme runtime) checked its own source in 93 seconds.
+* The bootstrapping Idris 2 (compiled with Idris 1) checked the same source in 125s.
+* Idris 1 checked the bootstrapping Idris 2's source (the same as the above,
   but with minor variations due to the syntax changes) in 768 seconds.
+
+Unfortunately we can't repeat this experiment with the latest version, since
+the bootstrapping Idris 2 is no longer able to build the current version.
 
 This is, nevertheless, not intended to be a long term solution, even if it
 is a very convenient way to bootstrap.
@@ -90,7 +96,7 @@ Why aren't there more linearity annotations in the library?
 ===========================================================
 
 In theory, now that Idris 2 is based on Quantitative Type Theory (see
-Section :ref:`sect-multiplicities`, we can write more precise types in the
+Section :ref:`sect-multiplicities`), we can write more precise types in the
 Prelude and Base libraries which give more precise usage information. We have
 chosen not to do that (yet) however. Consider, for example, what would happen
 if we did::
@@ -117,7 +123,7 @@ impact the way you write programs.
 How do I get command history in the Idris2 REPL?
 ================================================
 
-The Idris2 repl does not support readline in the interest of
+The Idris2 REPL does not support readline in the interest of
 keeping dependencies minimal. A useful work around is to
 install `rlwrap <https://linux.die.net/man/1/rlwrap>`_, this
 utility provides command history simply by invoking the Idris2
@@ -338,5 +344,5 @@ Where can I find the community standards for the Idris community?
 ==================================================================
 
 The Idris Community Standards are stated `here
-<https://www.idris-lang.org/documentation/community-standards/>`_ .
+<https://www.idris-lang.org/pages/community-standards.html>`_
 

--- a/src/TTImp/Elab.idr
+++ b/src/TTImp/Elab.idr
@@ -129,7 +129,8 @@ elabTermSub {vars} defining mode opts nest env env' sub tm ty
          solveConstraints solvemode Normal
          logTerm "elab" 5 "Looking for delayed in " chktm
          ust <- get UST
-         catch (retryDelayed (sortBy (\x, y => compare (fst x) (fst y))
+         catch (retryDelayed solvemode
+                             (sortBy (\x, y => compare (fst x) (fst y))
                                        (delayedElab ust)))
                  (\err =>
                     do ust <- get UST

--- a/src/TTImp/Elab/Case.idr
+++ b/src/TTImp/Elab/Case.idr
@@ -370,7 +370,7 @@ checkCase : {vars : _} ->
             Maybe (Glued vars) ->
             Core (Term vars, Glued vars)
 checkCase rig elabinfo nest env fc scr scrty_in alts exp
-    = delayElab fc rig env exp 0 $
+    = delayElab fc rig env exp 10 $
         do scrty_exp <- case scrty_in of
                              Implicit _ _ => guessScrType alts
                              _ => pure scrty_in
@@ -407,7 +407,7 @@ checkCase rig elabinfo nest env fc scr scrty_in alts exp
     -- type of the case block. But (TODO) consider delaying on failure?
     checkConcrete : NF vs -> Core ()
     checkConcrete (NApp _ (NMeta n i _) _)
-        = throw (GenericMsg (getFC scr) "Can't infer type for case scrutinee")
+        = throw (GenericMsg fc "Can't infer type for case scrutinee")
     checkConcrete _ = pure ()
 
     applyTo : Defs -> RawImp -> NF [] -> Core RawImp

--- a/src/TTImp/Elab/ImplicitBind.idr
+++ b/src/TTImp/Elab/ImplicitBind.idr
@@ -533,12 +533,13 @@ checkBindHere rig elabinfo nest env fc bindmode tm exp
                                            bindingVars = True }
                                          elabinfo)
                              nest env tm exp
-         solveConstraints (case elabMode elabinfo of
-                                InLHS c => inLHS
-                                _ => inTerm) Normal
+         let solvemode = case elabMode elabinfo of
+                              InLHS c => inLHS
+                              _ => inTerm
+         solveConstraints solvemode Normal
 
          ust <- get UST
-         catch (retryDelayed (delayedElab ust))
+         catch (retryDelayed solvemode (delayedElab ust))
                (\err =>
                   do ust <- get UST
                      put UST (record { delayedElab = [] } ust)

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -124,7 +124,7 @@ idrisTestsRegression = MkTestPool "Various regressions" [] Nothing
        "reg022", "reg023", "reg024", "reg025", "reg026", "reg027", "reg028",
        "reg029", "reg030", "reg031", "reg032", "reg033", "reg034", "reg035",
        "reg036", "reg037", "reg038", "reg039", "reg040", "reg041", "reg042",
-       "reg043", "reg044", "reg045", "reg046", "reg047"]
+       "reg043", "reg044", "reg045", "reg046", "reg047", "reg048"]
 
 idrisTestsData : TestPool
 idrisTestsData = MkTestPool "Data and record types" [] Nothing

--- a/tests/idris2/reg048/expected
+++ b/tests/idris2/reg048/expected
@@ -1,0 +1,13 @@
+1/1: Building inferror (inferror.idr)
+Error: While processing right hand side of g. Ambiguous elaboration. Possible results:
+    Data.SortedMap.toList m
+    Prelude.toList ?arg
+
+inferror:10:15--10:21
+ 06 |     as => as
+ 07 | 
+ 08 | g : Ord k => SortedMap k v -> List (k, v)                        
+ 09 | g m = 
+ 10 |     let kvs = toList m 
+                    ^^^^^^
+

--- a/tests/idris2/reg048/expected
+++ b/tests/idris2/reg048/expected
@@ -3,11 +3,11 @@ Error: While processing right hand side of g. Ambiguous elaboration. Possible re
     Data.SortedMap.toList m
     Prelude.toList ?arg
 
-inferror:10:15--10:21
- 06 |     as => as
- 07 | 
- 08 | g : Ord k => SortedMap k v -> List (k, v)                        
- 09 | g m = 
- 10 |     let kvs = toList m 
-                    ^^^^^^
+inferror:9:17--9:23
+ 5 | f m = case sortBy (\(x, _), (y, _) => compare x y) (SortedMap.toList m) of
+ 6 |     as => as
+ 7 | 
+ 8 | g : Ord k => SortedMap k v -> List (k, v)
+ 9 | g m = let kvs = toList m in
+                     ^^^^^^
 

--- a/tests/idris2/reg048/inferror.idr
+++ b/tests/idris2/reg048/inferror.idr
@@ -1,0 +1,14 @@
+import Data.SortedMap
+import Data.List
+
+f : Ord k => SortedMap k v -> List (k, v)                        
+f m = case sortBy (\(x, _), (y, _) => compare x y) (SortedMap.toList m) of
+    as => as
+
+g : Ord k => SortedMap k v -> List (k, v)                        
+g m = 
+    let kvs = toList m 
+        t = sortBy (\(x, _), (y, _) => compare x y) kvs in
+        ?halp
+--     case sortBy (\(x, _), (y, _) => compare x y) kvs of
+--         as => as

--- a/tests/idris2/reg048/inferror.idr
+++ b/tests/idris2/reg048/inferror.idr
@@ -1,14 +1,11 @@
 import Data.SortedMap
 import Data.List
 
-f : Ord k => SortedMap k v -> List (k, v)                        
+f : Ord k => SortedMap k v -> List (k, v)
 f m = case sortBy (\(x, _), (y, _) => compare x y) (SortedMap.toList m) of
     as => as
 
-g : Ord k => SortedMap k v -> List (k, v)                        
-g m = 
-    let kvs = toList m 
-        t = sortBy (\(x, _), (y, _) => compare x y) kvs in
-        ?halp
---     case sortBy (\(x, _), (y, _) => compare x y) kvs of
---         as => as
+g : Ord k => SortedMap k v -> List (k, v)
+g m = let kvs = toList m in
+          case sortBy (\(x, _), (y, _) => compare x y) kvs of
+               as => as

--- a/tests/idris2/reg048/run
+++ b/tests/idris2/reg048/run
@@ -1,0 +1,2 @@
+rm -rf build
+$1 --no-banner --no-color --console-width 0 inferror.idr --check -p contrib


### PR DESCRIPTION
This is for the sake of error messages (changing the ordering) and removing a restriction on how often we'd retry them. That restriction was for the sake of performance but given that the evidence is that it isn't the source of any performance problems, we now retry until we stop making progress. Let's see what effect it has.

I accidentally included an FAQ update here too. Sorry about that. I'm not going to try disentangling it since I'm just going to merge this if CI confirms it's okay...