### PR TITLE
[ cleanup ] various public export & cleanup

### DIFF
--- a/libs/base/Control/WellFounded.idr
+++ b/libs/base/Control/WellFounded.idr
@@ -43,11 +43,12 @@ wfInd step myz = accInd step myz (wellFounded {rel} myz)
 
 public export
 interface Sized a where
-  size : a -> Nat
+  constructor MkSized
+  total size : a -> Nat
 
 public export
 Smaller : Sized a => a -> a -> Type
-Smaller x y = size x `LT` size y
+Smaller = \x, y => size x `LT` size y
 
 public export
 SizeAccessible : Sized a => a -> Type
@@ -75,13 +76,17 @@ sizeRec : Sized a =>
 sizeRec step z = accRec step z (sizeAccessible z)
 
 export
-implementation Sized Nat where
+Sized Nat where
   size = id
 
 export
-implementation Sized (List a) where
+WellFounded Nat LT where
+  wellFounded = sizeAccessible
+
+export
+Sized (List a) where
   size = length
 
 export
-implementation (Sized a, Sized b) => Sized (Pair a b) where
+(Sized a, Sized b) => Sized (Pair a b) where
   size (x,y) = size x + size y

--- a/libs/base/Data/Nat/Order.idr
+++ b/libs/base/Data/Nat/Order.idr
@@ -39,6 +39,10 @@ Decidable 2 [Nat,Nat] LTE where
   decide = decideLTE
 
 public export
+Decidable 2 [Nat,Nat] LT where
+  decide m = decideLTE (S m)
+
+public export
 lte : (m : Nat) -> (n : Nat) -> Dec (LTE m n)
 lte m n = decide {ts = [Nat,Nat]} {p = LTE} m n
 


### PR DESCRIPTION
Turns out that `Smaller` and `LT` won't unify because
1. the instance Sized Nat is not publicly exported
2. Smaller, and LT are stuck until fully applied

The given changes make that go away.