### PR TITLE
Split Windows CI build into multiple steps

### DIFF
--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -158,8 +158,12 @@ jobs:
       - name: Test Scheme
         run: |
           scheme --version
-      - name: Bootstrap and install
-        run: c:\msys64\usr\bin\bash -l -c "cd $env:PWD && make bootstrap && make bootstrap-test && make install"
+      - name: Bootstrap
+        run: c:\msys64\usr\bin\bash -l -c "cd $env:PWD && make bootstrap"
+      - name: Bootstrap test
+        run: c:\msys64\usr\bin\bash -l -c "cd $env:PWD && make bootstrap-test"
+      - name: Install
+        run: c:\msys64\usr\bin\bash -l -c "cd $env:PWD && make install"
 
   nix-bootstrap-chez:
     needs: quick-check


### PR DESCRIPTION
It's easier to follow Windows CI output this way.