### PR TITLE
[ ci ] controlling builds via commit messages

### DIFF
--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -46,11 +46,11 @@ jobs:
       - name: Get commit message
         id: get_commit_message
         run: |
-          echo ${{ github.event_name }}
-          if   [[ github.event_name == 'push' ]]; then
+          echo '${{ github.event_name }}'
+          if   [[ '${{ github.event_name }}' == 'push' ]]; then
             echo "push";
             echo ::set-output namecommit_message::$(git log --format=%B -n 1 HEAD)
-          elif [[ github.event_name == 'pull_request' ]]; then
+          elif [[ '${{ github.event_name }}' == 'pull_request' ]]; then
             echo "pull request";
             echo ::set-output namecommit_message::$(git log --format=%B -n 1 HEAD^2)
           fi

--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -49,10 +49,10 @@ jobs:
           echo '${{ github.event_name }}'
           if   [[ '${{ github.event_name }}' == 'push' ]]; then
             echo "push";
-            echo ::set-output namecommit_message::$(git log --format=%B -n 1 HEAD)
+            echo ::set-output name=commit_message::$(git log --format=%B -n 1 HEAD)
           elif [[ '${{ github.event_name }}' == 'pull_request' ]]; then
             echo "pull request";
-            echo ::set-output namecommit_message::$(git log --format=%B -n 1 HEAD^2)
+            echo ::set-output name=commit_message::$(git log --format=%B -n 1 HEAD^2)
           fi
           echo ${{ steps.get_commit_message.outputs.commit_message }}
 

--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -25,6 +25,8 @@ jobs:
 
   quick-check:
     runs-on: ubuntu-latest
+    if: |
+      !contains(github.event.head_commit.message, '[ci: skip]')
     env:
       IDRIS2_CG: chez
       SCHEME: scheme
@@ -79,6 +81,11 @@ jobs:
   ubuntu-bootstrap-chez:
     needs: quick-check
     runs-on: ubuntu-latest
+    if: |
+      contains(github.event.head_commit.message, '[ci:')
+      && !(   contains(github.event.head_commit.message, '[ci: ubuntu]')
+           || contains(github.event.head_commit.message, '[ci: chez]')
+          )
     env:
       IDRIS2_CG: chez
       SCHEME: scheme
@@ -104,6 +111,11 @@ jobs:
   macos-bootstrap-chez:
     needs: quick-check
     runs-on: macos-latest
+    if: |
+      contains(github.event.head_commit.message, '[ci:')
+      && !(   contains(github.event.head_commit.message, '[ci: macos]')
+           || contains(github.event.head_commit.message, '[ci: chez]')
+          )
     env:
       SCHEME: chez
     steps:
@@ -128,6 +140,11 @@ jobs:
   windows-bootstrap-chez:
     needs: quick-check
     runs-on: windows-latest
+    if: |
+      contains(github.event.head_commit.message, '[ci:')
+      && !(   contains(github.event.head_commit.message, '[ci: windows]')
+           || contains(github.event.head_commit.message, '[ci: chez]')
+          )
     env:
       MSYSTEM: MINGW64
       MSYS2_PATH_TYPE: inherit
@@ -168,6 +185,11 @@ jobs:
   nix-bootstrap-chez:
     needs: quick-check
     runs-on: ubuntu-latest
+    if: |
+      contains(github.event.head_commit.message, '[ci:')
+      && !(   contains(github.event.head_commit.message, '[ci: nix]')
+           || contains(github.event.head_commit.message, '[ci: chez]')
+          )
     steps:
     - uses: actions/checkout@v2
       with:
@@ -182,6 +204,11 @@ jobs:
   ubuntu-bootstrap-racket:
     needs: quick-check
     runs-on: ubuntu-latest
+    if: |
+      contains(github.event.head_commit.message, '[ci:')
+      && !(   contains(github.event.head_commit.message, '[ci: ubuntu]')
+           || contains(github.event.head_commit.message, '[ci: racket]')
+          )
     env:
       IDRIS2_CG: racket
     steps:
@@ -287,6 +314,9 @@ jobs:
   ubuntu-self-host-previous-version:
     needs: quick-check
     runs-on: ubuntu-latest
