### PR TITLE
[ new ] semantic highlighting in REPL & holes

### DIFF
--- a/idris2api.ipkg
+++ b/idris2api.ipkg
@@ -199,6 +199,7 @@ modules =
     TTImp.ProcessType,
     TTImp.Reflect,
     TTImp.TTImp,
+    TTImp.TTImp.Functor,
     TTImp.Unelab,
     TTImp.Utils,
     TTImp.WithClause,

--- a/src/Core/Metadata.idr
+++ b/src/Core/Metadata.idr
@@ -34,6 +34,21 @@ nameTypeDecoration Func          = Function
 nameTypeDecoration (DataCon _ _) = Data
 nameTypeDecoration (TyCon _ _  ) = Typ
 
+export
+defDecoration : Def -> Maybe Decoration
+defDecoration None = Nothing
+defDecoration (PMDef {}) = Just Function
+defDecoration (ExternDef {}) = Just Function
+defDecoration (ForeignDef {}) = Just Function
+defDecoration (Builtin {}) = Just Function
+defDecoration (DCon {}) = Just Data
+defDecoration (TCon {}) = Just Typ
+defDecoration (Hole {}) = Just Function
+defDecoration (BySearch {}) = Nothing
+defDecoration (Guess {}) = Nothing
+defDecoration ImpBind = Just Bound
+defDecoration Delayed = Nothing
+
 public export
 ASemanticDecoration : Type
 ASemanticDecoration = (NonEmptyFC, Decoration, Maybe Name)

--- a/src/Core/Metadata.idr
+++ b/src/Core/Metadata.idr
@@ -34,6 +34,21 @@ nameTypeDecoration Func          = Function
 nameTypeDecoration (DataCon _ _) = Data
 nameTypeDecoration (TyCon _ _  ) = Typ
 
+export
+defDecoration : Def -> Maybe Decoration
+defDecoration None = Nothing
+defDecoration (PMDef{}) = Just Function
+defDecoration (ExternDef{}) = Just Function
+defDecoration (ForeignDef{}) = Just Function
+defDecoration (Builtin{}) = Just Function
+defDecoration (DCon{}) = Just Data
+defDecoration (TCon{}) = Just Typ
+defDecoration (Hole{}) = Just Function
+defDecoration (BySearch{}) = Nothing
+defDecoration (Guess{}) = Nothing
+defDecoration (ImpBind{}) = Just Bound
+defDecoration (Delayed{}) = Nothing
+
 public export
 ASemanticDecoration : Type
 ASemanticDecoration = (NonEmptyFC, Decoration, Maybe Name)

--- a/src/Core/Metadata.idr
+++ b/src/Core/Metadata.idr
@@ -34,21 +34,6 @@ nameTypeDecoration Func          = Function
 nameTypeDecoration (DataCon _ _) = Data
 nameTypeDecoration (TyCon _ _  ) = Typ
 
-export
-defDecoration : Def -> Maybe Decoration
-defDecoration None = Nothing
-defDecoration (PMDef{}) = Just Function
-defDecoration (ExternDef{}) = Just Function
-defDecoration (ForeignDef{}) = Just Function
-defDecoration (Builtin{}) = Just Function
-defDecoration (DCon{}) = Just Data
-defDecoration (TCon{}) = Just Typ
-defDecoration (Hole{}) = Just Function
-defDecoration (BySearch{}) = Nothing
-defDecoration (Guess{}) = Nothing
-defDecoration (ImpBind{}) = Just Bound
-defDecoration (Delayed{}) = Nothing
-
 public export
 ASemanticDecoration : Type
 ASemanticDecoration = (NonEmptyFC, Decoration, Maybe Name)

