### PR TITLE
Fix error message for incorrect function patterns

### DIFF
--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -694,14 +694,15 @@ mutual
            pure $ MkImpTy fc nameFC n !(bindTypeNames fc (usingImpl syn)
                                                ps !(desugar AnyExpr ps ty))
 
-  -- Attempt to get function name from function pattern. For example, given the
-  -- pattern 'f x y', getClauseFn would return 'f'.
+  -- Attempt to get the function name from a function pattern. For example,
+  --   - given the pattern 'f x y', getClauseFn would return 'f'.
+  --   - given the pattern 'x == y', getClausefn would return '=='.
   getClauseFn : RawImp -> Core Name
   getClauseFn (IVar _ n) = pure n
   getClauseFn (IApp _ f _) = getClauseFn f
   getClauseFn (IAutoApp _ f _) = getClauseFn f
   getClauseFn (INamedApp _ f _ _) = getClauseFn f
-  getClauseFn tm = throw $ GenericMsg (getFC tm) "Leftmost term in pattern must be a function name"
+  getClauseFn tm = throw $ GenericMsg (getFC tm) "Head term in pattern must be a function name"
 
   desugarLHS : {auto s : Ref Syn SyntaxInfo} ->
                {auto c : Ref Ctxt Defs} ->

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -694,14 +694,14 @@ mutual
            pure $ MkImpTy fc nameFC n !(bindTypeNames fc (usingImpl syn)
                                                ps !(desugar AnyExpr ps ty))
 
+  -- Attempt to get function name from function pattern. For example, given the
+  -- pattern 'f x y', getClauseFn would return 'f'.
   getClauseFn : RawImp -> Core Name
   getClauseFn (IVar _ n) = pure n
   getClauseFn (IApp _ f _) = getClauseFn f
   getClauseFn (IAutoApp _ f _) = getClauseFn f
   getClauseFn (INamedApp _ f _ _) = getClauseFn f
-  getClauseFn tm = throw $ case tm of
-    Implicit fc _ => GenericMsg fc "Invalid name for a declaration"
-    _ => InternalError (show tm ++ " is not a function application")
+  getClauseFn tm = throw $ GenericMsg (getFC tm) "Leftmost term in pattern must be a function name"
 
   desugarLHS : {auto s : Ref Syn SyntaxInfo} ->
                {auto c : Ref Ctxt Defs} ->

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -67,7 +67,7 @@ idrisTestsError = MkTestPool "Error messages" [] Nothing
       ["error001", "error002", "error003", "error004", "error005",
        "error006", "error007", "error008", "error009", "error010",
        "error011", "error012", "error013", "error014", "error015",
-       "error016", "error017", "error018", "error019",
+       "error016", "error017", "error018", "error019", "error020",
        -- Parse errors
        "perror001", "perror002", "perror003", "perror004", "perror005",
        "perror006", "perror007", "perror008", "perror009"]

--- a/tests/idris2/error020/Error.idr
+++ b/tests/idris2/error020/Error.idr
@@ -1,0 +1,5 @@
+some : Bool -> Bool
+some True = True
+some False = True
+some False = True
+some False = False

--- a/tests/idris2/error020/Error.idr
+++ b/tests/idris2/error020/Error.idr
@@ -1,5 +1,1 @@
-some : Bool -> Bool
-some True = True
-some False = True
-some False = True
-some False = False
+(a, b) = (1, 2)

--- a/tests/idris2/error020/expected
+++ b/tests/idris2/error020/expected
@@ -1,0 +1,20 @@
+1/1: Building Error (Error.idr)
+Error: Unreachable clause: some False
+
+Error:4:1--4:11
+ 1 | some : Bool -> Bool
+ 2 | some True = True
+ 3 | some False = True
+ 4 | some False = True
+     ^^^^^^^^^^
+
+Error: Unreachable clause: some False
+
+Error:5:1--5:11
+ 1 | some : Bool -> Bool
+ 2 | some True = True
+ 3 | some False = True
+ 4 | some False = True
+ 5 | some False = False
+     ^^^^^^^^^^
+

--- a/tests/idris2/error020/expected
+++ b/tests/idris2/error020/expected
@@ -1,5 +1,5 @@
 1/1: Building Error (Error.idr)
-Error: Leftmost term in pattern must be a function name
+Error: Head term in pattern must be a function name
 
 Error:1:3--1:4
  1 | (a, b) = (1, 2)

--- a/tests/idris2/error020/expected
+++ b/tests/idris2/error020/expected
@@ -1,20 +1,7 @@
 1/1: Building Error (Error.idr)
-Error: Unreachable clause: some False
+Error: Leftmost term in pattern must be a function name
 
-Error:4:1--4:11
- 1 | some : Bool -> Bool
- 2 | some True = True
- 3 | some False = True
- 4 | some False = True
-     ^^^^^^^^^^
-
-Error: Unreachable clause: some False
-
-Error:5:1--5:11
- 1 | some : Bool -> Bool
- 2 | some True = True
- 3 | some False = True
- 4 | some False = True
- 5 | some False = False
-     ^^^^^^^^^^
+Error:1:3--1:4
+ 1 | (a, b) = (1, 2)
+       ^
 

--- a/tests/idris2/error020/run
+++ b/tests/idris2/error020/run
@@ -1,0 +1,4 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --no-banner -Werror --check Error.idr
+


### PR DESCRIPTION
Produces a proper error message when the leftmost term in a function clause's pattern is not a function name. Fixes #1441 