### PR TITLE
Better ordering of delayed elaborators

### DIFF
--- a/docs/source/faq/faq.rst
+++ b/docs/source/faq/faq.rst
@@ -43,19 +43,25 @@ from the generated Scheme code, as described in Section :ref:`sect-starting`.
 Why does Idris 2 target Scheme? Surely a dynamically typed target language is going to be slow?
 ===============================================================================================
 
-You may be surprised at how fast Chez Scheme is :). `Racket <https://download.racket-lang.org/>`_,
+You may be surprised at how fast Chez Scheme is! `Racket <https://download.racket-lang.org/>`_,
 as an alternative target, also performs well. Both perform better than the
 Idris 1 back end, which is written in C but has not had the decades of
 engineering effort by run time system specialists that Chez and Racket have.
 Chez Scheme also allows us to turn off run time checks, which we do.
 
-As anecdotal evidence of the performance improvement, as of 23rd May 2020, on a
-Dell XPS 13 running Ubuntu, the performance is:
+As anecdotal evidence of the performance improvement, we compared the
+performance of the Idris 2 runtime with the Idris 1 runtime, using a version of
+the compiler built with the Chez runtime and the same version built with the
+bootstrapping Idris 2.  On a Dell XPS 13 running Ubuntu, with the versions of
+23rd May 2020, the performance was:
 
-* Idris 2 (with the Chez Scheme runtime) checks its own source in 93 seconds.
-* The bootstrapping Idris 2 (compiled with Idris 1) checks the same source in 125s.
-* Idris 1 checks the bootstrapping Idris 2's source (the same as the above,
+* Idris 2 (with the Chez Scheme runtime) checked its own source in 93 seconds.
+* The bootstrapping Idris 2 (compiled with Idris 1) checked the same source in 125s.
+* Idris 1 checked the bootstrapping Idris 2's source (the same as the above,
   but with minor variations due to the syntax changes) in 768 seconds.
+
+Unfortunately we can't repeat this experiment with the latest version, since
+the bootstrapping Idris 2 is no longer able to build the current version.
 
 This is, nevertheless, not intended to be a long term solution, even if it
 is a very convenient way to bootstrap.
@@ -90,7 +96,7 @@ Why aren't there more linearity annotations in the library?
 ===========================================================
 
 In theory, now that Idris 2 is based on Quantitative Type Theory (see
-Section :ref:`sect-multiplicities`, we can write more precise types in the
+Section :ref:`sect-multiplicities`), we can write more precise types in the
 Prelude and Base libraries which give more precise usage information. We have
 chosen not to do that (yet) however. Consider, for example, what would happen
 if we did::
@@ -117,7 +123,7 @@ impact the way you write programs.
 How do I get command history in the Idris2 REPL?
 ================================================
 
-The Idris2 repl does not support readline in the interest of
+The Idris2 REPL does not support readline in the interest of
 keeping dependencies minimal. A useful work around is to
 install `rlwrap <https://linux.die.net/man/1/rlwrap>`_, this
 utility provides command history simply by invoking the Idris2
@@ -338,5 +344,5 @@ Where can I find the community standards for the Idris community?
 ==================================================================
 
 The Idris Community Standards are stated `here
-<https://www.idris-lang.org/documentation/community-standards/>`_ .
+<https://www.idris-lang.org/pages/community-standards.html>`_
 

--- a/src/TTImp/Elab.idr
+++ b/src/TTImp/Elab.idr
@@ -129,7 +129,8 @@ elabTermSub {vars} defining mode opts nest env env' sub tm ty
          solveConstraints solvemode Normal
          logTerm "elab" 5 "Looking for delayed in " chktm
          ust <- get UST