+    if: |
+      contains(github.event.head_commit.message, '[ci:')
+      && !contains(github.event.head_commit.message, '[ci: ubuntu]')
     env:
       IDRIS2_CG: chez
     steps:

--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -46,9 +46,12 @@ jobs:
       - name: Get commit message
         id: get_commit_message
         run: |
+          echo ${{ github.event_name }}
           if   [[ github.event_name == 'push' ]]; then
+            echo "push";
             echo ::set-output namecommit_message::$(git log --format=%B -n 1 HEAD)
           elif [[ github.event_name == 'pull_request' ]]; then
+            echo "pull request";
             echo ::set-output namecommit_message::$(git log --format=%B -n 1 HEAD^2)
           fi
           echo ${{ steps.get_commit_message.outputs.commit_message }}

--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -100,10 +100,9 @@ jobs:
     needs: quick-check
     runs-on: ubuntu-latest
     if: |
-      contains(github.event.head_commit.message, '[ci:')
-      && !(   contains(github.event.head_commit.message, '[ci: ubuntu]')
-           || contains(github.event.head_commit.message, '[ci: chez]')
-          )
+      !contains(github.event.head_commit.message, '[ci:')
+      || contains(github.event.head_commit.message, '[ci: ubuntu]')
+      || contains(github.event.head_commit.message, '[ci: chez]')
     env:
       IDRIS2_CG: chez
       SCHEME: scheme
@@ -130,10 +129,9 @@ jobs:
     needs: quick-check
     runs-on: macos-latest
     if: |
-      contains(github.event.head_commit.message, '[ci:')
-      && !(   contains(github.event.head_commit.message, '[ci: macos]')
-           || contains(github.event.head_commit.message, '[ci: chez]')
-          )
+      !contains(github.event.head_commit.message, '[ci:')
+      || contains(github.event.head_commit.message, '[ci: macos]')
+      || contains(github.event.head_commit.message, '[ci: chez]')
     env:
       SCHEME: chez
     steps:
@@ -159,10 +157,9 @@ jobs:
     needs: quick-check
     runs-on: windows-latest
     if: |
-      contains(github.event.head_commit.message, '[ci:')
-      && !(   contains(github.event.head_commit.message, '[ci: windows]')
-           || contains(github.event.head_commit.message, '[ci: chez]')
-          )
+      !contains(github.event.head_commit.message, '[ci:')
+      || contains(github.event.head_commit.message, '[ci: windows]')
+      || contains(github.event.head_commit.message, '[ci: chez]')
     env:
       MSYSTEM: MINGW64
       MSYS2_PATH_TYPE: inherit
@@ -204,10 +201,9 @@ jobs:
     needs: quick-check
     runs-on: ubuntu-latest
     if: |
-      contains(github.event.head_commit.message, '[ci:')
-      && !(   contains(github.event.head_commit.message, '[ci: nix]')
-           || contains(github.event.head_commit.message, '[ci: chez]')
-          )
+      !contains(github.event.head_commit.message, '[ci:')
+      || contains(github.event.head_commit.message, '[ci: nix]')
+      || contains(github.event.head_commit.message, '[ci: chez]')
     steps:
     - uses: actions/checkout@v2
       with:
@@ -223,10 +219,9 @@ jobs:
     needs: quick-check
     runs-on: ubuntu-latest
     if: |
-      contains(github.event.head_commit.message, '[ci:')
-      && !(   contains(github.event.head_commit.message, '[ci: ubuntu]')
-           || contains(github.event.head_commit.message, '[ci: racket]')
-          )
+      !contains(github.event.head_commit.message, '[ci:')
+      || contains(github.event.head_commit.message, '[ci: ubuntu]')
+      || contains(github.event.head_commit.message, '[ci: racket]')
     env:
       IDRIS2_CG: racket
     steps:
@@ -333,8 +328,8 @@ jobs:
     needs: quick-check
     runs-on: ubuntu-latest
     if: |
-      contains(github.event.head_commit.message, '[ci:')
-      && !contains(github.event.head_commit.message, '[ci: ubuntu]')
+      !contains(github.event.head_commit.message, '[ci:')
+      || contains(github.event.head_commit.message, '[ci: ubuntu]')
     env:
       IDRIS2_CG: chez
     steps:

