### PR TITLE
Define and implement Injective interface

### DIFF
--- a/libs/base/Control/Function.idr
+++ b/libs/base/Control/Function.idr
@@ -1,0 +1,5 @@
+module Control.Function
+
+public export
+interface Injective (f : a -> b) where
+  injective : f x = f y -> x = y

--- a/libs/base/Control/Function.idr
+++ b/libs/base/Control/Function.idr
@@ -2,4 +2,9 @@ module Control.Function
 
 public export
 interface Injective (f : a -> b) where
-  injective : f x = f y -> x = y
+  constructor MkInjective
+  injective : {x, y : a} -> f x = f y -> x = y
+
+public export
+inj : (f : a -> b) -> Injective f => {x, y : a} -> f x = f y -> x = y
+inj _ = injective

--- a/libs/base/Data/Either.idr
+++ b/libs/base/Data/Either.idr
@@ -1,5 +1,6 @@
 module Data.Either
 
+import public Control.Function
 import Data.List1
 
 %default total
@@ -116,10 +117,10 @@ eitherToMaybe (Right x) = Just x
 
 ||| Left is injective
 export
-leftInjective : Left x = Left y -> x = y
-leftInjective Refl = Refl
+Injective Left where
+  injective Refl = Refl
 
 ||| Right is injective
 export
-rightInjective : Right x = Right y -> x = y
-rightInjective Refl = Refl
+Injective Right where
+  injective Refl = Refl

--- a/libs/base/Data/Fin.idr
+++ b/libs/base/Data/Fin.idr
@@ -1,5 +1,6 @@
 module Data.Fin
 
+import Control.Function
 import Data.List1
 import public Data.Maybe
 import Data.Nat
@@ -22,7 +23,7 @@ public export
 coerce : {n : Nat} -> (0 eq : m = n) -> Fin m -> Fin n
 coerce {n = S _} eq FZ = FZ
 coerce {n = Z} eq FZ impossible
-coerce {n = S _} eq (FS k) = FS (coerce (succInjective _ _ eq) k)
+coerce {n = S _} eq (FS k) = FS (coerce (injective eq) k)
 coerce {n = Z} eq (FS k) impossible
 
 %transform "coerce-identity" coerce = replace {p = Fin}
@@ -45,8 +46,8 @@ Uninhabited (n = m) => Uninhabited (FS n = FS m) where
   uninhabited Refl @{nm} = uninhabited Refl @{nm}
 
 export
-fsInjective : FS m = FS n -> m = n
-fsInjective Refl = Refl
+Injective FS where
+  injective Refl = Refl
 
 export
 Eq (Fin n) where
@@ -67,7 +68,7 @@ finToNatInjective FZ     FZ     _    = Refl
 finToNatInjective (FS _) FZ     Refl impossible
 finToNatInjective FZ     (FS _) Refl impossible
 finToNatInjective (FS m) (FS n) prf  =
-  cong FS $ finToNatInjective m n $ succInjective (finToNat m) (finToNat n) prf
+  cong FS $ finToNatInjective m n $ injective prf
 
 export
 Cast (Fin n) Nat where
