### PR TITLE
Implement Cast in place of ad hoc conversions

### DIFF
--- a/libs/base/Data/Colist.idr
+++ b/libs/base/Data/Colist.idr
@@ -19,14 +19,14 @@ data Colist : (a : Type) -> Type where
 
 ||| Convert a list to a `Colist`.
 public export
-fromList : List a -> Colist a
-fromList []        = Nil
-fromList (x :: xs) = x :: fromList xs
+Cast (List a) (Colist a) where
+  cast []        = Nil
+  cast (x :: xs) = x :: cast xs
 
 ||| Convert a stream to a `Colist`.
 public export
-fromStream : Stream a -> Colist a
-fromStream (x :: xs) = x :: fromStream xs
+Cast (Stream a) (Colist a) where
+  cast (x :: xs) = x :: cast xs
 
 ||| Create a `Colist` of only a single element.
 public export
@@ -99,12 +99,12 @@ append (x :: xs) ys = x :: append xs ys
 ||| Append a `Colist` to a `List`.
 public export
 lappend : List a -> Colist a -> Colist a
-lappend xs = append (fromList xs)
+lappend xs = append (cast xs)
 
 ||| Append a `List` to a `Colist`.
 public export
 appendl : Colist a -> List a -> Colist a
-appendl xs = append xs . fromList
+appendl xs = append xs . cast
 
 ||| Try to extract the head and tail of a `Colist`.
 public export

--- a/libs/base/Data/Colist1.idr
+++ b/libs/base/Data/Colist1.idr
@@ -19,26 +19,26 @@ data Colist1 : (a : Type) -> Type where
 
 ||| Convert a `List1` to a `Colist1`.
 public export
-fromList1 : List1 a -> Colist1 a
-fromList1 (h ::: t) = h ::: fromList t
+Cast (List1 a) (Colist1 a) where
+  cast (h ::: t) = h ::: cast t
 
 ||| Convert a stream to a `Colist1`.
 public export
-fromStream : Stream a -> Colist1 a
-fromStream (x :: xs) = x ::: fromStream xs
+Cast (Stream a) (Colist1 a) where
+  cast (x :: xs) = x ::: cast xs
 
 ||| Try to convert a `Colist` to a `Colist1`. Returns `Nothing` if
 ||| the given `Colist` is empty.
 public export
-fromColist : Colist a -> Maybe (Colist1 a)
-fromColist Nil       = Nothing
-fromColist (x :: xs) = Just (x ::: xs)
+Cast (Colist a) (Maybe (Colist1 a)) where
+  cast Nil       = Nothing
+  cast (x :: xs) = Just (x ::: xs)
 
 ||| Try to convert a list to a `Colist1`. Returns `Nothing` if
 ||| the given list is empty.
 public export
-fromList : List a -> Maybe (Colist1 a)
-fromList = fromColist . fromList
+Cast (List a) (Maybe (Colist1 a)) where
+  cast xs = cast $ the (Colist a) $ cast xs
 
 ||| Create a `Colist1` of only a single element.
 public export
@@ -232,18 +232,18 @@ namespace Colist
     zag hds tls
 
   zag (x ::: []) zs [] = x ::
