### PR TITLE
Get a bit more specific about the GMP library requirement.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,10 +10,12 @@ The requirements are:
 
 - A Scheme compiler; either Chez Scheme (default), or Racket.
 - `bash`, `GNU make`, `sha256sum` and `GMP`.  On Linux, you probably already
-  have this.  On macOS and major BSD flavours, you can install them using a
+  have these.  On macOS and major BSD flavours, you can install them using a
   package manager: for instance, on macOS, you can install with the
   `brew install coreutils gmp` and on OpenBSD, with the `pkg_add coreutils
-  bash gmake gmp` command.
+  bash gmake gmp` command. You specifically need the dev GMP library, which
+  means on some systems the package you need to install will be named
+  something more like `libgmp3-dev`.
 
 On Windows, it has been reported that installing via `MSYS2` works
 [MSYS2](https://www.msys2.org/). On Windows older than Windows 8, you may need to


### PR DESCRIPTION
The other day a bit of confusion came up in Discord over the fact that installing "gmp" was not working; it was because the dev library was needed instead.