### PR TITLE
[ doc ] Fix a complain of not being in a toctree

### DIFF
--- a/docs/source/tutorial/starting.rst
+++ b/docs/source/tutorial/starting.rst
@@ -7,6 +7,11 @@ Getting Started
 Installing from Source
 ======================
 
+.. toctree::
+   :hidden:
+
+   windows
+
 Prerequisites
 -------------
 
@@ -81,7 +86,7 @@ program is doing and how it works, but if not, we will explain the
 details later. You can compile the program to an executable by
 entering ``idris2 hello.idr -o hello`` at the shell prompt. This will,
 by default, create an executable called ``hello``, which invokes a generated
-and compiled Chez Schem program, in the destination directory ``build/exec``
+and compiled Chez Scheme program, in the destination directory ``build/exec``
 which you can run:
 
 ::


### PR DESCRIPTION
I've figured out the genesis of the warning introduced at #1775. Sphinx (and, thus Github) requires every `rst` file to be either included using `.. include::` or included through table of contents (`toctree`) or explicitly orphaned. `windows.rst` does not conform to any of these.

What we can do is to include it as hidden into the `starting.rst` document, an addition to which `windows.rst` actually is. Unfortunately, you cannot add a `toctree` item between existing sections, only above them. So, if this PR is applied, `toctree` (table of contents on the left) starts looking like this:

![x](https://user-images.githubusercontent.com/2602116/129237419-9a480c49-7b0e-45a7-82ce-e183da841af6.png)

i.e., prerequisites for windows are listed before the general prerequisites.

If you add a `toctree` directive to the "Prerequisites" section (not to the upper "Installing from Source", as it is in this PR), then you don't have "Prerequisites for Windows" listed in the table of contents at all because it starts to be too deep inside the table of contents. However, this still removes the warning.

I'm not sure whether this table of contents' look is acceptable, but I think it is still better than having warnings in each PR and during the docs building.