-    let Just zs = List.toList1' $ mapMaybe fromColist (forget zs)
+    let Just zs = cast @{toList1'} $ mapMaybe cast (forget zs)
           | Nothing => []
     in zig zs []
   zag (x ::: []) zs (l :: ls) = x ::
-    let zs = mapMaybe fromColist (forget zs)
+    let zs = mapMaybe cast (forget zs)
     in zig (l ::: zs) ls
   zag (x ::: (y :: xs)) zs ls = x :: zag (y ::: xs) zs ls
 
   public export
   cantor : List (Colist a) -> Colist a
   cantor xs =
-    let Just (l ::: ls) = List.toList1' $ mapMaybe fromColist xs
+    let Just (l ::: ls) = cast @{toList1'} $ mapMaybe cast xs
           | Nothing => []
     in zig (l ::: []) ls
 
@@ -256,11 +256,11 @@ zag : List1 a -> List1 (Colist a) -> Colist (Colist1 a) -> Colist1 a
 zig xs = zag (head <$> xs) (tail <$> xs)
 
 zag (x ::: []) zs [] = x :::
-  let Just zs = List.toList1' (mapMaybe fromColist (forget zs))
+  let Just zs = cast @{toList1'} (mapMaybe cast (forget zs))
         | Nothing => []
   in Colist.zig zs []
 zag (x ::: []) zs (l :: ls) =  x :::
-  let zs = mapMaybe fromColist (forget zs)
+  let zs = mapMaybe cast (forget zs)
   in forgetInf (zig (l ::: zs) ls)
 zag (x ::: (y :: xs)) zs ls = x ::: forgetInf (zag (y ::: xs) zs ls)
 

--- a/libs/base/Data/Either.idr
+++ b/libs/base/Data/Either.idr
@@ -81,15 +81,19 @@ partitionEithers l = (lefts l, rights l)
 
 ||| Remove a "useless" Either by collapsing the case distinction
 public export
-fromEither : Either a a -> a
-fromEither (Left l)  = l
-fromEither (Right r) = r
+Cast (Either a a) a where
+  cast (Left  l) = l
+  cast (Right r) = r
 
 ||| Right becomes left and left becomes right
 public export
+Cast (Either a b) (Either b a) where
+  cast (Left  x) = Right x
+  cast (Right x) = Left x
+
+public export
 mirror : Either a b -> Either b a
-mirror (Left  x) = Right x
-mirror (Right x) = Left x
+mirror = cast
 
 --------------------------------------------------------------------------------
 -- Bifunctor
@@ -112,9 +116,9 @@ maybeToEither def Nothing  = Left  def
 
 ||| Convert an Either to a Maybe from Right injection
 public export
-eitherToMaybe : Either e a -> Maybe a
-eitherToMaybe (Left _) = Nothing
-eitherToMaybe (Right x) = Just x
+Cast (Either _ a) (Maybe a) where
+  cast (Left  _) = Nothing
+  cast (Right x) = Just x
 
 -- Injectivity of constructors
 

--- a/libs/base/Data/Fin.idr
+++ b/libs/base/Data/Fin.idr
@@ -91,9 +91,13 @@ Cast (Fin n) Integer where
 
 ||| Weaken the bound on a Fin by 1
 public export
+Cast (Fin n) (Fin (S n)) where
+  cast FZ     = FZ
+  cast (FS k) = FS $ cast k
+
+public export
 weaken : Fin n -> Fin (S n)
-weaken FZ     = FZ
-weaken (FS k) = FS $ weaken k
+weaken = cast
 
 ||| Weaken the bound on a Fin by some amount
 public export

--- a/libs/base/Data/IOArray.idr
+++ b/libs/base/Data/IOArray.idr
@@ -57,26 +57,26 @@ newArrayCopy newsize arr
                      copyFrom old new $ assert_smaller pos (pos - 1)
 
 export
-toList : HasIO io => IOArray elem -> io (List (Maybe elem))
-toList arr = iter 0 (max arr) []
-  where
-    iter : Int -> Int -> List (Maybe elem) -> io (List (Maybe elem))
-    iter pos end acc
-         = if pos >= end
-              then pure (reverse acc)
-              else do el <- readArray arr pos
-                      assert_total (iter (pos + 1) end (el :: acc))
+HasIO io => Cast (IOArray elem) (io (List (Maybe elem))) where
+  cast arr = iter 0 (max arr) []
+    where
+      iter : Int -> Int -> List (Maybe elem) -> io (List (Maybe elem))
+      iter pos end acc
+           = if pos >= end
+                then pure (reverse acc)
+                else do el <- readArray arr pos
+                        assert_total (iter (pos + 1) end (el :: acc))
 
 export
-fromList : HasIO io => List (Maybe elem) -> io (IOArray elem)
-fromList ns
-    = do arr <- newArray (cast (length ns))
-         addToArray 0 ns arr
-         pure arr
-  where
-    addToArray : Int -> List (Maybe elem) -> IOArray elem -> io ()
-    addToArray loc [] arr = pure ()
-    addToArray loc (Nothing :: ns) arr = addToArray (loc + 1) ns arr
-    addToArray loc (Just el :: ns) arr
-        = do primIO $ prim__arraySet (content arr) loc (Just el)
-             addToArray (loc + 1) ns arr
+HasIO io => Cast (List (Maybe elem)) (io (IOArray elem)) where
+  cast ns
+      = do arr <- newArray (cast (length ns))
+           addToArray 0 ns arr
+           pure arr
+    where
+      addToArray : Int -> List (Maybe elem) -> IOArray elem -> io ()
+      addToArray loc [] arr = pure ()
+      addToArray loc (Nothing :: ns) arr = addToArray (loc + 1) ns arr
+      addToArray loc (Just el :: ns) arr
+          = do primIO $ prim__arraySet (content arr) loc (Just el)
+               addToArray (loc + 1) ns arr

--- a/libs/base/Data/List.idr
+++ b/libs/base/Data/List.idr
@@ -486,9 +486,9 @@ toList1 (x :: xs) = x ::: xs
 
 ||| Convert to a non-empty list, returning Nothing if the list is empty.
 export
-toList1' : (l : List a) -> Maybe (List1 a)
-toList1' [] = Nothing
-toList1' (x :: xs) = Just (x ::: xs)
+[toList1'] Cast (List a) (Maybe (List1 a)) where
+  cast [] = Nothing
+  cast (x :: xs) = Just (x ::: xs)
 
 ||| Prefix every element in the list with the given element
 |||

--- a/libs/base/Data/List1.idr
+++ b/libs/base/Data/List1.idr
@@ -19,9 +19,9 @@ record List1 a where
 -- Basic functions
 
 public export
-fromList : List a -> Maybe (List1 a)
-fromList [] = Nothing
-fromList (x :: xs) = Just (x ::: xs)
+Cast (List a) (Maybe (List1 a)) where
+  cast [] = Nothing
+  cast (x :: xs) = Just (x ::: xs)
 
 public export
 singleton : (x : a) -> List1 a

--- a/libs/base/Data/Maybe.idr
+++ b/libs/base/Data/Maybe.idr
@@ -54,14 +54,14 @@ justInjective Refl = Refl
 ||| Convert a `Maybe a` value to an `a` value, using `neutral` in the case
 ||| that the `Maybe` value is `Nothing`.
 public export
-lowerMaybe : Monoid a => Maybe a -> a
-lowerMaybe Nothing = neutral
-lowerMaybe (Just x) = x
+Monoid a => Cast (Maybe a) a where
+  cast Nothing  = neutral
+  cast (Just x) = x
 
 ||| Returns `Nothing` when applied to `neutral`, and `Just` the value otherwise.
 export
-raiseToMaybe : (Monoid a, Eq a) => a -> Maybe a
-raiseToMaybe x = if x == neutral then Nothing else Just x
+(Monoid a, Eq a) => Cast a (Maybe a) where
+  cast x = if x == neutral then Nothing else Just x
 
 public export
 filter : (a -> Bool) -> Maybe a -> Maybe a

--- a/libs/base/Data/Nat.idr
+++ b/libs/base/Data/Nat.idr
@@ -157,13 +157,17 @@ succNotLTEzero : Not (LTE (S m) Z)
 succNotLTEzero LTEZero impossible
 
 export
+Cast (LTE (S m) (S n)) (LTE m n) where
+  cast (LTESucc x) = x
+
+export
 fromLteSucc : LTE (S m) (S n) -> LTE m n
-fromLteSucc (LTESucc x) = x
+fromLteSucc = cast
 
 export
 succNotLTEpred : {x : Nat} -> Not $ LTE (S x) x
 succNotLTEpred {x =   0} prf = succNotLTEzero prf
-succNotLTEpred {x = S _} prf = succNotLTEpred $ fromLteSucc prf
+succNotLTEpred {x = S k} prf = succNotLTEpred $ the (LTE (S k) k) $ cast prf
 
 public export
 isLTE : (m, n : Nat) -> Dec (LTE m n)
@@ -171,7 +175,7 @@ isLTE Z n = Yes LTEZero
 isLTE (S k) Z = No succNotLTEzero
 isLTE (S k) (S j)
     = case isLTE k j of
-           No contra => No (contra . fromLteSucc)
+           No contra => No (contra . cast)
            Yes prf => Yes (LTESucc prf)
 
 public export
@@ -213,7 +217,7 @@ LTEImpliesNotGT (LTESucc p) (LTESucc q) = LTEImpliesNotGT p q
 
 export
 notLTImpliesGTE : {a, b : _} -> Not (LT a b) -> GTE a b
-notLTImpliesGTE notLT = fromLteSucc $ notLTEImpliesGT notLT
+notLTImpliesGTE notLT = cast $ notLTEImpliesGT notLT
 
 export
 LTImpliesNotGTE : a `LT` b -> Not (a `GTE` b)
@@ -632,7 +636,7 @@ plusMinusLte  Z     m    _   = rewrite minusZeroRight m in
                                plusZeroRightNeutral m
 plusMinusLte (S _)  Z    lte = absurd lte
 plusMinusLte (S n) (S m) lte = rewrite sym $ plusSuccRightSucc (minus m n) n in
-                               cong S $ plusMinusLte n m (fromLteSucc lte)
+                               cong S $ plusMinusLte n m (cast lte)
 
 export
 minusMinusMinusPlus : (left, centre, right : Nat) ->

--- a/libs/base/Data/These.idr
+++ b/libs/base/Data/These.idr
@@ -6,20 +6,20 @@ public export
 data These a b = This a | That b | Both a b
 
 public export
-fromEither : Either a b -> These a b
-fromEither = either This That
+Cast (Either a b) (These a b) where
+  cast = either This That
 
 public export
-fromThis : These a b -> Maybe a
-fromThis (This a) = Just a
-fromThis (That _) = Nothing
-fromThis (Both a _) = Just a
+Cast (These a b) (Maybe a) where
+  cast (This a) = Just a
+  cast (That _) = Nothing
+  cast (Both a _) = Just a
 
 public export
-fromThat : These a b -> Maybe b
-fromThat (This _) = Nothing
-fromThat (That b) = Just b
-fromThat (Both _ b) = Just b
+Cast (These a b) (Maybe b) where
+  cast (This _) = Nothing
+  cast (That b) = Just b
+  cast (Both _ b) = Just b
 
 public export
 these : (a -> c) -> (b -> c) -> (a -> b -> c) -> These a b -> c

--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -732,9 +732,9 @@ isSuffixOf = isSuffixOfBy (==)
 ||| maybeToVect (Just 2)
 ||| ```
 public export
-maybeToVect : Maybe elem -> (p ** Vect p elem)
-maybeToVect Nothing  = (_ ** [])
-maybeToVect (Just j) = (_ ** [j])
+Cast (Maybe elem) (p ** Vect p elem) where
+  cast Nothing  = (_ ** [])
+  cast (Just j) = (_ ** [j])
 
 ||| Convert first element of Vect (if exists) into Maybe.
 |||
@@ -742,9 +742,9 @@ maybeToVect (Just j) = (_ ** [j])
 ||| vectToMaybe [2]
 ||| ```
 public export
-vectToMaybe : Vect len elem -> Maybe elem
-vectToMaybe []      = Nothing
-vectToMaybe (x::xs) = Just x
+Cast (Vect len elem) (Maybe elem) where
+  cast []     = Nothing
+  cast (x::_) = Just x
 
 --------------------------------------------------------------------------------
 -- Misc

--- a/libs/contrib/Control/Arrow.idr
+++ b/libs/contrib/Control/Arrow.idr
@@ -74,16 +74,11 @@ interface Arrow arr => ArrowChoice (0 arr : Type -> Type -> Type) where
   right : arr a b -> arr (Either c a) (Either c b)
   right f = arrow mirror >>> left f >>> arrow mirror
 
-
   (+++) : arr a b -> arr c d -> arr (Either a c) (Either b d)
   f +++ g = left f >>> right g
 
   (\|/) : arr a b -> arr c b -> arr (Either a c) b
-  f \|/ g = f +++ g >>> arrow fromEither
-    where
-    fromEither : Either b b -> b
-    fromEither (Left b) = b
-    fromEither (Right b) = b
+  f \|/ g = f +++ g >>> arrow cast
 
 public export
 implementation Monad m => ArrowChoice (Kleislimorphism m) where

--- a/libs/contrib/Data/Binary.idr
+++ b/libs/contrib/Data/Binary.idr
@@ -17,8 +17,8 @@ Bin = List Digit
 
 ||| Conversion from lists of bits to natural number.
 public export
-toNat : Bin -> Nat
-toNat = foldr (\ b, acc => toNat b + 2 * acc) 0
+Cast Bin Nat where
+  cast = foldr (\ b, acc => cast b + 2 * acc) 0
 
 ||| Successor function on binary numbers.
 ||| Amortised constant time.
@@ -30,13 +30,13 @@ suc (I :: bs) = O :: (suc bs)
 
 ||| Correctness proof of `suc` with respect to the semantics in terms of Nat
 export
-sucCorrect : {bs : Bin} -> toNat (suc bs) === S (toNat bs)
+sucCorrect : {bs : Bin} -> cast (suc bs) === S (cast bs)
 sucCorrect {bs = []} = Refl
 sucCorrect {bs = O :: bs} = Refl
 sucCorrect {bs = I :: bs} = Calc $
-  |~ toNat (suc (I :: bs))
-  ~~ toNat (O :: suc bs) ...( Refl )
-  ~~ 2 * toNat (suc bs)  ...( Refl )
-  ~~ 2 * S (toNat bs)    ...( cong (2 *) sucCorrect )
-  ~~ 2 + 2 * toNat bs    ...( unfoldDoubleS )
-  ~~ S (toNat (I :: bs)) ...( Refl )
+  |~ cast (suc (I :: bs))
+  ~~ cast (O :: suc bs) ...( Refl )
+  ~~ 2 * cast (suc bs)  ...( Refl )
+  ~~ 2 * S (cast bs)    ...( cong (2 *) sucCorrect )
+  ~~ 2 + 2 * cast bs    ...( unfoldDoubleS )
+  ~~ S (cast (I :: bs)) ...( Refl )

--- a/libs/contrib/Data/Binary/Digit.idr
+++ b/libs/contrib/Data/Binary/Digit.idr
@@ -16,6 +16,6 @@ isI I = True
 isI O = False
 
 public export
-toNat : Digit -> Nat
-toNat O = 0
-toNat I = 1
+Cast Digit Nat where
+  cast O = 0
+  cast I = 1

--- a/libs/contrib/Data/Fin/Extra.idr
+++ b/libs/contrib/Data/Fin/Extra.idr
@@ -49,7 +49,7 @@ finToNatShift (S k) a = cong S (finToNatShift k a)
 export
 invFin : {n : Nat} -> Fin n -> Fin n
 invFin FZ = last
-invFin (FS k) = weaken (invFin k)
+invFin (FS k) = cast $ invFin k
 
 ||| The inverse of a weakened element is the successor of its inverse
 export

--- a/libs/contrib/Data/IMaybe.idr
+++ b/libs/contrib/Data/IMaybe.idr
@@ -9,8 +9,8 @@ data IMaybe : Bool -> Type -> Type where
   Nothing : IMaybe False a
 
 public export
-fromJust : IMaybe True a -> a
-fromJust (Just a) = a
+Cast (IMaybe True a) a where
+  cast (Just a) = a
 
 public export
 Functor (IMaybe b) where

--- a/libs/contrib/Data/List/Lazy.idr
+++ b/libs/contrib/Data/List/Lazy.idr
@@ -156,9 +156,9 @@ Zippable LazyList where
 --- Lists creation ---
 
 public export
-fromList : List a -> LazyList a
-fromList []      = []
-fromList (x::xs) = x :: fromList xs
+Cast (List a) (LazyList a) where
+  cast []      = []
+  cast (x::xs) = x :: cast xs
 
 covering
 public export
@@ -271,6 +271,6 @@ intercalate sep xss = choice $ intersperse sep xss
 --- Functions converting lazy lists to something ---
 
 public export
-toColist : LazyList a -> Colist a
-toColist [] = []
-toColist (x::xs) = x :: toColist xs
+Cast (LazyList a) (Colist a) where
+  cast [] = []
+  cast (x::xs) = x :: cast xs

--- a/libs/contrib/Data/SortedMap.idr
+++ b/libs/contrib/Data/SortedMap.idr
@@ -238,8 +238,8 @@ delete k (M (S n) t) =
     Right t' => (M _ t')
 
 export
-fromList : Ord k => List (k, v) -> SortedMap k v
-fromList l = foldl (flip (uncurry insert)) empty l
+Ord k => Cast (List (k, v)) (SortedMap k v) where
+  cast l = foldl (flip (uncurry insert)) empty l
 
 export
 toList : SortedMap k v -> List (k, v)

--- a/libs/contrib/Data/SortedSet.idr
+++ b/libs/contrib/Data/SortedSet.idr
@@ -25,8 +25,8 @@ contains : k -> SortedSet k -> Bool
 contains k (SetWrapper m) = isJust (Data.SortedMap.lookup k m)
 
 export
-fromList : Ord k => List k -> SortedSet k
-fromList l = SetWrapper (Data.SortedMap.fromList (map (\i => (i, ())) l))
+Ord k => Cast (List k) (SortedSet k) where
+  cast l = SetWrapper (cast (map (\i => (i, ())) l))
 
 export
 toList : SortedSet k -> List k

--- a/libs/contrib/Data/String/Parser/Expression.idr
+++ b/libs/contrib/Data/String/Parser/Expression.idr
@@ -35,13 +35,13 @@ public export
 ReturnType : Type -> Type
 ReturnType a = (BinaryOperator a, BinaryOperator a, BinaryOperator a, UnaryOperator a, UnaryOperator a)
 
-toParserBin : BinaryOperator a -> Parser (a -> a -> a)
-toParserBin [] = fail "couldn't create binary parser"
-toParserBin (x :: xs) = x <|> toParserBin xs
+Cast (BinaryOperator a) (Parser (a -> a -> a)) where
+  cast [] = fail "couldn't create binary parser"
+  cast (x :: xs) = x <|> cast xs
 
-toParserUn : UnaryOperator a -> Parser (a -> a)
-toParserUn [] = fail "couldn't create unary parser"
-toParserUn (x :: xs) = x <|> toParserUn xs
+Cast (UnaryOperator a) (Parser (a -> a)) where
+  cast [] = fail "couldn't create unary parser"
+  cast (x :: xs) = x <|> cast xs
 
 ambiguous : (assoc : String) -> (op : Parser (a -> a -> a)) -> Parser a
 ambiguous assoc op = do ignore op
@@ -96,11 +96,11 @@ buildExpressionParser a operators simpleExpr =
     makeParser a term ops =
       let (rassoc,lassoc,nassoc
                ,prefixx,postfix) = foldr (splitOp a) ([],[],[],[],[]) ops
-          rassocOp = toParserBin rassoc
-          lassocOp = toParserBin lassoc
-          nassocOp = toParserBin nassoc
-          prefixxOp = toParserUn prefixx
-          postfixOp = toParserUn postfix
+          rassocOp = cast rassoc
+          lassocOp = cast lassoc
+          nassocOp = cast nassoc
+          prefixxOp = cast prefixx
+          postfixOp = cast postfix
 
           amRight = ambiguous "right" rassocOp
           amLeft = ambiguous "left" lassocOp

--- a/libs/contrib/Data/Telescope/Segment.idr
+++ b/libs/contrib/Data/Telescope/Segment.idr
@@ -42,8 +42,8 @@ tabulate (S n) tel = (sigma :: tabulate n (uncurry delta)) where
 ||| Any telescope is a segment in the empty telescope. It amounts to looking
 ||| at it left-to-right instead of right-to-left.
 public export
-fromTelescope : {k : Nat} -> Left.Telescope k -> Segment k []
-fromTelescope gamma = tabulate _ (const gamma)
+{k : Nat} -> Cast (Left.Telescope k) (Segment k []) where
+  cast gamma = tabulate _ (const gamma)
 
 ||| Conversely, a segment of size `n` in telescope `gamma` can be seen as a function
 ||| from environments for `gamma` to telescopes of size `n`.
@@ -52,10 +52,10 @@ untabulate : {n : Nat} -> Segment n gamma -> (Left.Environment gamma -> Left.Tel
 untabulate []            _   = []
 untabulate (ty :: delta) env = cons (ty env) (untabulate delta . (\ v => (env ** v)))
 
-||| Any segment in the empty telescope correspond to a telescope.
+||| Any segment in the empty telescope corresponds to a telescope.
 public export
-toTelescope : {k : Nat} -> Segment k [] -> Left.Telescope k
-toTelescope seg = untabulate seg ()
+{k : Nat} -> Cast (Segment k []) (Left.Telescope k) where
+  cast seg = untabulate seg ()
 
 %name Segment delta,delta',delta1,delta2
 

--- a/libs/contrib/Data/Validated.idr
+++ b/libs/contrib/Data/Validated.idr
@@ -152,31 +152,31 @@ oneInvalid = Invalid . pure
 --- Conversions to and from `Either` ---
 
 public export %inline
-fromEither : Either e a -> Validated e a
-fromEither $ Right x = Valid x
-fromEither $ Left  e = Invalid e
+Cast (Either e a) (Validated e a) where
+  cast $ Right x = Valid x
+  cast $ Left  e = Invalid e
 
 public export %inline
-fromEitherL : Either e a -> ValidatedL e a
-fromEitherL $ Right x = Valid x
-fromEitherL $ Left  e = oneInvalid e
+Cast (Either e a) (ValidatedL e a) where
+  cast $ Right x = Valid x
+  cast $ Left  e = oneInvalid e
 
 public export %inline
-toEither : Validated e a -> Either e a
-toEither $ Valid   x = Right x
-toEither $ Invalid e = Left e
+Cast (Validated e a) (Either e a) where
+  cast $ Valid   x = Right x
+  cast $ Invalid e = Left e
 
 --- Conversions to and from `Maybe` ---
 
 public export %inline
-fromMaybe : Monoid e => Maybe a -> Validated e a
-fromMaybe $ Just x  = Valid x
-fromMaybe $ Nothing = empty
+Monoid e => Cast (Maybe a) (Validated e a) where
+  cast $ Just x  = Valid x
+  cast $ Nothing = empty
 
 public export %inline
-toMaybe : Validated e a -> Maybe a
-toMaybe $ Valid x   = Just x
-toMaybe $ Invalid _ = Nothing
+Cast (Validated e a) (Maybe a) where
+  cast $ Valid x   = Just x
+  cast $ Invalid _ = Nothing
 
 --- Property of being valid ---
 

--- a/libs/contrib/Data/Vect/Binary.idr
+++ b/libs/contrib/Data/Vect/Binary.idr
@@ -32,12 +32,12 @@ zero {bs} = case bs of
 
 public export
 lookup : BVect n bs a -> Path n bs -> a
-lookup (hd :: _) (Here p) = lookup (fromJust hd) p
+lookup (hd :: _) (Here p) = lookup (cast hd) p
 lookup (_ :: tl) (There p) = lookup tl p
 
 public export
 cons : {bs : _} -> Tree n a -> BVect n bs a -> BVect n (suc bs) a
 cons t [] = [Just t]
 cons {bs = b :: _} t (u :: us) = case b of
-  I => Nothing :: cons (Node t (fromJust u)) us
+  I => Nothing :: cons (Node t (cast u)) us
   O => Just t :: us

--- a/libs/contrib/Language/JSON/Lexer.idr
+++ b/libs/contrib/Language/JSON/Lexer.idr
@@ -19,7 +19,7 @@ numberLit
 
 private
 jsonTokenMap : TokenMap JSONToken
-jsonTokenMap = toTokenMap $
+jsonTokenMap = cast $
   [ (spaces, JTIgnore)
   , (is ',', JTPunct Comma)
   , (is ':', JTPunct Colon)

--- a/libs/contrib/Language/JSON/String/Lexer.idr
+++ b/libs/contrib/Language/JSON/String/Lexer.idr
@@ -28,7 +28,7 @@ legalChar = non (quo <|> is '\\' <|> control)
 
 private
 jsonStringTokenMap : TokenMap JSONStringToken
-jsonStringTokenMap = toTokenMap $
+jsonStringTokenMap = cast $
   [ (quo, JSTQuote)
   , (unicodeEscape, JSTUnicodeEscape)
   , (simpleEscape, JSTSimpleEscape)

--- a/libs/contrib/Search/Generator.idr
+++ b/libs/contrib/Search/Generator.idr
@@ -14,6 +14,7 @@ import Data.Colist
 import Data.Colist1
 import Data.Fin
 import Data.List
+import Data.List1
 import Data.Stream
 import Data.Vect
 
@@ -34,7 +35,7 @@ interface Generator a where
 ||| ALL of the natural numbers
 public export
 Generator Nat where
-  generate = fromStream nats
+  generate = cast nats
 
 ||| ALL of the booleans
 public export
@@ -44,7 +45,7 @@ Generator Bool where
 ||| ALL of the Fins
 public export
 {n : Nat} -> Generator (Fin (S n)) where
-  generate = fromList1 (allFins n)
+  generate = cast $ allFins n
 
 -- Polymorphic generators
 

--- a/libs/contrib/Search/HDecidable.idr
+++ b/libs/contrib/Search/HDecidable.idr
@@ -34,18 +34,18 @@ no : HDec a
 no = MkHDec False absurd
 
 public export
-fromDec : Dec a -> HDec a
-fromDec (Yes p) = yes p
-fromDec (No _) = no
+Cast (Dec a) (HDec a) where
+  cast (Yes p) = yes p
+  cast (No _) = no
 
 public export
-fromMaybe : Maybe a -> HDec a
-fromMaybe = maybe no yes
+Cast (Maybe a) (HDec a) where
+  cast = maybe no yes
 
 public export
-toMaybe : HDec a -> Maybe a
-toMaybe (MkHDec True p) = Just (p Oh)
-toMaybe (MkHDec False _) = Nothing
+Cast (HDec a) (Maybe a) where
+  cast (MkHDec True p) = Just (p Oh)
+  cast (MkHDec False _) = Nothing
 
 ||| A type constructor satisfying AnHdec is morally an HDec i.e. we can
 ||| turn values of this type constructor into half deciders
@@ -55,9 +55,9 @@ public export
 interface AnHDec (0 t : Type -> Type) where
   toHDec : t a -> HDec a
 
-public export AnHDec Dec where toHDec = fromDec
+public export AnHDec Dec where toHDec = cast
 public export AnHDec HDec where toHDec = id
-public export AnHDec Maybe where toHDec = fromMaybe
+public export AnHDec Maybe where toHDec = cast
 
 ------------------------------------------------------------------------
 -- Implementations

--- a/libs/contrib/System/Directory/Tree.idr
+++ b/libs/contrib/System/Directory/Tree.idr
@@ -34,13 +34,13 @@ namespace FileName
 ||| Convert a filename anchored in `root` to a filepath by appending the name
 ||| to the root path.
 export
-toFilePath : {root : Path} -> FileName root -> Path
-toFilePath file = root /> fileName file
+{root : Path} -> Cast (FileName root) Path where
+  cast file = root /> fileName file
 
 export
 directoryExists : {root : Path} -> FileName root -> IO Bool
 directoryExists fp = do
-  Right dir <- openDir (show $ toFilePath fp)
+  Right dir <- openDir $ show $ the Path $ cast fp
     | Left _ => pure False
   closeDir dir
   pure True
@@ -157,7 +157,7 @@ findFile needle t = depthFirst check t (pure Nothing) where
   check : {root : Path} -> FileName root ->
           Lazy (IO (Maybe Path)) -> IO (Maybe Path)
   check fn next = if fileName fn == needle
-                    then pure (Just (toFilePath fn))
+                    then pure $ Just $ cast fn
                     else next
 
 ||| Display a tree by printing it procedurally. Note that because directory

--- a/libs/contrib/System/Path.idr
+++ b/libs/contrib/System/Path.idr
@@ -145,7 +145,7 @@ TokenKind PathTokenKind where
   tokValue (PTPunct _) _ = ()
 
 pathTokenMap : TokenMap PathToken
-pathTokenMap = toTokenMap $
+pathTokenMap = cast $
   [ (is '/', PTPunct '/')
   , (is '\\', PTPunct '\\')
   , (is ':', PTPunct ':')

--- a/libs/contrib/Text/Lexer.idr
+++ b/libs/contrib/Text/Lexer.idr
@@ -11,8 +11,8 @@ import public Text.Token
 %default total
 
 export
-toTokenMap : List (Lexer, k) -> TokenMap (Token k)
-toTokenMap = map $ \(l, kind) => (l, Tok kind)
+Cast (List (Lexer, k)) (TokenMap (Token k)) where
+  cast = map $ \(l, kind) => (l, Tok kind)
 
 ||| Recognise any character.
 ||| /./

--- a/libs/test/Test/Golden.idr
+++ b/libs/test/Test/Golden.idr
@@ -363,9 +363,9 @@ data Codegen
     Just Requirement
 
 export
-toList : Codegen -> List Requirement
-toList (Just r) = [r]
-toList _ = []
+Cast Codegen (List Requirement) where
+  cast (Just r) = [r]
+  cast _ = []
 
 ||| A test pool is characterised by
 |||  + a name
@@ -452,7 +452,7 @@ poolRunner opts pool
        let (_ :: _) = tests
              | [] => pure initSummary
        -- if so make sure the constraints are satisfied
-       cs <- for (toList (codegen pool) ++ constraints pool) $ \ req => do
+       cs <- for (cast (codegen pool) ++ constraints pool) $ \ req => do
           mfp <- checkRequirement req
           let msg = case mfp of
                       Nothing => "✗ " ++ show req ++ " not found"


### PR DESCRIPTION
This PR doesn't introduce any new interfaces. It just implements an existing interface in places where I feel it ought to be used. The net result is a significant reduction in horrible names like `fromList`.

As usual there are still a few places where inference struggles, requiring explicit type annotations and other hacks.