--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -46,15 +46,11 @@ jobs:
       - name: Get commit message
         id: get_commit_message
         run: |
-          echo '${{ github.event_name }}'
           if   [[ '${{ github.event_name }}' == 'push' ]]; then
-            echo "push";
             echo ::set-output name=commit_message::$(git log --format=%B -n 1 HEAD)
           elif [[ '${{ github.event_name }}' == 'pull_request' ]]; then
-            echo "pull request";
             echo ::set-output name=commit_message::$(git log --format=%B -n 1 HEAD^2)
           fi
-          echo ${{ steps.get_commit_message.outputs.commit_message }}
 
     outputs:
       commit_message:
@@ -80,9 +76,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Install build dependencies
         run: |
-          echo "MSG"
-          echo ${{ needs.initialise.outputs.commit_message }}
-          false
           echo "deb http://security.ubuntu.com/ubuntu hirsute universe" | sudo tee -a /etc/apt/sources.list
           sudo apt-get update
           sudo apt-get install -y -t hirsute chezscheme

--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -44,15 +44,18 @@ jobs:
           fetch-depth: 2
 
       - name: Get commit message
+        id: get_commit_message
         run: |
           if   [[ github.event_name == 'push' ]]; then
-            echo "MSG=$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
+            echo ::set-output namecommit_message::$(git log --format=%B -n 1 HEAD)
           elif [[ github.event_name == 'pull_request' ]]; then
-            echo "MSG=$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
+            echo ::set-output namecommit_message::$(git log --format=%B -n 1 HEAD^2)
           fi
+          echo ${{ steps.get_commit_message.outputs.commit_message }}
 
     outputs:
-      commit_message: ${{ env.MSG }}
+      commit_message:
+        echo "${{ steps.get_commit_message.outputs.commit_message }}"
 
   ######################################################################
   # Build from the previous version
@@ -74,6 +77,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Install build dependencies
         run: |
+          echo "MSG"
+          echo ${{ needs.initialise.outputs.commit_message }}
+          false
           echo "deb http://security.ubuntu.com/ubuntu hirsute universe" | sudo tee -a /etc/apt/sources.list
           sudo apt-get update
           sudo apt-get install -y -t hirsute chezscheme

--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -44,7 +44,7 @@ jobs:
   quick-check:
     runs-on: ubuntu-latest
     if: |
-      !contains(github.event.head_commit.message, '[ci: skip]')
+      !contains(github.event.commits[0].message, '[ci: skip]')
     env:
       IDRIS2_CG: chez
       SCHEME: scheme
@@ -100,9 +100,9 @@ jobs:
     needs: quick-check
     runs-on: ubuntu-latest
     if: |
-      !contains(github.event.head_commit.message, '[ci:')
-      || contains(github.event.head_commit.message, '[ci: ubuntu]')
-      || contains(github.event.head_commit.message, '[ci: chez]')
+      !contains(github.event.commits[0].message, '[ci:')
+      || contains(github.event.commits[0].message, '[ci: ubuntu]')
+      || contains(github.event.commits[0].message, '[ci: chez]')
     env:
       IDRIS2_CG: chez
       SCHEME: scheme
@@ -129,9 +129,9 @@ jobs:
     needs: quick-check
     runs-on: macos-latest
     if: |
-      !contains(github.event.head_commit.message, '[ci:')
-      || contains(github.event.head_commit.message, '[ci: macos]')
-      || contains(github.event.head_commit.message, '[ci: chez]')
+      !contains(github.event.commits[0].message, '[ci:')
+      || contains(github.event.commits[0].message, '[ci: macos]')
+      || contains(github.event.commits[0].message, '[ci: chez]')
     env:
       SCHEME: chez
     steps:
@@ -157,9 +157,9 @@ jobs:
     needs: quick-check
     runs-on: windows-latest
     if: |
-      !contains(github.event.head_commit.message, '[ci:')
-      || contains(github.event.head_commit.message, '[ci: windows]')
-      || contains(github.event.head_commit.message, '[ci: chez]')
+      !contains(github.event.commits[0].message, '[ci:')
+      || contains(github.event.commits[0].message, '[ci: windows]')
+      || contains(github.event.commits[0].message, '[ci: chez]')
     env:
       MSYSTEM: MINGW64
       MSYS2_PATH_TYPE: inherit
