### PR TITLE
flake.nix: Use Racket's Chez for non-x86_64-linux platforms (more platforms supported)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -45,11 +45,28 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-chez-racket": {
+      "locked": {
+        "lastModified": 1627484694,
+        "narHash": "sha256-UsEb5G0ZJ8l/2y9u9FNj2akXx2PC5QAan24U3t32cfI=",
+        "owner": "L-as",
+        "repo": "nixpkgs",
+        "rev": "9b3c4bee8cee477ac03b0cfd4ebca40954c66106",
+        "type": "github"
+      },
+      "original": {
+        "owner": "L-as",
+        "ref": "chez-racket",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "idris-emacs-src": "idris-emacs-src",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-chez-racket": "nixpkgs-chez-racket"
       }
     }
   },

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -7,7 +7,6 @@
 , makeWrapper
 , idris2-version
 , srcRev
-, racket
 , gambit
 , nodejs
 , zsh

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -92,7 +92,7 @@ schHeader chez libs whole
     "(import (chezscheme))\n" ++
     "(case (machine-type)\n" ++
     "  [(i3fb ti3fb a6fb ta6fb) #f]\n" ++
-    "  [(i3le ti3le a6le ta6le) (load-shared-object \"libc.so.6\")]\n" ++
+    "  [(i3le ti3le a6le ta6le tarm64le) (load-shared-object \"libc.so.6\")]\n" ++
     "  [(i3osx ti3osx a6osx ta6osx) (load-shared-object \"libc.dylib\")]\n" ++
     "  [(i3nt ti3nt a6nt ta6nt) (load-shared-object \"msvcrt.dll\")]\n" ++
     "  [else (load-shared-object \"libc.so\")])\n\n" ++

--- a/src/Compiler/Scheme/ChezSep.idr
+++ b/src/Compiler/Scheme/ChezSep.idr
@@ -44,7 +44,7 @@ schHeader libs compilationUnits = unlines
       ++ unwords ["(" ++ cu ++ ")" | cu <- compilationUnits]
       ++ ")"
   , "(case (machine-type)"
-  , "  [(i3le ti3le a6le ta6le) (load-shared-object \"libc.so.6\")]"
+  , "  [(i3le ti3le a6le ta6le tarm64le) (load-shared-object \"libc.so.6\")]"
   , "  [(i3osx ti3osx a6osx ta6osx) (load-shared-object \"libc.dylib\")]"
   , "  [(i3nt ti3nt a6nt ta6nt) (load-shared-object \"msvcrt.dll\")"
   , "                           (load-shared-object \"ws2_32.dll\")]"


### PR DESCRIPTION
Use Racket's Chez for non-x86_64-linux platforms in flake.nix.
The nix expression is taken from https://github.com/NixOS/nixpkgs/pull/131833.

It supports many more platforms, excerpt from the README:
> Supported platforms:
>
>     Windows: x86, x86_64
>     Mac OS: x86, x86_64, AArch64, PowerPC32
>     Linux: x86, x86_64, ARMv6, AArch64, PowerPC32
>     FreeBSD: x86, x86_64, ARMv6, AArch64, PowerPC32
>     OpenBSD: x86, x86_64, ARMv6, AArch64, PowerPC32
>     NetBSD: x86, x86_64, ARMv6, AArch64, PowerPC32
>     Solaris: x86, x86_64
>     Android: ARMv7, AArch64
>     iOS: AArch64

Link to the fork: https://github.com/racket/ChezScheme
