### PR TITLE
Support tarm64osx (AArch64, Apple M1) target

### DIFF
--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -93,7 +93,7 @@ schHeader chez libs whole
     "(case (machine-type)\n" ++
     "  [(i3fb ti3fb a6fb ta6fb) #f]\n" ++
     "  [(i3le ti3le a6le ta6le tarm64le) (load-shared-object \"libc.so.6\")]\n" ++
-    "  [(i3osx ti3osx a6osx ta6osx) (load-shared-object \"libc.dylib\")]\n" ++
+    "  [(i3osx ti3osx a6osx ta6osx tarm64osx) (load-shared-object \"libc.dylib\")]\n" ++
     "  [(i3nt ti3nt a6nt ta6nt) (load-shared-object \"msvcrt.dll\")]\n" ++
     "  [else (load-shared-object \"libc.so\")])\n\n" ++
     showSep "\n" (map (\x => "(load-shared-object \"" ++ escapeStringChez x ++ "\")") libs) ++ "\n\n" ++

--- a/src/Compiler/Scheme/ChezSep.idr
+++ b/src/Compiler/Scheme/ChezSep.idr
@@ -45,7 +45,7 @@ schHeader libs compilationUnits = unlines
       ++ ")"
   , "(case (machine-type)"
   , "  [(i3le ti3le a6le ta6le tarm64le) (load-shared-object \"libc.so.6\")]"
-  , "  [(i3osx ti3osx a6osx ta6osx) (load-shared-object \"libc.dylib\")]"
+  , "  [(i3osx ti3osx a6osx ta6osx tarm64osx) (load-shared-object \"libc.dylib\")]"
   , "  [(i3nt ti3nt a6nt ta6nt) (load-shared-object \"msvcrt.dll\")"
   , "                           (load-shared-object \"ws2_32.dll\")]"
   , "  [else (load-shared-object \"libc.so\")]"


### PR DESCRIPTION
On Racket, the Mac M1 target (AArch64) is known as `tarm64osx`. Currently, Idris2 does not account for this when looking for the `libc.(so/dylib)` shared object file. This does not cause the build to fail, and it actually takes a while for the error to surface (for me it only appeared when trying to run `idris2-lsp`, getting the error `Exception: (while loading libc.so) dlopen(libc.so, 2): image not found`).

This pull request simply addr `tarm64osx` to the `case`-statements selecting macOS-targets, overriding the default behaviour of defaulting to `libc.so`.

