### PR TITLE
[ fix ] invalid Cast instances

### DIFF
--- a/libs/prelude/Prelude/Cast.idr
+++ b/libs/prelude/Prelude/Cast.idr
@@ -730,7 +730,7 @@ Cast Double Nat where
 
 export
 Cast Char Nat where
-  cast = believe_me . cast {to = Integer}
+  cast = integerToNat . cast {to = Integer}
 
 export
 Cast Int Nat where
@@ -742,19 +742,19 @@ Cast Integer Nat where
 
 export
 Cast Bits8 Nat where
-  cast = believe_me . cast {to = Integer}
+  cast = integerToNat . cast {to = Integer}
 
 export
 Cast Bits16 Nat where
-  cast = believe_me . cast {to = Integer}
+  cast = integerToNat . cast {to = Integer}
 
 export
 Cast Bits32 Nat where
-  cast = believe_me . cast {to = Integer}
+  cast = integerToNat . cast {to = Integer}
 
 export
 Cast Bits64 Nat where
-  cast = believe_me . cast {to = Integer}
+  cast = integerToNat . cast {to = Integer}
 
 export
 Cast Int8 Nat where


### PR DESCRIPTION
integerToNat is only equal to `believe_me` at runtime, not at compile
time. You'd believe it cannot be a problem given that the implementation
of `Cast` is not exported but the REPL reduces everything.