### PR TITLE
Add a `--list-packages` command to the `idris2` executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@
   cause some programs not to type check which previously did - in these cases,
   you will need to give the reduced expressions explicitly.
 
+### REPL/CLI/IDE mode changes
+
+* Added `--list-packages` CLI option.
+
 ### Library Changes
 
 #### Prelude

--- a/src/Idris/CommandLine.idr
+++ b/src/Idris/CommandLine.idr
@@ -42,11 +42,16 @@ Show PkgCommand where
 
 public export
 data DirCommand
-      = LibDir -- show top level package directory
+      = LibDir | -- show top level package directory
+         ||| Show the installation prefix
+        Prefix |
+        BlodwenPaths
 
 export
 Show DirCommand where
   show LibDir = "--libdir"
+  show Prefix = "--prefix"
+  show BlodwenPaths = "--paths"
 
 ||| Help topics
 public export
@@ -85,8 +90,6 @@ data CLOpt
   OutputDir String |
    ||| Generate profile data when compiling (backend dependent)
   Profile |
-   ||| Show the installation prefix
-  ShowPrefix |
    ||| Display Idris version
   Version |
    ||| Display help text
@@ -105,6 +108,8 @@ data CLOpt
   Logging LogLevel |
    ||| Add a package as a dependency
   PkgPath String |
+   ||| List installed packages
+  ListPackages |
    ||| Build or install a given package, depending on PkgCommand
   Package PkgCommand (Maybe String) |
    ||| Show locations of data/library directories
@@ -134,7 +139,6 @@ data CLOpt
   Timing |
   DebugElabCheck |
   AltErrorCount Nat |
-  BlodwenPaths |
    ||| Treat warnings as errors
   WarningsAsErrors |
    ||| Do not print shadowing warnings
