### PR TITLE
[ base ] Add semigroup and monoid instances for `Vect`

### DIFF
--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -858,6 +858,7 @@ implementation {k : Nat} -> Applicative (Vect k) where
 
 -- ||| This monad is different from the List monad, (>>=)
 -- ||| uses the diagonal.
+public export
 implementation {k : Nat} -> Monad (Vect k) where
     m >>= f = diag (map f m)
 

--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -867,6 +867,18 @@ implementation Traversable (Vect k) where
     traverse f (x :: xs) = [| f x :: traverse f xs |]
 
 --------------------------------------------------------------------------------
+-- Semigroup/Monoid
+--------------------------------------------------------------------------------
+
+public export
+Semigroup a => Semigroup (Vect k a) where
+  (<+>) = zipWith (<+>)
+
+public export
+{k : Nat} -> Monoid a => Monoid (Vect k a) where
+  neutral = replicate k neutral
+
+--------------------------------------------------------------------------------
 -- Show
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
I think these implementations are very consistent to the ideology of other `Vect`'s instances.

Also, existing `Monad` instance was not exported at all, seems to be non-intended.