@@ -201,9 +201,9 @@ jobs:
     needs: quick-check
     runs-on: ubuntu-latest
     if: |
-      !contains(github.event.head_commit.message, '[ci:')
-      || contains(github.event.head_commit.message, '[ci: nix]')
-      || contains(github.event.head_commit.message, '[ci: chez]')
+      !contains(github.event.commits[0].message, '[ci:')
+      || contains(github.event.commits[0].message, '[ci: nix]')
+      || contains(github.event.commits[0].message, '[ci: chez]')
     steps:
     - uses: actions/checkout@v2
       with:
@@ -219,9 +219,9 @@ jobs:
     needs: quick-check
     runs-on: ubuntu-latest
     if: |
-      !contains(github.event.head_commit.message, '[ci:')
-      || contains(github.event.head_commit.message, '[ci: ubuntu]')
-      || contains(github.event.head_commit.message, '[ci: racket]')
+      !contains(github.event.commits[0].message, '[ci:')
+      || contains(github.event.commits[0].message, '[ci: ubuntu]')
+      || contains(github.event.commits[0].message, '[ci: racket]')
     env:
       IDRIS2_CG: racket
     steps:
@@ -328,8 +328,8 @@ jobs:
     needs: quick-check
     runs-on: ubuntu-latest
     if: |
-      !contains(github.event.head_commit.message, '[ci:')
-      || contains(github.event.head_commit.message, '[ci: ubuntu]')
+      !contains(github.event.commits[0].message, '[ci:')
+      || contains(github.event.commits[0].message, '[ci: ubuntu]')
     env:
       IDRIS2_CG: chez
     steps:

--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -53,6 +53,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install build dependencies
         run: |
+          echo ${{ toJSON(github.event) }}
+          false
           echo "deb http://security.ubuntu.com/ubuntu hirsute universe" | sudo tee -a /etc/apt/sources.list
           sudo apt-get update
           sudo apt-get install -y -t hirsute chezscheme

--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -6,10 +6,28 @@ on:
       - '*'
     tags:
       - '*'
+    paths-ignore:
+      - 'docs/**'
+      - 'icons/**'
+      - '*.md'
+      - 'CONTRIBUTORS'
+      - 'LICENSE'
+      - '.github/workflows/ci-lint.yml'
+      - '.github/workflows/ci-sphinx.yml'
+      - '.github/workflows/ci-super-linter.yml'
   pull_request:
     branches:
       - master
       - main
+    paths-ignore:
+      - 'docs/**'
+      - 'icons/**'
+      - '*.md'
+      - 'CONTRIBUTORS'
+      - 'LICENSE'
+      - '.github/workflows/ci-lint.yml'
+      - '.github/workflows/ci-sphinx.yml'
+      - '.github/workflows/ci-super-linter.yml'
 
 env:
   IDRIS2_VERSION: 0.4.0 # For previous-version build

--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -34,6 +34,26 @@ env:
 
 jobs:
 
+  initialise:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v2
+        with:
+          # for pull_request so we can do HEAD^2
+          fetch-depth: 2
+
+      - name: Get commit message
+        run: |
+          if   [[ github.event_name == 'push' ]]; then
+            echo "MSG=$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
+          elif [[ github.event_name == 'pull_request' ]]; then
+            echo "MSG=$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
+          fi
+
+    outputs:
+      commit_message: ${{ env.MSG }}
+
   ######################################################################
   # Build from the previous version
   # We perform this check before all the other ones because:
@@ -42,9 +62,10 @@ jobs:
   ######################################################################
 
   quick-check:
+    needs: initialise
     runs-on: ubuntu-latest
     if: |
-      !contains(github.event.commits[0].message, '[ci: skip]')
+      !contains(needs.initialise.outputs.commit_message, '[ci: skip]')
     env:
       IDRIS2_CG: chez
       SCHEME: scheme
@@ -53,8 +74,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Install build dependencies
         run: |
-          echo ${{ toJSON(github.event) }}
-          false
           echo "deb http://security.ubuntu.com/ubuntu hirsute universe" | sudo tee -a /etc/apt/sources.list
           sudo apt-get update
           sudo apt-get install -y -t hirsute chezscheme
