### PR TITLE
[ base ] Relax requirements of `Alternative` of `ReaderT` + lazy `<|>` for transformers + cleanup

### DIFF
--- a/libs/base/Control/Monad/Error/Either.idr
+++ b/libs/base/Control/Monad/Error/Either.idr
@@ -130,10 +130,10 @@ Monad m => Monad (EitherT e m) where
 public export
 (Monad m, Monoid e) => Alternative (EitherT e m) where
   empty = left neutral
-  MkEitherT x <|> MkEitherT y = MkEitherT $ do
+  MkEitherT x <|> my = MkEitherT $ do
     Left l <- x
       | Right r => pure (Right r)
-    Left l' <- y
+    Left l' <- runEitherT my
       | Right r => pure (Right r)
     pure (Left (l <+> l'))
 

--- a/libs/base/Control/Monad/Maybe.idr
+++ b/libs/base/Control/Monad/Maybe.idr
@@ -130,7 +130,9 @@ Monad m => Monad (MaybeT m) where
 public export
 Monad m => Alternative (MaybeT m) where
   empty = nothing
-  a <|> b = a <+> b
+  MkMaybeT x <|> my = MkMaybeT $ x >>= \case
+    r@(Just _) => pure r
+    Nothing    => runMaybeT my
 
 public export
 MonadTrans MaybeT where

--- a/libs/base/Control/Monad/RWS/CPS.idr
+++ b/libs/base/Control/Monad/RWS/CPS.idr
@@ -119,7 +119,7 @@ Monad m => Applicative (RWST r w s m) where
 public export %inline
 (Monad m, Alternative m) => Alternative (RWST r w s m) where
   empty = MkRWST $ \_,_,_ => empty
-  MkRWST m <|> MkRWST n = MkRWST $ \r,s,w => m r s w <|> n r s w
+  MkRWST m <|> mn = MkRWST $ \r,s,w => m r s w <|> unRWST mn r s w
 
 public export %inline
 Monad m => Monad (RWST r w s m) where

--- a/libs/base/Control/Monad/Reader/Reader.idr
+++ b/libs/base/Control/Monad/Reader/Reader.idr
@@ -42,35 +42,33 @@ runReader s = runIdentity . runReaderT s
 
 public export
 implementation Functor f => Functor (ReaderT stateType f) where
-  map f (MkReaderT g) = MkReaderT (\st => map f (g st))
+  map f (MkReaderT g) = MkReaderT $ \st => f <$> g st
 
 public export
 implementation Applicative f => Applicative (ReaderT stateType f) where
-  pure x = MkReaderT (\st => pure x)
+  pure x = MkReaderT $ \_ => pure x
 
-  (MkReaderT f) <*> (MkReaderT a) =
-    MkReaderT (\st =>
+  MkReaderT f <*> MkReaderT a =
+    MkReaderT $ \st =>
       let f' = f st in
       let a' = a st in
-      f' <*> a')
+      f' <*> a'
 
 public export
 implementation Monad m => Monad (ReaderT stateType m) where
-  (MkReaderT f) >>= k =
-    MkReaderT (\st => do v <- f st
-                         let MkReaderT kv = k v
-                         kv st)
+  MkReaderT f >>= k =
+    MkReaderT $ \st => f st >>= runReaderT st . k
 
 public export
 implementation MonadTrans (ReaderT stateType) where
-  lift x = MkReaderT (\_ => x)
+  lift x = MkReaderT $ \_ => x
 
 public export
 implementation HasIO m => HasIO (ReaderT stateType m) where
-  liftIO f = MkReaderT (\_ => liftIO f)
+  liftIO f = MkReaderT $ \_ => liftIO f
 
 public export
 implementation Alternative f => Alternative (ReaderT stateType f) where
   empty = MkReaderT $ const empty
 
-  (MkReaderT f) <|> (MkReaderT g) = MkReaderT (\st => f st <|> g st)
+  MkReaderT f <|> MkReaderT g = MkReaderT $ \st => f st <|> g st

--- a/libs/base/Control/Monad/Reader/Reader.idr
+++ b/libs/base/Control/Monad/Reader/Reader.idr
@@ -70,7 +70,7 @@ implementation HasIO m => HasIO (ReaderT stateType m) where
   liftIO f = MkReaderT (\_ => liftIO f)
 
 public export
-implementation (Monad f, Alternative f) => Alternative (ReaderT stateType f) where
-  empty = lift empty
+implementation Alternative f => Alternative (ReaderT stateType f) where
+  empty = MkReaderT $ const empty
 
   (MkReaderT f) <|> (MkReaderT g) = MkReaderT (\st => f st <|> g st)

--- a/libs/base/Control/Monad/Reader/Reader.idr
+++ b/libs/base/Control/Monad/Reader/Reader.idr
@@ -71,4 +71,4 @@ public export
 implementation Alternative f => Alternative (ReaderT stateType f) where
   empty = MkReaderT $ const empty
 
-  MkReaderT f <|> MkReaderT g = MkReaderT $ \st => f st <|> g st
+  MkReaderT f <|> mg = MkReaderT $ \st => f st <|> runReaderT' mg st

--- a/libs/base/Control/Monad/State/State.idr
+++ b/libs/base/Control/Monad/State/State.idr
@@ -95,7 +95,7 @@ implementation MonadTrans (StateT stateType) where
 public export
 implementation (Monad f, Alternative f) => Alternative (StateT st f) where
     empty = lift empty
-    ST f <|> ST g = ST $ \st => f st <|> g st
+    ST f <|> mg = ST $ \st => f st <|> runStateT' mg st
 
 public export
 implementation HasIO m => HasIO (StateT stateType m) where

--- a/libs/base/Control/Monad/Writer/CPS.idr
+++ b/libs/base/Control/Monad/Writer/CPS.idr
@@ -93,7 +93,7 @@ Monad m => Applicative (WriterT w m) where
 public export %inline
 (Monad m, Alternative m) => Alternative (WriterT w m) where
   empty = MkWriterT $ \_ => empty
-  MkWriterT m <|> MkWriterT n = MkWriterT $ \w => m w <|> n w
+  MkWriterT m <|> mn = MkWriterT $ \w => m w <|> unWriterT mn w
 
 public export %inline
 Monad m => Monad (WriterT w m) where


### PR DESCRIPTION
There are three more-or-less independent changes, but all about transformers. All of them are in different commits and all can be considered independently if needed:

- the current implementation of `Alternative` for `ReaderT` requires `Monad` but it may not;
- some (hopefully) readability cleanup;
- the current signature of `Alternative` has its second argument lazy; however, the current implementations of `Alternative` for transformers do not treat it nicely, they force its second argument despite the underlying alternative/monad may not require its second argument; the fix is proposed.