### PR TITLE
Add `break` in each case alt in js backend

### DIFF
--- a/src/Compiler/ES/Codegen.idr
+++ b/src/Compiler/ES/Codegen.idr
@@ -616,7 +616,7 @@ mutual
     as <- traverse alt alts
     d  <- traverseOpt stmt def
     pure $  switch (minimal sc <+> ".h") as d
-    where 
+    where
         alt' : {r : _} -> EConAlt r -> Core (Doc,Doc)
         alt' (MkEConAlt _ RECORD b)  = ("undefined",) <$> stmt b
         alt' (MkEConAlt _ NIL b)     = ("0",) <$> stmt b

--- a/src/Compiler/ES/Codegen.idr
+++ b/src/Compiler/ES/Codegen.idr
@@ -570,7 +570,7 @@ switch sc alts def =
 
   where anyCase : Doc -> Doc -> Doc
         anyCase s d =
-          let b = if isMultiline d then block d else d
+          let b = block $ vcat [d, "break;"]
            in s <+> softColon <+> b
 
         alt : (Doc,Doc) -> Doc
@@ -610,7 +610,7 @@ mutual
   stmt (Declare v s) =
     (\d => vcat ["let" <++> var v <+> ";",d]) <$> stmt s
   stmt (Assign v x) =
-    (\d => vcat [hcat [var v,softEq,d,";"], "break;"]) <$> exp x
+    (\d => vcat [hcat [var v,softEq,d,";"]]) <$> exp x
 
   stmt (ConSwitch r sc alts def) = do
     as <- traverse alt alts

--- a/src/Compiler/ES/Codegen.idr
+++ b/src/Compiler/ES/Codegen.idr
@@ -614,7 +614,7 @@ mutual
   stmt (Declare v s) =
     (\d => vcat ["let" <++> var v <+> ";",d]) <$> stmt s
   stmt (Assign v x) =
-    (\d => vcat [hcat [var v,softEq,d,";"]]) <$> exp x
+    (\d => hcat [var v,softEq,d,";"]) <$> exp x
 
   stmt (ConSwitch r sc alts def) = do
     as <- traverse (map (insertBreak r) . alt) alts

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -251,7 +251,7 @@ nodeTests = MkTestPool "Node backend" [] (Just Node)
     [ "node001", "node002", "node003", "node004", "node005", "node006"
     , "node007", "node008", "node009", "node011", "node012", "node015"
     , "node017", "node018", "node019", "node021", "node022", "node023"
-    , "node024", "node025"
+    , "node024", "node025", "node026"
     , "perf001"
     -- , "node14", "node020"
     , "args"

--- a/tests/node/node026/Fix1795.idr
+++ b/tests/node/node026/Fix1795.idr
@@ -1,0 +1,6 @@
+import Data.String.Parser
+
+main : IO ()
+main = do
+    let res = parse (satisfy isDigit) "100"
+    printLn res

--- a/tests/node/node026/expected
+++ b/tests/node/node026/expected
@@ -1,0 +1,3 @@
+1/1: Building Fix1795 (Fix1795.idr)
+Main> Right ('1', 1)
+Main> Bye for now!

--- a/tests/node/node026/input
+++ b/tests/node/node026/input
@@ -1,0 +1,2 @@
+:exec main
+:q

--- a/tests/node/node026/run
+++ b/tests/node/node026/run
@@ -1,0 +1,4 @@
+rm -rf build
+
+$1 -p contrib --cg node --no-banner --no-color --console-width 0 Fix1795.idr < input
+


### PR DESCRIPTION
Fixes #1795
Currently this isn't very clever, and inserts an uneeded `break` after every `return`.