@@ -102,9 +121,9 @@ jobs:
     needs: quick-check
     runs-on: ubuntu-latest
     if: |
-      !contains(github.event.commits[0].message, '[ci:')
-      || contains(github.event.commits[0].message, '[ci: ubuntu]')
-      || contains(github.event.commits[0].message, '[ci: chez]')
+      !contains(needs.initialise.outputs.commit_message, '[ci:')
+      || contains(needs.initialise.outputs.commit_message, '[ci: ubuntu]')
+      || contains(needs.initialise.outputs.commit_message, '[ci: chez]')
     env:
       IDRIS2_CG: chez
       SCHEME: scheme
@@ -131,9 +150,9 @@ jobs:
     needs: quick-check
     runs-on: macos-latest
     if: |
-      !contains(github.event.commits[0].message, '[ci:')
-      || contains(github.event.commits[0].message, '[ci: macos]')
-      || contains(github.event.commits[0].message, '[ci: chez]')
+      !contains(needs.initialise.outputs.commit_message, '[ci:')
+      || contains(needs.initialise.outputs.commit_message, '[ci: macos]')
+      || contains(needs.initialise.outputs.commit_message, '[ci: chez]')
     env:
       SCHEME: chez
     steps:
@@ -159,9 +178,9 @@ jobs:
     needs: quick-check
     runs-on: windows-latest
     if: |
-      !contains(github.event.commits[0].message, '[ci:')
-      || contains(github.event.commits[0].message, '[ci: windows]')
-      || contains(github.event.commits[0].message, '[ci: chez]')
+      !contains(needs.initialise.outputs.commit_message, '[ci:')
+      || contains(needs.initialise.outputs.commit_message, '[ci: windows]')
+      || contains(needs.initialise.outputs.commit_message, '[ci: chez]')
     env:
       MSYSTEM: MINGW64
       MSYS2_PATH_TYPE: inherit
@@ -203,9 +222,9 @@ jobs:
     needs: quick-check
     runs-on: ubuntu-latest
     if: |
-      !contains(github.event.commits[0].message, '[ci:')
-      || contains(github.event.commits[0].message, '[ci: nix]')
-      || contains(github.event.commits[0].message, '[ci: chez]')
+      !contains(needs.initialise.outputs.commit_message, '[ci:')
+      || contains(needs.initialise.outputs.commit_message, '[ci: nix]')
+      || contains(needs.initialise.outputs.commit_message, '[ci: chez]')
     steps:
     - uses: actions/checkout@v2
       with:
@@ -221,9 +240,9 @@ jobs:
     needs: quick-check
     runs-on: ubuntu-latest
     if: |
-      !contains(github.event.commits[0].message, '[ci:')
-      || contains(github.event.commits[0].message, '[ci: ubuntu]')
-      || contains(github.event.commits[0].message, '[ci: racket]')
+      !contains(needs.initialise.outputs.commit_message, '[ci:')
+      || contains(needs.initialise.outputs.commit_message, '[ci: ubuntu]')
+      || contains(needs.initialise.outputs.commit_message, '[ci: racket]')
     env:
       IDRIS2_CG: racket
     steps:
@@ -330,8 +349,8 @@ jobs:
     needs: quick-check
     runs-on: ubuntu-latest
     if: |
-      !contains(github.event.commits[0].message, '[ci:')
-      || contains(github.event.commits[0].message, '[ci: ubuntu]')
+      !contains(needs.initialise.outputs.commit_message, '[ci:')
+      || contains(needs.initialise.outputs.commit_message, '[ci: ubuntu]')
     env:
       IDRIS2_CG: chez
     steps:


### PR DESCRIPTION
Checking commit messages for instructions:

* `[ci: skip]` to skip all idris2 builds
* `[ci: ubuntu]` to build the ubuntu-based ones (same for `macos`, `windows`, `nix`)
* `[ci: chez]` to only build the chez-based ones (same for `racket`)

If `[ci: skip]` is not present then the resulting action is the *union* of all the tags so
a message containing both `[ci: windows]` and `[ci: racket]` will run all of the windows
tests as well as the racket ones on ubuntu & macos.