### PR TITLE
[ fix ] fix #1839

### DIFF
--- a/support/js/support.js
+++ b/support/js/support.js
@@ -45,9 +45,6 @@ const _idrisworld = Symbol('idrisworld')
 
 const _crashExp = x=>{throw new IdrisError(x)}
 
-const _sysos =
-  ((o => o === 'linux'?'unix':o==='win32'?'windows':o)(require('os').platform()));
-
 const _bigIntOfString = s=>{
   const idx = s.indexOf('.')
   return idx === -1 ? BigInt(s) : BigInt(s.slice(0, idx))

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -264,6 +264,7 @@ nodeTests = MkTestPool "Node backend" [] (Just Node)
     , "tailrec001"
     , "idiom001"
     , "integers"
+    , "fix1839"
     ]
 
 vmcodeInterpTests : IO TestPool

--- a/tests/node/fix1839/OS.idr
+++ b/tests/node/fix1839/OS.idr
@@ -1,0 +1,4 @@
+import System.Info
+
+main : IO ()
+main = printLn (os /= "")

--- a/tests/node/fix1839/expected
+++ b/tests/node/fix1839/expected
@@ -1,0 +1,4 @@
+1/1: Building OS (OS.idr)
+Main> True
+Main> Bye for now!
+Error: INTERNAL ERROR: prim not implemented: prim__os

--- a/tests/node/fix1839/input
+++ b/tests/node/fix1839/input
@@ -1,0 +1,2 @@
+:exec main
+:q

--- a/tests/node/fix1839/run
+++ b/tests/node/fix1839/run
@@ -1,4 +1,4 @@
 rm -rf build
 
 $1 --cg node --no-banner --no-color --console-width 0 OS.idr < input
-$1 --cg javascript --no-color -o os.js OS.idr
+$1 --cg javascript --no-banner --no-color --console-width 0 -o os.js OS.idr

--- a/tests/node/fix1839/run
+++ b/tests/node/fix1839/run
@@ -1,0 +1,4 @@
+rm -rf build
+
+$1 --cg node --no-banner --no-color --console-width 0 OS.idr < input
+$1 --cg javascript --no-color -o os.js OS.idr


### PR DESCRIPTION
Fixes #1839.

This fix removes the implementation of `prim__os` from the static Javascript preamble. After this, `prim__os` is only supported in the `node` backend but not the `javascript` backend. If people can show me a reliable and useful way to determine the OS in the browser, I'll happily add that as the new implementation of `prim__os` for the `javascript` backend.