### PR TITLE
[ elab ] Add an ability to fail elaboration script with a custom `FC`

### DIFF
--- a/libs/base/Language/Reflection.idr
+++ b/libs/base/Language/Reflection.idr
@@ -12,7 +12,7 @@ export
 data Elab : Type -> Type where
      Pure : a -> Elab a
      Bind : Elab a -> (a -> Elab b) -> Elab b
-     Fail : String -> Elab a
+     Fail : FC -> String -> Elab a
 
      LogMsg : String -> Nat -> String -> Elab ()
      LogTerm : String -> Nat -> String -> TTImp -> Elab ()
@@ -63,7 +63,11 @@ Monad Elab where
 ||| Report an error in elaboration
 export
 fail : String -> Elab a
-fail = Fail
+fail = Fail EmptyFC
+
+export
+failAt : FC -> String -> Elab a
+failAt = Fail
 
 ||| Write a log message, if the log level is >= the given level
 export

--- a/libs/base/Language/Reflection/TTImp.idr
+++ b/libs/base/Language/Reflection/TTImp.idr
@@ -167,3 +167,36 @@ mutual
        IRunElabDecl : FC -> TTImp -> Decl
        ILog : Maybe (List String, Nat) -> Decl
        IBuiltin : FC -> BuiltinType -> Name -> Decl
+
+public export
+getFC : TTImp -> FC
+getFC (IVar fc y)                = fc
+getFC (IPi fc _ _ _ _ _)         = fc
+getFC (ILam fc _ _ _ _ _)        = fc
+getFC (ILet fc _ _ _ _ _ _)      = fc
+getFC (ICase fc _ _ _)           = fc
+getFC (ILocal fc _ _)            = fc
+getFC (IUpdate fc _ _)           = fc
+getFC (IApp fc _ _)              = fc
+getFC (INamedApp fc _ _ _)       = fc
+getFC (IAutoApp fc _ _)          = fc
+getFC (IWithApp fc _ _)          = fc
+getFC (ISearch fc _)             = fc
+getFC (IAlternative fc _ _)      = fc
+getFC (IRewrite fc _ _)          = fc
+getFC (IBindHere fc _ _)         = fc
+getFC (IBindVar fc _)            = fc
+getFC (IAs fc _ _ _ _)           = fc
+getFC (IMustUnify fc _ _)        = fc
+getFC (IDelayed fc _ _)          = fc
+getFC (IDelay fc _)              = fc
+getFC (IForce fc _)              = fc
+getFC (IQuote fc _)              = fc
+getFC (IQuoteName fc _)          = fc
+getFC (IQuoteDecl fc _)          = fc
+getFC (IUnquote fc _)            = fc
+getFC (IPrimVal fc _)            = fc
+getFC (IType fc)                 = fc
+getFC (IHole fc _)               = fc
+getFC (Implicit fc _)            = fc
+getFC (IWithUnambigNames fc _ _) = fc

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -63,9 +63,12 @@ elabScript fc nest env script@(NDCon nfc nm t ar args) exp
                               !(sc defs (toClosure withAll env
                                               !(quote defs env act'))) exp
                   x => failWith defs $ "non-function RHS of a Bind: " ++ show x
-    elabCon defs "Fail" [_,msg]
+    elabCon defs "Fail" [_, mbfc, msg]
         = do msg' <- evalClosure defs msg
-             throw (GenericMsg fc ("Error during reflection: " ++
+             let customFC = case !(evalClosure defs mbfc >>= reify defs) of
+                               EmptyFC => fc
+                               x       => x
+             throw (GenericMsg customFC ("Error during reflection: " ++
                                       !(reify defs msg')))
     elabCon defs "LogMsg" [topic, verb, str]
         = do topic' <- evalClosure defs topic


### PR DESCRIPTION
I sometimes find myself wanting to complain about a particular point of a user code inside my elaboration scripts. This PR adds such an ability while keeping the original behaviour unchanged.