### PR TITLE
[ close #1313 ] test case

### DIFF
--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -186,7 +186,7 @@ idrisTests = MkTestPool "Misc" [] Nothing
        -- Implicit laziness, lazy evaluation
        "lazy001", "lazy002",
        -- Namespace blocks
-       "namespace001",
+       "namespace001", "namespace002",
        -- Parameters blocks
        "params001", "params002", "params003",
        -- Packages and ipkg files

--- a/tests/idris2/namespace002/Issue1313.idr
+++ b/tests/idris2/namespace002/Issue1313.idr
@@ -1,0 +1,14 @@
+namespace X
+
+  export
+  f : Int -> Int
+
+namespace Y
+
+  g : Int -> Int -> Int
+  g x y = x + f g
+
+namespace X
+
+  f 5 = 6
+  f x = x - 1

--- a/tests/idris2/namespace002/expected
+++ b/tests/idris2/namespace002/expected
@@ -1,0 +1,12 @@
+1/1: Building Issue1313 (Issue1313.idr)
+Error: While processing right hand side of g. When unifying Int -> Int -> Int and Int.
+Mismatch between: Int -> Int -> Int and Int.
+
+Issue1313:9:17--9:18
+ 5 | 
+ 6 | namespace Y
+ 7 | 
+ 8 |   g : Int -> Int -> Int
+ 9 |   g x y = x + f g
+                     ^
+

--- a/tests/idris2/namespace002/run
+++ b/tests/idris2/namespace002/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --check Issue1313.idr || true


### PR DESCRIPTION
This was fixed by, I believe, the addition of `withExtendedNS` in #1342