@@ -250,12 +254,14 @@ options = [MkOpt ["--check", "-c"] [] [CheckOnly]
               (Just "Apply experimental optimizations to case tree generation"),
 
            optSeparator,
-           MkOpt ["--prefix"] [] [ShowPrefix]
+           MkOpt ["--prefix"] [] [Directory Prefix]
               (Just "Show installation prefix"),
-           MkOpt ["--paths"] [] [BlodwenPaths]
+           MkOpt ["--paths"] [] [Directory BlodwenPaths]
               (Just "Show paths"),
            MkOpt ["--libdir"] [] [Directory LibDir]
               (Just "Show library directory"),
+           MkOpt ["--list-packages"] [] [ListPackages]
+              (Just "List installed packages"),
 
            optSeparator,
            MkOpt ["--init"] [Optional "package file"]

--- a/src/Idris/Driver.idr
+++ b/src/Idris/Driver.idr
@@ -111,10 +111,6 @@ showInfo : {auto c : Ref Ctxt Defs}
         -> List CLOpt
         -> Core Bool
 showInfo Nil = pure False
-showInfo (BlodwenPaths :: _)
-    = do defs <- get Ctxt
-         iputStrLn $ pretty (toString (dirs (options defs)))
-         pure True
 showInfo (_::rest) = showInfo rest
 
 tryYaffle : List CLOpt -> Core Bool
@@ -267,9 +263,6 @@ quitOpts (Help (Just HelpLogging) :: _)
          pure False
 quitOpts (Help (Just HelpPragma) :: _)
     = do putStrLn pragmaTopics
-         pure False
-quitOpts (ShowPrefix :: _)
-    = do putStrLn yprefix
          pure False
 quitOpts (_ :: opts) = quitOpts opts
 

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -32,6 +32,8 @@ import System.Directory
 
 %default covering
 
+%hide Libraries.Data.String.Extra.unlines
+
 ||| Dissected information about a package directory
 record PkgDir where
   constructor MkPkgDir
@@ -259,14 +261,14 @@ opts x _ = pure $ if (x `elem` optionFlags)
 completionScript : (fun : String) -> String
 completionScript fun =
   let fun' = "_" ++ fun
-   in String.unlines [ fun' ++ "()"
-                     , "{"
-                     , "  ED=$([ -z $2 ] && echo \"--\" || echo $2)"
-                     , "  COMPREPLY=($(idris2 --bash-completion $ED $3))"
-                     , "}"
-                     , ""
-                     , "complete -F " ++ fun' ++ " -o default idris2"
-                     ]
+   in unlines [ fun' ++ "()"
+              , "{"
+              , "  ED=$([ -z $2 ] && echo \"--\" || echo $2)"
+              , "  COMPREPLY=($(idris2 --bash-completion $ED $3))"
+              , "}"
+              , ""
+              , "complete -F " ++ fun' ++ " -o default idris2"
+              ]
 
 --------------------------------------------------------------------------------
 --          Processing Options
@@ -425,7 +427,7 @@ preOptions (WholeProgram :: opts)
          preOptions opts
 preOptions (BashCompletion a b :: _)
     = do os <- opts a b
-         coreLift $ putStr $ String.unlines os
+         coreLift $ putStr $ unlines os
          pure False
 preOptions (BashCompletionScript fun :: _)
     = do coreLift $ putStrLn $ completionScript fun

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -12,6 +12,7 @@ import Libraries.Data.List.Extra
 
 import Idris.CommandLine
 import Idris.Package.Types
+import Idris.Pretty
 import Idris.ProcessIdr
 import Idris.REPL
 import Idris.Syntax
@@ -91,17 +92,27 @@ candidateDirs dname pkg bounds =
           do guard (pkgName == pkg && inBounds ver bounds)
              pure ((dname </> dirName), ver)
 
+globalPackageDir : {auto c : Ref Ctxt Defs} -> Core String
+globalPackageDir
+    = do defs <- get Ctxt
+         pure $ prefix_dir (dirs (options defs)) </>
+                  "idris2-" ++ showVersion False version
+
+localPackageDir : {auto c : Ref Ctxt Defs} -> Core String
+localPackageDir
+    = do defs <- get Ctxt
+         Just srcdir <- coreLift currentDir
+             | Nothing => throw (InternalError "Can't get current directory")
+         let depends = depends_dir (dirs (options defs))
+         pure $ srcdir </> depends
+
 export
 addPkgDir : {auto c : Ref Ctxt Defs} ->
             String -> PkgVersionBounds -> Core ()
 addPkgDir p bounds
     = do defs <- get Ctxt
-         let globaldir = prefix_dir (dirs (options defs)) </>
-                               "idris2-" ++ showVersion False version
-         let depends = depends_dir (dirs (options defs))
-         Just srcdir <- coreLift currentDir
-             | Nothing => throw (InternalError "Can't get current directory")
-         let localdir = srcdir </> depends
+         globaldir <- globalPackageDir
+         localdir <- localPackageDir
 
          -- Get candidate directories from the global install location,
          -- and the local package directory
@@ -127,10 +138,49 @@ addPkgDir p bounds
                        else throw (CantFindPackage (p ++ " (" ++ show bounds ++ ")"))
               ((p, _) :: ps) => addExtraDir p
 
-dirOption : Dirs -> DirCommand -> Core ()
+visiblePackages : String -> IO (List PkgDir)
+visiblePackages dir = filter viable <$> getPackageDirs dir
+  where notHidden : PkgDir -> Bool
+        notHidden = not . isPrefixOf "." . pkgName
+
+        notDenylisted : PkgDir -> Bool
+        notDenylisted = not . flip elem ["include", "lib", "support", "refc"] . pkgName
+
+        viable : PkgDir -> Bool
+        viable p = notHidden p && notDenylisted p
+
+findPackages : {auto c : Ref Ctxt Defs} -> Core (List PkgDir)
+findPackages 
+    = do -- global packages
+         defs <- get Ctxt
+         globalPkgs <- coreLift $ visiblePackages !globalPackageDir
+         -- additional packages in directories specified
+         let pkgDirs = (options defs).dirs.package_dirs
+         additionalPkgs <- coreLift $ traverse (\d => visiblePackages d) pkgDirs
+         -- local packages
+         localPkgs <- coreLift $ visiblePackages !localPackageDir
+         pure $ globalPkgs ++ (join additionalPkgs) ++ localPkgs
+
+listPackages : {auto c : Ref Ctxt Defs} ->
+               {auto o : Ref ROpts REPLOpts} ->
+               Core ()
+listPackages
+    = do pkgs <- sortBy (compare `on` pkgName) <$> findPackages
+         traverse_ (iputStrLn . pkgDesc) pkgs
+  where
+    pkgDesc : PkgDir -> Doc IdrisAnn
+    pkgDesc (MkPkgDir _ pkgName version) = pretty pkgName <++> parens (pretty version)
+
+dirOption : {auto c : Ref Ctxt Defs} ->
+            {auto o : Ref ROpts REPLOpts} ->
+            Dirs -> DirCommand -> Core ()
 dirOption dirs LibDir
     = coreLift $ putStrLn
          (prefix_dir dirs </> "idris2-" ++ showVersion False version)
+dirOption dirs BlodwenPaths
+    = iputStrLn $ pretty (toString dirs)
+dirOption dirs Prefix
+    = coreLift $ putStrLn yprefix
 
 --------------------------------------------------------------------------------
 --          Bash Autocompletions
@@ -142,28 +192,6 @@ findIpkg =
        | Nothing => throw (InternalError "Can't get current directory")
      fs <- coreLift $ dirEntries srcdir
      pure $ filter (".ipkg" `isSuffixOf`) fs
-
-packageNames : String -> IO (List String)
-packageNames dir = filter notHidden . map pkgName <$> getPackageDirs dir
-  where notHidden : String -> Bool
-        notHidden = not . isPrefixOf "."
-
-
-findPackages : {auto c : Ref Ctxt Defs} -> Core (List String)
-findPackages =
-  do defs <- get Ctxt
-     let globaldir = prefix_dir (dirs (options defs)) </>
-                           "idris2-" ++ showVersion False version
-     let depends = depends_dir (dirs (options defs))
-     Just srcdir <- coreLift currentDir
-         | Nothing => throw (InternalError "Can't get current directory")
-     let localdir = srcdir </> depends
-
-     -- Get candidate directories from the global install location,
-     -- and the local package directory
-     locFiles <- coreLift $ packageNames localdir
-     globFiles <- coreLift $ packageNames globaldir
-     pure $ locFiles ++ globFiles
 
 -- keep only those Strings, of which `x` is a prefix
 prefixOnly : String -> List String -> List String
@@ -199,8 +227,8 @@ opts x "--cg"      = prefixOnlyIfNonEmpty x <$> codegens
 opts x "--codegen" = prefixOnlyIfNonEmpty x <$> codegens
 
 -- packages
-opts x "-p"        = prefixOnlyIfNonEmpty x <$> findPackages
-opts x "--package" = prefixOnlyIfNonEmpty x <$> findPackages
+opts x "-p"        = prefixOnlyIfNonEmpty x . (map pkgName) <$> findPackages
+opts x "--package" = prefixOnlyIfNonEmpty x . (map pkgName) <$> findPackages
 
 -- logging
 opts x "--log"     = pure $ prefixOnlyIfNonEmpty x logLevels
@@ -231,14 +259,14 @@ opts x _ = pure $ if (x `elem` optionFlags)
 completionScript : (fun : String) -> String
 completionScript fun =
   let fun' = "_" ++ fun
-   in unlines [ fun' ++ "()"
-              , "{"
-              , "  ED=$([ -z $2 ] && echo \"--\" || echo $2)"
-              , "  COMPREPLY=($(idris2 --bash-completion $ED $3))"
-              , "}"
-              , ""
-              , "complete -F " ++ fun' ++ " -o default idris2"
-              ]
+   in String.unlines [ fun' ++ "()"
+                     , "{"
+                     , "  ED=$([ -z $2 ] && echo \"--\" || echo $2)"
+                     , "  COMPREPLY=($(idris2 --bash-completion $ED $3))"
+                     , "}"
+                     , ""
+                     , "complete -F " ++ fun' ++ " -o default idris2"
+                     ]
 
 --------------------------------------------------------------------------------
 --          Processing Options
@@ -332,6 +360,9 @@ preOptions (Directory d :: opts)
     = do defs <- get Ctxt
          dirOption (dirs (options defs)) d
          pure False
+preOptions (ListPackages :: opts)
+    = do listPackages
+         pure False
 preOptions (Timing :: opts)
     = do setLogTimings True
          preOptions opts
@@ -394,7 +425,7 @@ preOptions (WholeProgram :: opts)
          preOptions opts
 preOptions (BashCompletion a b :: _)
     = do os <- opts a b
-         coreLift $ putStr $ unlines os
+         coreLift $ putStr $ String.unlines os
          pure False
 preOptions (BashCompletionScript fun :: _)
     = do coreLift $ putStrLn $ completionScript fun

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -150,7 +150,7 @@ visiblePackages dir = filter viable <$> getPackageDirs dir
         viable p = notHidden p && notDenylisted p
 
 findPackages : {auto c : Ref Ctxt Defs} -> Core (List PkgDir)
-findPackages 
+findPackages
     = do -- global packages
          defs <- get Ctxt
          globalPkgs <- coreLift $ visiblePackages !globalPackageDir


### PR DESCRIPTION
When I was deciding where to add the `ListPackages` option I noticed there were a few options handled in disparate places all having to do with directories so I relocated them under the existing `DirCommand` type.