--- a/src/Core/Options/Log.idr
+++ b/src/Core/Options/Log.idr
@@ -119,6 +119,8 @@ knownTopics = [
     ("interaction.search", Nothing),
     ("metadata.names", Nothing),
     ("module.hash", Nothing),
+    ("pretty.auto", Nothing),
+    ("pretty.colour", Nothing),
     ("quantity", Nothing),
     ("quantity.hole", Nothing),
     ("quantity.hole.update", Nothing),

--- a/src/Core/Options/Log.idr
+++ b/src/Core/Options/Log.idr
@@ -119,8 +119,6 @@ knownTopics = [
     ("interaction.search", Nothing),
     ("metadata.names", Nothing),
     ("module.hash", Nothing),
-    ("pretty.auto", Nothing),
-    ("pretty.colour", Nothing),
     ("quantity", Nothing),
     ("quantity.hole", Nothing),
     ("quantity.hole.update", Nothing),

--- a/src/Core/TT.idr
+++ b/src/Core/TT.idr
@@ -30,6 +30,15 @@ isCon (TyCon t a) = Just (t, a)
 isCon _ = Nothing
 
 public export
+record KindedName where
+  constructor MkKindedName
+  nameKind : NameType
+  rawName  : Name
+
+export
+Show KindedName where show = show . rawName
+
+public export
 data Constant
     = I Int
     | I8 Integer -- reuse code from I64 with fewer casts

--- a/src/Core/TT.idr
+++ b/src/Core/TT.idr
@@ -32,7 +32,7 @@ isCon _ = Nothing
 public export
 record KindedName where
   constructor MkKindedName
-  nameKind : NameType
+  nameKind : Maybe NameType
   rawName  : Name
 
 export

--- a/src/Idris/Doc/String.idr
+++ b/src/Idris/Doc/String.idr
@@ -4,6 +4,7 @@ import Core.Context
 import Core.Context.Log
 import Core.Core
 import Core.Env
+import Core.Metadata
 import Core.TT
 
 import Idris.Pretty
@@ -51,6 +52,7 @@ styleAnn (TCon _) = color BrightBlue
 styleAnn DCon = color BrightRed
 styleAnn (Fun _) = color BrightGreen
 styleAnn Header = underline
+styleAnn (Syntax syn) = syntaxAnn syn
 styleAnn _ = []
 
 export
@@ -293,13 +295,9 @@ getDocsForName fc n
            _ => pure []
 
     showCategory : GlobalDef -> Doc IdrisDocAnn -> Doc IdrisDocAnn
-    showCategory d = case definition d of
-      TCon _ _ _ _ _ _ _ _ => tCon (fullname d)
-      DCon _ _ _ => dCon
-      PMDef _ _ _ _ _ => fun (fullname d)
-      ForeignDef _ _ => fun (fullname d)
-      Builtin _ => fun (fullname d)
-      _ => id
+    showCategory d = case defDecoration (definition d) of
+      Nothing => id
+      Just decor => annotate (Syntax $ SynDecor decor)
 
     showDoc : (Name, String) -> Core (Doc IdrisDocAnn)
     showDoc (n, str)

--- a/src/Idris/Doc/String.idr
+++ b/src/Idris/Doc/String.idr
@@ -190,12 +190,13 @@ getDocsForName fc n
              syn <- get Syn
              ty <- resugar [] =<< normaliseHoles defs [] (type def)
              let conWithTypeDoc = annotate (Decl con) (hsep [dCon (prettyName con), colon, prettyTerm ty])
-             let [(n, str)] = lookupName con (docstrings syn)
-                  | _ => pure conWithTypeDoc
-             pure $ vcat
-               [ conWithTypeDoc
-               , annotate DocStringBody $ vcat $ reflowDoc str
-               ]
+             case lookupName con (docstrings syn) of
+               [(n, "")] => pure conWithTypeDoc
+               [(n, str)] => pure $ vcat
+                    [ conWithTypeDoc
+                    , annotate DocStringBody $ vcat $ reflowDoc str
+                    ]
+               _ => pure conWithTypeDoc
 
     getImplDoc : Name -> Core (List (Doc IdrisDocAnn))
     getImplDoc n

--- a/src/Idris/Doc/String.idr
+++ b/src/Idris/Doc/String.idr
@@ -221,7 +221,7 @@ getDocsForName fc n
                      [] => []
                      ps => [hsep (header "Parameters" :: punctuate comma (map (pretty . show) ps))]
              let constraints =
-                case the (List Nat) [1] of -- !(traverse pterm (parents iface)) of
+                case !(traverse (pterm . map (MkKindedName Nothing)) (parents iface)) of
                      [] => []
                      ps => [hsep (header "Constraints" :: punctuate comma (map (pretty . show) ps))]
              mdocs <- traverse getMethDoc (methods iface)

--- a/src/Idris/Doc/String.idr
+++ b/src/Idris/Doc/String.idr
@@ -102,7 +102,7 @@ addDocStringNS ns n_in doc
          put Syn (record { docstrings $= addName n' doc,
                            saveDocstrings $= insert n' () } syn)
 
-prettyTerm : PTerm' KindedName -> Doc IdrisDocAnn
+prettyTerm : IPTerm -> Doc IdrisDocAnn
 prettyTerm = reAnnotate Syntax . Idris.Pretty.prettyTerm
 
 showCategory : GlobalDef -> Doc IdrisDocAnn -> Doc IdrisDocAnn

--- a/src/Idris/Doc/String.idr
+++ b/src/Idris/Doc/String.idr
@@ -346,7 +346,7 @@ summarise n -- n is fully qualified
          --                _ => Nothing
          ty <- normaliseHoles defs [] (type def)
          pure $ showCategory def (prettyName n)
-              <++> colon <++> prettyTerm !(resugar [] ty)
+              <++> colon <++> nest 2 (prettyTerm !(resugar [] ty))
 --              <+> maybe "" ((Line <+>) . indent 2 . pretty) doc)
 
 -- Display all the exported names in the given namespace

--- a/src/Idris/Doc/String.idr
+++ b/src/Idris/Doc/String.idr
@@ -13,6 +13,7 @@ import Idris.Resugar
 import Idris.Syntax
 
 import TTImp.TTImp
+import TTImp.TTImp.Functor
 import TTImp.Elab.Prim
 
 import Data.List
@@ -177,7 +178,7 @@ getDocsForName fc n
         = do syn <- get Syn
              let [(n, str)] = lookupName meth.name (docstrings syn)
                   | _ => pure []
-             ty <- pterm ?a -- meth.type
+             ty <- pterm (map (MkKindedName Nothing) meth.type) -- hack
              let nm = prettyName meth.name
              pure $ pure $ vcat [
                annotate (Decl meth.name) (hsep [fun (meth.name) nm, colon, prettyTerm ty])

--- a/src/Idris/Doc/String.idr
+++ b/src/Idris/Doc/String.idr
@@ -247,6 +247,9 @@ getDocsForName fc n
                 case !(traverse (pterm . map (MkKindedName Nothing)) (parents iface)) of
                      [] => []
                      ps => [hsep (header "Constraints" :: punctuate comma (map (pretty . show) ps))]
+             let icon = case dropNS (iconstructor iface) of
+                          DN _ _ => [] -- machine inserted
+                          nm => [hsep [header "Constructor", dCon (prettyName nm)]]
              mdocs <- traverse getMethDoc (methods iface)
              let meths = case concat mdocs of
                            [] => []
@@ -260,7 +263,7 @@ getDocsForName fc n
                            [doc] => [header "Implementation" <++> annotate Declarations doc]
                            docs => [vcat [header "Implementations"
                                    , annotate Declarations $ vcat $ map (indent 2) docs]]
-             pure (vcat (params ++ constraints ++ meths ++ insts))
+             pure (vcat (params ++ constraints ++ icon ++ meths ++ insts))
 
     getFieldDoc : Name -> Core (Doc IdrisDocAnn)
     getFieldDoc nm

--- a/src/Idris/Doc/String.idr
+++ b/src/Idris/Doc/String.idr
@@ -346,7 +346,7 @@ summarise n -- n is fully qualified
          --                _ => Nothing
          ty <- normaliseHoles defs [] (type def)
          pure $ showCategory def (prettyName n)
-              <++> colon <++> nest 2 (prettyTerm !(resugar [] ty))
+              <++> colon <++> hang 0 (prettyTerm !(resugar [] ty))
 --              <+> maybe "" ((Line <+>) . indent 2 . pretty) doc)
 
 -- Display all the exported names in the given namespace

--- a/src/Idris/Doc/String.idr
+++ b/src/Idris/Doc/String.idr
@@ -273,7 +273,7 @@ getDocsForName fc n
                 -- should never happen, since we know that the DCon exists:
                 | Nothing => pure Empty
            ty <- resugar [] =<< normaliseHoles defs [] (type def)
-           let prettyName = pretty (nameRoot nm)
+           let prettyName = prettyName nm
            let projDecl = annotate (Decl nm) $ hsep [ fun nm prettyName, colon, prettyTerm ty ]
            case lookupName nm (docstrings syn) of
                 [(_, "")] => pure projDecl

--- a/src/Idris/Doc/String.idr
+++ b/src/Idris/Doc/String.idr
@@ -339,15 +339,15 @@ summarise n -- n is fully qualified
          defs <- get Ctxt
          Just def <- lookupCtxtExact n (gamma defs)
              | _ => pure ""
-         let doc = case lookupName n (docstrings syn) of
-                        [(_, doc)] => case Extra.lines doc of
-                                           ("" ::: _) => Nothing
-                                           (d ::: _) => Just d
-                        _ => Nothing
+         -- let doc = case lookupName n (docstrings syn) of
+         --                [(_, doc)] => case Extra.lines doc of
+         --                                   ("" ::: _) => Nothing
+         --                                   (d ::: _) => Just d
+         --                _ => Nothing
          ty <- normaliseHoles defs [] (type def)
-         pure (showCategory def (prettyName n)
+         pure $ showCategory def (prettyName n)
               <++> colon <++> prettyTerm !(resugar [] ty)
-              <+> maybe "" ((Line <+>) . indent 2 . pretty) doc)
+--              <+> maybe "" ((Line <+>) . indent 2 . pretty) doc)
 
 -- Display all the exported names in the given namespace
 export

--- a/src/Idris/Elab/Implementation.idr
+++ b/src/Idris/Elab/Implementation.idr
@@ -17,6 +17,7 @@ import TTImp.Elab
 import TTImp.Elab.Check
 import TTImp.ProcessDecls
 import TTImp.TTImp
+import TTImp.TTImp.Functor
 import TTImp.Unelab
 import TTImp.Utils
 
@@ -101,7 +102,7 @@ getMethImps : {vars : _} ->
               Env Term vars -> Term vars ->
               Core (List (Name, RigCount, RawImp))
 getMethImps env (Bind fc x (Pi fc' c Implicit ty) sc)
-    = do rty <- unelabNoSugar env ty
+    = do rty <- map (map rawName) $ unelabNoSugar env ty
          ts <- getMethImps (Pi fc' c Implicit ty :: env) sc
          pure ((x, c, rty) :: ts)
 getMethImps env tm = pure []

--- a/src/Idris/Error.idr
+++ b/src/Idris/Error.idr
@@ -4,6 +4,7 @@ import Core.CaseTree
 import Core.Core
 import Core.Context
 import Core.Env
+import Core.Metadata
 import Core.Options
 import Core.Value
 
@@ -38,7 +39,7 @@ import System.File
 %default covering
 
 keyword : Doc IdrisAnn -> Doc IdrisAnn
-keyword = annotate (Syntax SynKeyword)
+keyword = annotate (Syntax $ SynDecor Keyword)
 
 -- | Add binding site information if the term is simply a machine-inserted name
 pShowMN : {vars : _} -> Term vars -> Env t vars -> Doc IdrisAnn -> Doc IdrisAnn

--- a/src/Idris/Error.idr
+++ b/src/Idris/Error.idr
@@ -57,7 +57,7 @@ pshow env tm
     = do defs <- get Ctxt
          ntm <- normaliseHoles defs env tm
          itm <- resugar env ntm
-         pure (pShowMN ntm env $ reAnnotate Syntax $ prettyTerm itm)
+         pure (pShowMN ntm env $ reAnnotate Syntax $ !(prettyTerm itm))
 
 pshowNoNorm : {vars : _} ->
               {auto c : Ref Ctxt Defs} ->
@@ -66,7 +66,7 @@ pshowNoNorm : {vars : _} ->
 pshowNoNorm env tm
     = do defs <- get Ctxt
          itm <- resugar env tm
-         pure (pShowMN tm env $ reAnnotate Syntax $ prettyTerm itm)
+         pure (pShowMN tm env $ reAnnotate Syntax $ !(prettyTerm itm))
 
 ploc : {auto o : Ref ROpts REPLOpts} ->
        FC -> Core (Doc IdrisAnn)

--- a/src/Idris/Error.idr
+++ b/src/Idris/Error.idr
@@ -57,7 +57,7 @@ pshow env tm
     = do defs <- get Ctxt
          ntm <- normaliseHoles defs env tm
          itm <- resugar env ntm
-         pure (pShowMN ntm env $ reAnnotate Syntax $ !(prettyTerm itm))
+         pure (pShowMN ntm env $ reAnnotate Syntax $ prettyTerm itm)
 
 pshowNoNorm : {vars : _} ->
               {auto c : Ref Ctxt Defs} ->
@@ -66,7 +66,7 @@ pshowNoNorm : {vars : _} ->
 pshowNoNorm env tm
     = do defs <- get Ctxt
          itm <- resugar env tm
-         pure (pShowMN tm env $ reAnnotate Syntax $ !(prettyTerm itm))
+         pure (pShowMN tm env $ reAnnotate Syntax $ prettyTerm itm)
 
 ploc : {auto o : Ref ROpts REPLOpts} ->
        FC -> Core (Doc IdrisAnn)

--- a/src/Idris/IDEMode/CaseSplit.idr
+++ b/src/Idris/IDEMode/CaseSplit.idr
@@ -45,7 +45,7 @@ toStrUpdate : {auto c : Ref Ctxt Defs} ->
               {auto s : Ref Syn SyntaxInfo} ->
               (Name, RawImp) -> Core Updates
 toStrUpdate (UN n, term)
-    = do clause <- pterm (map (MkKindedName Bound) term) -- hack
+    = do clause <- pterm (map (MkKindedName Nothing) term) -- hack
          pure [(n, show (bracket clause))]
   where
     bracket : PTerm' nm -> PTerm' nm
@@ -147,7 +147,7 @@ showImpossible : {auto c : Ref Ctxt Defs} ->
                  {auto o : Ref ROpts REPLOpts} ->
                  (indent : Nat) -> RawImp -> Core String
 showImpossible indent lhs
-    = do clause <- pterm (map (MkKindedName Bound) lhs) -- hack
+    = do clause <- pterm (map (MkKindedName Nothing) lhs) -- hack
          pure (fastPack (replicate indent ' ') ++ show clause ++ " impossible")
 
 -- Given a list of updates and a line and column, find the relevant line in

--- a/src/Idris/IDEMode/CaseSplit.idr
+++ b/src/Idris/IDEMode/CaseSplit.idr
@@ -12,6 +12,7 @@ import Parser.Unlit
 
 import TTImp.Interactive.CaseSplit
 import TTImp.TTImp
+import TTImp.TTImp.Functor
 import TTImp.Utils
 
 import Idris.IDEMode.TokenLine
@@ -44,10 +45,10 @@ toStrUpdate : {auto c : Ref Ctxt Defs} ->
               {auto s : Ref Syn SyntaxInfo} ->
               (Name, RawImp) -> Core Updates
 toStrUpdate (UN n, term)
-    = do clause <- pterm term
+    = do clause <- pterm (map (MkKindedName Bound) term) -- hack
          pure [(n, show (bracket clause))]
   where
-    bracket : PTerm -> PTerm
+    bracket : PTerm' nm -> PTerm' nm
     bracket tm@(PRef _ _) = tm
     bracket tm@(PList _ _ _) = tm
     bracket tm@(PSnocList _ _ _) = tm
@@ -146,7 +147,7 @@ showImpossible : {auto c : Ref Ctxt Defs} ->
                  {auto o : Ref ROpts REPLOpts} ->
                  (indent : Nat) -> RawImp -> Core String
 showImpossible indent lhs
-    = do clause <- pterm lhs
+    = do clause <- pterm (map (MkKindedName Bound) lhs) -- hack
          pure (fastPack (replicate indent ' ') ++ show clause ++ " impossible")
 
 -- Given a list of updates and a line and column, find the relevant line in

--- a/src/Idris/IDEMode/Holes.idr
+++ b/src/Idris/IDEMode/Holes.idr
@@ -18,7 +18,7 @@ public export
 record HolePremise where
   constructor MkHolePremise
   name         : Name
-  type         : PTerm
+  type         : PTerm' KindedName
   multiplicity : RigCount
   isImplicit   : Bool
 
@@ -27,7 +27,7 @@ public export
 record HoleData where
   constructor MkHoleData
   name : Name
-  type : PTerm
+  type : PTerm' KindedName
   context : List HolePremise
 
 ||| If input is a hole, return number of locals in scope at binding
@@ -150,14 +150,13 @@ prettyHole : {vars : _} ->
 prettyHole defs env fn args ty
   = do hdata <- holeData defs env fn args ty
        case hdata.context of
-            [] => pure $ pretty hdata.name <++> colon <++> !(prettyTerm hdata.type)
+            [] => pure $ pretty hdata.name <++> colon <++> prettyTerm hdata.type
             _  => pure $ (indent 1 $ vsep $
-                            !(traverse (\premise => pure $ prettyRigHole premise.multiplicity
-                                    <+> prettyImpBracket premise.isImplicit
-                                        (prettyName premise.name <++> colon <++> !(prettyTerm premise.type)))
-                                    hdata.context)) <+> hardline
+                            map (\premise => prettyRigHole premise.multiplicity
+                                    <+> prettyImpBracket premise.isImplicit (prettyName premise.name <++> colon <++> prettyTerm premise.type))
+                                    hdata.context) <+> hardline
                     <+> (pretty $ L.replicate 30 '-') <+> hardline
-                    <+> pretty (nameRoot $ hdata.name) <++> colon <++> !(prettyTerm hdata.type)
+                    <+> pretty (nameRoot $ hdata.name) <++> colon <++> prettyTerm hdata.type
 
 sexpPremise : HolePremise -> SExp
 sexpPremise premise =

--- a/src/Idris/IDEMode/Holes.idr
+++ b/src/Idris/IDEMode/Holes.idr
@@ -18,7 +18,7 @@ public export
 record HolePremise where
   constructor MkHolePremise
   name         : Name
-  type         : PTerm' KindedName
+  type         : IPTerm
   multiplicity : RigCount
   isImplicit   : Bool
 
@@ -27,7 +27,7 @@ public export
 record HoleData where
   constructor MkHoleData
   name : Name
-  type : PTerm' KindedName
+  type : IPTerm
   context : List HolePremise
 
 ||| If input is a hole, return number of locals in scope at binding

--- a/src/Idris/IDEMode/Holes.idr
+++ b/src/Idris/IDEMode/Holes.idr
@@ -150,13 +150,14 @@ prettyHole : {vars : _} ->
 prettyHole defs env fn args ty
   = do hdata <- holeData defs env fn args ty
        case hdata.context of
-            [] => pure $ pretty hdata.name <++> colon <++> prettyTerm hdata.type
+            [] => pure $ pretty hdata.name <++> colon <++> !(prettyTerm hdata.type)
             _  => pure $ (indent 1 $ vsep $
-                            map (\premise => prettyRigHole premise.multiplicity
-                                    <+> prettyImpBracket premise.isImplicit (prettyName premise.name <++> colon <++> prettyTerm premise.type))
-                                    hdata.context) <+> hardline
+                            !(traverse (\premise => pure $ prettyRigHole premise.multiplicity
+                                    <+> prettyImpBracket premise.isImplicit
+                                        (prettyName premise.name <++> colon <++> !(prettyTerm premise.type)))
+                                    hdata.context)) <+> hardline
                     <+> (pretty $ L.replicate 30 '-') <+> hardline
-                    <+> pretty (nameRoot $ hdata.name) <++> colon <++> prettyTerm hdata.type
+                    <+> pretty (nameRoot $ hdata.name) <++> colon <++> !(prettyTerm hdata.type)
 
 sexpPremise : HolePremise -> SExp
 sexpPremise premise =

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1093,12 +1093,13 @@ simpleData : OriginDesc -> WithBounds t ->
 simpleData fname start tyName indents
     = do b <- bounds (do params <- many (bounds $ decorate fname Bound name)
                          tyend <- bounds (decoratedSymbol fname "=")
-                         let tyfc = boundToFC fname (mergeBounds start tyend)
-                         let tyCon = PRef (boundToFC fname tyName) tyName.val
-                         let toPRef = \ t => PRef (boundToFC fname t) t.val
-                         let conRetTy = papply tyfc tyCon (map toPRef params)
-                         cons <- sepBy1 (decoratedSymbol fname "|") (simpleCon fname conRetTy indents)
-                         pure (params, tyfc, forget cons))
+                         mustWork $ do
+                           let tyfc = boundToFC fname (mergeBounds start tyend)
+                           let tyCon = PRef (boundToFC fname tyName) tyName.val
+                           let toPRef = \ t => PRef (boundToFC fname t) t.val
+                           let conRetTy = papply tyfc tyCon (map toPRef params)
+                           cons <- sepBy1 (decoratedSymbol fname "|") (simpleCon fname conRetTy indents)
+                           pure (params, tyfc, forget cons))
          (params, tyfc, cons) <- pure b.val
          pure (MkPData (boundToFC fname (mergeBounds start b)) tyName.val
                        (mkTyConType fname tyfc params) [] cons)

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1126,7 +1126,7 @@ dataBody fname mincol start n indents ty
 gadtData : OriginDesc -> Int -> WithBounds t ->
            WithBounds Name -> IndentInfo -> Rule PDataDecl
 gadtData fname mincol start tyName indents
-    = do decoratedSymbol fname ":"
+    = do mustWork $ decoratedSymbol fname ":"
          commit
          ty <- typeExpr pdef fname indents
          dataBody fname mincol start tyName.val indents ty

--- a/src/Idris/Pretty.idr
+++ b/src/Idris/Pretty.idr
@@ -1,5 +1,6 @@
 module Idris.Pretty
 
+import Core.Metadata
 import Data.List
 import Data.Maybe
 import Data.String
@@ -21,7 +22,7 @@ import Idris.Syntax
 public export
 data IdrisSyntax
   = SynHole
-  | SynKeyword
+  | SynDecor Decoration
   | SynPragma
   | SynRef Name
 
@@ -44,7 +45,11 @@ colorAnn FileCtxt = color BrightBlue
 colorAnn Code = color Magenta
 colorAnn Meta = color Green
 colorAnn (Syntax SynHole) = color Green
-colorAnn (Syntax SynKeyword) = color Red
+colorAnn (Syntax (SynDecor Keyword)) = color BrightWhite
+colorAnn (Syntax (SynDecor Typ)) = color Blue
+colorAnn (Syntax (SynDecor Data)) = color Red
+colorAnn (Syntax (SynDecor Function)) = color Green
+colorAnn (Syntax (SynDecor Bound)) = italic
 colorAnn (Syntax SynPragma) = color BrightMagenta
 colorAnn (Syntax (SynRef _)) = []
 
@@ -66,7 +71,7 @@ fileCtxt = annotate FileCtxt
 
 export
 keyword : Doc IdrisSyntax -> Doc IdrisSyntax
-keyword = annotate SynKeyword
+keyword = annotate (SynDecor Keyword)
 
 export
 meta : Doc IdrisAnn -> Doc IdrisAnn

--- a/src/Idris/Pretty.idr
+++ b/src/Idris/Pretty.idr
@@ -37,6 +37,21 @@ data IdrisAnn
   | Syntax IdrisSyntax
 
 export
+decorAnn : Decoration -> AnsiStyle
+decorAnn Keyword = color BrightWhite
+decorAnn Typ = color BrightBlue
+decorAnn Data = color BrightRed
+decorAnn Function = color BrightGreen
+decorAnn Bound = italic
+
+export
+syntaxAnn : IdrisSyntax -> AnsiStyle
+syntaxAnn SynHole = color BrightGreen
+syntaxAnn (SynDecor decor) = decorAnn decor
+syntaxAnn SynPragma = color BrightMagenta
+syntaxAnn (SynRef _) = []
+
+export
 colorAnn : IdrisAnn -> AnsiStyle
 colorAnn Warning = color Yellow <+> bold
 colorAnn Error = color BrightRed <+> bold
@@ -44,14 +59,7 @@ colorAnn ErrorDesc = bold
 colorAnn FileCtxt = color BrightBlue
 colorAnn Code = color Magenta
 colorAnn Meta = color Green
-colorAnn (Syntax SynHole) = color Green
-colorAnn (Syntax (SynDecor Keyword)) = color BrightWhite
-colorAnn (Syntax (SynDecor Typ)) = color BrightBlue
-colorAnn (Syntax (SynDecor Data)) = color BrightRed
-colorAnn (Syntax (SynDecor Function)) = color BrightGreen
-colorAnn (Syntax (SynDecor Bound)) = italic
-colorAnn (Syntax SynPragma) = color BrightMagenta
-colorAnn (Syntax (SynRef _)) = []
+colorAnn (Syntax syn) = syntaxAnn syn
 
 export
 warning : Doc IdrisAnn -> Doc IdrisAnn

--- a/src/Idris/Pretty.idr
+++ b/src/Idris/Pretty.idr
@@ -180,7 +180,7 @@ mutual
   prettyBinder = annotate (SynDecor Bound) . pretty
 
   export
-  prettyTerm : PTerm' KindedName -> Doc IdrisSyntax
+  prettyTerm : IPTerm -> Doc IdrisSyntax
   prettyTerm = go Open
     where
       startPrec : Prec
@@ -194,7 +194,7 @@ mutual
         then annotate (SynRef op) $ pretty op
         else Chara '`' <+> annotate (SynRef op) (pretty op) <+> Chara '`'
 
-      go : Prec -> PTerm' KindedName -> Doc IdrisSyntax
+      go : Prec -> IPTerm -> Doc IdrisSyntax
       go d (PRef _ (MkKindedName mnt n))
         = maybe id (annotate . SynDecor . nameTypeDecoration) mnt
         $ annotate (SynRef n) $ pretty n
@@ -249,13 +249,13 @@ mutual
               parenthesise (d > startPrec) $ group $
                 backslash <+> prettyBindings ns <++> "=>" <+> softline <+> go startPrec sc
         where
-          getLamNames : List (RigCount, PTerm' KindedName, PTerm' KindedName) ->
-                        PTerm' KindedName ->
-                        (List (RigCount, PTerm' KindedName, PTerm' KindedName), PTerm' KindedName)
+          getLamNames : List (RigCount, IPTerm, IPTerm) ->
+                        IPTerm ->
+                        (List (RigCount, IPTerm, IPTerm), IPTerm)
           getLamNames acc (PLam _ rig _ n ty sc) = getLamNames ((rig, n, ty) :: acc) sc
           getLamNames acc sc = (reverse acc, sc)
 
-          prettyBindings : List (RigCount, PTerm' KindedName, PTerm' KindedName) -> Doc IdrisSyntax
+          prettyBindings : List (RigCount, IPTerm, IPTerm) -> Doc IdrisSyntax
           prettyBindings [] = neutral
           prettyBindings [(rig, n, (PImplicit _))] = prettyRig rig <+> go startPrec n
           prettyBindings [(rig, n, ty)] = prettyRig rig <+> go startPrec n <++> colon <++> go startPrec ty
@@ -291,7 +291,7 @@ mutual
             let_ <++> (group $ align $ hang 2 $ prettyRig rig <+> go startPrec n <++> equals <+> line <+> go startPrec val) <+> line
               <+> in_ <++> (group $ align $ hang 2 $ continuation)
 
-          getPRefName : PTerm' KindedName -> Maybe Name
+          getPRefName : IPTerm -> Maybe Name
           getPRefName (PRef _ n) = Just (rawName n)
           getPRefName _ = Nothing
 
@@ -370,7 +370,7 @@ mutual
       go d (PComprehension _ ret es) =
           group $ brackets (go startPrec (dePure ret) <++> pipe <++> vsep (punctuate comma (prettyDo . deGuard <$> es)))
         where
-          dePure : PTerm' KindedName -> PTerm' KindedName
+          dePure : IPTerm -> IPTerm
           dePure tm@(PApp _ (PRef _ n) arg)
             = if dropNS (rawName n) == UN "pure" then arg else tm
           dePure tm = tm

--- a/src/Idris/Pretty.idr
+++ b/src/Idris/Pretty.idr
@@ -203,7 +203,7 @@ mutual
 
   export
   prettyTerm : {auto c : Ref Ctxt Defs} ->
-               PTerm -> Core (Doc IdrisSyntax)
+               PTerm' KindedName -> Core (Doc IdrisSyntax)
   prettyTerm = go Open
     where
       startPrec : Prec
@@ -217,8 +217,8 @@ mutual
         then annotate (SynRef op) $ pretty op
         else Chara '`' <+> annotate (SynRef op) (pretty op) <+> Chara '`'
 
-      go : Prec -> PTerm -> Core (Doc IdrisSyntax)
-      go d (PRef _ n@(NS _ _))
+      go : Prec -> PTerm' KindedName -> Core (Doc IdrisSyntax)
+      go d (PRef _ (MkKindedName nt n)
         = do defs <- get Ctxt
              ns <- fullNamespace
              n' <- ifThenElse ns (pure n) (cleanName n)
@@ -231,8 +231,6 @@ mutual
              let Just decor = defDecoration def
                | Nothing => pure dflt
              pure $ annotate (SynDecor decor) dflt
-      go d (PRef _ n) =
-        pure $ annotate (SynDecor Bound) $ annotate (SynRef n) $ pretty n
       go d (PPi _ rig Explicit Nothing arg ret) = do
         parg <- go startPrec arg
         pret <- go startPrec ret

--- a/src/Idris/Pretty.idr
+++ b/src/Idris/Pretty.idr
@@ -203,51 +203,51 @@ mutual
           branchVal
             (go startPrec arg <++> "->" <++> go startPrec ret)
             (parens (prettyRig rig <+> "_" <++> colon <++> go startPrec arg)
-                    <++> "->" <+> line <+> go startPrec ret)
+                    <++> "->" <+> softline <+> go startPrec ret)
             rig
       go d (PPi _ rig Explicit (Just n) arg ret) =
         parenthesise (d > startPrec) $ group $
           parens (prettyRig rig <+> prettyBinder n
                  <++> colon <++> go startPrec arg)
-                  <++> "->" <+> line <+> go startPrec ret
+                  <++> "->" <+> softline <+> go startPrec ret
       go d (PPi _ rig Implicit Nothing arg ret) =
         parenthesise (d > startPrec) $ group $
           braces (prettyRig rig <+> pretty '_'
                  <++> colon <++> go startPrec arg)
-                 <++> "->" <+> line <+> go startPrec ret
+                 <++> "->" <+> softline <+> go startPrec ret
       go d (PPi _ rig Implicit (Just n) arg ret) =
         parenthesise (d > startPrec) $ group $
           braces (prettyRig rig <+> prettyBinder n
                  <++> colon <++> go startPrec arg)
-                 <++> "->" <+> line <+> go startPrec ret
+                 <++> "->" <+> softline <+> go startPrec ret
       go d (PPi _ rig AutoImplicit Nothing arg ret) =
         parenthesise (d > startPrec) $ group $
           branchVal
-            (go startPrec arg <++> "=>" <+> line <+> go startPrec ret)
+            (go startPrec arg <++> "=>" <+> softline <+> go startPrec ret)
             (braces (auto_ <++> prettyRig rig <+> "_"
                     <++> colon <++> go startPrec arg)
-                    <++> "->" <+> line <+> go startPrec ret)
+                    <++> "->" <+> softline <+> go startPrec ret)
             rig
       go d (PPi _ rig AutoImplicit (Just n) arg ret) =
         parenthesise (d > startPrec) $ group $
           braces (auto_ <++> prettyRig rig <+> prettyBinder n
                  <++> colon <++> go startPrec arg)
-                 <++> "->" <+> line <+> go startPrec ret
+                 <++> "->" <+> softline <+> go startPrec ret
       go d (PPi _ rig (DefImplicit t) Nothing arg ret) =
         parenthesise (d > startPrec) $ group $
           braces (default_ <++> go appPrec t <++> prettyRig rig <+> "_"
                  <++> colon <++> go startPrec arg)
-                 <++> "->" <+> line <+> go startPrec ret
+                 <++> "->" <+> softline <+> go startPrec ret
       go d (PPi _ rig (DefImplicit t) (Just n) arg ret) =
         parenthesise (d > startPrec) $ group $
           braces (default_ <++> go appPrec t
                  <++> prettyRig rig <+> prettyBinder n
                  <++> colon <++> go startPrec arg)
-                 <++> "->" <+> line <+> go startPrec ret
+                 <++> "->" <+> softline <+> go startPrec ret
       go d (PLam _ rig _ n ty sc) =
           let (ns, sc) = getLamNames [(rig, n, ty)] sc in
-              parenthesise (d > startPrec) $ group $ align $ hang 2 $
-                backslash <+> prettyBindings ns <++> "=>" <+> line <+> go startPrec sc
+              parenthesise (d > startPrec) $ group $
+                backslash <+> prettyBindings ns <++> "=>" <+> softline <+> go startPrec sc
         where
           getLamNames : List (RigCount, PTerm' KindedName, PTerm' KindedName) ->
                         PTerm' KindedName ->

--- a/src/Idris/Pretty.idr
+++ b/src/Idris/Pretty.idr
@@ -1,5 +1,6 @@
 module Idris.Pretty
 
+import Core.Context.Log
 import Core.Metadata
 import Data.List
 import Data.Maybe
@@ -44,11 +45,11 @@ colorAnn ErrorDesc = bold
 colorAnn FileCtxt = color BrightBlue
 colorAnn Code = color Magenta
 colorAnn Meta = color Green
-colorAnn (Syntax SynHole) = color Green
+colorAnn (Syntax SynHole) = color BrightGreen
 colorAnn (Syntax (SynDecor Keyword)) = color BrightWhite
-colorAnn (Syntax (SynDecor Typ)) = color Blue
-colorAnn (Syntax (SynDecor Data)) = color Red
-colorAnn (Syntax (SynDecor Function)) = color Green
+colorAnn (Syntax (SynDecor Typ)) = color BrightBlue
+colorAnn (Syntax (SynDecor Data)) = color BrightRed
+colorAnn (Syntax (SynDecor Function)) = color BrightGreen
 colorAnn (Syntax (SynDecor Bound)) = italic
 colorAnn (Syntax SynPragma) = color BrightMagenta
 colorAnn (Syntax (SynRef _)) = []
@@ -128,48 +129,81 @@ prettyRig = elimSemi (pretty '0' <+> space)
                      (pretty '1' <+> space)
                      (const emptyDoc)
 
+export
+fullNamespace : {auto c : Ref Ctxt Defs} ->
+                Core Bool
+fullNamespace
+    = do pp <- getPPrint
+         pure (fullNamespace pp)
+
+export
+cleanName : {auto c : Ref Ctxt Defs} ->
+            Name -> Core Name
+cleanName nm = case nm of
+      MN n _     => pure (UN n)
+      PV n _     => pure n
+      DN n _     => pure (UN n)
+      NS ns n    => cleanName n
+      Nested _ n => cleanName n
+      RF n       => pure (RF n)
+      _          => UN <$> prettyName nm
+
 mutual
-  prettyAlt : PClause -> Doc IdrisSyntax
+  prettyAlt : {auto c : Ref Ctxt Defs} ->
+              PClause -> Core (Doc IdrisSyntax)
   prettyAlt (MkPatClause _ lhs rhs _) =
-    space <+> pipe <++> prettyTerm lhs <++> pretty "=>" <++> prettyTerm rhs <+> semi
+    pure $ space <+> pipe <++> !(prettyTerm lhs)
+           <++> pretty "=>" <++> !(prettyTerm rhs) <+> semi
   prettyAlt (MkWithClause _ lhs wval prf flags cs) =
-    space <+> pipe <++> angles (angles (reflow "with alts not possible")) <+> semi
+    pure $ space <+> pipe <++> angles (angles (reflow "with alts not possible")) <+> semi
   prettyAlt (MkImpossible _ lhs) =
-    space <+> pipe <++> prettyTerm lhs <++> impossible_ <+> semi
+    pure $ space <+> pipe <++> !(prettyTerm lhs) <++> impossible_ <+> semi
 
-  prettyCase : PClause -> Doc IdrisSyntax
+  prettyCase : {auto c : Ref Ctxt Defs} ->
+               PClause -> Core (Doc IdrisSyntax)
   prettyCase (MkPatClause _ lhs rhs _) =
-    prettyTerm lhs <++> pretty "=>" <++> prettyTerm rhs
+    pure $ !(prettyTerm lhs) <++> pretty "=>" <++> !(prettyTerm rhs)
   prettyCase (MkWithClause _ lhs rhs prf flags _) =
-    space <+> pipe <++> angles (angles (reflow "with alts not possible"))
+    pure $ space <+> pipe <++> angles (angles (reflow "with alts not possible"))
   prettyCase (MkImpossible _ lhs) =
-    prettyTerm lhs <++> impossible_
+    pure $ !(prettyTerm lhs) <++> impossible_
 
-  prettyString : PStr -> Doc IdrisSyntax
-  prettyString (StrLiteral _ str) = pretty str
+  prettyString : {auto c : Ref Ctxt Defs} ->
+                 PStr -> Core (Doc IdrisSyntax)
+  prettyString (StrLiteral _ str) = pure $ pretty str
   prettyString (StrInterp _ tm) = prettyTerm tm
 
-  prettyDo : PDo -> Doc IdrisSyntax
+  prettyDo : {auto c : Ref Ctxt Defs} ->
+             PDo -> Core (Doc IdrisSyntax)
   prettyDo (DoExp _ tm) = prettyTerm tm
-  prettyDo (DoBind _ _ n tm) = pretty n <++> pretty "<-" <++> prettyTerm tm
+  prettyDo (DoBind _ _ n tm) =
+    pure $ pretty n <++> pretty "<-" <++> !(prettyTerm tm)
   prettyDo (DoBindPat _ l tm alts) =
-    prettyTerm l <++> pretty "<-" <++> prettyTerm tm <+> hang 4 (fillSep $ prettyAlt <$> alts)
+    pure $ !(prettyTerm l) <++> pretty "<-" <++> !(prettyTerm tm)
+         <+> hang 4 (fillSep $ !(traverse prettyAlt alts))
   prettyDo (DoLet _ _ l rig _ tm) =
-    let_ <++> prettyRig rig <+> pretty l <++> equals <++> prettyTerm tm
+    pure $ let_ <++> prettyRig rig <+> pretty l
+           <++> equals <++> !(prettyTerm tm)
   prettyDo (DoLetPat _ l _ tm alts) =
-    let_ <++> prettyTerm l <++> equals <++> prettyTerm tm <+> hang 4 (fillSep $ prettyAlt <$> alts)
+    pure $ let_ <++> !(prettyTerm l)
+           <++> equals <++> !(prettyTerm tm)
+            <+> hang 4 (fillSep !(traverse prettyAlt alts))
   prettyDo (DoLetLocal _ ds) =
-    let_ <++> braces (angles (angles (pretty "definitions")))
-  prettyDo (DoRewrite _ rule) = rewrite_ <+> prettyTerm rule
+    pure $ let_ <++> braces (angles (angles (pretty "definitions")))
+  prettyDo (DoRewrite _ rule) = pure $ rewrite_ <+> !(prettyTerm rule)
 
-  prettyUpdate : PFieldUpdate -> Doc IdrisSyntax
+  prettyUpdate : {auto c : Ref Ctxt Defs} ->
+                 PFieldUpdate -> Core (Doc IdrisSyntax)
   prettyUpdate (PSetField path v) =
-    concatWith (surround dot) (pretty <$> path) <++> equals <++> prettyTerm v
+    pure $ concatWith (surround dot) (pretty <$> path)
+           <++> equals <++> !(prettyTerm v)
   prettyUpdate (PSetFieldApp path v) =
-    concatWith (surround dot) (pretty <$> path) <++> pretty '$' <+> equals <++> prettyTerm v
+    pure $ concatWith (surround dot) (pretty <$> path)
+         <++> pretty '$' <+> equals <++> !(prettyTerm v)
 
   export
-  prettyTerm : PTerm -> Doc IdrisSyntax
+  prettyTerm : {auto c : Ref Ctxt Defs} ->
+               PTerm -> Core (Doc IdrisSyntax)
   prettyTerm = go Open
     where
       startPrec : Prec
@@ -183,52 +217,90 @@ mutual
         then annotate (SynRef op) $ pretty op
         else Chara '`' <+> annotate (SynRef op) (pretty op) <+> Chara '`'
 
-      go : Prec -> PTerm -> Doc IdrisSyntax
-      go d (PRef _ n) = annotate (SynRef n) $ pretty n
-      go d (PPi _ rig Explicit Nothing arg ret) =
-        parenthesise (d > startPrec) $ group $
+      go : Prec -> PTerm -> Core (Doc IdrisSyntax)
+      go d (PRef _ n@(NS _ _))
+        = do defs <- get Ctxt
+             ns <- fullNamespace
+             n' <- ifThenElse ns (pure n) (cleanName n)
+             let dflt = annotate (SynRef n) $ pretty n'
+             log "pretty.colour" 20 $ "Looking up " ++ show n
+             [(_,_,def)] <- lookupDefName n (gamma defs)
+               | [] => pure $ annotate (SynDecor Bound) dflt
+               | _ => pure dflt
+             log "pretty.colour" 20 $ "Got " ++ show def
+             let Just decor = defDecoration def
+               | Nothing => pure dflt
+             pure $ annotate (SynDecor decor) dflt
+      go d (PRef _ n) =
+        pure $ annotate (SynDecor Bound) $ annotate (SynRef n) $ pretty n
+      go d (PPi _ rig Explicit Nothing arg ret) = do
+        parg <- go startPrec arg
+        pret <- go startPrec ret
+        pure $ parenthesise (d > startPrec) $ group $
           branchVal
-            (go startPrec arg <++> "->" <++> go startPrec ret)
-            (parens (prettyRig rig <+> "_" <++> colon <++> go startPrec arg) <++> "->" <+> line <+> go startPrec ret)
+            (parg <++> "->" <++> pret)
+            (parens (prettyRig rig <+> "_" <++> colon <++> parg)
+                     <++> "->" <+> line <+> pret)
             rig
       go d (PPi _ rig Explicit (Just n) arg ret) =
-        parenthesise (d > startPrec) $ group $
-          parens (prettyRig rig <+> pretty n <++> colon <++> go startPrec arg) <++> "->" <+> line <+> go startPrec ret
+        pure $ parenthesise (d > startPrec) $ group $
+          parens (prettyRig rig <+> pretty n <++> colon <++> !(go startPrec arg))
+           <++> "->" <+> line <+> !(go startPrec ret)
       go d (PPi _ rig Implicit Nothing arg ret) =
-        parenthesise (d > startPrec) $ group $
-          braces (prettyRig rig <+> pretty '_' <++> colon <++> go startPrec arg) <++> "->" <+> line <+> go startPrec ret
+        pure $ parenthesise (d > startPrec) $ group $
+          braces (prettyRig rig <+> pretty '_' <++> colon <++> !(go startPrec arg))
+            <++> "->" <+> line <+> !(go startPrec ret)
       go d (PPi _ rig Implicit (Just n) arg ret) =
-        parenthesise (d > startPrec) $ group $
-          braces (prettyRig rig <+> pretty n <++> colon <++> go startPrec arg) <++> "->" <+> line <+> go startPrec ret
-      go d (PPi _ rig AutoImplicit Nothing arg ret) =
-        parenthesise (d > startPrec) $ group $
-          branchVal
-            (go startPrec arg <++> "=>" <+> line <+> go startPrec ret)
-            (braces (auto_ <++> prettyRig rig <+> "_" <++> colon <++> go startPrec arg) <++> "->" <+> line <+> go startPrec ret)
-            rig
-      go d (PPi _ rig AutoImplicit (Just n) arg ret) =
-        parenthesise (d > startPrec) $ group $
-          braces (auto_ <++> prettyRig rig <+> pretty n <++> colon <++> go startPrec arg) <++> "->" <+> line <+> go startPrec ret
+        pure $ parenthesise (d > startPrec) $ group $
+          braces (prettyRig rig <+> pretty n <++> colon <++> !(go startPrec arg))
+            <++> "->" <+> line <+> !(go startPrec ret)
+      go d (PPi _ rig AutoImplicit mnm arg ret) = do
+        parg <- go startPrec arg
+        pret <- go startPrec ret
+        let prig = prettyRig rig
+        pure $ parenthesise (d > startPrec) $ group $
+        -- If the name is machine generated then act as if it were not given
+          case (mnm >>= \nm => guard (isSourceName nm)) of
+            Nothing => branchVal
+              (parg <++> "=>" <+> line <+> pret)
+              (braces (auto_ <++> prig <+> "_" <++> colon <++> parg)
+                      <++> "->" <+> line <+> pret)
+              rig
+            Just n =>
+              braces (auto_ <++> prig <+> pretty n <++> colon <++> parg)
+                      <++> "->" <+> line <+> pret
       go d (PPi _ rig (DefImplicit t) Nothing arg ret) =
-        parenthesise (d > startPrec) $ group $
-          braces (default_ <++> go appPrec t <++> prettyRig rig <+> "_" <++> colon <++> go startPrec arg) <++> "->" <+> line <+> go startPrec ret
+        pure $ parenthesise (d > startPrec) $ group $
+          braces (default_ <++> !(go appPrec t) <++> prettyRig rig <+> "_"
+            <++> colon <++> !(go startPrec arg))
+            <++> "->" <+> line <+> !(go startPrec ret)
       go d (PPi _ rig (DefImplicit t) (Just n) arg ret) =
-        parenthesise (d > startPrec) $ group $
-          braces (default_ <++> go appPrec t <++> prettyRig rig <+> pretty n <++> colon <++> go startPrec arg) <++> "->" <+> line <+> go startPrec ret
+        pure $ parenthesise (d > startPrec) $ group $
+          braces (default_ <++> !(go appPrec t) <++> prettyRig rig <+> pretty n
+           <++> colon <++> !(go startPrec arg))
+           <++> "->" <+> line <+> !(go startPrec ret)
       go d (PLam _ rig _ n ty sc) =
           let (ns, sc) = getLamNames [(rig, n, ty)] sc in
-              parenthesise (d > startPrec) $ group $ align $ hang 2 $
-                backslash <+> prettyBindings ns <++> "=>" <+> line <+> go startPrec sc
+          pure $ parenthesise (d > startPrec) $ group $ align $ hang 2 $
+                backslash <+> !(prettyBindings ns) <++> "=>" <+> line <+> !(go startPrec sc)
         where
           getLamNames : List (RigCount, PTerm, PTerm) -> PTerm -> (List (RigCount, PTerm, PTerm), PTerm)
           getLamNames acc (PLam _ rig _ n ty sc) = getLamNames ((rig, n, ty) :: acc) sc
           getLamNames acc sc = (reverse acc, sc)
-          prettyBindings : List (RigCount, PTerm, PTerm) -> Doc IdrisSyntax
-          prettyBindings [] = neutral
-          prettyBindings [(rig, n, (PImplicit _))] = prettyRig rig <+> go startPrec n
-          prettyBindings [(rig, n, ty)] = prettyRig rig <+> go startPrec n <++> colon <++> go startPrec ty
-          prettyBindings ((rig, n, (PImplicit _)) :: ns) = prettyRig rig <+> go startPrec n <+> comma <+> line <+> prettyBindings ns
-          prettyBindings ((rig, n, ty) :: ns) = prettyRig rig <+> go startPrec n <++> colon <++> go startPrec ty <+> comma <+> line <+> prettyBindings ns
+          prettyBindings : List (RigCount, PTerm, PTerm) -> Core (Doc IdrisSyntax)
+          prettyBindings [] = pure neutral
+          prettyBindings [(rig, n, (PImplicit _))] =
+            pure $ prettyRig rig <+> !(go startPrec n)
+          prettyBindings [(rig, n, ty)] =
+            pure $ prettyRig rig <+> !(go startPrec n)
+                   <++> colon <++> !(go startPrec ty)
+          prettyBindings ((rig, n, (PImplicit _)) :: ns) =
+            pure $ prettyRig rig <+> !(go startPrec n)
+                   <+> comma <+> line <+> !(prettyBindings ns)
+          prettyBindings ((rig, n, ty) :: ns) =
+            pure $ prettyRig rig <+> !(go startPrec n)
+                   <++> colon <++> !(go startPrec ty)
+                   <+> comma <+> line <+> !(prettyBindings ns)
       go d (PLet _ rig n (PImplicit _) val sc alts) =
           -- Hide uninformative lets
           -- (Those that look like 'let x = x in ...')
@@ -251,90 +323,140 @@ mutual
 
         where
 
-          continuation : Doc IdrisSyntax
+          continuation : Core (Doc IdrisSyntax)
           continuation = go startPrec sc
 
-          fullLet : Doc IdrisSyntax
-          fullLet = parenthesise (d > startPrec) $ group $ align $
-            let_ <++> (group $ align $ hang 2 $ prettyRig rig <+> go startPrec n <++> equals <+> line <+> go startPrec val) <+> line
-              <+> in_ <++> (group $ align $ hang 2 $ continuation)
+          fullLet : Core (Doc IdrisSyntax)
+          fullLet = pure $ parenthesise (d > startPrec) $ group $ align $
+            let_ <++> (group $ align $ hang 2 $ prettyRig rig <+> !(go startPrec n)
+              <++> equals <+> line <+> !(go startPrec val)) <+> line
+              <+> in_ <++> (group $ align $ hang 2 $ !continuation)
 
           getPRefName : PTerm -> Maybe Name
           getPRefName (PRef _ n) = Just n
           getPRefName _ = Nothing
 
       go d (PLet _ rig n ty val sc alts) =
-        parenthesise (d > startPrec) $ group $ align $
-          let_ <++> (group $ align $ hang 2 $ prettyRig rig <+> go startPrec n <++> colon <++> go startPrec ty <++> equals <+> line <+> go startPrec val) <+> hardline
-            <+> hang 4 (fillSep (prettyAlt <$> alts)) <+> line <+> in_ <++> (group $ align $ hang 2 $ go startPrec sc)
+        pure $ parenthesise (d > startPrec) $ group $ align $
+          let_ <++> (group $ align $ hang 2 $ prettyRig rig <+> !(go startPrec n)
+                     <++> colon <++> !(go startPrec ty)
+                     <++> equals <+> line <+> !(go startPrec val))
+            <+> hardline
+            <+> hang 4 (fillSep !(traverse prettyAlt alts))
+            <+> line <+> in_ <++> (group $ align $ hang 2 $ !(go startPrec sc))
       go d (PCase _ tm cs) =
-        parenthesise (d > appPrec) $ align $ case_ <++> go startPrec tm <++> of_ <+> line <+>
-          braces (vsep $ punctuate semi (prettyCase <$> cs))
+        pure $ parenthesise (d > appPrec) $
+          align $ case_ <++> !(go startPrec tm) <++> of_ <+> line <+>
+          braces (vsep $ punctuate semi !(traverse prettyCase cs))
       go d (PLocal _ ds sc) =
-        parenthesise (d > startPrec) $ group $ align $
-          let_ <++> braces (angles (angles "definitions")) <+> line <+> in_ <++> go startPrec sc
+        pure $ parenthesise (d > startPrec) $ group $ align $
+          let_ <++> braces (angles (angles "definitions"))
+          <+> line <+> in_ <++> !(go startPrec sc)
       go d (PUpdate _ fs) =
-        parenthesise (d > appPrec) $ group $ record_ <++> braces (vsep $ punctuate comma (prettyUpdate <$> fs))
-      go d (PApp _ f a) =
-        let catchall : Lazy (Doc IdrisSyntax)
-               := go leftAppPrec f <++> go appPrec a
-
-        in parenthesise (d > appPrec) $ group $ case f of
+        pure $ parenthesise (d > appPrec) $ group $
+          record_ <++> braces (vsep $ punctuate comma !(traverse prettyUpdate fs))
+      go d (PApp _ f a) = case f of
           (PRef _ n) =>
             if isJust (isRF n)
-            then go leftAppPrec a <++> go appPrec f
-            else catchall
-          _ => catchall
-      go d (PWithApp _ f a) = go d f <++> pipe <++> go d a
-      go d (PDelayed _ LInf ty) = parenthesise (d > appPrec) $ "Inf" <++> go appPrec ty
-      go d (PDelayed _ _ ty) = parenthesise (d > appPrec) $ "Lazy" <++> go appPrec ty
-      go d (PDelay _ tm) = parenthesise (d > appPrec) $ "Delay" <++> go appPrec tm
-      go d (PForce _ tm) = parenthesise (d > appPrec) $ "Force" <++> go appPrec tm
+            then pure $ parenthesise (d > appPrec) $ group
+                      $ !(go leftAppPrec a) <++> !(go appPrec f)
+            else pure $ parenthesise (d > appPrec) $ group
+                      $ !(go leftAppPrec f) <++> !(go appPrec a)
+          _ => pure $ parenthesise (d > appPrec) $ group
+                    $ !(go leftAppPrec f) <++> !(go appPrec a)
+      go d (PWithApp _ f a) = pure $ !(go d f) <++> pipe <++> !(go d a)
+      go d (PDelayed _ LInf ty) =
+        pure $ parenthesise (d > appPrec) $ "Inf" <++> !(go appPrec ty)
+      go d (PDelayed _ _ ty) =
+        pure $ parenthesise (d > appPrec) $ "Lazy" <++> !(go appPrec ty)
+      go d (PDelay _ tm) =
+        pure $ parenthesise (d > appPrec) $ "Delay" <++> !(go appPrec tm)
+      go d (PForce _ tm) =
+        pure $ parenthesise (d > appPrec) $ "Force" <++> !(go appPrec tm)
       go d (PAutoApp _ f a) =
-        parenthesise (d > appPrec) $ group $ go leftAppPrec f <++> "@" <+> braces (go startPrec a)
-      go d (PNamedApp _ f n (PRef _ a)) =
-        parenthesise (d > appPrec) $ group $
+        pure $ parenthesise (d > appPrec) $ group $
+          !(go leftAppPrec f) <++> "@" <+> braces !(go startPrec a)
+      go d (PNamedApp _ f n (PRef _ a)) = do
+        pf <- go leftAppPrec f
+        pure $ parenthesise (d > appPrec) $ group $
           if n == a
-             then go leftAppPrec f <++> braces (pretty n)
-             else go leftAppPrec f <++> braces (pretty n <++> equals <++> pretty a)
+             then pf <++> braces (pretty n)
+             else pf <++> braces (pretty n <++> equals <++> pretty a)
       go d (PNamedApp _ f n a) =
-        parenthesise (d > appPrec) $ group $ go leftAppPrec f <++> braces (pretty n <++> equals <++> go d a)
-      go d (PSearch _ _) = pragma "%search"
-      go d (PQuote _ tm) = parenthesise (d > appPrec) $ "`" <+> parens (go startPrec tm)
-      go d (PQuoteName _ n) = parenthesise (d > appPrec) $ "`" <+> braces (braces (pretty n))
-      go d (PQuoteDecl _ tm) = parenthesise (d > appPrec) $ "`" <+> brackets (angles (angles (pretty "declaration")))
-      go d (PUnquote _ tm) = parenthesise (d > appPrec) $ "~" <+> parens (go startPrec tm)
-      go d (PRunElab _ tm) = parenthesise (d > appPrec) $ pragma "%runElab" <++> go startPrec tm
-      go d (PPrimVal _ c) = pretty c
-      go d (PHole _ _ n) = hole (pretty (strCons '?' n))
-      go d (PType _) = pretty "Type"
-      go d (PAs _ _ n p) = pretty n <+> "@" <+> go d p
-      go d (PDotted _ p) = dot <+> go d p
-      go d (PImplicit _) = "_"
-      go d (PInfer _) = "?"
-      go d (POp _ _ op x y) = parenthesise (d > appPrec) $ group $ go startPrec x <++> prettyOp op <++> go startPrec y
-      go d (PPrefixOp _ _ op x) = parenthesise (d > appPrec) $ pretty op <+> go startPrec x
-      go d (PSectionL _ _ op x) = parens (prettyOp op <++> go startPrec x)
-      go d (PSectionR _ _ x op) = parens (go startPrec x <++> prettyOp op)
-      go d (PEq fc l r) = parenthesise (d > appPrec) $ go startPrec l <++> equals <++> go startPrec r
-      go d (PBracketed _ tm) = parens (go startPrec tm)
-      go d (PString _ xs) = parenthesise (d > appPrec) $ hsep $ punctuate "++" (prettyString <$> xs)
-      go d (PMultiline _ indent xs) = "multiline" <++> (parenthesise (d > appPrec) $ hsep $ punctuate "++" (prettyString <$> concat xs))
-      go d (PDoBlock _ ns ds) = parenthesise (d > appPrec) $ group $ align $ hang 2 $ do_ <++> (vsep $ punctuate semi (prettyDo <$> ds))
-      go d (PBang _ tm) = "!" <+> go d tm
-      go d (PIdiom _ tm) = enclose (pretty "[|") (pretty "|]") (go startPrec tm)
-      go d (PList _ _ xs) = brackets (group $ align $ vsep $ punctuate comma (go startPrec . snd <$> xs))
-      go d (PSnocList _ _ xs) = brackets {ldelim = "[<"}
-                                   (group $ align $ vsep $ punctuate comma (go startPrec . snd <$> xs))
-      go d (PPair _ l r) = group $ parens (go startPrec l <+> comma <+> line <+> go startPrec r)
-      go d (PDPair _ _ l (PImplicit _) r) = group $ parens (go startPrec l <++> pretty "**" <+> line <+> go startPrec r)
-      go d (PDPair _ _ l ty r) = group $ parens (go startPrec l <++> colon <++> go startPrec ty <++> pretty "**" <+> line <+> go startPrec r)
-      go d (PUnit _) = "()"
+        pure $  parenthesise (d > appPrec) $ group $
+          !(go leftAppPrec f) <++> braces (pretty n <++> equals <++> !(go d a))
+      go d (PSearch _ _) = pure $ pragma "%search"
+      go d (PQuote _ tm) =
+        pure $ parenthesise (d > appPrec) $ "`" <+> parens !(go startPrec tm)
+      go d (PQuoteName _ n) =
+        pure $ parenthesise (d > appPrec) $ "`" <+> braces (braces (pretty n))
+      go d (PQuoteDecl _ tm) =
+        pure $ parenthesise (d > appPrec) $ "`" <+> brackets (angles (angles (pretty "declaration")))
+      go d (PUnquote _ tm) =
+        pure $ parenthesise (d > appPrec) $ "~" <+> parens !(go startPrec tm)
+      go d (PRunElab _ tm) =
+        pure $ parenthesise (d > appPrec) $ pragma "%runElab" <++> !(go startPrec tm)
+      go d (PPrimVal _ c) =
+        pure $ if isPrimType c
+               then annotate (SynDecor Typ) (pretty c)
+               else annotate (SynDecor Data) (pretty c)
+      go d (PHole _ _ n) = pure $ hole (pretty (strCons '?' n))
+      go d (PType _) = pure $ annotate (SynDecor Typ) $ pretty "Type"
+      go d (PAs _ _ n p) = pure $ pretty n <+> "@" <+> !(go d p)
+      go d (PDotted _ p) = pure $ dot <+> !(go d p)
+      go d (PImplicit _) = pure "_"
+      go d (PInfer _) = pure "?"
+      go d (POp _ _ op x y) =
+        pure $ parenthesise (d > appPrec) $ group $
+          !(go startPrec x) <++> prettyOp op <++> !(go startPrec y)
+      go d (PPrefixOp _ _ op x) =
+        pure $ parenthesise (d > appPrec) $ pretty op <+> !(go startPrec x)
+      go d (PSectionL _ _ op x) =
+        pure $ parens (prettyOp op <++> !(go startPrec x))
+      go d (PSectionR _ _ x op) =
+        pure $ parens (!(go startPrec x) <++> prettyOp op)
+      go d (PEq fc l r) =
+        pure $ parenthesise (d > appPrec) $
+          !(go startPrec l) <++> equals <++> !(go startPrec r)
+      go d (PBracketed _ tm) = pure $ parens !(go startPrec tm)
+      go d (PString _ xs) =
+        pure $ parenthesise (d > appPrec) $
+          hsep $ punctuate "++" !(traverse prettyString xs)
+      go d (PMultiline _ indent xs) =
+        pure $ "multiline" <++> (parenthesise (d > appPrec) $
+          hsep $ punctuate "++" !(traverse prettyString $ concat xs))
+      go d (PDoBlock _ ns ds) =
+        pure $ parenthesise (d > appPrec) $ group $ align $
+           hang 2 $ do_ <++> (vsep $ punctuate semi !(traverse prettyDo ds))
+      go d (PBang _ tm) = pure $ "!" <+> !(go d tm)
+      go d (PIdiom _ tm) =
+        pure $ enclose (pretty "[|") (pretty "|]") !(go startPrec tm)
+      go d (PList _ _ xs) =
+        pure $ brackets $ group $ align $ vsep $
+          punctuate comma !(traverse (go startPrec . snd) xs)
+      go d (PSnocList _ _ xs) =
+         pure $ brackets {ldelim = "[<"} $ group $ align $ vsep $
+           punctuate comma !(traverse (go startPrec . snd) xs)
+      go d (PPair _ l r) =
+        pure $ group $ parens $
+          !(go startPrec l) <+> comma <+> line <+> !(go startPrec r)
+      go d (PDPair _ _ l (PImplicit _) r) =
+        pure $ group $ parens $
+          !(go startPrec l) <++> pretty "**" <+> line <+> !(go startPrec r)
+      go d (PDPair _ _ l ty r) =
+        pure $ group $ parens $
+          !(go startPrec l) <++> colon <++> !(go startPrec ty)
+            <++> "**" <+> line <+> !(go startPrec r)
+      go d (PUnit _) = pure "()"
       go d (PIfThenElse _ x t e) =
-        parenthesise (d > appPrec) $ group $ align $ hang 2 $ vsep
-          [keyword "if" <++> go startPrec x, keyword "then" <++> go startPrec t, keyword "else" <++> go startPrec e]
+        pure $ parenthesise (d > appPrec) $ group $ align $ hang 2 $ vsep
+          [ keyword "if" <++> !(go startPrec x)
+          , keyword "then" <++> !(go startPrec t)
+          , keyword "else" <++> !(go startPrec e)]
       go d (PComprehension _ ret es) =
-          group $ brackets (go startPrec (dePure ret) <++> pipe <++> vsep (punctuate comma (prettyDo . deGuard <$> es)))
+          pure $ group $ brackets $
+            !(go startPrec (dePure ret)) <++> pipe
+             <++> vsep (punctuate comma ! (traverse (prettyDo . deGuard) es))
         where
           dePure : PTerm -> PTerm
           dePure tm@(PApp _ (PRef _ n) arg) = if dropNS n == UN "pure" then arg else tm
@@ -344,20 +466,34 @@ mutual
           deGuard tm@(DoExp fc (PApp _ (PRef _ n) arg)) = if dropNS n == UN "guard" then DoExp fc arg else tm
           deGuard tm = tm
       go d (PRewrite _ rule tm) =
-        parenthesise (d > appPrec) $ group $ rewrite_ <++> go startPrec rule <+> line <+> in_ <++> go startPrec tm
+        pure $ parenthesise (d > appPrec) $ group $
+          rewrite_ <++> !(go startPrec rule)
+           <+> line <+> in_ <++> !(go startPrec tm)
       go d (PRange _ start Nothing end) =
-        brackets (go startPrec start <++> pretty ".." <++> go startPrec end)
+        pure $ brackets $
+          !(go startPrec start) <++> pretty ".." <++> !(go startPrec end)
       go d (PRange _ start (Just next) end) =
-        brackets (go startPrec start <+> comma <++> go startPrec next <++> pretty ".." <++> go startPrec end)
-      go d (PRangeStream _ start Nothing) = brackets (go startPrec start <++> pretty "..")
+        pure $ brackets $
+          !(go startPrec start)
+           <+> comma <++> !(go startPrec next)
+           <++> pretty ".." <++> !(go startPrec end)
+      go d (PRangeStream _ start Nothing) =
+        pure $ brackets $ !(go startPrec start) <++> pretty ".."
       go d (PRangeStream _ start (Just next)) =
-        brackets (go startPrec start <+> comma <++> go startPrec next <++> pretty "..")
+        pure $ brackets $
+          !(go startPrec start)
+          <+> comma <++> !(go startPrec next)
+          <++> pretty ".."
       go d (PUnifyLog _ lvl tm) = go d tm
       go d (PPostfixApp fc rec fields) =
-        parenthesise (d > appPrec) $ go startPrec rec <++> dot <+> concatWith (surround dot) (map pretty fields)
+        pure $ parenthesise (d > appPrec) $
+          !(go startPrec rec) <++>
+           dot <+> concatWith (surround dot) (map pretty fields)
       go d (PPostfixAppPartial fc fields) =
-        parens (dot <+> concatWith (surround dot) (map pretty fields))
-      go d (PWithUnambigNames fc ns rhs) = parenthesise (d > appPrec) $ group $ with_ <++> pretty ns <+> line <+> go startPrec rhs
+        pure $ parens (dot <+> concatWith (surround dot) (map pretty fields))
+      go d (PWithUnambigNames fc ns rhs) =
+        pure $ parenthesise (d > appPrec) $ group $
+          with_ <++> pretty ns <+> line <+> !(go startPrec rhs)
 
 export
 render : {auto o : Ref ROpts REPLOpts} -> Doc IdrisAnn -> Core String

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -111,7 +111,7 @@ showInfo (n, idx, d)
                 coreLift_ $ putStrLn $
                         "Size change: " ++ showSep ", " scinfo
 
-prettyTerm : PTerm' KindedName -> Doc IdrisAnn
+prettyTerm : IPTerm -> Doc IdrisAnn
 prettyTerm = reAnnotate Syntax . Idris.Pretty.prettyTerm
 
 displayType : {auto c : Ref Ctxt Defs} ->

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -120,7 +120,10 @@ displayType : {auto c : Ref Ctxt Defs} ->
               Core (Doc IdrisAnn)
 displayType defs (n, i, gdef)
     = maybe (do tm <- resugar [] !(normaliseHoles defs [] (type gdef))
-                pure (pretty !(aliasName (fullname gdef)) <++> colon <++> prettyTerm tm))
+                nm <- aliasName (fullname gdef)
+                let ann = maybe id (annotate . Syntax . SynDecor)
+                        $ defDecoration $ definition gdef
+                pure (ann (pretty nm) <++> colon <++> prettyTerm tm))
             (\num => reAnnotate Syntax <$> prettyHole defs [] n num (type gdef))
             (isHole gdef)
 
@@ -216,12 +219,12 @@ printClause : {auto c : Ref Ctxt Defs} ->
               Maybe String -> Nat -> ImpClause ->
               Core String
 printClause l i (PatClause _ lhsraw rhsraw)
-    = do lhs <- pterm $ map (MkKindedName Bound) lhsraw -- hack
-         rhs <- pterm $ map (MkKindedName Bound) rhsraw -- hack
+    = do lhs <- pterm $ map (MkKindedName Nothing) lhsraw -- hack
+         rhs <- pterm $ map (MkKindedName Nothing) rhsraw -- hack
          pure (relit l (pack (replicate i ' ') ++ show lhs ++ " = " ++ show rhs))
 printClause l i (WithClause _ lhsraw wvraw prf flags csraw)
-    = do lhs <- pterm $ map (MkKindedName Bound) lhsraw -- hack
-         wval <- pterm $ map (MkKindedName Bound) wvraw -- hack
+    = do lhs <- pterm $ map (MkKindedName Nothing) lhsraw -- hack
+         wval <- pterm $ map (MkKindedName Nothing) wvraw -- hack
          cs <- traverse (printClause l (i + 2)) csraw
          pure (relit l ((pack (replicate i ' ')
                 ++ show lhs
@@ -230,7 +233,7 @@ printClause l i (WithClause _ lhsraw wvraw prf flags csraw)
                 ++ "\n"))
                ++ showSep "\n" cs)
 printClause l i (ImpossibleClause _ lhsraw)
-    = do lhs <- pterm $ map (MkKindedName Bound) lhsraw -- hack
+    = do lhs <- pterm $ map (MkKindedName Nothing) lhsraw -- hack
          pure (relit l (pack (replicate i ' ') ++ show lhs ++ " impossible"))
 
 
@@ -425,7 +428,7 @@ processEdit (ExprSearch upd line name hints)
                      Just (_, restm) <- nextProofSearch
                           | Nothing => pure $ EditError "No search results"
                      let tm' = dropLams locs restm
-                     itm <- pterm $ map (MkKindedName Bound) tm' -- hack
+                     itm <- pterm $ map (MkKindedName Nothing) tm' -- hack
                      let itm'  = ifThenElse brack (addBracket replFC itm) itm
                      if upd
                         then updateFile (proofSearch name (show itm') (integerToNat (cast (line - 1))))
@@ -451,7 +454,7 @@ processEdit ExprSearchNext
               | _ => pure $ EditError "Not a searchable hole"
          let brack = elemBy (\x, y => dropNS x == dropNS y) name (bracketholes syn)
          let tm' = dropLams locs restm
-         itm <- pterm $ map (MkKindedName Bound) tm' --hack
+         itm <- pterm $ map (MkKindedName Nothing) tm'
          let itm' = ifThenElse brack (addBracket replFC itm) itm
          pure $ DisplayEdit (prettyTerm itm')
 
@@ -495,8 +498,8 @@ processEdit (MakeLemma upd line name)
          case !(lookupDefTyName name (gamma defs)) of
               [(n, nidx, Hole locs _, ty)] =>
                   do (lty, lapp) <- makeLemma replFC name locs ty
-                     pty <- pterm $ map (MkKindedName Bound) lty -- hack
-                     papp <- pterm $ map (MkKindedName Bound) lapp -- hack
+                     pty <- pterm $ map (MkKindedName Nothing) lty -- hack
+                     papp <- pterm $ map (MkKindedName Nothing) lapp -- hack
                      opts <- get ROpts
                      let pappstr = show (ifThenElse brack
                                             (addBracket replFC papp)
@@ -1071,9 +1074,9 @@ mutual
          {auto o : Ref ROpts REPLOpts} -> REPLResult -> Core ()
   displayResult (REPLError err) = printError err
   displayResult (Evaluated x Nothing) = printResult $ prettyTerm x
-  displayResult (Evaluated x (Just y)) = printResult (prettyTerm x <++> colon <++> code (prettyTerm y))
+  displayResult (Evaluated x (Just y)) = printResult (prettyTerm x <++> colon <++> prettyTerm y)
   displayResult (Printed xs) = printResult xs
-  displayResult (TermChecked x y) = printResult (prettyTerm x <++> colon <++> code (prettyTerm y))
+  displayResult (TermChecked x y) = printResult (prettyTerm x <++> colon <++> prettyTerm y)
   displayResult (FileLoaded x) = printResult (reflow "Loaded file" <++> pretty x)
   displayResult (ModuleLoaded x) = printResult (reflow "Imported module" <++> pretty x)
   displayResult (ErrorLoadingModule x err) = printResult (reflow "Error loading module" <++> pretty x <+> colon <++> !(perror err))

--- a/src/Idris/REPL/Common.idr
+++ b/src/Idris/REPL/Common.idr
@@ -175,7 +175,7 @@ public export
 data EditResult : Type where
   DisplayEdit : Doc IdrisAnn -> EditResult
   EditError : Doc IdrisAnn -> EditResult
-  MadeLemma : Maybe String -> Name -> PTerm' KindedName -> String -> EditResult
+  MadeLemma : Maybe String -> Name -> IPTerm -> String -> EditResult
   MadeWith : Maybe String -> List String -> EditResult
   MadeCase : Maybe String -> List String -> EditResult
 
@@ -191,9 +191,9 @@ data REPLResult : Type where
   REPLError : Doc IdrisAnn -> REPLResult
   Executed : PTerm -> REPLResult
   RequestedHelp : REPLResult
-  Evaluated : PTerm' KindedName -> Maybe (PTerm' KindedName) -> REPLResult
+  Evaluated : IPTerm -> Maybe IPTerm -> REPLResult
   Printed : Doc IdrisAnn -> REPLResult
-  TermChecked : PTerm' KindedName -> PTerm' KindedName -> REPLResult
+  TermChecked : IPTerm -> IPTerm -> REPLResult
   FileLoaded : String -> REPLResult
   ModuleLoaded : String -> REPLResult
   ErrorLoadingModule : String -> Error -> REPLResult
@@ -203,7 +203,7 @@ data REPLResult : Type where
   CurrentDirectory : String -> REPLResult
   CompilationFailed: REPLResult
   Compiled : String -> REPLResult
-  ProofFound : PTerm' KindedName -> REPLResult
+  ProofFound : IPTerm -> REPLResult
   Missed : List MissedResult -> REPLResult
   CheckedTotal : List (Name, Totality) -> REPLResult
   FoundHoles : List HoleData -> REPLResult

--- a/src/Idris/REPL/Common.idr
+++ b/src/Idris/REPL/Common.idr
@@ -175,7 +175,7 @@ public export
 data EditResult : Type where
   DisplayEdit : Doc IdrisAnn -> EditResult
   EditError : Doc IdrisAnn -> EditResult
-  MadeLemma : Maybe String -> Name -> PTerm -> String -> EditResult
+  MadeLemma : Maybe String -> Name -> PTerm' KindedName -> String -> EditResult
   MadeWith : Maybe String -> List String -> EditResult
   MadeCase : Maybe String -> List String -> EditResult
 
@@ -191,9 +191,9 @@ data REPLResult : Type where
   REPLError : Doc IdrisAnn -> REPLResult
   Executed : PTerm -> REPLResult
   RequestedHelp : REPLResult
-  Evaluated : PTerm -> (Maybe PTerm) -> REPLResult
+  Evaluated : PTerm' KindedName -> Maybe (PTerm' KindedName) -> REPLResult
   Printed : Doc IdrisAnn -> REPLResult
-  TermChecked : PTerm -> PTerm -> REPLResult
+  TermChecked : PTerm' KindedName -> PTerm' KindedName -> REPLResult
   FileLoaded : String -> REPLResult
   ModuleLoaded : String -> REPLResult
   ErrorLoadingModule : String -> Error -> REPLResult
@@ -203,7 +203,7 @@ data REPLResult : Type where
   CurrentDirectory : String -> REPLResult
   CompilationFailed: REPLResult
   Compiled : String -> REPLResult
-  ProofFound : PTerm -> REPLResult
+  ProofFound : PTerm' KindedName -> REPLResult
   Missed : List MissedResult -> REPLResult
   CheckedTotal : List (Name, Totality) -> REPLResult
   FoundHoles : List HoleData -> REPLResult

--- a/src/Idris/Resugar.idr
+++ b/src/Idris/Resugar.idr
@@ -6,6 +6,7 @@ import Core.Env
 import Core.Options
 
 import Idris.Syntax
+import Idris.Pretty
 
 import TTImp.TTImp
 import TTImp.Unelab
@@ -85,12 +86,6 @@ showFullEnv : {auto c : Ref Ctxt Defs} ->
 showFullEnv
     = do pp <- getPPrint
          pure (showFullEnv pp)
-
-fullNamespace : {auto c : Ref Ctxt Defs} ->
-                Core Bool
-fullNamespace
-    = do pp <- getPPrint
-         pure (fullNamespace pp)
 
 unbracket : PTerm -> PTerm
 unbracket (PBracketed _ tm) = tm
@@ -462,19 +457,9 @@ cleanPTerm : {auto c : Ref Ctxt Defs} ->
              PTerm -> Core PTerm
 cleanPTerm ptm
    = do ns <- fullNamespace
-        if ns then pure ptm else mapPTermM cleanNode ptm
+        if True then pure ptm else mapPTermM cleanNode ptm
 
   where
-
-    cleanName : Name -> Core Name
-    cleanName nm = case nm of
-      MN n _     => pure (UN n)
-      PV n _     => pure n
-      DN n _     => pure (UN n)
-      NS _ n     => cleanName n
-      Nested _ n => cleanName n
-      RF n       => pure (RF n)
-      _          => UN <$> prettyName nm
 
     cleanNode : PTerm -> Core PTerm
     cleanNode (PRef fc nm)    =

--- a/src/Idris/Resugar.idr
+++ b/src/Idris/Resugar.idr
@@ -516,6 +516,8 @@ cleanPTerm ptm
       (\ op => PSectionL fc opFC op x) <$> cleanName op
     cleanNode (PSectionR fc opFC x op) =
       PSectionR fc opFC x <$> cleanName op
+    cleanNode (PPi fc rig vis (Just n) arg ret) =
+      (\ n => PPi fc rig vis (Just n) arg ret) <$> cleanName n
     cleanNode tm = pure tm
 
 toCleanPTerm : {auto c : Ref Ctxt Defs} ->

--- a/src/Idris/Resugar.idr
+++ b/src/Idris/Resugar.idr
@@ -6,7 +6,6 @@ import Core.Env
 import Core.Options
 
 import Idris.Syntax
-import Idris.Pretty
 
 import TTImp.TTImp
 import TTImp.TTImp.Functor
@@ -89,6 +88,12 @@ showFullEnv : {auto c : Ref Ctxt Defs} ->
 showFullEnv
     = do pp <- getPPrint
          pure (showFullEnv pp)
+
+fullNamespace : {auto c : Ref Ctxt Defs} ->
+                Core Bool
+fullNamespace
+    = do pp <- getPPrint
+         pure (fullNamespace pp)
 
 unbracket : PTerm' nm -> PTerm' nm
 unbracket (PBracketed _ tm) = tm
@@ -473,6 +478,16 @@ cleanPTerm ptm
         if ns then pure ptm else mapPTermM cleanNode ptm
 
   where
+
+    cleanName : Name -> Core Name
+    cleanName nm = case nm of
+      MN n _     => pure (UN n)
+      PV n _     => pure n
+      DN n _     => pure (UN n)
+      NS _ n     => cleanName n
+      Nested _ n => cleanName n
+      RF n       => pure (RF n)
+      _          => UN <$> prettyName nm
 
     cleanKindedName : KindedName -> Core KindedName
     cleanKindedName (MkKindedName nt nm) = MkKindedName nt <$> cleanName nm

--- a/src/Idris/Resugar.idr
+++ b/src/Idris/Resugar.idr
@@ -107,10 +107,11 @@ extractNat acc tm = case tm of
     do guard (n == "Z")
        guard (ns == typesNS || ns == preludeNS)
        pure acc
-  PApp _ (PRef _ (MkKindedName _ (NS ns (UN n)))) k => do
-    do guard (n == "S")
-       guard (ns == typesNS || ns == preludeNS)
-       extractNat (1 + acc) k
+  PApp _ (PRef _ (MkKindedName _ (NS ns (UN n)))) k => case n of
+    "S" => do guard (ns == typesNS || ns == preludeNS)
+              extractNat (1 + acc) k
+    "fromInteger" => extractNat acc k
+    _ => Nothing
   PPrimVal _ (BI n) => pure (acc + integerToNat n)
   PBracketed _ k    => extractNat acc k
   _                 => Nothing

--- a/src/Idris/Resugar.idr
+++ b/src/Idris/Resugar.idr
@@ -54,7 +54,10 @@ addBracket fc tm = if needed tm then PBracketed fc tm else tm
     needed (PList _ _ _) = False
     needed (PSnocList _ _ _) = False
     needed (PRange{}) = False
+    needed (PRangeStream{}) = False
     needed (PPrimVal _ _) = False
+    needed (PIdiom{}) = False
+    needed (PBang{}) = False
     needed tm = True
 
 bracket : {auto s : Ref Syn SyntaxInfo} ->

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -266,7 +266,7 @@ mutual
        MkPatClause : FC -> (lhs : PTerm' nm) -> (rhs : PTerm' nm) ->
                      (whereblock : List (PDecl' nm)) -> PClause' nm
        MkWithClause : FC -> (lhs : PTerm' nm) ->
-                      (wval : PTerm' nm) -> (prf : Maybe nm) ->
+                      (wval : PTerm' nm) -> (prf : Maybe Name) ->
                       List WithFlag -> List (PClause' nm) -> PClause' nm
        MkImpossible : FC -> (lhs : PTerm' nm) -> PClause' nm
 

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -41,88 +41,93 @@ OpStr : Type
 OpStr = Name
 
 mutual
+
+  public export
+  PTerm : Type
+  PTerm = PTerm' Name
+
   -- The full high level source language
   -- This gets desugared to RawImp (TTImp.TTImp), then elaborated to
   -- Term (Core.TT)
   public export
-  data PTerm : Type where
+  data PTerm' : Type -> Type where
        -- Direct (more or less) translations to RawImp
 
-       PRef : FC -> Name -> PTerm
-       PPi : FC -> RigCount -> PiInfo PTerm -> Maybe Name ->
-             (argTy : PTerm) -> (retTy : PTerm) -> PTerm
-       PLam : FC -> RigCount -> PiInfo PTerm -> PTerm ->
-              (argTy : PTerm) -> (scope : PTerm) -> PTerm
-       PLet : FC -> RigCount -> (pat : PTerm) ->
-              (nTy : PTerm) -> (nVal : PTerm) -> (scope : PTerm) ->
-              (alts : List PClause) -> PTerm
-       PCase : FC -> PTerm -> List PClause -> PTerm
-       PLocal : FC -> List PDecl -> (scope : PTerm) -> PTerm
-       PUpdate : FC -> List PFieldUpdate -> PTerm
-       PApp : FC -> PTerm -> PTerm -> PTerm
-       PWithApp : FC -> PTerm -> PTerm -> PTerm
-       PNamedApp : FC -> PTerm -> Name -> PTerm -> PTerm
-       PAutoApp : FC -> PTerm -> PTerm -> PTerm
+       PRef : FC -> nm -> PTerm' nm
+       PPi : FC -> RigCount -> PiInfo (PTerm' nm) -> Maybe Name ->
+             (argTy : PTerm' nm) -> (retTy : PTerm' nm) -> PTerm' nm
+       PLam : FC -> RigCount -> PiInfo (PTerm' nm) -> PTerm' nm ->
+              (argTy : PTerm' nm) -> (scope : PTerm' nm) -> PTerm' nm
+       PLet : FC -> RigCount -> (pat : PTerm' nm) ->
+              (nTy : PTerm' nm) -> (nVal : PTerm' nm) -> (scope : PTerm' nm) ->
+              (alts : List (PClause' nm)) -> PTerm' nm
+       PCase : FC -> PTerm' nm -> List (PClause' nm) -> PTerm' nm
+       PLocal : FC -> List (PDecl' nm) -> (scope : PTerm' nm) -> PTerm' nm
+       PUpdate : FC -> List (PFieldUpdate' nm) -> PTerm' nm
+       PApp : FC -> PTerm' nm -> PTerm' nm -> PTerm' nm
+       PWithApp : FC -> PTerm' nm -> PTerm' nm -> PTerm' nm
+       PNamedApp : FC -> PTerm' nm -> Name -> PTerm' nm -> PTerm' nm
+       PAutoApp : FC -> PTerm' nm -> PTerm' nm -> PTerm' nm
 
-       PDelayed : FC -> LazyReason -> PTerm -> PTerm
-       PDelay : FC -> PTerm -> PTerm
-       PForce : FC -> PTerm -> PTerm
+       PDelayed : FC -> LazyReason -> PTerm' nm -> PTerm' nm
+       PDelay : FC -> PTerm' nm -> PTerm' nm
+       PForce : FC -> PTerm' nm -> PTerm' nm
 
-       PSearch : FC -> (depth : Nat) -> PTerm
-       PPrimVal : FC -> Constant -> PTerm
-       PQuote : FC -> PTerm -> PTerm
-       PQuoteName : FC -> Name -> PTerm
-       PQuoteDecl : FC -> List PDecl -> PTerm
-       PUnquote : FC -> PTerm -> PTerm
-       PRunElab : FC -> PTerm -> PTerm
-       PHole : FC -> (bracket : Bool) -> (holename : String) -> PTerm
-       PType : FC -> PTerm
-       PAs : FC -> (nameFC : FC) -> Name -> (pattern : PTerm) -> PTerm
-       PDotted : FC -> PTerm -> PTerm
-       PImplicit : FC -> PTerm
-       PInfer : FC -> PTerm
+       PSearch : FC -> (depth : Nat) -> PTerm' nm
+       PPrimVal : FC -> Constant -> PTerm' nm
+       PQuote : FC -> PTerm' nm -> PTerm' nm
+       PQuoteName : FC -> Name -> PTerm' nm
+       PQuoteDecl : FC -> List (PDecl' nm) -> PTerm' nm
+       PUnquote : FC -> PTerm' nm -> PTerm' nm
+       PRunElab : FC -> PTerm' nm -> PTerm' nm
+       PHole : FC -> (bracket : Bool) -> (holename : String) -> PTerm' nm
+       PType : FC -> PTerm' nm
+       PAs : FC -> (nameFC : FC) -> Name -> (pattern : PTerm' nm) -> PTerm' nm
+       PDotted : FC -> PTerm' nm -> PTerm' nm
+       PImplicit : FC -> PTerm' nm
+       PInfer : FC -> PTerm' nm
 
        -- Operators
 
-       POp : (full, opFC : FC) -> OpStr -> PTerm -> PTerm -> PTerm
-       PPrefixOp : (full, opFC : FC) -> OpStr -> PTerm -> PTerm
-       PSectionL : (full, opFC : FC) -> OpStr -> PTerm -> PTerm
-       PSectionR : (full, opFC : FC) -> PTerm -> OpStr -> PTerm
-       PEq : FC -> PTerm -> PTerm -> PTerm
-       PBracketed : FC -> PTerm -> PTerm
+       POp : (full, opFC : FC) -> OpStr -> PTerm' nm -> PTerm' nm -> PTerm' nm
+       PPrefixOp : (full, opFC : FC) -> OpStr -> PTerm' nm -> PTerm' nm
+       PSectionL : (full, opFC : FC) -> OpStr -> PTerm' nm -> PTerm' nm
+       PSectionR : (full, opFC : FC) -> PTerm' nm -> OpStr -> PTerm' nm
+       PEq : FC -> PTerm' nm -> PTerm' nm -> PTerm' nm
+       PBracketed : FC -> PTerm' nm -> PTerm' nm
 
        -- Syntactic sugar
-       PString : FC -> List PStr -> PTerm
-       PMultiline : FC -> (indent : Nat) -> List (List PStr) -> PTerm
-       PDoBlock : FC -> Maybe Namespace -> List PDo -> PTerm
-       PBang : FC -> PTerm -> PTerm
-       PIdiom : FC -> PTerm -> PTerm
-       PList : (full, nilFC : FC) -> List (FC, PTerm) -> PTerm
+       PString : FC -> List (PStr' nm) -> PTerm' nm
+       PMultiline : FC -> (indent : Nat) -> List (List (PStr' nm)) -> PTerm' nm
+       PDoBlock : FC -> Maybe Namespace -> List (PDo' nm) -> PTerm' nm
+       PBang : FC -> PTerm' nm -> PTerm' nm
+       PIdiom : FC -> PTerm' nm -> PTerm' nm
+       PList : (full, nilFC : FC) -> List (FC, PTerm' nm) -> PTerm' nm
                                         -- ^   v location of the conses/snocs
-       PSnocList : (full, nilFC : FC) -> List ((FC, PTerm)) -> PTerm
-       PPair : FC -> PTerm -> PTerm -> PTerm
-       PDPair : (full, opFC : FC) -> PTerm -> PTerm -> PTerm -> PTerm
-       PUnit : FC -> PTerm
-       PIfThenElse : FC -> PTerm -> PTerm -> PTerm -> PTerm
-       PComprehension : FC -> PTerm -> List PDo -> PTerm
-       PRewrite : FC -> PTerm -> PTerm -> PTerm
+       PSnocList : (full, nilFC : FC) -> List ((FC, PTerm' nm)) -> PTerm' nm
+       PPair : FC -> PTerm' nm -> PTerm' nm -> PTerm' nm
+       PDPair : (full, opFC : FC) -> PTerm' nm -> PTerm' nm -> PTerm' nm -> PTerm' nm
+       PUnit : FC -> PTerm' nm
+       PIfThenElse : FC -> PTerm' nm -> PTerm' nm -> PTerm' nm -> PTerm' nm
+       PComprehension : FC -> PTerm' nm -> List (PDo' nm) -> PTerm' nm
+       PRewrite : FC -> PTerm' nm -> PTerm' nm -> PTerm' nm
        -- A list range  [x,y..z]
-       PRange : FC -> PTerm -> Maybe PTerm -> PTerm -> PTerm
+       PRange : FC -> PTerm' nm -> Maybe (PTerm' nm) -> PTerm' nm -> PTerm' nm
        -- A stream range [x,y..]
-       PRangeStream : FC -> PTerm -> Maybe PTerm -> PTerm
+       PRangeStream : FC -> PTerm' nm -> Maybe (PTerm' nm) -> PTerm' nm
        -- r.x.y
-       PPostfixApp : FC -> PTerm -> List (FC, Name) -> PTerm
+       PPostfixApp : FC -> PTerm' nm -> List (FC, Name) -> PTerm' nm
        -- .x.y
-       PPostfixAppPartial : FC -> List (FC, Name) -> PTerm
+       PPostfixAppPartial : FC -> List (FC, Name) -> PTerm' nm
 
        -- Debugging
-       PUnifyLog : FC -> LogLevel -> PTerm -> PTerm
+       PUnifyLog : FC -> LogLevel -> PTerm' nm -> PTerm' nm
 
        -- with-disambiguation
-       PWithUnambigNames : FC -> List Name -> PTerm -> PTerm
+       PWithUnambigNames : FC -> List Name -> PTerm' nm -> PTerm' nm
 
   export
-  getPTermLoc : PTerm -> FC
+  getPTermLoc : PTerm' nm -> FC
   getPTermLoc (PRef fc _) = fc
   getPTermLoc (PPi fc _ _ _ _ _) = fc
   getPTermLoc (PLam fc _ _ _ _ _) = fc
@@ -177,27 +182,39 @@ mutual
   getPTermLoc (PWithUnambigNames fc _ _) = fc
 
   public export
-  data PFieldUpdate : Type where
-       PSetField : (path : List String) -> PTerm -> PFieldUpdate
-       PSetFieldApp : (path : List String) -> PTerm -> PFieldUpdate
+  PFieldUpdate : Type
+  PFieldUpdate = PFieldUpdate' Name
 
   public export
-  data PDo : Type where
-       DoExp : FC -> PTerm -> PDo
-       DoBind : FC -> (nameFC : FC) -> Name -> PTerm -> PDo
-       DoBindPat : FC -> PTerm -> PTerm -> List PClause -> PDo
-       DoLet : FC -> (lhs : FC) -> Name -> RigCount -> PTerm -> PTerm -> PDo
-       DoLetPat : FC -> PTerm -> PTerm -> PTerm -> List PClause -> PDo
-       DoLetLocal : FC -> List PDecl -> PDo
-       DoRewrite : FC -> PTerm -> PDo
+  data PFieldUpdate' : Type -> Type where
+       PSetField : (path : List String) -> PTerm' nm -> PFieldUpdate' nm
+       PSetFieldApp : (path : List String) -> PTerm' nm -> PFieldUpdate' nm
 
   public export
-  data PStr : Type where
-       StrLiteral : FC -> String -> PStr
-       StrInterp : FC -> PTerm -> PStr
+  PDo : Type
+  PDo = PDo' Name
+
+  public export
+  data PDo' : Type -> Type where
+       DoExp : FC -> PTerm' nm -> PDo' nm
+       DoBind : FC -> (nameFC : FC) -> Name -> PTerm' nm -> PDo' nm
+       DoBindPat : FC -> PTerm' nm -> PTerm' nm -> List (PClause' nm) -> PDo' nm
+       DoLet : FC -> (lhs : FC) -> Name -> RigCount -> PTerm' nm -> PTerm' nm -> PDo' nm
+       DoLetPat : FC -> PTerm' nm -> PTerm' nm -> PTerm' nm -> List (PClause' nm) -> PDo' nm
+       DoLetLocal : FC -> List (PDecl' nm) -> PDo' nm
+       DoRewrite : FC -> PTerm' nm -> PDo' nm
+
+  public export
+  PStr : Type
+  PStr = PStr' Name
+
+  public export
+  data PStr' : Type -> Type where
+       StrLiteral : FC -> String -> PStr' nm
+       StrInterp : FC -> PTerm' nm -> PStr' nm
 
   export
-  getLoc : PDo -> FC
+  getLoc : PDo' nm -> FC
   getLoc (DoExp fc _) = fc
   getLoc (DoBind fc _ _ _) = fc
   getLoc (DoBindPat fc _ _ _) = fc
@@ -207,38 +224,51 @@ mutual
   getLoc (DoRewrite fc _) = fc
 
   export
-  papply : FC -> PTerm -> List PTerm -> PTerm
+  papply : FC -> PTerm' nm -> List (PTerm' nm) -> PTerm' nm
   papply fc f [] = f
   papply fc f (a :: as) = papply fc (PApp fc f a) as
 
   public export
-  data PTypeDecl : Type where
-       MkPTy : FC -> (nameFC : FC) -> (n : Name) -> (doc: String) -> (type : PTerm) -> PTypeDecl
+  PTypeDecl : Type
+  PTypeDecl = PTypeDecl' Name
+
+  public export
+  data PTypeDecl' : Type -> Type where
+       MkPTy : FC -> (nameFC : FC) -> (n : Name) ->
+               (doc: String) -> (type : PTerm' nm) -> PTypeDecl' nm
 
   export
-  getPTypeDeclLoc : PTypeDecl -> FC
+  getPTypeDeclLoc : PTypeDecl' nm -> FC
   getPTypeDeclLoc (MkPTy fc _ _ _ _) = fc
 
   public export
-  data PDataDecl : Type where
-       MkPData : FC -> (tyname : Name) -> (tycon : PTerm) ->
+  PDataDecl : Type
+  PDataDecl = PDataDecl' Name
+
+  public export
+  data PDataDecl' : Type -> Type where
+       MkPData : FC -> (tyname : Name) -> (tycon : PTerm' nm) ->
                  (opts : List DataOpt) ->
-                 (datacons : List PTypeDecl) -> PDataDecl
-       MkPLater : FC -> (tyname : Name) -> (tycon : PTerm) -> PDataDecl
+                 (datacons : List (PTypeDecl' nm)) -> PDataDecl' nm
+       MkPLater : FC -> (tyname : Name) -> (tycon : PTerm' nm) -> PDataDecl' nm
 
   export
-  getPDataDeclLoc : PDataDecl -> FC
+  getPDataDeclLoc : PDataDecl' nm -> FC
   getPDataDeclLoc (MkPData fc _ _ _ _) = fc
   getPDataDeclLoc (MkPLater fc _ _) = fc
 
   public export
-  data PClause : Type where
-       MkPatClause : FC -> (lhs : PTerm) -> (rhs : PTerm) ->
-                     (whereblock : List PDecl) -> PClause
-       MkWithClause : FC -> (lhs : PTerm) ->
-                      (wval : PTerm) -> (prf : Maybe Name) ->
-                      List WithFlag -> List PClause -> PClause
-       MkImpossible : FC -> (lhs : PTerm) -> PClause
+  PClause : Type
+  PClause = PClause' Name
+
+  public export
+  data PClause' : Type -> Type where
+       MkPatClause : FC -> (lhs : PTerm' nm) -> (rhs : PTerm' nm) ->
+                     (whereblock : List (PDecl' nm)) -> PClause' nm
+       MkWithClause : FC -> (lhs : PTerm' nm) ->
+                      (wval : PTerm' nm) -> (prf : Maybe nm) ->
+                      List WithFlag -> List (PClause' nm) -> PClause' nm
+       MkImpossible : FC -> (lhs : PTerm' nm) -> PClause' nm
 
   export
   getPClauseLoc : PClause -> FC
@@ -261,7 +291,7 @@ mutual
        PrimDouble : Name -> Directive
        CGAction : String -> String -> Directive
        Names : Name -> List String -> Directive
-       StartExpr : PTerm -> Directive
+       StartExpr : PTerm' nm -> Directive
        Overloadable : Name -> Directive
        Extension : LangExt -> Directive
        DefaultTotality : TotalReq -> Directive
@@ -321,9 +351,13 @@ mutual
         "%search_timeout ms"
 
   public export
-  data PField : Type where
-       MkField : FC -> (doc : String) -> RigCount -> PiInfo PTerm ->
-                 Name -> (ty : PTerm) -> PField
+  PField : Type
+  PField = PField' Name
+
+  public export
+  data PField' : Type -> Type where
+       MkField : FC -> (doc : String) -> RigCount -> PiInfo (PTerm' nm) ->
+                 Name -> (ty : PTerm' nm) -> PField' nm
 
   -- For noting the pass we're in when desugaring a mutual block
   -- TODO: Decide whether we want mutual blocks!
@@ -346,59 +380,70 @@ mutual
   defPass p = p == Single || p == AsDef
 
   public export
-  data PFnOpt : Type where
-       IFnOpt : FnOpt -> PFnOpt
-       PForeign : List PTerm -> PFnOpt
+  PFnOpt : Type
+  PFnOpt = PFnOpt' Name
 
   public export
-  data PDecl : Type where
-       PClaim : FC -> RigCount -> Visibility -> List PFnOpt -> PTypeDecl -> PDecl
-       PDef : FC -> List PClause -> PDecl
-       PData : FC -> (doc : String) -> Visibility -> PDataDecl -> PDecl
-       PParameters : FC -> List (Name, RigCount, PiInfo PTerm, PTerm) -> List PDecl -> PDecl
-       PUsing : FC -> List (Maybe Name, PTerm) -> List PDecl -> PDecl
-       PReflect : FC -> PTerm -> PDecl
+  data PFnOpt' : Type -> Type where
+       IFnOpt : FnOpt' nm -> PFnOpt' nm
+       PForeign : List (PTerm' nm) -> PFnOpt' nm
+
+  public export
+  PDecl : Type
+  PDecl = PDecl' Name
+
+  public export
+  data PDecl' : Type -> Type where
+       PClaim : FC -> RigCount -> Visibility -> List (PFnOpt' nm) -> PTypeDecl' nm -> PDecl' nm
+       PDef : FC -> List (PClause' nm) -> PDecl' nm
+       PData : FC -> (doc : String) -> Visibility -> PDataDecl' nm -> PDecl' nm
+       PParameters : FC ->
+                     List (Name, RigCount, PiInfo (PTerm' nm), PTerm' nm) ->
+                     List (PDecl' nm) -> PDecl' nm
+       PUsing : FC -> List (Maybe Name, PTerm' nm) ->
+                List (PDecl' nm) -> PDecl' nm
+       PReflect : FC -> PTerm' nm -> PDecl' nm
        PInterface : FC ->
                     Visibility ->
-                    (constraints : List (Maybe Name, PTerm)) ->
+                    (constraints : List (Maybe Name, PTerm' nm)) ->
                     Name ->
                     (doc : String) ->
-                    (params : List (Name, (RigCount, PTerm))) ->
+                    (params : List (Name, (RigCount, PTerm' nm))) ->
                     (det : List Name) ->
                     (conName : Maybe Name) ->
-                    List PDecl ->
-                    PDecl
+                    List (PDecl' nm) ->
+                    PDecl' nm
        PImplementation : FC ->
                          Visibility -> List PFnOpt -> Pass ->
-                         (implicits : List (Name, RigCount, PTerm)) ->
-                         (constraints : List (Maybe Name, PTerm)) ->
+                         (implicits : List (Name, RigCount, PTerm' nm)) ->
+                         (constraints : List (Maybe Name, PTerm' nm)) ->
                          Name ->
-                         (params : List PTerm) ->
+                         (params : List (PTerm' nm)) ->
                          (implName : Maybe Name) ->
                          (nusing : List Name) ->
-                         Maybe (List PDecl) ->
-                         PDecl
+                         Maybe (List (PDecl' nm)) ->
+                         PDecl' nm
        PRecord : FC ->
                  (doc : String) ->
                  Visibility ->
                  Name ->
-                 (params : List (Name, RigCount, PiInfo PTerm, PTerm)) ->
+                 (params : List (Name, RigCount, PiInfo (PTerm' nm), PTerm' nm)) ->
                  (conName : Maybe Name) ->
-                 List PField ->
-                 PDecl
+                 List (PField' nm) ->
+                 PDecl' nm
 
        -- TODO: PPostulate
        -- TODO: POpen (for opening named interfaces)
-       PMutual : FC -> List PDecl -> PDecl
-       PFixity : FC -> Fixity -> Nat -> OpStr -> PDecl
-       PNamespace : FC -> Namespace -> List PDecl -> PDecl
-       PTransform : FC -> String -> PTerm -> PTerm -> PDecl
-       PRunElabDecl : FC -> PTerm -> PDecl
-       PDirective : FC -> Directive -> PDecl
-       PBuiltin : FC -> BuiltinType -> Name -> PDecl
+       PMutual : FC -> List (PDecl' nm) -> PDecl' nm
+       PFixity : FC -> Fixity -> Nat -> OpStr -> PDecl' nm
+       PNamespace : FC -> Namespace -> List (PDecl' nm) -> PDecl' nm
+       PTransform : FC -> String -> PTerm' nm -> PTerm' nm -> PDecl' nm
+       PRunElabDecl : FC -> PTerm' nm -> PDecl' nm
+       PDirective : FC -> Directive -> PDecl' nm
+       PBuiltin : FC -> BuiltinType -> Name -> PDecl' nm
 
   export
-  getPDeclLoc : PDecl -> FC
+  getPDeclLoc : PDecl' nm -> FC
   getPDeclLoc (PClaim fc _ _ _ _) = fc
   getPDeclLoc (PDef fc _) = fc
   getPDeclLoc (PData fc _ _ _) = fc
@@ -508,19 +553,19 @@ data EditCmd : Type where
 public export
 data REPLCmd : Type where
      NewDefn : List PDecl -> REPLCmd
-     Eval : PTerm -> REPLCmd
-     Check : PTerm -> REPLCmd
-     CheckWithImplicits : PTerm -> REPLCmd
+     Eval : PTerm' nm -> REPLCmd
+     Check : PTerm' nm -> REPLCmd
+     CheckWithImplicits : PTerm' nm -> REPLCmd
      PrintDef : Name -> REPLCmd
      Reload : REPLCmd
      Load : String -> REPLCmd
      ImportMod : ModuleIdent -> REPLCmd
      Edit : REPLCmd
-     Compile : PTerm -> String -> REPLCmd
-     Exec : PTerm -> REPLCmd
+     Compile : PTerm' nm -> String -> REPLCmd
+     Exec : PTerm' nm -> REPLCmd
      Help : REPLCmd
-     TypeSearch : PTerm -> REPLCmd
-     FuzzyTypeSearch : PTerm -> REPLCmd
+     TypeSearch : PTerm' nm -> REPLCmd
+     FuzzyTypeSearch : PTerm' nm -> REPLCmd
      DebugInfo : Name -> REPLCmd
      SetOpt : REPLOpt -> REPLCmd
      GetOpts : REPLCmd
@@ -529,7 +574,7 @@ data REPLCmd : Type where
      CWD: REPLCmd
      Missing : Name -> REPLCmd
      Total : Name -> REPLCmd
-     Doc : PTerm -> REPLCmd
+     Doc : PTerm' nm -> REPLCmd
      Browse : Namespace -> REPLCmd
      SetLog : Maybe LogLevel -> REPLCmd
      SetConsoleWidth : Maybe Nat -> REPLCmd
@@ -923,12 +968,12 @@ withSyn : {auto s : Ref Syn SyntaxInfo} -> Core a -> Core a
 withSyn = wrapRef Syn (\_ => pure ())
 
 export
-mapPTermM : (PTerm -> Core PTerm) -> PTerm -> Core PTerm
+mapPTermM : (PTerm' nm -> Core (PTerm' nm)) -> PTerm' nm -> Core (PTerm' nm)
 mapPTermM f = goPTerm where
 
   mutual
 
-    goPTerm : PTerm -> Core PTerm
+    goPTerm : PTerm' nm -> Core (PTerm' nm)
     goPTerm t@(PRef _ _) = f t
     goPTerm (PPi fc x info z argTy retTy) =
       PPi fc x <$> goPiInfo info
@@ -1098,15 +1143,15 @@ mapPTermM f = goPTerm where
       PWithUnambigNames fc ns <$> goPTerm rhs
       >>= f
 
-    goPFieldUpdate : PFieldUpdate -> Core PFieldUpdate
+    goPFieldUpdate : PFieldUpdate' nm -> Core (PFieldUpdate' nm)
     goPFieldUpdate (PSetField p t)    = PSetField p <$> goPTerm t
     goPFieldUpdate (PSetFieldApp p t) = PSetFieldApp p <$> goPTerm t
 
-    goPStr : PStr -> Core PStr
+    goPStr : PStr' nm -> Core (PStr' nm)
     goPStr (StrInterp fc t) = StrInterp fc <$> goPTerm t
     goPStr x                = pure x
 
-    goPDo : PDo -> Core PDo
+    goPDo : PDo' nm -> Core (PDo' nm)
     goPDo (DoExp fc t) = DoExp fc <$> goPTerm t
     goPDo (DoBind fc nameFC n t) = DoBind fc nameFC n <$> goPTerm t
     goPDo (DoBindPat fc t u cls) =
@@ -1124,7 +1169,7 @@ mapPTermM f = goPTerm where
     goPDo (DoLetLocal fc decls) = DoLetLocal fc <$> goPDecls decls
     goPDo (DoRewrite fc t) = DoRewrite fc <$> goPTerm t
 
-    goPClause : PClause -> Core PClause
+    goPClause : PClause' nm -> Core (PClause' nm)
     goPClause (MkPatClause fc lhs rhs wh) =
       MkPatClause fc <$> goPTerm lhs
                      <*> goPTerm rhs
@@ -1137,7 +1182,7 @@ mapPTermM f = goPTerm where
                       <*> goPClauses cls
     goPClause (MkImpossible fc lhs) = MkImpossible fc <$> goPTerm lhs
 
-    goPDecl : PDecl -> Core PDecl
+    goPDecl : PDecl' nm -> Core (PDecl' nm)
     goPDecl (PClaim fc c v opts tdecl) =
       PClaim fc c v <$> goPFnOpts opts
                     <*> goPTypeDecl tdecl
@@ -1179,95 +1224,96 @@ mapPTermM f = goPTerm where
     goPDecl p@(PBuiltin _ _ _) = pure p
 
 
-    goPTypeDecl : PTypeDecl -> Core PTypeDecl
+    goPTypeDecl : PTypeDecl' nm -> Core (PTypeDecl' nm)
     goPTypeDecl (MkPTy fc nameFC n d t) = MkPTy fc nameFC n d <$> goPTerm t
 
-    goPDataDecl : PDataDecl -> Core PDataDecl
+    goPDataDecl : PDataDecl' nm -> Core (PDataDecl' nm)
     goPDataDecl (MkPData fc n t opts tdecls) =
       MkPData fc n <$> goPTerm t
                    <*> pure opts
                    <*> goPTypeDecls tdecls
     goPDataDecl (MkPLater fc n t) = MkPLater fc n <$> goPTerm t
 
-    goPField : PField -> Core PField
+    goPField : PField' nm -> Core (PField' nm)
     goPField (MkField fc doc c info n t) =
       MkField fc doc c <$> goPiInfo info
                        <*> pure n
                        <*> goPTerm t
 
-    goPiInfo : PiInfo PTerm -> Core (PiInfo PTerm)
+    goPiInfo : PiInfo (PTerm' nm) -> Core (PiInfo (PTerm' nm))
     goPiInfo (DefImplicit t) = DefImplicit <$> goPTerm t
     goPiInfo t = pure t
 
-    goPFnOpt : PFnOpt -> Core PFnOpt
+    goPFnOpt : PFnOpt' nm -> Core (PFnOpt' nm)
     goPFnOpt o@(IFnOpt _) = pure o
     goPFnOpt (PForeign ts) = PForeign <$> goPTerms ts
 
     -- Traversable stuff. Inlined for termination checking.
 
-    goMPTerm : Maybe PTerm -> Core (Maybe PTerm)
+    goMPTerm : Maybe (PTerm' nm) -> Core (Maybe $ PTerm' nm)
     goMPTerm Nothing  = pure Nothing
     goMPTerm (Just t) = Just <$> goPTerm t
 
-    goPTerms : List PTerm -> Core (List PTerm)
+    goPTerms : List (PTerm' nm) -> Core (List $ PTerm' nm)
     goPTerms []        = pure []
     goPTerms (t :: ts) = (::) <$> goPTerm t <*> goPTerms ts
 
-    goPairedPTerms : List (a, PTerm) -> Core (List (a, PTerm))
+    goPairedPTerms : List (x, PTerm' nm) -> Core (List (x, PTerm' nm))
     goPairedPTerms []             = pure []
     goPairedPTerms ((a, t) :: ts) =
        (::) . MkPair a <$> goPTerm t
                        <*> goPairedPTerms ts
 
-    go3TupledPTerms : List (a, b, PTerm) -> Core (List (a, b, PTerm))
+    go3TupledPTerms : List (x, y, PTerm' nm) -> Core (List (x, y, PTerm' nm))
     go3TupledPTerms [] = pure []
     go3TupledPTerms ((a, b, t) :: ts) =
       (::) . (\ c => (a, b, c)) <$> goPTerm t
                                 <*> go3TupledPTerms ts
 
-    go4TupledPTerms : List (a, b, PiInfo PTerm, PTerm) -> Core (List (a, b, PiInfo PTerm, PTerm))
+    go4TupledPTerms : List (x, y, PiInfo (PTerm' nm), PTerm' nm) ->
+                      Core (List (x, y, PiInfo (PTerm' nm), PTerm' nm))
     go4TupledPTerms [] = pure []
     go4TupledPTerms ((a, b, p, t) :: ts) =
       (\ p, d, ts => (a, b, p, d) :: ts) <$> goPiInfo p
                                          <*> goPTerm t
                                          <*> go4TupledPTerms ts
 
-    goPStringLines : List (List PStr) -> Core (List (List PStr))
+    goPStringLines : List (List (PStr' nm)) -> Core (List (List (PStr' nm)))
     goPStringLines []        = pure []
     goPStringLines (line :: lines) = (::) <$> goPStrings line <*> goPStringLines lines
 
-    goPStrings : List PStr -> Core (List PStr)
+    goPStrings : List (PStr' nm) -> Core (List (PStr' nm))
     goPStrings []        = pure []
     goPStrings (str :: strs) = (::) <$> goPStr str <*> goPStrings strs
 
-    goPDos : List PDo -> Core (List PDo)
+    goPDos : List (PDo' nm) -> Core (List (PDo' nm))
     goPDos []        = pure []
     goPDos (d :: ds) = (::) <$> goPDo d <*> goPDos ds
 
-    goPClauses : List PClause -> Core (List PClause)
+    goPClauses : List (PClause' nm) -> Core (List (PClause' nm))
     goPClauses []          = pure []
     goPClauses (cl :: cls) = (::) <$> goPClause cl <*> goPClauses cls
 
-    goMPDecls : Maybe (List PDecl) -> Core (Maybe (List PDecl))
+    goMPDecls : Maybe (List (PDecl' nm)) -> Core (Maybe (List (PDecl' nm)))
     goMPDecls Nothing   = pure Nothing
     goMPDecls (Just ps) = Just <$> goPDecls ps
 
-    goPDecls : List PDecl -> Core (List PDecl)
+    goPDecls : List (PDecl' nm) -> Core (List (PDecl' nm))
     goPDecls []          = pure []
     goPDecls (d :: ds) = (::) <$> goPDecl d <*> goPDecls ds
 
-    goPFieldUpdates : List PFieldUpdate -> Core (List PFieldUpdate)
+    goPFieldUpdates : List (PFieldUpdate' nm) -> Core (List (PFieldUpdate' nm))
     goPFieldUpdates []          = pure []
     goPFieldUpdates (fu :: fus) = (::) <$> goPFieldUpdate fu <*> goPFieldUpdates fus
 
-    goPFields : List PField -> Core (List PField)
+    goPFields : List (PField' nm) -> Core (List (PField' nm))
     goPFields []        = pure []
     goPFields (f :: fs) = (::) <$> goPField f <*> goPFields fs
 
-    goPFnOpts : List PFnOpt -> Core (List PFnOpt)
+    goPFnOpts : List (PFnOpt' nm) -> Core (List (PFnOpt' nm))
     goPFnOpts []        = pure []
     goPFnOpts (o :: os) = (::) <$> goPFnOpt o <*> goPFnOpts os
 
-    goPTypeDecls : List PTypeDecl -> Core (List PTypeDecl)
+    goPTypeDecls : List (PTypeDecl' nm) -> Core (List (PTypeDecl' nm))
     goPTypeDecls []        = pure []
     goPTypeDecls (t :: ts) = (::) <$> goPTypeDecl t <*> goPTypeDecls ts

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -42,13 +42,21 @@ OpStr = Name
 
 mutual
 
+  ||| Source language as produced by the parser
   public export
   PTerm : Type
   PTerm = PTerm' Name
 
-  -- The full high level source language
-  -- This gets desugared to RawImp (TTImp.TTImp), then elaborated to
-  -- Term (Core.TT)
+  ||| Internal PTerm
+  ||| Source language as produced by the unelaboration of core Terms
+  ||| KindedNames carry extra information about the nature of the variable
+  public export
+  IPTerm : Type
+  IPTerm = PTerm' KindedName
+
+  ||| The full high level source language
+  ||| This gets desugared to RawImp (TTImp.TTImp),
+  ||| then elaborated to Term (Core.TT)
   public export
   data PTerm' : Type -> Type where
        -- Direct (more or less) translations to RawImp
@@ -788,7 +796,7 @@ Show PTerm where
   showPrec = showPTermPrec id
 
 export
-Show (PTerm' KindedName) where
+Show IPTerm where
   showPrec = showPTermPrec rawName
 
 public export

--- a/src/Parser/Lexer/Source.idr
+++ b/src/Parser/Lexer/Source.idr
@@ -247,7 +247,11 @@ export
 ||| Test whether a user name begins with an operator symbol.
 isOpName : Name -> Bool
 isOpName n = fromMaybe False $ do
-   n <- userNameRoot n
+   -- NB: we can't use userNameRoot because that'll prefix `RF`
+   -- names with a `.` which means that record fields will systematically
+   -- be declared to be operators.
+   guard (isUserName n)
+   let n = nameRoot n
    c <- fst <$> strUncons n
    guard (isOpChar c)
    pure True

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -17,6 +17,7 @@ import TTImp.Elab.Check
 import TTImp.Elab.Delayed
 import TTImp.Reflect
 import TTImp.TTImp
+import TTImp.TTImp.Functor
 import TTImp.Unelab
 import TTImp.Utils
 
@@ -97,7 +98,7 @@ elabScript fc nest env script@(NDCon nfc nm t ar args) exp
         = do tm' <- evalClosure defs tm
              defs <- get Ctxt
              empty <- clearDefs defs
-             scriptRet !(unelabUniqueBinders env !(quote empty env tm'))
+             scriptRet $ map rawName !(unelabUniqueBinders env !(quote empty env tm'))
     elabCon defs "Lambda" [x, _, scope]
         = do empty <- clearDefs defs
              NBind bfc x (Lam fc' c p ty) sc <- evalClosure defs scope
@@ -124,7 +125,7 @@ elabScript fc nest env script@(NDCon nfc nm t ar args) exp
                  | Nothing => nfOpts withAll defs env
                                      !(reflect fc defs False env (the (Maybe RawImp) Nothing))
              ty <- getTerm gty
-             scriptRet (Just !(unelabUniqueBinders env ty))
+             scriptRet (Just $ map rawName $ !(unelabUniqueBinders env ty))
     elabCon defs "LocalVars" []
         = scriptRet vars
     elabCon defs "GenSym" [str]
@@ -142,7 +143,7 @@ elabScript fc nest env script@(NDCon nfc nm t ar args) exp
       where
         unelabType : (Name, Int, ClosedTerm) -> Core (Name, RawImp)
         unelabType (n, _, ty)
-            = pure (n, !(unelabUniqueBinders [] ty))
+            = pure (n, map rawName !(unelabUniqueBinders [] ty))
     elabCon defs "GetLocalType" [n]
         = do n' <- evalClosure defs n
              n <- reify defs n'
@@ -150,7 +151,7 @@ elabScript fc nest env script@(NDCon nfc nm t ar args) exp
                   Just (MkIsDefined rigb lv) =>
                        do let binder = getBinder lv env
                           let bty = binderType binder
-                          scriptRet !(unelabUniqueBinders env bty)
+                          scriptRet $ map rawName !(unelabUniqueBinders env bty)
                   _ => throw (GenericMsg fc (show n ++ " is not a local variable"))
     elabCon defs "GetCons" [n]
         = do n' <- evalClosure defs n

--- a/src/TTImp/Interactive/CaseSplit.idr
+++ b/src/TTImp/Interactive/CaseSplit.idr
@@ -16,6 +16,7 @@ import TTImp.Elab.Check
 import TTImp.ProcessDef
 import TTImp.ProcessDecls
 import TTImp.TTImp
+import TTImp.TTImp.Functor
 import TTImp.Unelab
 import TTImp.Utils
 
@@ -354,7 +355,7 @@ mkCase {c} {u} fn orig lhs_raw
                setAllPublic False
                put Ctxt defs -- reset the context, we don't want any updates
                put UST ust
-               lhs' <- unelabNoSugar [] lhs
+               lhs' <- map (map rawName) $ unelabNoSugar [] lhs
 
                log "interaction.casesplit" 3 $ "Original LHS: " ++ show orig
                log "interaction.casesplit" 3 $ "New LHS: " ++ show lhs'
@@ -401,7 +402,7 @@ getSplitsLHS fc envlen lhs_in n
          OK (fn, tyn, cons) <- findCons n lhs
             | SplitFail err => pure (SplitFail err)
 
-         rawlhs <- unelabNoSugar [] lhs
+         rawlhs <- map (map rawName) $ unelabNoSugar [] lhs
          trycases <- traverse (\c => newLHS fc envlen usedns n c rawlhs) cons
 
          let Just idx = getNameID fn (gamma defs)

--- a/src/TTImp/Interactive/ExprSearch.idr
+++ b/src/TTImp/Interactive/ExprSearch.idr
@@ -26,6 +26,7 @@ import Core.Value
 import TTImp.Elab.Check
 import TTImp.Interactive.CaseSplit
 import TTImp.TTImp
+import TTImp.TTImp.Functor
 import TTImp.Unelab
 import TTImp.Utils
 
@@ -862,7 +863,7 @@ firstLinearOK fc (Result (t, ds) next)
                 defs <- get Ctxt
                 nft <- normaliseHoles defs [] t
                 raw <- unelab [] !(toFullNames nft)
-                pure (Result raw (firstLinearOK fc !next)))
+                pure (Result (map rawName raw) (firstLinearOK fc !next)))
             (\err =>
                 do next' <- next
                    firstLinearOK fc next')
@@ -882,7 +883,7 @@ exprSearchOpts opts fc n_in hints
          let Hole _ _ = definition gdef
              | PMDef pi [] (STerm _ tm) _ _
                  => do raw <- unelab [] !(toFullNames !(normaliseHoles defs [] tm))
-                       one raw
+                       one (map rawName raw)
              | _ => throw (GenericMsg fc "Name is already defined")
          lhs <- findHoleLHS !(getFullName (Resolved idx))
          log "interaction.search" 10 $ "LHS hole data " ++ show (n, lhs)

--- a/src/TTImp/Interactive/MakeLemma.idr
+++ b/src/TTImp/Interactive/MakeLemma.idr
@@ -9,6 +9,7 @@ import Core.Value
 
 import TTImp.Unelab
 import TTImp.TTImp
+import TTImp.TTImp.Functor
 import TTImp.Utils
 
 import Data.List
@@ -45,7 +46,7 @@ getArgs : {vars : _} ->
           Core (List (Name, Maybe Name, PiInfo RawImp, RigCount, RawImp), RawImp)
 getArgs {vars} env (S k) (Bind _ x b@(Pi _ c _ ty) sc)
     = do defs <- get Ctxt
-         ty' <- unelab env !(normalise defs env ty)
+         ty' <- map (map rawName) $ unelab env !(normalise defs env ty)
          let x' = UN !(uniqueName defs (map nameRoot vars) (nameRoot x))
          (sc', ty) <- getArgs (b :: env) k (renameTop x' sc)
          -- Don't need to use the name if it's not used in the scope type
@@ -60,7 +61,7 @@ getArgs {vars} env (S k) (Bind _ x b@(Pi _ c _ ty) sc)
          pure ((x, mn, p', c, ty') :: sc', ty)
 getArgs env k ty
       = do defs <- get Ctxt
-           ty' <- unelab env !(normalise defs env ty)
+           ty' <- map (map rawName) $ unelab env !(normalise defs env ty)
            pure ([], ty')
 
 mkType : FC -> List (Name, Maybe Name, PiInfo RawImp, RigCount, RawImp) ->

--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -23,6 +23,7 @@ import TTImp.Elab.Utils
 import TTImp.Impossible
 import TTImp.PartialEval
 import TTImp.TTImp
+import TTImp.TTImp.Functor
 import TTImp.Unelab
 import TTImp.Utils
 import TTImp.WithClause
@@ -959,6 +960,7 @@ processDef opts nest env fc n_in cs_in
                       Core (Maybe ClosedTerm)
     checkImpossible n mult tm
         = do itm <- unelabNoPatvars [] tm
+             let itm = map rawName itm
              handleUnify
                (do ctxt <- get Ctxt
                    log "declare.def.impossible" 3 $ "Checking for impossibility: " ++ show itm

--- a/src/TTImp/ProcessRecord.idr
+++ b/src/TTImp/ProcessRecord.idr
@@ -13,6 +13,7 @@ import TTImp.BindImplicits
 import TTImp.Elab
 import TTImp.Elab.Check
 import TTImp.TTImp
+import TTImp.TTImp.Functor
 import TTImp.Unelab
 import TTImp.Utils
 
@@ -143,7 +144,7 @@ elabRecord {vars} eopts fc env nest newns vis tn params conName_in fields
                                 (names nest)
                    nestDrop <- traverse (\ (n, ns) => pure (!(toFullNames n), ns)) nestDrop
                    ty <- unelabNest nestDrop tyenv ty_chk
-                   let ty' = substNames vars upds ty
+                   let ty' = substNames vars upds $ map rawName ty
                    log "declare.record.field" 5 $ "Field type: " ++ show ty'
                    let rname = MN "rec" 0
 

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -46,88 +46,101 @@ public export
 data BindMode = PI RigCount | PATTERN | NONE
 
 mutual
+
   public export
-  data RawImp : Type where
-       IVar : FC -> Name -> RawImp
-       IPi : FC -> RigCount -> PiInfo RawImp -> Maybe Name ->
-             (argTy : RawImp) -> (retTy : RawImp) -> RawImp
-       ILam : FC -> RigCount -> PiInfo RawImp -> Maybe Name ->
-              (argTy : RawImp) -> (lamTy : RawImp) -> RawImp
+  RawImp : Type
+  RawImp = RawImp' Name
+
+  public export
+  data RawImp' : Type -> Type where
+       IVar : FC -> nm -> RawImp' nm
+       IPi : FC -> RigCount -> PiInfo (RawImp' nm) -> Maybe Name ->
+             (argTy : RawImp' nm) -> (retTy : RawImp' nm) -> RawImp' nm
+       ILam : FC -> RigCount -> PiInfo (RawImp' nm) -> Maybe Name ->
+              (argTy : RawImp' nm) -> (lamTy : RawImp' nm) -> RawImp' nm
        ILet : FC -> (lhsFC : FC) -> RigCount -> Name ->
-              (nTy : RawImp) -> (nVal : RawImp) ->
-              (scope : RawImp) -> RawImp
-       ICase : FC -> RawImp -> (ty : RawImp) ->
-               List ImpClause -> RawImp
-       ILocal : FC -> List ImpDecl -> RawImp -> RawImp
+              (nTy : RawImp' nm) -> (nVal : RawImp' nm) ->
+              (scope : RawImp' nm) -> RawImp' nm
+       ICase : FC -> RawImp' nm -> (ty : RawImp' nm) ->
+               List (ImpClause' nm) -> RawImp' nm
+       ILocal : FC -> List (ImpDecl' nm) -> RawImp' nm -> RawImp' nm
        -- Local definitions made elsewhere, but that we're pushing
        -- into a case branch as nested names.
        -- An appearance of 'uname' maps to an application of
        -- 'internalName' to 'args'.
        ICaseLocal : FC -> (uname : Name) ->
                     (internalName : Name) ->
-                    (args : List Name) -> RawImp -> RawImp
+                    (args : List Name) -> RawImp' nm -> RawImp' nm
 
-       IUpdate : FC -> List IFieldUpdate -> RawImp -> RawImp
+       IUpdate : FC -> List (IFieldUpdate' nm) -> RawImp' nm -> RawImp' nm
 
-       IApp : FC -> RawImp -> RawImp -> RawImp
-       IAutoApp : FC -> RawImp -> RawImp -> RawImp
-       INamedApp : FC -> RawImp -> Name -> RawImp -> RawImp
-       IWithApp : FC -> RawImp -> RawImp -> RawImp
+       IApp : FC -> RawImp' nm -> RawImp' nm -> RawImp' nm
+       IAutoApp : FC -> RawImp' nm -> RawImp' nm -> RawImp' nm
+       INamedApp : FC -> RawImp' nm -> Name -> RawImp' nm -> RawImp' nm
+       IWithApp : FC -> RawImp' nm -> RawImp' nm -> RawImp' nm
 
-       ISearch : FC -> (depth : Nat) -> RawImp
-       IAlternative : FC -> AltType -> List RawImp -> RawImp
-       IRewrite : FC -> RawImp -> RawImp -> RawImp
-       ICoerced : FC -> RawImp -> RawImp
+       ISearch : FC -> (depth : Nat) -> RawImp' nm
+       IAlternative : FC -> AltType' nm -> List (RawImp' nm) -> RawImp' nm
+       IRewrite : FC -> RawImp' nm -> RawImp' nm -> RawImp' nm
+       ICoerced : FC -> RawImp' nm -> RawImp' nm
 
        -- Any implicit bindings in the scope should be bound here, using
        -- the given binder
-       IBindHere : FC -> BindMode -> RawImp -> RawImp
+       IBindHere : FC -> BindMode -> RawImp' nm -> RawImp' nm
        -- A name which should be implicitly bound
-       IBindVar : FC -> String -> RawImp
+       IBindVar : FC -> String -> RawImp' nm
        -- An 'as' pattern, valid on the LHS of a clause only
-       IAs : FC -> (nameFC : FC) -> UseSide -> Name -> RawImp -> RawImp
+       IAs : FC -> (nameFC : FC) -> UseSide -> Name -> RawImp' nm -> RawImp' nm
        -- A 'dot' pattern, i.e. one which must also have the given value
        -- by unification
-       IMustUnify : FC -> DotReason -> RawImp -> RawImp
+       IMustUnify : FC -> DotReason -> RawImp' nm -> RawImp' nm
 
        -- Laziness annotations
-       IDelayed : FC -> LazyReason -> RawImp -> RawImp -- the type
-       IDelay : FC -> RawImp -> RawImp -- delay constructor
-       IForce : FC -> RawImp -> RawImp
+       IDelayed : FC -> LazyReason -> RawImp' nm -> RawImp' nm -- the type
+       IDelay : FC -> RawImp' nm -> RawImp' nm -- delay constructor
+       IForce : FC -> RawImp' nm -> RawImp' nm
 
        -- Quasiquoting
-       IQuote : FC -> RawImp -> RawImp
-       IQuoteName : FC -> Name -> RawImp
-       IQuoteDecl : FC -> List ImpDecl -> RawImp
-       IUnquote : FC -> RawImp -> RawImp
-       IRunElab : FC -> RawImp -> RawImp
+       IQuote : FC -> RawImp' nm -> RawImp' nm
+       IQuoteName : FC -> Name -> RawImp' nm
+       IQuoteDecl : FC -> List (ImpDecl' nm) -> RawImp' nm
+       IUnquote : FC -> RawImp' nm -> RawImp' nm
+       IRunElab : FC -> RawImp' nm -> RawImp' nm
 
-       IPrimVal : FC -> (c : Constant) -> RawImp
-       IType : FC -> RawImp
-       IHole : FC -> String -> RawImp
+       IPrimVal : FC -> (c : Constant) -> RawImp' nm
+       IType : FC -> RawImp' nm
+       IHole : FC -> String -> RawImp' nm
 
-       IUnifyLog : FC -> LogLevel -> RawImp -> RawImp
+       IUnifyLog : FC -> LogLevel -> RawImp' nm -> RawImp' nm
        -- An implicit value, solved by unification, but which will also be
        -- bound (either as a pattern variable or a type variable) if unsolved
        -- at the end of elaborator
-       Implicit : FC -> (bindIfUnsolved : Bool) -> RawImp
+       Implicit : FC -> (bindIfUnsolved : Bool) -> RawImp' nm
 
        -- with-disambiguation
-       IWithUnambigNames : FC -> List Name -> RawImp -> RawImp
+       IWithUnambigNames : FC -> List Name -> RawImp' nm -> RawImp' nm
 
   public export
-  data IFieldUpdate : Type where
-       ISetField : (path : List String) -> RawImp -> IFieldUpdate
-       ISetFieldApp : (path : List String) -> RawImp -> IFieldUpdate
+  IFieldUpdate : Type
+  IFieldUpdate = IFieldUpdate' Name
 
   public export
-  data AltType : Type where
-       FirstSuccess : AltType
-       Unique : AltType
-       UniqueDefault : RawImp -> AltType
+  data IFieldUpdate' : Type -> Type where
+       ISetField : (path : List String) -> RawImp' nm -> IFieldUpdate' nm
+       ISetFieldApp : (path : List String) -> RawImp' nm -> IFieldUpdate' nm
+
+  public export
+  AltType : Type
+  AltType = AltType' Name
+
+  public export
+  data AltType' : Type -> Type where
+       FirstSuccess : AltType' nm
+       Unique : AltType' nm
+       UniqueDefault : RawImp' nm -> AltType' nm
 
   export
-    Show RawImp where
+    Show nm => Show (RawImp' nm) where
       show (IVar fc n) = show n
       show (IPi fc c p n arg ret)
          = "(%pi " ++ show c ++ " " ++ show p ++ " " ++
@@ -185,35 +198,39 @@ mutual
       show (IWithUnambigNames fc ns rhs) = "(%with " ++ show ns ++ " " ++ show rhs ++ ")"
 
   export
-  Show IFieldUpdate where
+  Show nm => Show (IFieldUpdate' nm) where
     show (ISetField p val) = showSep "->" p ++ " = " ++ show val
     show (ISetFieldApp p val) = showSep "->" p ++ " $= " ++ show val
 
   public export
-  data FnOpt : Type where
-       Inline : FnOpt
-       TCInline : FnOpt
-       -- Flag means the hint is a direct hint, not a function which might
-       -- find the result (e.g. chasing parent interface dictionaries)
-       Hint : Bool -> FnOpt
-       -- Flag means to use as a default if all else fails
-       GlobalHint : Bool -> FnOpt
-       ExternFn : FnOpt
-       -- Defined externally, list calling conventions
-       ForeignFn : List RawImp -> FnOpt
-       -- assume safe to cancel arguments in unification
-       Invertible : FnOpt
-       Totality : TotalReq -> FnOpt
-       Macro : FnOpt
-       SpecArgs : List Name -> FnOpt
+  FnOpt : Type
+  FnOpt = FnOpt' Name
 
   public export
-  isTotalityReq : FnOpt -> Bool
+  data FnOpt' : Type -> Type where
+       Inline : FnOpt' nm
+       TCInline : FnOpt' nm
+       -- Flag means the hint is a direct hint, not a function which might
+       -- find the result (e.g. chasing parent interface dictionaries)
+       Hint : Bool -> FnOpt' nm
+       -- Flag means to use as a default if all else fails
+       GlobalHint : Bool -> FnOpt' nm
+       ExternFn : FnOpt' nm
+       -- Defined externally, list calling conventions
+       ForeignFn : List (RawImp' nm) -> FnOpt' nm
+       -- assume safe to cancel arguments in unification
+       Invertible : FnOpt' nm
+       Totality : TotalReq -> FnOpt' nm
+       Macro : FnOpt' nm
+       SpecArgs : List Name -> FnOpt' nm
+
+  public export
+  isTotalityReq : FnOpt' nm -> Bool
   isTotalityReq (Totality _) = True
   isTotalityReq _ = False
 
   export
-  Show FnOpt where
+  Show nm => Show (FnOpt' nm) where
     show Inline = "%inline"
     show TCInline = "%tcinline"
     show (Hint t) = "%hint " ++ show t
@@ -242,11 +259,15 @@ mutual
     _ == _ = False
 
   public export
-  data ImpTy : Type where
-       MkImpTy : FC -> (nameFC : FC) -> (n : Name) -> (ty : RawImp) -> ImpTy
+  ImpTy : Type
+  ImpTy = ImpTy' Name
+
+  public export
+  data ImpTy' : Type -> Type where
+       MkImpTy : FC -> (nameFC : FC) -> (n : Name) -> (ty : RawImp' nm) -> ImpTy' nm
 
   export
-  Show ImpTy where
+  Show nm => Show (ImpTy' nm) where
     show (MkImpTy fc _ n ty) = "(%claim " ++ show n ++ " " ++ show ty ++ ")"
 
   public export
@@ -267,14 +288,18 @@ mutual
     (==) _ _ = False
 
   public export
-  data ImpData : Type where
-       MkImpData : FC -> (n : Name) -> (tycon : RawImp) ->
+  ImpData : Type
+  ImpData = ImpData' Name
+
+  public export
+  data ImpData' : Type -> Type where
+       MkImpData : FC -> (n : Name) -> (tycon : RawImp' nm) ->
                    (opts : List DataOpt) ->
-                   (datacons : List ImpTy) -> ImpData
-       MkImpLater : FC -> (n : Name) -> (tycon : RawImp) -> ImpData
+                   (datacons : List (ImpTy' nm)) -> ImpData' nm
+       MkImpLater : FC -> (n : Name) -> (tycon : RawImp' nm) -> ImpData' nm
 
   export
-  Show ImpData where
+  Show nm => Show (ImpData' nm) where
     show (MkImpData fc n tycon _ cons)
         = "(%data " ++ show n ++ " " ++ show tycon ++ " " ++
            show cons ++ ")"
@@ -282,25 +307,38 @@ mutual
         = "(%datadecl " ++ show n ++ " " ++ show tycon ++ ")"
 
   public export
-  data IField : Type where
-       MkIField : FC -> RigCount -> PiInfo RawImp -> Name -> RawImp ->
-                  IField
+  IField : Type
+  IField = IField' Name
 
   public export
-  data ImpRecord : Type where
+  data IField' : Type -> Type where
+       MkIField : FC -> RigCount -> PiInfo (RawImp' nm) -> Name -> RawImp' nm ->
+                  IField' nm
+
+  -- TODO: turn into a proper datatype
+  public export
+  ImpParameter' : Type -> Type
+  ImpParameter' nm = (Name, RigCount, PiInfo (RawImp' nm), RawImp' nm)
+
+  public export
+  ImpRecord : Type
+  ImpRecord = ImpRecord' Name
+
+  public export
+  data ImpRecord' : Type -> Type where
        MkImpRecord : FC -> (n : Name) ->
-                     (params : List (Name, RigCount, PiInfo RawImp, RawImp)) ->
+                     (params : List (ImpParameter' nm)) ->
                      (conName : Name) ->
-                     (fields : List IField) ->
-                     ImpRecord
+                     (fields : List (IField' nm)) ->
+                     ImpRecord' nm
 
   export
-  Show IField where
+  Show nm => Show (IField' nm) where
     show (MkIField _ c Explicit n ty) = show n ++ " : " ++ show ty
     show (MkIField _ c _ n ty) = "{" ++ show n ++ " : " ++ show ty ++ "}"
 
   export
-  Show ImpRecord where
+  Show nm => Show (ImpRecord' nm) where
     show (MkImpRecord _ n params con fields)
         = "record " ++ show n ++ " " ++ show params ++
           " " ++ show con ++ "\n\t" ++
@@ -315,16 +353,20 @@ mutual
       Syntactic == Syntactic = True
 
   public export
-  data ImpClause : Type where
-       PatClause : FC -> (lhs : RawImp) -> (rhs : RawImp) -> ImpClause
-       WithClause : FC -> (lhs : RawImp) ->
-                    (wval : RawImp) -> (prf : Maybe Name) ->
+  ImpClause : Type
+  ImpClause = ImpClause' Name
+
+  public export
+  data ImpClause' : Type -> Type where
+       PatClause : FC -> (lhs : RawImp' nm) -> (rhs : RawImp' nm) -> ImpClause' nm
+       WithClause : FC -> (lhs : RawImp' nm) ->
+                    (wval : RawImp' nm) -> (prf : Maybe Name) ->
                     (flags : List WithFlag) ->
-                    List ImpClause -> ImpClause
-       ImpossibleClause : FC -> (lhs : RawImp) -> ImpClause
+                    List (ImpClause' nm) -> ImpClause' nm
+       ImpossibleClause : FC -> (lhs : RawImp' nm) -> ImpClause' nm
 
   export
-  Show ImpClause where
+  Show nm => Show (ImpClause' nm) where
     show (PatClause fc lhs rhs)
        = show lhs ++ " = " ++ show rhs
     show (WithClause fc lhs wval prf flags block)
@@ -336,30 +378,35 @@ mutual
        = show lhs ++ " impossible"
 
   public export
-  data ImpDecl : Type where
-       IClaim : FC -> RigCount -> Visibility -> List FnOpt ->
-                ImpTy -> ImpDecl
-       IData : FC -> Visibility -> ImpData -> ImpDecl
-       IDef : FC -> Name -> List ImpClause -> ImpDecl
-       IParameters : FC -> List (Name, RigCount, PiInfo RawImp, RawImp) ->
-                     List ImpDecl -> ImpDecl
+  ImpDecl : Type
+  ImpDecl = ImpDecl' Name
+
+  public export
+  data ImpDecl' : Type -> Type where
+       IClaim : FC -> RigCount -> Visibility -> List (FnOpt' nm) ->
+                ImpTy' nm -> ImpDecl' nm
+       IData : FC -> Visibility -> ImpData' nm -> ImpDecl' nm
+       IDef : FC -> Name -> List (ImpClause' nm) -> ImpDecl' nm
+       IParameters : FC ->
+                     List (ImpParameter' nm) ->
+                     List (ImpDecl' nm) -> ImpDecl' nm
        IRecord : FC ->
                  Maybe String -> -- nested namespace
-                 Visibility -> ImpRecord -> ImpDecl
-       INamespace : FC -> Namespace -> List ImpDecl -> ImpDecl
-       ITransform : FC -> Name -> RawImp -> RawImp -> ImpDecl
-       IRunElabDecl : FC -> RawImp -> ImpDecl
+                 Visibility -> ImpRecord' nm -> ImpDecl' nm
+       INamespace : FC -> Namespace -> List (ImpDecl' nm) -> ImpDecl' nm
+       ITransform : FC -> Name -> RawImp' nm -> RawImp' nm -> ImpDecl' nm
+       IRunElabDecl : FC -> RawImp' nm -> ImpDecl' nm
        IPragma : List Name -> -- pragmas might define names that wouldn't
                        -- otherwise be spotted in 'definedInBlock' so they
                        -- can be flagged here.
                  ({vars : _} ->
                   NestedNames vars -> Env Term vars -> Core ()) ->
-                 ImpDecl
-       ILog : Maybe (List String, Nat) -> ImpDecl
-       IBuiltin : FC -> BuiltinType -> Name -> ImpDecl
+                 ImpDecl' nm
+       ILog : Maybe (List String, Nat) -> ImpDecl' nm
+       IBuiltin : FC -> BuiltinType -> Name -> ImpDecl' nm
 
   export
-  Show ImpDecl where
+  Show nm => Show (ImpDecl' nm) where
     show (IClaim _ c _ opts ty) = show opts ++ " " ++ show c ++ " " ++ show ty
     show (IData _ _ d) = show d
     show (IDef _ n cs) = "(%def " ++ show n ++ " " ++ show cs ++ ")"
@@ -382,7 +429,7 @@ mutual
     show (IBuiltin _ type name) = "%builtin " ++ show type ++ " " ++ show name
 
 export
-isIPrimVal : RawImp -> Maybe Constant
+isIPrimVal : RawImp' nm -> Maybe Constant
 isIPrimVal (IPrimVal _ c) = Just c
 isIPrimVal _ = Nothing
 
@@ -400,7 +447,7 @@ data ImpREPL : Type where
      Quit : ImpREPL
 
 export
-mapAltType : (RawImp -> RawImp) -> AltType -> AltType
+mapAltType : (RawImp' nm -> RawImp' nm) -> AltType' nm -> AltType' nm
 mapAltType f (UniqueDefault x) = UniqueDefault (f x)
 mapAltType _ u = u
 
@@ -432,7 +479,7 @@ lhsInCurrentNS nest (IVar loc n)
 lhsInCurrentNS nest tm = pure tm
 
 export
-findIBinds : RawImp -> List String
+findIBinds : RawImp' nm -> List String
 findIBinds (IPi fc rig p mn aty retty)
     = findIBinds aty ++ findIBinds retty
 findIBinds (ILam fc rig p n aty sc)
@@ -466,7 +513,7 @@ findIBinds (IBindVar _ n) = [n]
 findIBinds tm = []
 
 export
-findImplicits : RawImp -> List String
+findImplicits : RawImp' nm -> List String
 findImplicits (IPi fc rig p (Just (UN mn)) aty retty)
     = mn :: findImplicits aty ++ findImplicits retty
 findImplicits (IPi fc rig p mn aty retty)
@@ -679,7 +726,7 @@ definedInBlock ns decls =
     defName _ _ = []
 
 export
-getFC : RawImp -> FC
+getFC : RawImp' nm -> FC
 getFC (IVar x _) = x
 getFC (IPi x _ _ _ _ _) = x
 getFC (ILam x _ _ _ _ _) = x
@@ -718,7 +765,7 @@ getFC (IWithUnambigNames x _ _) = x
 namespace ImpDecl
 
   public export
-  getFC : ImpDecl -> FC
+  getFC : ImpDecl' nm -> FC
   getFC (IClaim fc _ _ _ _) = fc
   getFC (IData fc _ _) = fc
   getFC (IDef fc _ _) = fc
@@ -732,24 +779,24 @@ namespace ImpDecl
   getFC (IBuiltin fc _ _) = fc
 
 export
-apply : RawImp -> List RawImp -> RawImp
+apply : RawImp' nm -> List (RawImp' nm) -> RawImp' nm
 apply f [] = f
 apply f (x :: xs) =
   let fFC = getFC f in
   apply (IApp (fromMaybe fFC (mergeFC fFC (getFC x))) f x) xs
 
 export
-gapply : RawImp -> List (Maybe Name, RawImp) -> RawImp
+gapply : RawImp' nm -> List (Maybe Name, RawImp' nm) -> RawImp' nm
 gapply f [] = f
 gapply f (x :: xs) = gapply (uncurry (app f) x) xs where
 
-  app : RawImp -> Maybe Name -> RawImp -> RawImp
+  app : RawImp' nm -> Maybe Name -> RawImp' nm -> RawImp' nm
   app f Nothing x =  IApp (getFC f) f x
   app f (Just nm) x = INamedApp (getFC f) f nm x
 
 
 export
-getFn : RawImp -> RawImp
+getFn : RawImp' nm -> RawImp' nm
 getFn (IApp _ f _) = getFn f
 getFn (IWithApp _ f _) = getFn f
 getFn (INamedApp _ f _ _) = getFn f

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -52,6 +52,10 @@ mutual
   RawImp = RawImp' Name
 
   public export
+  IRawImp : Type
+  IRawImp = RawImp' KindedName
+
+  public export
   data RawImp' : Type -> Type where
        IVar : FC -> nm -> RawImp' nm
        IPi : FC -> RigCount -> PiInfo (RawImp' nm) -> Maybe Name ->
@@ -355,6 +359,10 @@ mutual
   public export
   ImpClause : Type
   ImpClause = ImpClause' Name
+
+  public export
+  IImpClause : Type
+  IImpClause = ImpClause' KindedName
 
   public export
   data ImpClause' : Type -> Type where

--- a/src/TTImp/TTImp/Functor.idr
+++ b/src/TTImp/TTImp/Functor.idr
@@ -1,0 +1,160 @@
+module TTImp.TTImp.Functor
+
+import Core.TT
+import TTImp.TTImp
+
+%default covering
+
+mutual
+
+  export
+  Functor RawImp' where
+    map f (IVar fc nm) = IVar fc (f nm)
+    map f (IPi fc rig info nm a sc)
+      = IPi fc rig (map (map f) info) nm (map f a) (map f sc)
+    map f (ILam fc rig info nm a sc)
+      = ILam fc rig (map (map f) info) nm (map f a) (map f sc)
+    map f (ILet fc lhsFC rig nm ty val sc)
+      = ILet fc lhsFC rig nm (map f ty) (map f val) (map f sc)
+    map f (ICase fc sc ty cls)
+      = ICase fc (map f sc) (map f ty) (map (map f) cls)
+    map f (ILocal fc ds sc)
+      = ILocal fc (map (map f) ds) (map f sc)
+    map f (ICaseLocal fc userN intN args sc)
+      = ICaseLocal fc userN intN args (map f sc)
+    map f (IUpdate fc upds rec)
+      = IUpdate fc (map (map f) upds) (map f rec)
+    map f (IApp fc fn t)
+      = IApp fc (map f fn) (map f t)
+    map f (IAutoApp fc fn t)
+      = IAutoApp fc (map f fn) (map f t)
+    map f (INamedApp fc fn nm t)
+      = INamedApp fc (map f fn) nm (map f t)
+    map f (IWithApp fc fn t)
+      = IWithApp fc (map f fn) (map f t)
+    map f (ISearch fc n)
+      = ISearch fc n
+    map f (IAlternative fc alt ts)
+      = IAlternative fc (map f alt) (map (map f) ts)
+    map f (IRewrite fc e t)
+      = IRewrite fc (map f e) (map f t)
+    map f (ICoerced fc e)
+      = ICoerced fc (map f e)
+    map f (IBindHere fc bd t)
+      = IBindHere fc bd (map f t)
+    map f (IBindVar fc str)
+      = IBindVar fc str
+    map f (IAs fc nmFC side nm t)
+      = IAs fc nmFC side nm (map f t)
+    map f (IMustUnify fc reason t)
+      = IMustUnify fc reason (map f t)
+    map f (IDelayed fc reason t)
+      = IDelayed fc reason (map f t)
+    map f (IDelay fc t)
+      = IDelay fc (map f t)
+    map f (IForce fc t)
+      = IForce fc (map f t)
+    map f (IQuote fc t)
+      = IQuote fc (map f t)
+    map f (IQuoteName fc nm)
+      = IQuoteName fc nm
+    map f (IQuoteDecl fc ds)
+      = IQuoteDecl fc (map (map f) ds)
+    map f (IUnquote fc t)
+      = IUnquote fc (map f t)
+    map f (IRunElab fc t)
+      = IRunElab fc (map f t)
+    map f (IPrimVal fc c)
+      = IPrimVal fc c
+    map f (IType fc)
+      = IType fc
+    map f (IHole fc str)
+      = IHole fc str
+    map f (IUnifyLog fc lvl t)
+      = IUnifyLog fc lvl (map f t)
+    map f (Implicit fc b)
+      = Implicit fc b
+    map f (IWithUnambigNames fc ns t)
+      = IWithUnambigNames fc ns (map f t)
+
+  export
+  Functor ImpClause' where
+    map f (PatClause fc lhs rhs)
+      = PatClause fc (map f lhs) (map f rhs)
+    map f (WithClause fc lhs wval prf flags xs)
+      = WithClause fc (map f lhs) (map f wval) prf flags (map (map f) xs)
+    map f (ImpossibleClause fc lhs)
+      = ImpossibleClause fc (map f lhs)
+
+  export
+  Functor ImpDecl' where
+    map f (IClaim fc rig vis opts ty)
+      = IClaim fc rig vis (map (map f) opts) (map f ty)
+    map f (IData fc vis dt)
+      = IData fc vis (map f dt)
+    map f (IDef fc nm cls)
+      = IDef fc nm (map (map f) cls)
+    map f (IParameters fc ps ds)
+      = IParameters fc (map (map  {f = ImpParameter'} f) ps) (map (map f) ds)
+    map f (IRecord fc cs vis rec)
+      = IRecord fc cs vis (map f rec)
+    map f (INamespace fc ns ds)
+      = INamespace fc ns (map (map f) ds)
+    map f (ITransform fc n lhs rhs)
+      = ITransform fc n (map f lhs) (map f rhs)
+    map f (IRunElabDecl fc t)
+      = IRunElabDecl fc (map f t)
+    map f (IPragma xs k) = IPragma xs k
+    map f (ILog x) = ILog x
+    map f (IBuiltin fc ty n) = IBuiltin fc ty n
+
+  export
+  Functor FnOpt' where
+    map f Inline = Inline
+    map f TCInline = TCInline
+    map f (Hint b) = Hint b
+    map f (GlobalHint b) = GlobalHint b
+    map f ExternFn = ExternFn
+    map f (ForeignFn ts) = ForeignFn (map (map f) ts)
+    map f Invertible = Invertible
+    map f (Totality tot) = Totality tot
+    map f Macro = Macro
+    map f (SpecArgs ns) = SpecArgs ns
+
+  export
+  Functor ImpTy' where
+    map f (MkImpTy fc nameFC n ty)
+      = MkImpTy fc nameFC n (map f ty)
+
+  export
+  Functor ImpData' where
+    map f (MkImpData fc n tycon opts datacons)
+      = MkImpData fc n (map f tycon) opts (map (map f) datacons)
+    map f (MkImpLater fc n tycon)
+      = MkImpLater fc n (map f tycon)
+
+  export
+  Functor IField' where
+    map f (MkIField fc rig info n t)
+      = MkIField fc rig (map (map f) info) n (map f t)
+
+  export
+  Functor ImpRecord' where
+    map f (MkImpRecord fc n params conName fields)
+      = MkImpRecord fc n (map (map {f = ImpParameter'} f) params)
+                    conName (map (map f) fields)
+
+  export
+  Functor ImpParameter' where
+    map f (nm, rig, info, t) = (nm, rig, map (map f) info, map f t)
+
+  export
+  Functor IFieldUpdate' where
+    map f (ISetField path t) = ISetField path (map f t)
+    map f (ISetFieldApp path t) = ISetFieldApp path (map f t)
+
+  export
+  Functor AltType' where
+    map f FirstSuccess = FirstSuccess
+    map f Unique = Unique
+    map f (UniqueDefault t) = UniqueDefault (map f t)

--- a/src/TTImp/Unelab.idr
+++ b/src/TTImp/Unelab.idr
@@ -182,13 +182,13 @@ mutual
       = do let nm = nameAt p
            log "unelab.case" 20 $ "Found local name: " ++ show nm
            let ty = gnf env (binderType (getBinder p env))
-           pure (IVar fc (MkKindedName Bound nm), ty)
+           pure (IVar fc (MkKindedName (Just Bound) nm), ty)
   unelabTy' umode nest env (Ref fc nt n)
       = do defs <- get Ctxt
            Just ty <- lookupTyExact n (gamma defs)
                | Nothing => case umode of
                                  ImplicitHoles => pure (Implicit fc True, gErased fc)
-                                 _ => pure (IVar fc (MkKindedName nt n), gErased fc)
+                                 _ => pure (IVar fc (MkKindedName (Just nt) n), gErased fc)
            fn <- getFullName n
            n' <- case umode of
                       NoSugar _ => pure fn
@@ -199,7 +199,7 @@ mutual
                      , "sugared to", show n'
                      ]
 
-           pure (IVar fc (MkKindedName nt n'), gnf env (embed ty))
+           pure (IVar fc (MkKindedName (Just nt) n'), gnf env (embed ty))
   unelabTy' umode nest env (Meta fc n i args)
       = do defs <- get Ctxt
            let mkn = nameRoot n

--- a/src/TTImp/Unelab.idr
+++ b/src/TTImp/Unelab.idr
@@ -17,6 +17,22 @@ import Data.String
 
 %default covering
 
+public export
+record KindedName where
+  constructor MkKindedName
+  nameKind : NameType
+  rawName  : Name
+
+Show KindedName where show = show . rawName
+
+public export
+IRawImp : Type
+IRawImp = RawImp' KindedName
+
+public export
+IImpClause : Type
+IImpClause = ImpClause' KindedName
+
 used : (idx : Nat) -> Term vars -> Bool
 used idx (Local _ _ var _) = idx == var
 used {vars} idx (Bind _ x b sc) = usedBinder b || used (1 + idx) sc
@@ -33,11 +49,11 @@ used idx (TForce _ _ tm) = used idx tm
 used idx _ = False
 
 data IArg
-   = Exp FC RawImp
-   | Auto FC RawImp
-   | Named FC Name RawImp
+   = Exp FC IRawImp
+   | Auto FC IRawImp
+   | Named FC Name IRawImp
 
-unIArg : IArg -> RawImp
+unIArg : IArg -> IRawImp
 unIArg (Exp _ t) = t
 unIArg (Auto _ t) = t
 unIArg (Named _ _ t) = t
@@ -47,7 +63,7 @@ Show IArg where
   show (Auto fc t) = "@{" ++ show t ++ "}"
   show (Named fc n t) = "{" ++ show n ++ " = " ++ show t ++ "}"
 
-getFnArgs : RawImp -> List IArg -> (RawImp, List IArg)
+getFnArgs : IRawImp -> List IArg -> (IRawImp, List IArg)
 getFnArgs (IApp fc f arg) args = getFnArgs f (Exp fc arg :: args)
 getFnArgs (INamedApp fc f n arg) args = getFnArgs f (Named fc n arg :: args)
 getFnArgs (IAutoApp fc f arg) args = getFnArgs f (Auto fc arg :: args)
@@ -67,8 +83,8 @@ Eq UnelabMode where
 mutual
   unelabCase : {auto c : Ref Ctxt Defs} ->
                List (Name, Nat) ->
-               Name -> List IArg -> RawImp ->
-               Core RawImp
+               Name -> List IArg -> IRawImp ->
+               Core IRawImp
   unelabCase nest n args orig
       = do defs <- get Ctxt
            Just glob <- lookupCtxtExact n (gamma defs)
@@ -103,7 +119,7 @@ mutual
 
       mkClause : FC -> Nat ->
                  (vs ** (Env Term vs, Term vs, Term vs)) ->
-                 Core ImpClause
+                 Core IImpClause
       mkClause fc dropped (vs ** (env, lhs, rhs))
           = do let pat = nthArg fc dropped lhs
                logTerm "unelab.case" 20 "Unelaborating LHS" pat
@@ -114,7 +130,7 @@ mutual
                pure (PatClause fc (fst lhs') (fst rhs'))
 
       mkCase : List (vs ** (Env Term vs, Term vs, Term vs)) ->
-               Nat -> Nat -> List IArg -> Core RawImp
+               Nat -> Nat -> List IArg -> Core IRawImp
       mkCase pats (S k) dropped (_ :: args) = mkCase pats k (S dropped) args
       mkCase pats Z dropped (Exp fc tm :: _)
           = do pats' <- traverse (mkClause fc dropped) pats
@@ -124,14 +140,14 @@ mutual
   unelabSugar : {auto c : Ref Ctxt Defs} ->
                 (umode : UnelabMode) ->
                 (nest : List (Name, Nat)) ->
-                (RawImp, Glued vars) ->
-                Core (RawImp, Glued vars)
+                (IRawImp, Glued vars) ->
+                Core (IRawImp, Glued vars)
   unelabSugar (NoSugar _) nest res = pure res
   unelabSugar ImplicitHoles nest res = pure res
   unelabSugar _ nest (tm, ty)
       = let (f, args) = getFnArgs tm [] in
             case f of
-             IVar fc (NS ns (CaseBlock n i)) =>
+             IVar fc (MkKindedName _ (NS ns (CaseBlock n i))) =>
                do log "unelab.case" 20 $ unlines
                          [ "Unelaborating case " ++ show (n, i)
                          , "with arguments: " ++ show args
@@ -142,17 +158,17 @@ mutual
              _ => pure (tm, ty)
 
   dropParams : {auto c : Ref Ctxt Defs} ->
-               List (Name, Nat) -> (RawImp, Glued vars) ->
-               Core (RawImp, Glued vars)
+               List (Name, Nat) -> (IRawImp, Glued vars) ->
+               Core (IRawImp, Glued vars)
   dropParams nest (tm, ty)
      = case getFnArgs tm [] of
             (IVar fc n, args) =>
-                case lookup n nest of
+                case lookup (rawName n) nest of
                      Nothing => pure (tm, ty)
                      Just i => pure $ (apply (IVar fc n) (drop i args), ty)
             _ => pure (tm, ty)
     where
-      apply : RawImp -> List IArg -> RawImp
+      apply : IRawImp -> List IArg -> IRawImp
       apply tm [] = tm
       apply tm (Exp fc a :: args) = apply (IApp fc tm a) args
       apply tm (Auto fc a :: args) = apply (IAutoApp fc tm a) args
@@ -168,7 +184,7 @@ mutual
              (umode : UnelabMode) ->
              (nest : List (Name, Nat)) ->
              Env Term vars -> Term vars ->
-             Core (RawImp, Glued vars)
+             Core (IRawImp, Glued vars)
   unelabTy umode nest env tm
       = unelabSugar umode nest !(dropParams nest !(unelabTy' umode nest env tm))
 
@@ -177,18 +193,18 @@ mutual
               (umode : UnelabMode) ->
               (nest : List (Name, Nat)) ->
               Env Term vars -> Term vars ->
-              Core (RawImp, Glued vars)
+              Core (IRawImp, Glued vars)
   unelabTy' umode nest env (Local fc _ idx p)
       = do let nm = nameAt p
            log "unelab.case" 20 $ "Found local name: " ++ show nm
            let ty = gnf env (binderType (getBinder p env))
-           pure (IVar fc nm, ty)
+           pure (IVar fc (MkKindedName Bound nm), ty)
   unelabTy' umode nest env (Ref fc nt n)
       = do defs <- get Ctxt
            Just ty <- lookupTyExact n (gamma defs)
                | Nothing => case umode of
                                  ImplicitHoles => pure (Implicit fc True, gErased fc)
-                                 _ => pure (IVar fc n, gErased fc)
+                                 _ => pure (IVar fc (MkKindedName nt n), gErased fc)
            fn <- getFullName n
            n' <- case umode of
                       NoSugar _ => pure fn
@@ -199,7 +215,7 @@ mutual
                      , "sugared to", show n'
                      ]
 
-           pure (IVar fc n', gnf env (embed ty))
+           pure (IVar fc (MkKindedName nt n'), gnf env (embed ty))
   unelabTy' umode nest env (Meta fc n i args)
       = do defs <- get Ctxt
            let mkn = nameRoot n
@@ -250,7 +266,7 @@ mutual
            case p' of
                 IVar _ n =>
                     case umode of
-                         NoSugar _ => pure (IAs fc (getLoc p) s n tm', ty)
+                         NoSugar _ => pure (IAs fc (getLoc p) s n.rawName tm', ty)
                          _ => pure (tm', ty)
                 _ => pure (tm', ty) -- Should never happen!
   unelabTy' umode nest env (TDelayed fc r tm)
@@ -277,7 +293,7 @@ mutual
              (umode : UnelabMode) ->
              (nest : List (Name, Nat)) ->
              Env Term vars -> PiInfo (Term vars) ->
-             Core (PiInfo RawImp)
+             Core (PiInfo IRawImp)
   unelabPi umode nest env Explicit = pure Explicit
   unelabPi umode nest env Implicit = pure Implicit
   unelabPi umode nest env AutoImplicit = pure AutoImplicit
@@ -291,8 +307,8 @@ mutual
                  (nest : List (Name, Nat)) ->
                  FC -> Env Term vars -> (x : Name) ->
                  Binder (Term vars) -> Term (x :: vars) ->
-                 RawImp -> Term (x :: vars) ->
-                 Core (RawImp, Glued vars)
+                 IRawImp -> Term (x :: vars) ->
+                 Core (IRawImp, Glued vars)
   unelabBinder umode nest fc env x (Lam fc' rig p ty) sctm sc scty
       = do (ty', _) <- unelabTy umode nest env ty
            p' <- unelabPi umode nest env p
@@ -334,7 +350,7 @@ mutual
 export
 unelabNoSugar : {vars : _} ->
                 {auto c : Ref Ctxt Defs} ->
-                Env Term vars -> Term vars -> Core RawImp
+                Env Term vars -> Term vars -> Core IRawImp
 unelabNoSugar env tm
     = do tm' <- unelabTy (NoSugar False) [] env tm
          pure $ fst tm'
@@ -342,7 +358,7 @@ unelabNoSugar env tm
 export
 unelabUniqueBinders : {vars : _} ->
                 {auto c : Ref Ctxt Defs} ->
-                Env Term vars -> Term vars -> Core RawImp
+                Env Term vars -> Term vars -> Core IRawImp
 unelabUniqueBinders env tm
     = do tm' <- unelabTy (NoSugar True) [] env tm
          pure $ fst tm'
@@ -350,7 +366,7 @@ unelabUniqueBinders env tm
 export
 unelabNoPatvars : {vars : _} ->
                   {auto c : Ref Ctxt Defs} ->
-                  Env Term vars -> Term vars -> Core RawImp
+                  Env Term vars -> Term vars -> Core IRawImp
 unelabNoPatvars env tm
     = do tm' <- unelabTy ImplicitHoles [] env tm
          pure $ fst tm'
@@ -360,7 +376,7 @@ unelabNest : {vars : _} ->
              {auto c : Ref Ctxt Defs} ->
              List (Name, Nat) ->
              Env Term vars ->
-             Term vars -> Core RawImp
+             Term vars -> Core IRawImp
 unelabNest nest env (Meta fc n i args)
     = do let mkn = nameRoot n ++ showScope args
          pure (IHole fc mkn)
@@ -384,5 +400,5 @@ export
 unelab : {vars : _} ->
          {auto c : Ref Ctxt Defs} ->
          Env Term vars ->
-         Term vars -> Core RawImp
+         Term vars -> Core IRawImp
 unelab = unelabNest []

--- a/src/TTImp/Unelab.idr
+++ b/src/TTImp/Unelab.idr
@@ -17,22 +17,6 @@ import Data.String
 
 %default covering
 
-public export
-record KindedName where
-  constructor MkKindedName
-  nameKind : NameType
-  rawName  : Name
-
-Show KindedName where show = show . rawName
-
-public export
-IRawImp : Type
-IRawImp = RawImp' KindedName
-
-public export
-IImpClause : Type
-IImpClause = ImpClause' KindedName
-
 used : (idx : Nat) -> Term vars -> Bool
 used idx (Local _ _ var _) = idx == var
 used {vars} idx (Bind _ x b sc) = usedBinder b || used (1 + idx) sc

--- a/tests/idris2/coverage004/expected
+++ b/tests/idris2/coverage004/expected
@@ -1,5 +1,5 @@
 1/1: Building Cover (Cover.idr)
-Error: While processing left hand side of bad. Can't match on Just (fromInteger 0) as it must have a polymorphic type.
+Error: While processing left hand side of bad. Can't match on Just 0 as it must have a polymorphic type.
 
 Cover:14:6--14:12
  10 | 

--- a/tests/idris2/docs001/expected
+++ b/tests/idris2/docs001/expected
@@ -22,11 +22,12 @@ Main> Prelude.List : Type -> Type
 Main> Prelude.Show : Type -> Type
   Things that have a canonical `String` representation.
   Parameters: ty
+  Constructor: MkShow
   Methods:
-    show : (x : ty) -> String
+    show : ty -> String
       Convert a value to its `String` representation.
       @ x the value to convert
-    showPrec : (d : Prec) -> (x : ty) -> String
+    showPrec : Prec -> ty -> String
       Convert a value to its `String` representation in a certain precedence
       context.
       
@@ -69,9 +70,11 @@ Main> Prelude.show : Show ty => ty -> String
 Main> Prelude.Monad : (Type -> Type) -> Type
   Parameters: m
   Constraints: Applicative m
+  Constructor: MkMonad
   Methods:
     (>>=) : m a -> (a -> m b) -> m b
       Also called `bind`.
+      Fixity Declaration: infixl operator, level 1
     join : m (m a) -> m a
       Also called `flatten` or mu.
   Implementations:

--- a/tests/idris2/docs001/expected
+++ b/tests/idris2/docs001/expected
@@ -81,5 +81,5 @@ Main> Prelude.Monad : (Type -> Type) -> Type
     Monad (Either e)
     Monad List
 Main> 1 : Integer
-	Primitive
+  Primitive
 Main> Bye for now!

--- a/tests/idris2/docs002/expected
+++ b/tests/idris2/docs002/expected
@@ -6,9 +6,7 @@ WrappedInt : Type
 a : SimpleRec -> Int
 b : SimpleRec -> String
 hello : Int -> Int
-	Hello!
 world : Nat -> Nat
-	World!
 Doc> Doc.NS.NestedNS.Foo : Type
   A type of Foo
   

--- a/tests/idris2/docs002/expected
+++ b/tests/idris2/docs002/expected
@@ -13,7 +13,6 @@ Doc> Doc.NS.NestedNS.Foo : Type
 Doc> Doc.WrappedInt : Type
   Totality: total
   Constructor: MkWrappedInt : Int -> WrappedInt
-  
 Doc> Doc.SimpleRec : Type
   Totality: total
   Constructor: MkSimpleRec : Int -> String -> SimpleRec

--- a/tests/idris2/docs003/expected
+++ b/tests/idris2/docs003/expected
@@ -14,6 +14,6 @@ RecordDoc> RecordDoc.Singleton : a -> Type
   Totality: total
   Constructor: __mkSingleton : _
   Projections:
-    equal : ({rec:0} : Singleton v) -> value rec = v
+    equal : (rec : Singleton v) -> value rec = v
     value : Singleton v -> a
 RecordDoc> Bye for now!

--- a/tests/idris2/interactive030/expected
+++ b/tests/idris2/interactive030/expected
@@ -21,9 +21,11 @@ Main> Prelude.<$> : Functor f => (a -> b) -> f a -> f b
 Main> Prelude.Monad : (Type -> Type) -> Type
   Parameters: m
   Constraints: Applicative m
+  Constructor: MkMonad
   Methods:
     (>>=) : m a -> (a -> m b) -> m b
       Also called `bind`.
+      Fixity Declaration: infixl operator, level 1
     join : m (m a) -> m a
       Also called `flatten` or mu.
   Implementations:

--- a/tests/idris2/perf005/expected
+++ b/tests/idris2/perf005/expected
@@ -12,13 +12,13 @@ Lambda:62:3--88:9
  67 |                           (Func
 
 1/1: Building Bad1 (Bad1.idr)
-Error: Couldn't parse declaration.
+Error: Expected ':'.
 
-Bad1:3:1--3:5
+Bad1:3:10--3:11
  1 | module Bad1
  2 | 
  3 | data Bad = BadDCon (x : Nat)
-     ^^^^
+              ^
 
 1/1: Building Bad2 (Bad2.idr)
 Error: Cannot return a named argument.

--- a/tests/idris2/perf005/expected
+++ b/tests/idris2/perf005/expected
@@ -12,14 +12,15 @@ Lambda:62:3--88:9
  67 |                           (Func
 
 1/1: Building Bad1 (Bad1.idr)
-Error: Expected ':'.
+Error: Couldn't parse any alternatives:
+1: Not the end of a block entry.
 
-Bad1:3:10--3:11
+Bad1:3:20--3:21
  1 | module Bad1
  2 | 
  3 | data Bad = BadDCon (x : Nat)
-              ^
-
+                        ^
+... (2 others)
 1/1: Building Bad2 (Bad2.idr)
 Error: Cannot return a named argument.
 

--- a/tests/idris2/pretty001/expected
+++ b/tests/idris2/pretty001/expected
@@ -30,10 +30,10 @@ def1 m n = m `div` n
 Issue1328A> Issue1328A.def2 : Integer -> Integer -> Integer
 def2 m n = m `div` n
 Issue1328A> Issue1328A.inDef0 : Nat
-inDef0 = fromInteger 42 + fromInteger 21
+inDef0 = 42 + 21
 Issue1328A> Issue1328A.inDef1 : Nat
-inDef1 = fromInteger 42 + fromInteger 21
+inDef1 = 42 + 21
 Issue1328A> Issue1328A.inDef2 : Nat
-inDef2 = fromInteger 42 + fromInteger 21
+inDef2 = 42 + 21
 Issue1328A> 
 Bye for now!

--- a/tests/idris2/reflection002/expected
+++ b/tests/idris2/reflection002/expected
@@ -1,6 +1,6 @@
 1/1: Building power (power.idr)
 Main> Main.cube : Nat -> Nat
-cube = \x => mult x (mult x (mult x (const (fromInteger 1) x)))
+cube = \x => mult x (mult x (mult x (const 1 x)))
 Main> 27
 Main> Main.cube' : Nat -> Nat
 cube' = \x => mult (mult (plus x 0) x) x


### PR DESCRIPTION
This PR parametrises `RawImp` and `PTerm` over the notion of variable used in the
`IVar` / `PRef` constructor. This allows us to return a term containing `KindedName`s
rather than `Names` when unelaborating from a `Term`. This, in turn, allows us to
propagate downwards information about the names mentioned in the term & so to patch
the pretty printer to take advantage of that information to do semantic highlighting.