### PR TITLE
[ fix ] bash TAB completion for files

### DIFF
--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -237,7 +237,7 @@ completionScript fun =
               , "  COMPREPLY=($(idris2 --bash-completion $ED $3))"
               , "}"
               , ""
-              , "complete -F " ++ fun' ++ " -o dirnames idris2"
+              , "complete -F " ++ fun' ++ " -o default idris2"
               ]
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
As mentioned on [discord](https://discord.com/channels/827106007712661524/834611018775789568/868145988508975195), TAB completion for Idris2 does not work for files but only for directories. This PR should fix the issue.