### PR TITLE
Support explicitly setting a version tag during build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ ifeq ($(shell git status >/dev/null 2>&1; echo $$?), 0)
 		GIT_SHA1 := $(shell git rev-parse --short=9 HEAD)
 	endif
 endif
+VERSION_TAG ?= $(GIT_SHA1)
 
 export IDRIS2_VERSION := ${MAJOR}.${MINOR}.${PATCH}
 export NAME_VERSION := ${NAME}-${IDRIS2_VERSION}
@@ -66,7 +67,7 @@ ${TARGET}: src/IdrisPaths.idr
 src/IdrisPaths.idr: FORCE
 	echo "-- @""generated" > src/IdrisPaths.idr
 	echo 'module IdrisPaths' >> src/IdrisPaths.idr
-	echo 'export idrisVersion : ((Nat,Nat,Nat), String); idrisVersion = ((${MAJOR},${MINOR},${PATCH}), "${GIT_SHA1}")' >> src/IdrisPaths.idr
+	echo 'export idrisVersion : ((Nat,Nat,Nat), String); idrisVersion = ((${MAJOR},${MINOR},${PATCH}), "${VERSION_TAG}")' >> src/IdrisPaths.idr
 	echo 'export yprefix : String; yprefix="${IDRIS2_PREFIX}"' >> src/IdrisPaths.idr
 
 FORCE:


### PR DESCRIPTION
This minor change to the Makefile allows overriding the version tag that is used to tack a GIT commit SHA onto the end of an Idris 2 version when Idris 2 is built from source.

Overriding that tag is not just for vanity. I am currently making nightly builds of Idris 2 without `git` installed by downloading the source code from GitHub; I'd like to `VERSION_TAG=nightly make` so that `idris2 --version` does not _look_ like it is telling me I am running version 0.4.0 stable instead of the HEAD of main.

I imagine that forks of Idris 2 that add compiler backends might also be interested in specifying a suffix (e.g. `0.4.0-erlang`).