### PR TITLE
Inline Neg implementations

### DIFF
--- a/libs/prelude/Prelude/Num.idr
+++ b/libs/prelude/Prelude/Num.idr
@@ -68,6 +68,7 @@ Num Integer where
   (*) = prim__mul_Integer
   fromInteger = id
 
+%inline
 public export
 Neg Integer where
   negate x = prim__sub_Integer 0 x
@@ -104,6 +105,7 @@ Num Int where
   (*) = prim__mul_Int
   fromInteger = prim__cast_IntegerInt
 
+%inline
 public export
 Neg Int where
   negate x = prim__sub_Int 0 x
@@ -131,6 +133,7 @@ Num Int8 where
   (*) = prim__mul_Int8
   fromInteger = prim__cast_IntegerInt8
 
+%inline
 public export
 Neg Int8 where
   negate x = prim__sub_Int8 0 x
@@ -158,6 +161,7 @@ Num Int16 where
   (*) = prim__mul_Int16
   fromInteger = prim__cast_IntegerInt16
 
+%inline
 public export
 Neg Int16 where
   negate x = prim__sub_Int16 0 x
@@ -185,6 +189,7 @@ Num Int32 where
   (*) = prim__mul_Int32
   fromInteger = prim__cast_IntegerInt32
 
+%inline
 public export
 Neg Int32 where
   negate x = prim__sub_Int32 0 x
@@ -212,6 +217,7 @@ Num Int64 where
   (*) = prim__mul_Int64
   fromInteger = prim__cast_IntegerInt64
 
+%inline
 public export
 Neg Int64 where
   negate x = prim__sub_Int64 0 x
@@ -239,6 +245,7 @@ Num Bits8 where
   (*) = prim__mul_Bits8
   fromInteger = prim__cast_IntegerBits8
 
+%inline
 public export
 Neg Bits8 where
   negate x = prim__sub_Bits8 0 x
@@ -266,6 +273,7 @@ Num Bits16 where
   (*) = prim__mul_Bits16
   fromInteger = prim__cast_IntegerBits16
 
+%inline
 public export
 Neg Bits16 where
   negate x = prim__sub_Bits16 0 x
@@ -293,6 +301,7 @@ Num Bits32 where
   (*) = prim__mul_Bits32
   fromInteger = prim__cast_IntegerBits32
 
+%inline
 public export
 Neg Bits32 where
   negate x = prim__sub_Bits32 0 x
@@ -320,6 +329,7 @@ Num Bits64 where
   (*) = prim__mul_Bits64
   fromInteger = prim__cast_IntegerBits64
 
+%inline
 public export
 Neg Bits64 where
   negate x = prim__sub_Bits64 0 x
@@ -346,6 +356,7 @@ Num Double where
   (*) = prim__mul_Double
   fromInteger = prim__cast_IntegerDouble
 
+%inline
 public export
 Neg Double where
   negate x = prim__negate_Double x


### PR DESCRIPTION
This PR adds `%inline` pragmas to all `Neg`-implementations in `libs/prelude/Prelude/Num.idr`.