### PR TITLE
Mark prim__system C__collect_safe

### DIFF
--- a/libs/base/System.idr
+++ b/libs/base/System.idr
@@ -3,6 +3,7 @@ module System
 import public Data.So
 import Data.List
 import Data.String
+import System.FFI
 
 %default total
 
@@ -100,12 +101,16 @@ unsetEnv var
    = do ok <- primIO $ prim__unsetEnv var
         pure $ ok == 0
 
-%foreign "C:idris2_system, libidris2_support, idris_system.h"
-prim__system : String -> PrimIO Int
+%foreign "C__collect_safe:idris2_system, libidris2_support, idris_system.h"
+         "C:idris2_system, libidris2_support, idris_system.h"
+prim__system : Ptr String -> PrimIO Int
 
 export
 system : HasIO io => String -> io Int
-system cmd = primIO (prim__system cmd)
+system cmd = do cmdS <- strdup cmd
+                r <- primIO (prim__system cmdS)
+                free $ prim__forgetPtr cmdS
+                pure r
 
 %foreign "C:idris2_time, libidris2_support, idris2_support.h"
 prim__time : PrimIO Int

--- a/libs/base/System/FFI.idr
+++ b/libs/base/System/FFI.idr
@@ -41,6 +41,9 @@ prim__malloc : (size : Int) -> PrimIO AnyPtr
 %foreign "C:idris2_free, libidris2_support, idris_memory.h"
 prim__free : AnyPtr -> PrimIO ()
 
+%foreign "C:idris2_strdup, libidris2_support, idris_memory.h"
+prim__strdup : String -> PrimIO (Ptr String)
+
 ||| Allocate memory with libc `malloc`.
 export
 malloc : HasIO io => (size : Int) -> io AnyPtr
@@ -50,3 +53,7 @@ malloc size = primIO $ prim__malloc size
 export
 free : HasIO io => AnyPtr -> io ()
 free ptr = primIO $ prim__free ptr
+
+export
+strdup : HasIO io => String -> io (Ptr String)
+strdup s = primIO $ prim__strdup s

--- a/support/c/idris_memory.c
+++ b/support/c/idris_memory.c
@@ -35,3 +35,9 @@ void* idrnet_malloc(int size) {
 void idrnet_free(void* ptr) {
     idris2_free(ptr);
 }
+
+char* idris2_strdup(const char* s) {
+    char* r = strdup(s);
+    IDRIS2_VERIFY(r, "strdup failed");
+    return r;
+}

--- a/support/c/idris_memory.h
+++ b/support/c/idris_memory.h
@@ -2,3 +2,4 @@
 
 void* idris2_malloc(int size);
 void idris2_free(void* ptr);
+char* idris2_strdup(const char*);


### PR DESCRIPTION
It is a blocking call, so it should be marked `__collect_safe`.
Could not check if it really helps (or if the issue exists) because
on my mac laptop `system` seems to hold the global lock.  Checked
with this program:

```
#include <pthread.h>
#include <stdlib.h>

void* t(void *p) {
    system("echo tt; sleep 1; echo TT");
    return 0;
}

#define VERIFY(cond) do { if (!(cond)) abort(); } while (0)

int main() {
    pthread_t pt;
    VERIFY(pthread_create(&pt, 0, t, 0) == 0);
    system("echo mm; sleep 1; echo MM");
    void* r;
    VERIFY(pthread_join(pt, &r) == 0);
    return 0;
}
```

which outputs:

```
mm
MM
tt
TT
```

Chez `__collect_safe` function cannot accept `string` arguments, so this diff:
* adds `strdup` C function
* uses `strdup` to convert `String` to a pointer
* passes this pointer to `prim__system` function

The alternative to this PR is to revert #1620: when `system` for
Chez is implemented natively by Chez, it does some chez-specific
low-level machinery which probably handles blocking correctly.

I prefer this PR because:
* `strdup` costs nothing compared to the process spawn
* it allows keeping `system` implementation in different codegens same