### PR TITLE
[ new ] support prim__putStr in browser backend

### DIFF
--- a/libs/prelude/Prelude/IO.idr
+++ b/libs/prelude/Prelude/IO.idr
@@ -85,6 +85,7 @@ prim__getStr : PrimIO String
 
 %foreign "C:idris2_putStr, libidris2_support, idris_support.h"
          "node:lambda:x=>process.stdout.write(x)"
+         "browser:lambda:x=>console.log(x)"
 prim__putStr : String -> PrimIO ()
 
 ||| Output a string to stdout without a trailing newline.


### PR DESCRIPTION
Just a tiny but useful addition. I didn't even realize this was missing.