### PR TITLE
Make drop and drop' public exported from the vect module.

### DIFF
--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -88,11 +88,13 @@ take 0 xs = Nil
 take (S k) (x :: xs) = x :: take k xs
 
 ||| Drop the first `n` elements of a Vect.
+public export
 drop : (n : Nat) -> Vect (n + m) elem -> Vect m elem
 drop 0 xs = xs
 drop (S k) (x :: xs) = drop k xs
 
 ||| Drop up to the first `n` elements of a Vect.
+public export
 drop' : (n : Nat) -> Vect l elem -> Vect (l `minus` n) elem
 drop' 0 xs = rewrite minusZeroRight l in xs
 drop' (S k) [] = rewrite minusZeroLeft (S k) in []


### PR DESCRIPTION
When I added `Vect.drop` and `Vect.drop'` I forgot to export them!