@@ -194,7 +195,7 @@ DecEq (Fin n) where
   decEq (FS f) (FS f')
       = case decEq f f' of
              Yes p => Yes $ cong FS p
-             No p => No $ p . fsInjective
+             No p => No $ p . injective
 
 namespace Equality
 

--- a/libs/base/Data/Fin.idr
+++ b/libs/base/Data/Fin.idr
@@ -61,14 +61,18 @@ finToNat : Fin n -> Nat
 finToNat FZ = Z
 finToNat (FS k) = S $ finToNat k
 
-||| `finToNat` is injective
-export
 finToNatInjective : (fm : Fin k) -> (fn : Fin k) -> (finToNat fm) = (finToNat fn) -> fm = fn
 finToNatInjective FZ     FZ     _    = Refl
 finToNatInjective (FS _) FZ     Refl impossible
 finToNatInjective FZ     (FS _) Refl impossible
 finToNatInjective (FS m) (FS n) prf  =
   cong FS $ finToNatInjective m n $ injective prf
+
+||| `finToNat` is injective
+%hint
+export
+finToNatInj : Injective Fin.finToNat
+finToNatInj = MkInjective (finToNatInjective _ _)
 
 export
 Cast (Fin n) Nat where

--- a/libs/base/Data/List/Elem.idr
+++ b/libs/base/Data/List/Elem.idr
@@ -1,6 +1,7 @@
 module Data.List.Elem
 
 import Decidable.Equality
+import Control.Function
 
 %default total
 
@@ -24,9 +25,10 @@ export
 Uninhabited (There e = Here) where
   uninhabited Refl impossible
 
+%hint
 export
-thereInjective : {0 e1, e2 : Elem x xs} -> There e1 = There e2 -> e1 = e2
-thereInjective Refl = Refl
+thereInjective : Injective {a=Elem x xs} (There {x} {y} {xs})
+thereInjective = MkInjective (\Refl => Refl)
 
 export
 DecEq (Elem x xs) where
@@ -35,7 +37,7 @@ DecEq (Elem x xs) where
   decEq (There later) Here = No absurd
   decEq (There this) (There that) with (decEq this that)
     decEq (There this) (There this) | Yes Refl  = Yes Refl
-    decEq (There this) (There that) | No contra = No (contra . thereInjective)
+    decEq (There this) (There that) | No contra = No (contra . injective)
 
 export
 Uninhabited (Elem {a} x []) where

--- a/libs/base/Data/List1.idr
+++ b/libs/base/Data/List1.idr
@@ -1,6 +1,7 @@
 module Data.List1
 
 import public Data.Zippable
+import Control.Function
 
 %default total
 
@@ -163,6 +164,16 @@ Ord a => Ord (List1 a) where
 export
 consInjective : (x ::: xs) === (y ::: ys) -> (x === y, xs === ys)
 consInjective Refl = (Refl, Refl)
+
+%hint
+export
+consHeadInj : {x : a} -> Injective (x :::)
+consHeadInj = MkInjective (\Refl => Refl)
+
+%hint
+export
+consTailInj : {ys : List a} -> Injective (::: ys)
+consTailInj = MkInjective (\Refl => Refl)
 
 ------------------------------------------------------------------------
 -- Zippable

--- a/libs/base/Data/Maybe.idr
+++ b/libs/base/Data/Maybe.idr
@@ -1,5 +1,7 @@
 module Data.Maybe
 
+import Control.Function
+
 %default total
 
 public export
@@ -48,8 +50,8 @@ toMaybe True  j = Just j
 toMaybe False _ = Nothing
 
 export
-justInjective : Just x = Just y -> x = y
-justInjective Refl = Refl
+Injective Just where
+  injective Refl = Refl
 
 ||| Convert a `Maybe a` value to an `a` value, using `neutral` in the case
 ||| that the `Maybe` value is `Nothing`.

--- a/libs/base/Data/Nat.idr
+++ b/libs/base/Data/Nat.idr
@@ -2,6 +2,7 @@ module Data.Nat
 
 import public Control.Relation
 import public Control.Order
+import public Control.Function
 
 %default total
 
@@ -275,8 +276,8 @@ eqSucc : (0 left, right : Nat) -> left = right -> S left = S right
 eqSucc _ _ Refl = Refl
 
 export
-succInjective : (0 left, right : Nat) -> S left = S right -> left = right
-succInjective _ _ Refl = Refl
+Injective S where
+  injective Refl = Refl
 
 ||| A definition of non-zero with a better behaviour than `Not (x = Z)`
 ||| This is amenable to proof search and `NonZero Z` is more readily
@@ -445,7 +446,7 @@ plusLeftCancel : (left, right, right' : Nat) ->
   left + right = left + right' -> right = right'
 plusLeftCancel Z _ _ p = p
 plusLeftCancel (S left) right right' p =
-    plusLeftCancel left right right' (succInjective _ _ p)
+    plusLeftCancel left right right' $ injective p
 
 export
 plusRightCancel : (left, left', right : Nat) ->

--- a/libs/base/Data/SnocList/Elem.idr
+++ b/libs/base/Data/SnocList/Elem.idr
@@ -2,6 +2,7 @@ module Data.SnocList.Elem
 
 import Data.SnocList
 import Decidable.Equality
+import Control.Function
 
 ||| A proof that some element is found in a list.
 public export
@@ -9,7 +10,7 @@ data Elem : a -> SnocList a -> Type where
   ||| A proof that the element is at the head of the list
   Here : Elem x (sx :< x)
   ||| A proof that the element is in the tail of the list
-  There : Elem x sx -> Elem x (sx :< y)
+  There : {0 x, y : a} -> Elem x sx -> Elem x (sx :< y)
 
 export
 Uninhabited (Here = There e) where
@@ -24,9 +25,10 @@ Uninhabited (Elem {a} x [<]) where
   uninhabited Here impossible
   uninhabited (There p) impossible
 
+%hint
 export
-thereInjective : {0 e1, e2 : Elem x sx} -> There e1 = There e2 -> e1 = e2
-thereInjective Refl = Refl
+thereInjective : Injective {a=Elem x sx} (There {x} {y} {sx})
+thereInjective = MkInjective (\Refl => Refl)
 
 export
 DecEq (x `Elem` sx) where
@@ -35,7 +37,7 @@ DecEq (x `Elem` sx) where
   decEq (There _) Here = No absurd
   decEq (There y) (There z) with (decEq y z)
     decEq (There y) (There y) | Yes Refl = Yes Refl
-    decEq (There y) (There z) | No neq = No $ neq . thereInjective
+    decEq (There y) (There z) | No neq = No $ neq . injective
 
 ||| Remove the element at the given position.
 public export

--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -7,6 +7,7 @@ import public Data.Fin
 import public Data.Zippable
 
 import Decidable.Equality
+import Control.Function
 
 %default total
 
@@ -33,9 +34,18 @@ lengthCorrect []        = Refl
 lengthCorrect (_ :: xs) = rewrite lengthCorrect xs in Refl
 
 ||| If two vectors are equal, their heads and tails are equal
-export
 vectInjective : {0 xs : Vect n a} -> {0 ys : Vect m b} -> x::xs = y::ys -> (x = y, xs = ys)
 vectInjective Refl = (Refl, Refl)
+
+%hint
+export
+consVectHeadInj : {x : a} -> Injective (Vect.(::) x)
+consVectHeadInj = MkInjective (\Refl => Refl)
+
+%hint
+export
+consVectTailInj : {xs : Vect n a} -> Injective (\x => Vect.(::) x xs)
+consVectTailInj = MkInjective (\Refl => Refl)
 
 --------------------------------------------------------------------------------
 -- Indexing into vectors

--- a/libs/base/Decidable/Equality.idr
+++ b/libs/base/Decidable/Equality.idr
@@ -1,5 +1,6 @@
 module Decidable.Equality
 
+import Control.Function
 import Data.Maybe
 import Data.Either
 import Data.Nat
@@ -40,7 +41,7 @@ DecEq Nat where
   decEq (S _) Z     = No absurd
   decEq (S n) (S m) with (decEq n m)
    decEq (S n) (S m) | Yes p = Yes $ cong S p
-   decEq (S n) (S m) | No p = No $ \h : (S n = S m) => p $ succInjective n m h
+   decEq (S n) (S m) | No p = No $ \h : (S n = S m) => p $ injective h
 
 --------------------------------------------------------------------------------
 -- Maybe
@@ -54,7 +55,7 @@ DecEq t => DecEq (Maybe t) where
   decEq (Just x') (Just y') with (decEq x' y')
     decEq (Just x') (Just y') | Yes p = Yes $ cong Just p
     decEq (Just x') (Just y') | No p
-       = No $ \h : Just x' = Just y' => p $ justInjective h
+       = No $ \h : Just x' = Just y' => p $ injective h
 
 --------------------------------------------------------------------------------
 -- Either
@@ -64,12 +65,12 @@ public export
 (DecEq t, DecEq s) => DecEq (Either t s) where
   decEq (Left x) (Left y) with (decEq x y)
    decEq (Left x) (Left x) | Yes Refl = Yes Refl
-   decEq (Left x) (Left y) | No contra = No (contra . leftInjective)
+   decEq (Left x) (Left y) | No contra = No (contra . injective)
   decEq (Left x) (Right y) = No absurd
   decEq (Right x) (Left y) = No absurd
   decEq (Right x) (Right y) with (decEq x y)
    decEq (Right x) (Right x) | Yes Refl = Yes Refl
-   decEq (Right x) (Right y) | No contra = No (contra . rightInjective)
+   decEq (Right x) (Right y) | No contra = No (contra . injective)
 
 --------------------------------------------------------------------------------
 -- Tuple

--- a/libs/base/Decidable/Equality.idr
+++ b/libs/base/Decidable/Equality.idr
@@ -117,7 +117,7 @@ DecEq a => DecEq (List1 a) where
   decEq (x ::: xs) (y ::: ys) with (decEq x y)
     decEq (x ::: xs) (y ::: ys) | No contra = No (contra . fst . consInjective)
     decEq (x ::: xs) (y ::: ys) | Yes eqxy with (decEq xs ys)
-      decEq (x ::: xs) (y ::: ys) | Yes eqxy | No contra = No (contra . snd . consInjective)
+      decEq (x ::: xs) (y ::: ys) | Yes eqxy | No contra = No (contra . (rewrite sym eqxy in injective))
       decEq (x ::: xs) (y ::: ys) | Yes eqxy | Yes eqxsys = Yes (cong2 (:::) eqxy eqxsys)
 
 -- TODO: Other prelude data types

--- a/libs/base/base.ipkg
+++ b/libs/base/base.ipkg
@@ -29,6 +29,7 @@ modules = Control.App,
           Control.Monad.Writer.CPS,
           Control.Monad.Writer.Interface,
           Control.WellFounded,
+          Control.Function,
           Control.Relation,
           Control.Order,
 

--- a/libs/contrib/Data/Container.idr
+++ b/libs/contrib/Data/Container.idr
@@ -301,12 +301,12 @@ namespace Derivative
   fromPair (MkExtension ((shp1, shp2) ** p) chld) = case p of
     Left p1 => toSum {c = Pair (Derivative c) d} {d = Pair c (Derivative d)}
                      (Left (MkExtension ((shp1 ** p1), shp2) $ either
-                         (\ p1' => chld (Left (DPair.fst p1') ** DPair.snd p1' . leftInjective))
+                         (\ p1' => chld (Left (DPair.fst p1') ** DPair.snd p1' . injective))
                          (\ p2 => chld (Right p2 ** absurd))))
     Right p2 => toSum {c = Pair (Derivative c) d} {d = Pair c (Derivative d)}
                      (Right (MkExtension (shp1, (shp2 ** p2)) $ either
                          (\ p1 => chld (Left p1 ** absurd))
-                         (\ p2' => chld (Right (DPair.fst p2') ** DPair.snd p2' . rightInjective))))
+                         (\ p2' => chld (Right (DPair.fst p2') ** DPair.snd p2' . injective))))
 
 
   export

--- a/libs/contrib/Data/Nat/Equational.idr
+++ b/libs/contrib/Data/Nat/Equational.idr
@@ -11,7 +11,7 @@ import Data.Nat
 export
 subtractEqLeft : (a : Nat) -> {b, c : Nat} -> a + b = a + c -> b = c
 subtractEqLeft 0 prf = prf
-subtractEqLeft (S k) prf = subtractEqLeft k $ succInjective (k + b) (k + c) prf
+subtractEqLeft (S k) prf = subtractEqLeft k $ injective prf
 
 ||| Subtract a number from both sides of an equation.
 ||| Due to partial nature of subtraction in natural numbers, an equation of

--- a/libs/contrib/Data/Nat/Factor.idr
+++ b/libs/contrib/Data/Nat/Factor.idr
@@ -9,7 +9,6 @@ import Syntax.PreorderReasoning
 
 %default total
 
-
 ||| Factor n p is a witness that p is indeed a factor of n,
 ||| i.e. there exists a q such that p * q = n.
 public export
@@ -81,7 +80,7 @@ oneSoleFactorOfOne (S (S k)) (CofactorExists Z prf) =
 oneSoleFactorOfOne (S (S k)) (CofactorExists (S j) prf) =
   absurd . uninhabited $
     trans
-      (succInjective 0 (j + S (j + (k * S j))) prf)
+      (injective prf)
       (plusCommutative j (S (j + (k * S j))))
 
 ||| Every natural number is factor of itself.
@@ -124,8 +123,7 @@ multOneSoleNeutral (S k) (S (S j)) prf =
         rewrite plusCommutative k j in
         rewrite sym $ plusAssociative j k (k * S j) in
         rewrite sym $ multRightSuccPlus k (S j) in
-        succInjective k (j + (S (S (j + (k * (S (S j))))))) $
-        succInjective (S k) (S (j + (S (S (j + (k * (S (S j)))))))) prf
+        injective {f = S} $ injective prf
 
 ||| If a is a factor of b and b is a factor of a, then a = b.
 public export

--- a/libs/contrib/Data/Nat/Factor.idr
+++ b/libs/contrib/Data/Nat/Factor.idr
@@ -123,7 +123,7 @@ multOneSoleNeutral (S k) (S (S j)) prf =
         rewrite plusCommutative k j in
         rewrite sym $ plusAssociative j k (k * S j) in
         rewrite sym $ multRightSuccPlus k (S j) in
-        injective {f = S} $ injective prf
+        inj S $ injective prf
 
 ||| If a is a factor of b and b is a factor of a, then a = b.
 public export

--- a/src/Core/TT.idr
+++ b/src/Core/TT.idr
@@ -651,6 +651,9 @@ namespace HasLength
   cast : {ys : _} -> List.length xs = List.length ys -> HasLength m xs -> HasLength m ys
   cast {ys = []}      eq Z = Z
   cast {ys = y :: ys} eq (S p) = S (cast (succInjective _ _ eq) p)
+    where
+    succInjective : (0 l, r : Nat) -> S l = S r -> l = r
+    succInjective _ _ Refl = Refl
 
   hlReverseOnto : HasLength m acc -> HasLength n xs -> HasLength (m + n) (reverseOnto acc xs)
   hlReverseOnto p Z = rewrite plusZeroRightNeutral m in p


### PR DESCRIPTION
The idea here is similar to https://github.com/idris-lang/Idris2/pull/1472. Instead of claiming that functions are injective on an ad-hoc basis, make one Injective interface and then implement it for each function.

Unlike with the relation interfaces, there is no need to specify any implicit arguments (with one notable exception).

There are some existing ad-hoc injectivity proofs that I couldn't convert to the new interface, like `finToNatInjective`. I couldn't understand the error messages.