### PR TITLE
Document --init

### DIFF
--- a/docs/source/tutorial/packages.rst
+++ b/docs/source/tutorial/packages.rst
@@ -34,6 +34,7 @@ package file would be:
             , Maths.BinOps
             , Maths.HexOps
 
+Running ``idris2 --init`` will interactively create a new package file in the current directory. The generated pacakge file lists all configurable fields with a brief description.
 
 Other examples of package files can be found in the ``libs`` directory
 of the main Idris repository, and in `third-party libraries


### PR DESCRIPTION
Reference the --init option for creating package files in the tutorial documentation.