### PR TITLE
Optimise away case statements on unit-y types

### DIFF
--- a/src/Compiler/CompileExpr.idr
+++ b/src/Compiler/CompileExpr.idr
@@ -270,6 +270,14 @@ enumTree (CConCase fc sc alts def)
     toEnum _ = Nothing
 enumTree t = t
 
+-- remove pattern matches on unit
+unitTree : CExp vars -> CExp vars
+unitTree exp@(CConCase fc sc alts def) = fromMaybe exp
+    $ do let [MkConAlt _ UNIT _ [] e] = alts
+             | _ => Nothing
+         pure e
+unitTree t = t
+
 -- See if the constructor is a special constructor type, e.g a nil or cons
 -- shaped thing.
 dconFlag : {auto c : Ref Ctxt Defs} ->
@@ -504,7 +512,7 @@ mutual
                def <- getDef n alts
                if isNil cases
                   then pure (fromMaybe (CErased fc) def)
-                  else pure $ enumTree !(builtinNatTree $
+                  else pure $ unitTree $ enumTree !(builtinNatTree $
                             CConCase fc (CLocal fc x) cases def)
   toCExpTree' n (Case _ x scTy alts@(DelayCase _ _ _ :: _))
       = throw (InternalError "Unexpected DelayCase")

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -31,7 +31,7 @@ import public Libraries.Utils.Binary
 ||| (Increment this when changing anything in the data format)
 export
 ttcVersion : Int
-ttcVersion = 59
+ttcVersion = 60
 
 export
 checkTTCVersion : String -> Int -> Int -> Core ()

--- a/src/Core/CompileExpr.idr
+++ b/src/Core/CompileExpr.idr
@@ -24,8 +24,9 @@ data ConInfo = DATACON -- normal data constructor
              | NOTHING -- nothing of an option shaped thing
              | JUST -- just of an option shaped thing
              | RECORD -- record constructor (no tag)
-             | ZERO
-             | SUCC
+             | ZERO -- zero of a nat-like type
+             | SUCC -- successort of a nat-like type
+             | UNIT -- unit
 
 export
 Show ConInfo where
@@ -39,6 +40,7 @@ Show ConInfo where
   show RECORD  = "[record]"
   show ZERO    = "[zero]"
   show SUCC    = "[succ]"
+  show UNIT = "[unit]"
 
 export
 Eq ConInfo where
@@ -52,6 +54,7 @@ Eq ConInfo where
   RECORD == RECORD = True
   ZERO == ZERO = True
   SUCC == SUCC = True
+  UNIT == UNIT = True
   _ == _ = False
 
 mutual

--- a/src/Core/Hash.idr
+++ b/src/Core/Hash.idr
@@ -404,6 +404,7 @@ Hashable ConInfo where
     RECORD => h `hashWithSalt` 7
     ZERO => h `hashWithSalt` 8
     SUCC => h `hashWithSalt` 9
+    UNIT => h `hashWithSalt` 10
 
 mutual
   export

--- a/src/Core/TTC.idr
+++ b/src/Core/TTC.idr
@@ -663,6 +663,7 @@ TTC ConInfo where
   toBuf b RECORD = tag 7
   toBuf b ZERO = tag 8
   toBuf b SUCC = tag 9
+  toBuf b UNIT = tag 10
 
   fromBuf b
       = case !getTag of
@@ -676,6 +677,7 @@ TTC ConInfo where
              7 => pure RECORD
              8 => pure ZERO
              9 => pure SUCC
+             10 => pure UNIT
              _ => corrupt "ConInfo"
 
 mutual

--- a/src/TTImp/ProcessData.idr
+++ b/src/TTImp/ProcessData.idr
@@ -357,11 +357,22 @@ calcNaty fc tyCon cs@[_, _]
             else pure False
 calcNaty _ _ _ = pure False
 
+-- has 1 constructor with 0 args (so skip case on it)
+calcUnity : {auto c : Ref Ctxt Defs} ->
+            FC -> Name -> List Constructor -> Core Bool
+calcUnity fc tyCon cs@[_]
+    = do Just mkUnit <- shaped (hasArgs 0) cs
+              | Nothing => pure False
+         setFlag fc mkUnit (ConType UNIT)
+         pure True
+calcUnity _ _ _ = pure False
 
 calcConInfo : {auto c : Ref Ctxt Defs} ->
               FC -> Name -> List Constructor -> Core ()
 calcConInfo fc type cons
    = do False <- calcNaty fc type cons
+           | True => pure ()
+        False <- calcUnity fc type cons
            | True => pure ()
         False <- calcListy fc cons
            | True => pure ()

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -259,6 +259,7 @@ nodeTests = MkTestPool "Node backend" [] (Just Node)
     , "casts"
     , "newints"
     , "reg001"
+    , "reg002"
     , "syntax001"
     , "tailrec001"
     , "idiom001"

--- a/tests/node/reg002/Issue1843.idr
+++ b/tests/node/reg002/Issue1843.idr
@@ -1,0 +1,7 @@
+test : () -> IO ()
+test () = putStrLn "a test"
+test _  = putStrLn "oopsie"
+
+main : IO ()
+main = do test ()
+          putStrLn "foo" >>= test

--- a/tests/node/reg002/expected
+++ b/tests/node/reg002/expected
@@ -1,0 +1,3 @@
+a test
+foo
+a test

--- a/tests/node/reg002/run
+++ b/tests/node/reg002/run
@@ -1,0 +1,4 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --cg node Issue1843.idr -x main
+


### PR DESCRIPTION
This fixes the example in #1843, however, as @DrBearhands notes, it might not fix all cases.

I couldn't immediately think of how to fix the root cause of this issue, as the js ffi can have arbitrary expressions in.
Maybe @stefan-hoeck can think of something (feel free to make your own PR if you want)