-         catch (retryDelayed (sortBy (\x, y => compare (fst x) (fst y))
+         catch (retryDelayed solvemode
+                             (sortBy (\x, y => compare (fst x) (fst y))
                                        (delayedElab ust)))
                  (\err =>
                     do ust <- get UST

--- a/src/TTImp/Elab/Ambiguity.idr
+++ b/src/TTImp/Elab/Ambiguity.idr
@@ -353,7 +353,7 @@ checkAlternative rig elabinfo nest env fc (UniqueDefault def) alts mexpected
          let solvemode = case elabMode elabinfo of
                               InLHS c => inLHS
                               _ => inTerm
-         delayOnFailure fc rig env expected ambiguous 5 $
+         delayOnFailure fc rig env expected ambiguous Ambiguity $
              \delayed =>
                do solveConstraints solvemode Normal
                   defs <- get Ctxt
@@ -406,7 +406,7 @@ checkAlternative rig elabinfo nest env fc uniq alts mexpected
                 let solvemode = case elabMode elabinfo of
                                       InLHS c => inLHS
                                       _ => inTerm
-                delayOnFailure fc rig env expected ambiguous 5 $
+                delayOnFailure fc rig env expected ambiguous Ambiguity $
                      \delayed =>
                        do defs <- get Ctxt
                           exp <- getTerm expected

--- a/src/TTImp/Elab/Binders.idr
+++ b/src/TTImp/Elab/Binders.idr
@@ -208,16 +208,15 @@ checkLet rigc_in elabinfo nest env fc lhsFC rigl n nTy nVal scope expty {vars}
          -- try checking at Rig1 (meaning that we're using a linear variable
          -- so the resulting binding should be linear)
          -- Also elaborate any case blocks in the value via runDelays
-         -- (0 is the highest priority delays only)
          (valv, valt, rigb) <- handle
-              (do c <- runDelays 0 $ check (rigl |*| rigc)
+              (do c <- runDelays (==CaseBlock) $ check (rigl |*| rigc)
                              (record { preciseInf = True } elabinfo)
                              nest env nVal (Just (gnf env tyv))
                   pure (fst c, snd c, rigl |*| rigc))
               (\err => case linearErr err of
                             Just r
                               => do branchOne
-                                     (do c <- runDelays 0 $ check linear elabinfo
+                                     (do c <- runDelays (==CaseBlock) $ check linear elabinfo
                                                   nest env nVal (Just (gnf env tyv))
                                          pure (fst c, snd c, linear))
                                      (do c <- check (rigl |*| rigc)

--- a/src/TTImp/Elab/ImplicitBind.idr
+++ b/src/TTImp/Elab/ImplicitBind.idr
@@ -533,12 +533,13 @@ checkBindHere rig elabinfo nest env fc bindmode tm exp
                                            bindingVars = True }
                                          elabinfo)
                              nest env tm exp
-         solveConstraints (case elabMode elabinfo of
-                                InLHS c => inLHS
-                                _ => inTerm) Normal
+         let solvemode = case elabMode elabinfo of
+                              InLHS c => inLHS
+                              _ => inTerm
+         solveConstraints solvemode Normal
 
          ust <- get UST
-         catch (retryDelayed (delayedElab ust))
+         catch (retryDelayed solvemode (delayedElab ust))
                (\err =>
                   do ust <- get UST
                      put UST (record { delayedElab = [] } ust)

--- a/src/TTImp/Elab/Lazy.idr
+++ b/src/TTImp/Elab/Lazy.idr
@@ -50,7 +50,7 @@ checkDelay rig elabinfo nest env fc tm mexpected
          solveConstraints solvemode Normal
          -- Can only check if we know the expected type already because we
          -- need to infer the delay reason
-         delayOnFailure fc rig env expected delayError 5
+         delayOnFailure fc rig env expected delayError LazyDelay
             (\delayed =>
                  case !(getNF expected) of
                       NDelayed _ r expnf =>

--- a/src/TTImp/Elab/Record.idr
+++ b/src/TTImp/Elab/Record.idr
@@ -221,7 +221,7 @@ checkUpdate rig elabinfo nest env fc upds rec expected
          let solvemode = case elabMode elabinfo of
                               InLHS c => inLHS
                               _ => inTerm
-         delayOnFailure fc rig env recty needType 5 $
+         delayOnFailure fc rig env recty needType RecordUpdate $
            \delayed =>
              do solveConstraints solvemode Normal
                 exp <- getTerm recty

--- a/src/TTImp/Elab/Rewrite.idr
+++ b/src/TTImp/Elab/Rewrite.idr
@@ -108,7 +108,7 @@ checkRewrite : {vars : _} ->
 checkRewrite rigc elabinfo nest env fc rule tm Nothing
     = throw (GenericMsg fc "Can't infer a type for rewrite")
 checkRewrite {vars} rigc elabinfo nest env ifc rule tm (Just expected)
-    = delayOnFailure ifc rigc env expected rewriteErr 10 $ \delayed =>
+    = delayOnFailure ifc rigc env expected rewriteErr Rewrite $ \delayed =>
         do let vfc = virtualiseFC ifc
            (rulev, grulet) <- check erased elabinfo nest env rule Nothing
            rulet <- getTerm grulet

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -88,7 +88,7 @@ elabScript fc nest env script@(NDCon nfc nm t ar args) exp
              ttimp' <- evalClosure defs ttimp
              tidx <- resolveName (UN "[elaborator script]")
              e <- newRef EST (initEState tidx env)
-             (checktm, _) <- runDelays 0 $
+             (checktm, _) <- runDelays (const True) $
                      check top (initElabInfo InExpr) nest env !(reify defs ttimp')
                            (Just (glueBack defs env exp'))
              empty <- clearDefs defs
@@ -189,7 +189,7 @@ checkRunElab rig elabinfo nest env fc script exp
          let n = NS reflectionNS (UN "Elab")
          let ttn = reflectiontt "TT"
          elabtt <- appCon fc defs n [expected]
-         (stm, sty) <- runDelays 0 $
+         (stm, sty) <- runDelays (const True) $
                            check rig elabinfo nest env script (Just (gnf env elabtt))
          defs <- get Ctxt -- checking might have resolved some holes
          ntm <- elabScript fc nest env

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -124,7 +124,7 @@ idrisTestsRegression = MkTestPool "Various regressions" [] Nothing
        "reg022", "reg023", "reg024", "reg025", "reg026", "reg027", "reg028",
        "reg029", "reg030", "reg031", "reg032", "reg033", "reg034", "reg035",
        "reg036", "reg037", "reg038", "reg039", "reg040", "reg041", "reg042",
-       "reg043", "reg044", "reg045", "reg046", "reg047"]
+       "reg043", "reg044", "reg045", "reg046", "reg047", "reg048"]
 
 idrisTestsData : TestPool
 idrisTestsData = MkTestPool "Data and record types" [] Nothing

--- a/tests/idris2/reg048/expected
+++ b/tests/idris2/reg048/expected
@@ -1,0 +1,13 @@
+1/1: Building inferror (inferror.idr)
+Error: While processing right hand side of g. Ambiguous elaboration. Possible results:
+    Data.SortedMap.toList m
+    Prelude.toList ?arg
+
+inferror:9:17--9:23
+ 5 | f m = case sortBy (\(x, _), (y, _) => compare x y) (SortedMap.toList m) of
+ 6 |     as => as
+ 7 | 
+ 8 | g : Ord k => SortedMap k v -> List (k, v)
+ 9 | g m = let kvs = toList m in
+                     ^^^^^^
+

--- a/tests/idris2/reg048/inferror.idr
+++ b/tests/idris2/reg048/inferror.idr
@@ -1,0 +1,11 @@
+import Data.SortedMap
+import Data.List
+
+f : Ord k => SortedMap k v -> List (k, v)
+f m = case sortBy (\(x, _), (y, _) => compare x y) (SortedMap.toList m) of
+    as => as
+
+g : Ord k => SortedMap k v -> List (k, v)
+g m = let kvs = toList m in
+          case sortBy (\(x, _), (y, _) => compare x y) kvs of
+               as => as

--- a/tests/idris2/reg048/run
+++ b/tests/idris2/reg048/run
@@ -1,0 +1,2 @@
+rm -rf build
+$1 --no-banner --no-color --console-width 0 inferror.idr --check -p contrib


### PR DESCRIPTION
Instead of having an arbitrary looking priority number, record explicit reasons for the delay, which helps order them sensibly when rerunning them. Mostly this allows us to choose which ones to rerun, where it helps, and helps order things to get better error messages.

Also run them for longer - keep going as long as some progress is being made, rather than giving up after one pass. There's no good reason to stop early.