### PR TITLE
[ performance ] Common subexpression elimination

### DIFF
--- a/idris2api.ipkg
+++ b/idris2api.ipkg
@@ -15,6 +15,7 @@ modules =
     Compiler.Identity,
     Compiler.Inline,
     Compiler.LambdaLift,
+    Compiler.Opts.CSE,
     Compiler.Separate,
     Compiler.VMCode,
 
@@ -62,6 +63,7 @@ modules =
     Core.Normalise,
     Core.Options,
     Core.Options.Log,
+    Core.Ord,
     Core.Primitives,
     Core.Reflect,
     Core.Termination,

--- a/src/Compiler/Common.idr
+++ b/src/Compiler/Common.idr
@@ -146,7 +146,7 @@ getMinimalDef (Coded ns bin)
              = MkGlobalDef fc name (Erased fc False) [] [] [] [] mul
                            [] Public (MkTotality Unchecked IsCovering)
                            [] Nothing refsR False False True
-                           None cdef Nothing []
+                           None cdef []
          pure (def, Just (ns, bin))
 
 -- ||| Recursively get all calls in a function definition
@@ -185,16 +185,11 @@ warnIfHole n (MkNmError _)
 warnIfHole n _ = pure ()
 
 getNamedDef :  {auto c : Ref Ctxt Defs}
-            -> Name
-            -> Core (Maybe (Name, FC, NamedDef))
-getNamedDef n
-    = do defs <- get Ctxt
-         case !(lookupCtxtExact n (gamma defs)) of
-              Nothing => pure Nothing
-              Just def => case namedcompexpr def of
-                               Nothing => pure Nothing
-                               Just d => do warnIfHole n d
-                                            pure (Just (n, location def, d))
+            -> (Name,FC,CDef)
+            -> Core (Name, FC, NamedDef)
+getNamedDef (n,fc,cdef) =
+  let ndef = forgetDef cdef
+   in warnIfHole n ndef >> pure (n,fc,ndef)
 
 replaceEntry : {auto c : Ref Ctxt Defs} ->
                (Int, Maybe (Namespace, Binary)) -> Core ()
@@ -210,11 +205,10 @@ natHackNames
        NS typesNS (UN "prim__integerToNat")]
 
 -- Hmm, these dump functions are all very similar aren't they...
-dumpCases : Defs -> String -> List Name ->
-            Core ()
-dumpCases defs fn cns
-    = do cstrs <- traverse dumpCase cns
-         Right () <- coreLift $ writeFile fn (fastAppend cstrs)
+dumpCases : String -> List (Name,FC,NamedDef) -> Core ()
+dumpCases fn defs
+    = do Right () <- coreLift $ writeFile fn
+                     (fastAppend $ map dumpCase defs)
                | Left err => throw (FileErr fn err)
          pure ()
   where
@@ -222,14 +216,9 @@ dumpCases defs fn cns
     fullShow (DN _ n) = show n
     fullShow n = show n
 
-    dumpCase : Name -> Core String
-    dumpCase n
-        = case !(lookupCtxtExact n (gamma defs)) of
-               Nothing => pure ""
-               Just d =>
-                    case namedcompexpr d of
-                         Nothing => pure ""
-                         Just def => pure (fullShow n ++ " = " ++ show def ++ "\n")
+    dumpCase : (Name,FC,NamedDef) -> String
+    dumpCase (n,_,def)
+        = fullShow n ++ " = " ++ show def ++ "\n"
 
 dumpLifted : String -> List (Name, LiftedDef) -> Core ()
 dumpLifted fn lns
@@ -312,21 +301,22 @@ getCompileData doLazyAnnots phase_in tm_in
          rcns <- filterM nonErased cns
          logTime "++ Merge lambda" $ traverse_ mergeLamDef rcns
          logTime "++ Fix arity" $ traverse_ fixArityDef rcns
-         csens <- logTime "++ CSE" $ do
-           um <- analyzeNames rcns
-           traverse_ (cseDef um) rcns
-           newNames <- addToplevelDefs um
-           pure $ newNames ++ rcns
-         logTime "++ Forget names" $ traverse_ mkForgetDef csens
-
          compiledtm <- fixArityExp !(compileExp tm)
-         let mainname = MN "__mainExpression" 0
-         (liftedtm, ldefs) <- liftBody {doLazyAnnots} mainname compiledtm
 
-         namedefs  <- traverse getNamedDef csens
+         (cseDefs, csetm) <- logTime "++ CSE" $ do
+           um      <- analyzeNames compiledtm rcns
+           defs    <- mapMaybe id <$> traverse (cseDef um) rcns
+           pure $ (cseNewToplevelDefs um ++ defs, adjust um compiledtm)
+
+         namedDefs <- logTime "++ Forget names" $
+           traverse getNamedDef cseDefs
+
+         let mainname = MN "__mainExpression" 0
+         (liftedtm, ldefs) <- liftBody {doLazyAnnots} mainname csetm
+
          lifted_in <- if phase >= Lifted
                          then logTime "++ Lambda lift" $
-                              traverse (lambdaLift doLazyAnnots) csens
+                              traverse (lambdaLift doLazyAnnots) cseDefs
                          else pure []
 
          let lifted = (mainname, MkLFun [] [] liftedtm) ::
@@ -342,7 +332,7 @@ getCompileData doLazyAnnots phase_in tm_in
          defs <- get Ctxt
          maybe (pure ())
                (\f => do coreLift $ putStrLn $ "Dumping case trees to " ++ f
-                         dumpCases defs f csens)
+                         dumpCases f namedDefs)
                (dumpcases sopts)
          maybe (pure ())
                (\f => do coreLift $ putStrLn $ "Dumping lambda lifted defs to " ++ f
@@ -361,9 +351,7 @@ getCompileData doLazyAnnots phase_in tm_in
          -- it was. Back ends shouldn't look at the global context, because
          -- it'll have to decode the definitions again.
          traverse_ replaceEntry entries
-         pure (MkCompileData compiledtm
-                             (mapMaybe id namedefs)
-                             lifted anf vmcode)
+         pure (MkCompileData csetm namedDefs lifted anf vmcode)
 
 export
 compileTerm : {auto c : Ref Ctxt Defs} ->
@@ -382,11 +370,13 @@ getIncCompileData doLazyAnnots phase
          let ns = keys (toIR defs)
          cns <- traverse toFullNames ns
          rcns <- filterM nonErased cns
-         traverse_ mkForgetDef rcns
+         cseDefs <- mapMaybe id <$> traverse (cseDef empty) rcns
 
-         namedefs <- traverse getNamedDef rcns
+         namedDefs <- traverse getNamedDef cseDefs
+
          lifted_in <- if phase >= Lifted
-                         then logTime "++ Lambda lift" $ traverse (lambdaLift doLazyAnnots) rcns
+                         then logTime "++ Lambda lift" $
+                              traverse (lambdaLift doLazyAnnots) cseDefs
                          else pure []
          let lifted = concat lifted_in
          anf <- if phase >= ANF
@@ -395,9 +385,7 @@ getIncCompileData doLazyAnnots phase
          vmcode <- if phase >= VMCode
                       then logTime "++ Get VM Code" $ pure (allDefs anf)
                       else pure []
-         pure (MkCompileData (CErased emptyFC)
-                             (mapMaybe id namedefs)
-                             lifted anf vmcode)
+         pure (MkCompileData (CErased emptyFC) namedDefs lifted anf vmcode)
 
 -- Some things missing from Prelude.File
 

--- a/src/Compiler/Common.idr
+++ b/src/Compiler/Common.idr
@@ -304,7 +304,7 @@ getCompileData doLazyAnnots phase_in tm_in
          compiledtm <- fixArityExp !(compileExp tm)
 
          (cseDefs, csetm) <- logTime "++ CSE" $ do
-           um      <- analyzeNames compiledtm rcns
+           um      <- analyzeNames rcns
            defs    <- mapMaybe id <$> traverse (cseDef um) rcns
            pure $ (cseNewToplevelDefs um ++ defs, adjust um compiledtm)
 

--- a/src/Compiler/CompileExpr.idr
+++ b/src/Compiler/CompileExpr.idr
@@ -794,15 +794,12 @@ compileDef n
     noDefYet _ _ = False
 
 export
-mkForgetDef :  {auto c : Ref Ctxt Defs}
-            -> UsageMap
-            -> Name
-            -> Core ()
-mkForgetDef um n
+mkForgetDef :  {auto c : Ref Ctxt Defs} -> Name -> Core ()
+mkForgetDef n
     = do defs <- get Ctxt
          Just gdef <- lookupCtxtExact n (gamma defs)
               | Nothing => throw (InternalError ("Trying to compile unknown name " ++ show n))
          case compexpr gdef of
               Nothing => pure ()
-              Just cdef => do let ncdef = forgetDef (adjustDef um cdef)
+              Just cdef => do let ncdef = forgetDef cdef
                               setNamedCompiled n ncdef

--- a/src/Compiler/CompileExpr.idr
+++ b/src/Compiler/CompileExpr.idr
@@ -1,5 +1,6 @@
 module Compiler.CompileExpr
 
+import Compiler.Opts.CSE
 import Core.CaseTree
 import public Core.CompileExpr
 import Core.Context
@@ -793,13 +794,15 @@ compileDef n
     noDefYet _ _ = False
 
 export
-mkForgetDef : {auto c : Ref Ctxt Defs} ->
-              Name -> Core ()
-mkForgetDef n
+mkForgetDef :  {auto c : Ref Ctxt Defs}
+            -> UsageMap
+            -> Name
+            -> Core ()
+mkForgetDef um n
     = do defs <- get Ctxt
          Just gdef <- lookupCtxtExact n (gamma defs)
               | Nothing => throw (InternalError ("Trying to compile unknown name " ++ show n))
          case compexpr gdef of
               Nothing => pure ()
-              Just cdef => do let ncdef = forgetDef cdef
+              Just cdef => do let ncdef = forgetDef (adjustDef um cdef)
                               setNamedCompiled n ncdef

--- a/src/Compiler/CompileExpr.idr
+++ b/src/Compiler/CompileExpr.idr
@@ -792,14 +792,3 @@ compileDef n
     noDefYet : Def -> List CG -> Bool
     noDefYet None (_ :: _) = True
     noDefYet _ _ = False
-
-export
-mkForgetDef :  {auto c : Ref Ctxt Defs} -> Name -> Core ()
-mkForgetDef n
-    = do defs <- get Ctxt
-         Just gdef <- lookupCtxtExact n (gamma defs)
-              | Nothing => throw (InternalError ("Trying to compile unknown name " ++ show n))
-         case compexpr gdef of
-              Nothing => pure ()
-              Just cdef => do let ncdef = forgetDef cdef
-                              setNamedCompiled n ncdef

--- a/src/Compiler/ES/Codegen.idr
+++ b/src/Compiler/ES/Codegen.idr
@@ -674,6 +674,8 @@ def (MkFunction n as body) = do
   mde  <- mode <$> get ESs
   b    <- stmt Returns body >>= stmt
   case args of
+    -- zero argument toplevel functions are converted to
+    -- lazily evaluated constants.
     [] => pure $ printDoc mde $
       constant (var ref) (
         "__lazy(" <+> function neutral [] b <+> ")"

--- a/src/Compiler/ES/Codegen.idr
+++ b/src/Compiler/ES/Codegen.idr
@@ -673,7 +673,12 @@ def (MkFunction n as body) = do
   args <- traverse registerLocal as
   mde  <- mode <$> get ESs
   b    <- stmt Returns body >>= stmt
-  pure $ printDoc mde $ function (var ref) (map var args) b
+  case args of
+    [] => pure $ printDoc mde $
+      constant (var ref) (
+        "__lazy(" <+> function neutral [] b <+> ")"
+      )
+    _  => pure $ printDoc mde $ function (var ref) (map var args) b
 
 -- generate code for the given foreign function definition
 foreign :  {auto c : Ref ESs ESSt}

--- a/src/Compiler/LambdaLift.idr
+++ b/src/Compiler/LambdaLift.idr
@@ -429,11 +429,8 @@ lambdaLiftDef doLazyAnnots n (MkError exp)
 -- An empty list an error, because on success you will always get at least
 -- one definition, the lifted definition for the given name.
 export
-lambdaLift : {auto c : Ref Ctxt Defs} ->
-             (doLazyAnnots : Bool) ->
-             Name -> Core (List (Name, LiftedDef))
-lambdaLift doLazyAnnots n
-    = do defs <- get Ctxt
-         Just def <- lookupCtxtExact n (gamma defs) | Nothing => pure []
-         let Just cexpr = compexpr def              | Nothing => pure []
-         lambdaLiftDef doLazyAnnots n cexpr
+lambdaLift :  {auto c : Ref Ctxt Defs}
+           -> (doLazyAnnots : Bool)
+           -> (Name,FC,CDef)
+           -> Core (List (Name, LiftedDef))
+lambdaLift doLazyAnnots (n,_,def) = lambdaLiftDef doLazyAnnots n def

--- a/src/Compiler/LambdaLift.idr
+++ b/src/Compiler/LambdaLift.idr
@@ -412,6 +412,7 @@ liftBody n tm
          ldata <- get Lifts
          pure (tml, defs ldata)
 
+export
 lambdaLiftDef : (doLazyAnnots : Bool) -> Name -> CDef -> Core (List (Name, LiftedDef))
 lambdaLiftDef doLazyAnnots n (MkFun args exp)
     = do (expl, defs) <- liftBody {doLazyAnnots} n exp

--- a/src/Compiler/Opts/CSE.idr
+++ b/src/Compiler/Opts/CSE.idr
@@ -1,0 +1,279 @@
+module Compiler.Opts.CSE
+
+import Core.CompileExpr
+import Core.Context
+import Core.Context.Log
+import Core.Name
+import Core.TT
+
+import Core.Ord
+import Data.List
+import Data.Nat
+import Data.Vect
+import Libraries.Data.SortedMap
+
+public export
+UsageMap : Type
+UsageMap = SortedMap (Integer, CExp []) (Name, Integer)
+
+--------------------------------------------------------------------------------
+--          Size of Expressions
+--------------------------------------------------------------------------------
+
+mutual
+  -- comparison for `Nat` is (or used to be?) O(n),
+  -- therefore, we use `Integer`
+  size : CExp ns -> Integer
+  size (CLocal _ _) = 1
+  size (CRef _ _) = 1
+  size (CLam _ _ y) = size y + 1
+  size (CLet _ _ _ y z) = size y + size z + 1
+  size (CApp _ _ xs) = sum (map size xs) + 1
+  size (CCon _ _ _ _ xs) = sum (map size xs) + 1
+  size (COp _ _ xs) = sum (map size xs) + 1
+  size (CExtPrim _ _ xs) = sum (map size xs) + 1
+  size (CForce _ _ y) = size y + 1
+  size (CDelay _ _ y) = size y + 1
+  size (CConCase _ sc xs x) =
+    size sc + sum (map sizeConAlt xs) + sum (map size x) + 1
+
+  size (CConstCase _ sc xs x) =
+    size sc + sum (map sizeConstAlt xs) + sum (map size x) + 1
+
+  size (CPrimVal _ _) = 1
+  size (CErased _) = 1
+  size (CCrash _ _) = 1
+
+  sizeConAlt : CConAlt ns -> Integer
+  sizeConAlt (MkConAlt _ _ _ _ z) = 1 + size z
+
+  sizeConstAlt : CConstAlt ns -> Integer
+  sizeConstAlt (MkConstAlt _ y) = 1 + size y
+
+--------------------------------------------------------------------------------
+--          State
+--------------------------------------------------------------------------------
+
+data Sts : Type where
+
+record St where
+  constructor MkSt
+  map : UsageMap
+  idx : Int
+
+store : { auto c : Ref Sts St } -> CExp [] -> Core Integer
+store exp =
+  let sz = size exp
+   in if sz < 6
+         then pure 0
+         else do
+           (MkSt map idx)    <- get Sts
+           (name,count,idx2) <-
+             case lookup (sz,exp) map of
+               Just (nm,cnt) => pure (nm, cnt+1, idx)
+               Nothing       => pure (MN "gencon" idx, 1, idx + 1)
+           put Sts $ MkSt (insert (sz,exp) (name, count) map) idx2
+           pure count
+
+--------------------------------------------------------------------------------
+--          Strengthening of Expressions
+--------------------------------------------------------------------------------
+
+dropVar :  (pre : List Name)
+        -> (n : Nat)
+        -> (0 p : IsVar x n (pre ++ ns))
+        -> Maybe (IsVar x n pre)
+dropVar [] _ _        = Nothing
+dropVar (y :: xs) 0 First = Just First
+dropVar (y :: xs) (S k) (Later p) =
+  case dropVar xs k p of
+    Just p' => Just $ Later p'
+    Nothing => Nothing
+
+mutual
+  dropEnv : {pre : List Name} -> CExp (pre ++ ns) -> Maybe (CExp pre)
+  dropEnv (CLocal {idx} fc p) = (\q => CLocal fc q) <$> dropVar pre idx p
+  dropEnv (CRef fc x) = Just (CRef fc x)
+  dropEnv (CLam fc x y) = CLam fc x <$> dropEnv y
+  dropEnv (CLet fc x inlineOK y z) =
+    CLet fc x inlineOK <$> dropEnv y <*> dropEnv z
+  dropEnv (CApp fc x xs) = CApp fc <$> dropEnv x <*> traverse dropEnv xs
+  dropEnv (CCon fc x y tag xs) = CCon fc x y tag <$> traverse dropEnv xs
+  dropEnv (COp fc x xs) = COp fc x <$> traverse dropEnv xs
+  dropEnv (CExtPrim fc p xs) = CExtPrim fc p <$> traverse dropEnv xs
+  dropEnv (CForce fc x y) = CForce fc x <$> dropEnv y
+  dropEnv (CDelay fc x y) = CDelay fc x <$> dropEnv y
+  dropEnv (CConCase fc sc xs x) =
+    CConCase fc            <$>
+    dropEnv sc             <*>
+    traverse dropConAlt xs <*>
+    traverse dropEnv x
+
+  dropEnv (CConstCase fc sc xs x) =
+    CConstCase fc            <$>
+    dropEnv sc               <*>
+    traverse dropConstAlt xs <*>
+    traverse dropEnv x
+
+  dropEnv (CPrimVal fc x) = Just $ CPrimVal fc x
+  dropEnv (CErased fc) = Just $ CErased fc
+  dropEnv (CCrash fc x) = Just $ CCrash fc x
+
+  dropConAlt :  {pre : List Name}
+             -> CConAlt (pre ++ ns)
+             -> Maybe (CConAlt pre)
+  dropConAlt (MkConAlt x y tag args z) =
+    MkConAlt x y tag args . embed <$> dropEnv z
+
+  dropConstAlt :  {pre : List Name}
+               -> CConstAlt (pre ++ ns)
+               -> Maybe (CConstAlt pre)
+  dropConstAlt (MkConstAlt x y) = MkConstAlt x <$> dropEnv y
+
+--------------------------------------------------------------------------------
+--          Analysis
+--------------------------------------------------------------------------------
+
+mutual
+
+  analyze : Ref Sts St => CExp ns -> Core ()
+  analyze c@(COp _ _ xs) = analyzeSubExp c
+  analyze exp = case dropEnv {pre = []} exp of
+    Just e0 => do
+      count <- store e0
+      if count == 1 then analyzeSubExp exp else pure ()
+    Nothing => analyzeSubExp exp
+
+  -- store all calls to `CCon` that can be converted to
+  -- expressions with an empty environment together with
+  -- their count and a generated name in a sorted map.
+  analyzeSubExp : Ref Sts St => CExp ns -> Core ()
+  analyzeSubExp (CLocal _ _) = pure ()
+  analyzeSubExp (CRef _ _) = pure ()
+  analyzeSubExp (CLam _ _ y) = analyze y
+  analyzeSubExp (CLet _ _ _ y z) = analyze y >> analyze z
+  analyzeSubExp (CApp fc x xs) = analyze x >> traverse_ analyze xs
+  analyzeSubExp (CCon _ _ _ _ []) = pure ()
+  analyzeSubExp (CCon _ _ _ _ xs) = traverse_ analyze xs
+  analyzeSubExp (COp _ _ xs) = ignore $ traverseVect analyze xs
+  analyzeSubExp (CExtPrim _ _ xs) = traverse_ analyze xs
+  analyzeSubExp (CForce _ _ y) = analyze y
+  analyzeSubExp (CDelay _ _ y) = analyze y
+  analyzeSubExp (CConCase _ sc xs x) =
+    analyze sc                     >>
+    traverse_ analyzeConAlt xs     >>
+    ignore (traverseOpt analyze x)
+
+  analyzeSubExp (CConstCase _ sc xs x) =
+    analyze sc                     >>
+    traverse_ analyzeConstAlt xs   >>
+    ignore (traverseOpt analyze x)
+
+  analyzeSubExp (CPrimVal _ _) = pure ()
+  analyzeSubExp (CErased _) = pure ()
+  analyzeSubExp (CCrash _ _) = pure ()
+
+  analyzeConAlt : { auto c : Ref Sts St } -> CConAlt ns -> Core ()
+  analyzeConAlt (MkConAlt _ _ _ _ z) = analyze z
+
+  analyzeConstAlt : Ref Sts St => CConstAlt ns -> Core ()
+  analyzeConstAlt (MkConstAlt _ y) = analyze y
+
+analyzeDef : Ref Sts St => CDef -> Core ()
+analyzeDef (MkFun args x)                = analyze x
+analyzeDef (MkCon _ _ _)                 = pure ()
+analyzeDef (MkForeign _ _ _)             = pure ()
+analyzeDef (MkError _)                   = pure ()
+
+analyzeName : Ref Sts St => Ref Ctxt Defs => Name -> Core ()
+analyzeName fn = do
+    defs <- get Ctxt
+    Just def <- lookupCtxtExact fn (gamma defs)
+        | Nothing => pure ()
+    let Just cexp = compexpr def
+        | Nothing => pure ()
+    analyzeDef cexp
+
+export
+analyzeNames : Ref Ctxt Defs => List Name -> Core UsageMap
+analyzeNames cns = do
+  log "compiler.cse" 10 $ "Analysing " ++ show (length cns) ++ " names"
+  s <- newRef Sts $ MkSt empty 0
+  traverse_ analyzeName cns
+  MkSt map _ <- get Sts
+  let filtered = reverse
+               . sortBy (comparing $ snd . snd)
+               . filter ((> 1) . snd . snd)
+               $ SortedMap.toList map
+
+  traverse_ (\((sz,_),(name,cnt)) =>
+                log "compiler.cse" 10 (
+                  show name ++
+                  ": count " ++ show cnt ++
+                  ", size " ++ show sz
+                 )
+            ) filtered
+  pure map
+
+--------------------------------------------------------------------------------
+--          Adjusting Expressions
+--------------------------------------------------------------------------------
+
+mutual
+  export
+  adjust : UsageMap -> CExp ns -> CExp ns
+  adjust um exp = case dropEnv {pre = []} exp of
+    Nothing => adjustSubExp um exp
+    Just e0 => case lookup (size e0, e0) um of
+      Just (nm,_) => CApp EmptyFC (CRef EmptyFC nm) []
+      Nothing     => adjustSubExp um exp
+
+  adjustSubExp : UsageMap -> CExp ns -> CExp ns
+  adjustSubExp um e@(CLocal _ _) = e
+  adjustSubExp um e@(CRef _ _) = e
+  adjustSubExp um e@(CPrimVal _ _) = e
+  adjustSubExp um e@(CErased _) = e
+  adjustSubExp um e@(CCrash _ _) = e
+  adjustSubExp um (CLam fc x y) = CLam fc x $ adjust um y
+  adjustSubExp um (CLet fc x inlineOK y z) =
+    CLet fc x inlineOK (adjust um y) (adjust um z)
+
+  adjustSubExp um (CApp fc x xs) =
+    CApp fc (adjust um x) (map (adjust um) xs)
+
+  adjustSubExp um (CCon fc x y tag xs) =
+    CCon fc x y tag $ map (adjust um) xs
+
+  adjustSubExp um (COp fc x xs) = COp fc x $ map (adjust um) xs
+
+  adjustSubExp um (CExtPrim fc p xs) = CExtPrim fc p $ map (adjust um) xs
+
+  adjustSubExp um (CForce fc x y) = CForce fc x $ adjust um y
+
+  adjustSubExp um (CDelay fc x y) = CDelay fc x $ adjust um y
+
+  adjustSubExp um (CConCase fc sc xs x) =
+    CConCase fc (adjust um sc) (map (adjustConAlt um) xs) (map (adjust um) x)
+
+  adjustSubExp um (CConstCase fc sc xs x) =
+    CConstCase fc (adjust um sc) (map (adjustConstAlt um) xs) (map (adjust um) x)
+
+  adjustConAlt : UsageMap -> CConAlt ns -> CConAlt ns
+  adjustConAlt um (MkConAlt x y tag args z) =
+    MkConAlt x y tag args $ adjust um z
+
+  adjustConstAlt : UsageMap -> CConstAlt ns -> CConstAlt ns
+  adjustConstAlt um (MkConstAlt x y) = MkConstAlt x $ adjust um y
+
+export
+adjustDef : UsageMap -> CDef -> CDef
+adjustDef um (MkFun args x) = MkFun args $ adjust um x
+adjustDef um d@(MkCon _ _ _) = d
+adjustDef um d@(MkForeign _ _ _) = d
+adjustDef um d@(MkError _) = d
+
+export
+additionalToplevel : UsageMap -> List (Maybe (Name, FC, NamedDef))
+additionalToplevel um = map toDef $ SortedMap.toList um
+  where toDef : ((Integer, CExp[]),(Name,Integer)) -> Maybe (Name,FC,NamedDef)
+        toDef ((_,exp),(nm,_)) = Just (nm, EmptyFC, forgetDef $ MkFun [] $ adjustSubExp um exp)

--- a/src/Compiler/Opts/CSE.idr
+++ b/src/Compiler/Opts/CSE.idr
@@ -256,14 +256,10 @@ analyzeName fn = do
 ||| to their number of occurences plus newly generated
 ||| name in case they will be lifted to the toplevel)
 export
-analyzeNames :  Ref Ctxt Defs
-             => (mainExpr : CExp [])
-             -> List Name
-             -> Core UsageMap
-analyzeNames me cns = do
+analyzeNames :  Ref Ctxt Defs => List Name -> Core UsageMap
+analyzeNames cns = do
   log "compiler.cse" 10 $ "Analysing " ++ show (length cns) ++ " names"
   s <- newRef Sts $ MkSt empty 0
-  analyze me
   traverse_ analyzeName cns
   MkSt map _ <- get Sts
   let filtered = reverse

--- a/src/Compiler/Opts/CSE.idr
+++ b/src/Compiler/Opts/CSE.idr
@@ -191,7 +191,7 @@ mutual
   -- might interfere with other optimizations, for instance
   -- the one dealing with #1320.
   -- Some other terms are ignored, as I (@stefan-hoeck)
-  -- am being conversvative here,
+  -- am being conservative here,
   -- not daring to inadvertently change the semantics
   -- of the program.
   analyze c@(COp _ _ _)      = analyzeSubExp c

--- a/src/Compiler/Opts/CSE.idr
+++ b/src/Compiler/Opts/CSE.idr
@@ -64,7 +64,7 @@ record St where
 store : { auto c : Ref Sts St } -> CExp [] -> Core Integer
 store exp =
   let sz = size exp
-   in if sz < 6
+   in if sz < 5
          then pure 0
          else do
            (MkSt map idx)    <- get Sts
@@ -213,7 +213,7 @@ analyzeNames cns = do
                   ", size " ++ show sz
                  )
             ) filtered
-  pure map
+  pure $ fromList filtered
 
 --------------------------------------------------------------------------------
 --          Adjusting Expressions

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -309,7 +309,6 @@ record GlobalDef where
   linearChecked : Bool -- Flag whether we've already checked its linearity
   definition : Def
   compexpr : Maybe CDef
-  namedcompexpr : Maybe NamedDef
   sizeChange : List SCCall
 
 export
@@ -665,7 +664,6 @@ newDef fc n rig vars ty vis def
         , linearChecked = False
         , definition = def
         , compexpr = Nothing
-        , namedcompexpr = Nothing
         , sizeChange = []
         }
 
@@ -1363,7 +1361,6 @@ addBuiltin n ty tot op
          , linearChecked = True
          , definition = Builtin op
          , compexpr = Nothing
-         , namedcompexpr = Nothing
          , sizeChange = []
          }
 
@@ -1395,15 +1392,6 @@ setCompiled n cexp
          Just gdef <- lookupCtxtExact n (gamma defs)
               | Nothing => pure ()
          ignore $ addDef n (record { compexpr = Just cexp } gdef)
-
-export
-setNamedCompiled : {auto c : Ref Ctxt Defs} ->
-                   Name -> NamedDef -> Core ()
-setNamedCompiled n cexp
-    = do defs <- get Ctxt
-         Just gdef <- lookupCtxtExact n (gamma defs)
-              | Nothing => pure ()
-         ignore $ addDef n (record { namedcompexpr = Just cexp } gdef)
 
 -- Record that the name has been linearity checked so we don't need to do
 -- it again

--- a/src/Core/Options/Log.idr
+++ b/src/Core/Options/Log.idr
@@ -53,6 +53,7 @@ knownTopics = [
     ("compile.casetree.measure", Just "Log the node counts of each runtime case tree."),
     ("compile.casetree.pick", Nothing),
     ("compile.casetree.partition", Nothing),
+    ("compiler.cse", Nothing),
     ("compiler.identity", Nothing),
     ("compiler.inline.eval", Nothing),
     ("compiler.interpreter", Nothing),

--- a/src/Core/Ord.idr
+++ b/src/Core/Ord.idr
@@ -1,0 +1,272 @@
+module Core.Ord
+
+import Core.CompileExpr
+import Core.Name
+import Core.TT
+import Data.Vect
+
+infixl 5 `thenCmp`
+
+thenCmp : Ordering -> Lazy Ordering -> Ordering
+thenCmp LT _ = LT
+thenCmp EQ o = o
+thenCmp GT _ = GT
+
+export
+Ord Constant where
+    I x `compare` I y = compare x y
+    I8 x `compare` I8 y = compare x y
+    I16 x `compare` I16 y = compare x y
+    I32 x `compare` I32 y = compare x y
+    I64 x `compare` I64 y = compare x y
+    BI x `compare` BI y = compare x y
+    B8 x `compare` B8 y = compare x y
+    B16 x `compare` B16 y = compare x y
+    B32 x `compare` B32 y = compare x y
+    B64 x `compare` B64 y = compare x y
+    Str x `compare` Str y = compare x y
+    Ch x `compare` Ch y = compare x y
+    Db x `compare` Db y = compare x y
+    compare x y = compare (tag x) (tag y)
+      where
+        tag : Constant -> Int
+        tag (I _) = 0
+        tag (I8 _) = 1
+        tag (I16 _) = 2
+        tag (I32 _) = 3
+        tag (I64 _) = 4
+        tag (BI _) = 5
+        tag (B8 _) = 6
+        tag (B16 _) = 7
+        tag (B32 _) = 8
+        tag (B64 _) = 9
+        tag (Str _) = 10
+        tag (Ch _) = 11
+        tag (Db _) = 12
+        tag WorldVal = 13
+        tag IntType = 14
+        tag Int8Type = 15
+        tag Int16Type = 16
+        tag Int32Type = 17
+        tag Int64Type = 18
+        tag IntegerType = 19
+        tag Bits8Type = 20
+        tag Bits16Type = 21
+        tag Bits32Type = 22
+        tag Bits64Type = 23
+        tag StringType = 24
+        tag CharType = 25
+        tag DoubleType = 26
+        tag WorldType = 27
+
+
+primFnEq : PrimFn a1 -> PrimFn a2 -> Maybe (a1 = a2)
+primFnEq (Add t1) (Add t2) = if t1 == t2 then Just Refl else Nothing
+primFnEq (Sub t1) (Sub t2) = if t1 == t2 then Just Refl else Nothing
+primFnEq (Mul t1) (Mul t2) = if t1 == t2 then Just Refl else Nothing
+primFnEq (Div t1) (Div t2) = if t1 == t2 then Just Refl else Nothing
+primFnEq (Mod t1) (Mod t2) = if t1 == t2 then Just Refl else Nothing
+primFnEq (Neg t1) (Neg t2) = if t1 == t2 then Just Refl else Nothing
+primFnEq (ShiftL t1) (ShiftL t2) = if t1 == t2 then Just Refl else Nothing
+primFnEq (ShiftR t1) (ShiftR t2) = if t1 == t2 then Just Refl else Nothing
+primFnEq (BAnd t1) (BAnd t2) = if t1 == t2 then Just Refl else Nothing
+primFnEq (BOr t1) (BOr t2) = if t1 == t2 then Just Refl else Nothing
+primFnEq (BXOr t1) (BXOr t2) = if t1 == t2 then Just Refl else Nothing
+primFnEq (LT t1) (LT t2) = if t1 == t2 then Just Refl else Nothing
+primFnEq (LTE t1) (LTE t2) = if t1 == t2 then Just Refl else Nothing
+primFnEq (EQ t1) (EQ t2) = if t1 == t2 then Just Refl else Nothing
+primFnEq (GTE t1) (GTE t2) = if t1 == t2 then Just Refl else Nothing
+primFnEq (GT t1) (GT t2) = if t1 == t2 then Just Refl else Nothing
+primFnEq StrLength StrLength = Just Refl
+primFnEq StrHead StrHead = Just Refl
+primFnEq StrTail StrTail = Just Refl
+primFnEq StrIndex StrIndex = Just Refl
+primFnEq StrCons StrCons = Just Refl
+primFnEq StrAppend StrAppend = Just Refl
+primFnEq StrReverse StrReverse = Just Refl
+primFnEq StrSubstr StrSubstr = Just Refl
+primFnEq DoubleExp DoubleExp = Just Refl
+primFnEq DoubleLog DoubleLog = Just Refl
+primFnEq DoublePow DoublePow = Just Refl
+primFnEq DoubleSin DoubleSin = Just Refl
+primFnEq DoubleCos DoubleCos = Just Refl
+primFnEq DoubleTan DoubleTan = Just Refl
+primFnEq DoubleASin DoubleASin = Just Refl
+primFnEq DoubleACos DoubleACos = Just Refl
+primFnEq DoubleATan DoubleATan = Just Refl
+primFnEq DoubleSqrt DoubleSqrt = Just Refl
+primFnEq DoubleFloor DoubleFloor = Just Refl
+primFnEq DoubleCeiling DoubleCeiling = Just Refl
+primFnEq (Cast f1 t1) (Cast f2 t2) = if f1 == f2 && t1 == t2 then Just Refl else Nothing
+primFnEq BelieveMe BelieveMe = Just Refl
+primFnEq Crash Crash = Just Refl
+primFnEq _ _ = Nothing
+
+primFnCmp : PrimFn a1 -> PrimFn a2 -> Ordering
+primFnCmp (Add t1) (Add t2) = compare t1 t2
+primFnCmp (Sub t1) (Sub t2) = compare t1 t2
+primFnCmp (Mul t1) (Mul t2) = compare t1 t2
+primFnCmp (Div t1) (Div t2) = compare t1 t2
+primFnCmp (Mod t1) (Mod t2) = compare t1 t2
+primFnCmp (Neg t1) (Neg t2) = compare t1 t2
+primFnCmp (ShiftL t1) (ShiftL t2) = compare t1 t2
+primFnCmp (ShiftR t1) (ShiftR t2) = compare t1 t2
+primFnCmp (BAnd t1) (BAnd t2) = compare t1 t2
+primFnCmp (BOr t1) (BOr t2) = compare t1 t2
+primFnCmp (BXOr t1) (BXOr t2) = compare t1 t2
+primFnCmp (LT t1) (LT t2) = compare t1 t2
+primFnCmp (LTE t1) (LTE t2) = compare t1 t2
+primFnCmp (EQ t1) (EQ t2) = compare t1 t2
+primFnCmp (GTE t1) (GTE t2) = compare t1 t2
+primFnCmp (GT t1) (GT t2) = compare t1 t2
+primFnCmp (Cast f1 t1) (Cast f2 t2) = compare f1 f2 `thenCmp` compare t1 t2
+primFnCmp f1 f2 = compare (tag f1) (tag f2)
+  where
+    tag : forall ar. PrimFn ar -> Int
+    tag (Add _) = 0
+    tag (Sub _) = 1
+    tag (Mul _) = 2
+    tag (Div _) = 3
+    tag (Mod _) = 4
+    tag (Neg _) = 5
+    tag (ShiftL _) = 6
+    tag (ShiftR _) = 7
+    tag (BAnd _) = 8
+    tag (BOr _) = 9
+    tag (BXOr _) = 10
+    tag (LT _) = 11
+    tag (LTE _) = 12
+    tag (EQ _) = 13
+    tag (GTE _) = 14
+    tag (GT _) = 15
+    tag StrLength = 16
+    tag StrHead = 17
+    tag StrTail = 18
+    tag StrIndex = 19
+    tag StrCons = 20
+    tag StrAppend = 21
+    tag StrReverse = 22
+    tag StrSubstr = 23
+    tag DoubleExp = 24
+    tag DoubleLog = 25
+    tag DoublePow = 26
+    tag DoubleSin = 27
+    tag DoubleCos = 28
+    tag DoubleTan = 29
+    tag DoubleASin = 30
+    tag DoubleACos = 31
+    tag DoubleATan = 32
+    tag DoubleSqrt = 33
+    tag DoubleFloor = 34
+    tag DoubleCeiling = 35
+    tag (Cast _ _) = 36
+    tag BelieveMe = 37
+    tag Crash = 38
+
+
+lrTag : LazyReason -> Int
+lrTag LInf = 0
+lrTag LLazy = 1
+lrTag LUnknown = 2
+
+export
+Ord LazyReason where
+    compare l1 l2 = compare (lrTag l1) (lrTag l2)
+
+export
+Eq (Var vars) where
+    MkVar {i=i1} _ == MkVar {i=i2} _ = i1 == i2
+
+export
+Ord (Var vars) where
+    MkVar {i=i1} _ `compare` MkVar {i=i2} _ = compare i1 i2
+
+mutual
+    export
+    Eq (CExp vars) where
+        CLocal {idx=x1} _ _ == CLocal {idx=x2} _ _ = x1 == x2
+        CRef _ n1 == CRef _ n2 = n1 == n2
+        CLam _ n1 e1 == CLam _ n2 e2 = case nameEq n1 n2 of
+            Just Refl => e1 == e2
+            Nothing => False
+        CLet _ n1 _ val1 sc1 == CLet _ n2 _ val2 sc2 = case nameEq n1 n2 of
+            Just Refl => val1 == val2 && sc1 == sc2
+            Nothing => False
+        CApp _ f1 a1 == CApp _ f2 a2 = f1 == f2 && a1 == a2
+        CCon _ n1 _ t1 a1 == CCon _ n2 _ t2 a2 = t1 == t2 && n1 == n2 && a1 == a2
+        COp _ f1 a1 == COp _ f2 a2 = case primFnEq f1 f2 of
+            Just Refl => a1 == a2
+            Nothing => False
+        CExtPrim _ f1 a1 == CExtPrim _ f2 a2 = f1 == f2 && a1 == a2
+        CForce _ l1 e1 == CForce _ l2 e2 = l1 == l2 && e1 == e2
+        CDelay _ l1 e1 == CDelay _ l2 e2 = l1 == l2 && e1 == e2
+        CConCase _ s1 a1 d1 == CConCase _ s2 a2 d2 = s1 == s2 && a1 == a2 && d1 == d2
+        CConstCase _ s1 a1 d1 == CConstCase _ s2 a2 d2 = s1 == s2 && a1 == a2 && d1 == d2
+        CPrimVal _ c1 == CPrimVal _ c2 = c1 == c2
+        CErased _ == CErased _ = True
+        CCrash _ m1 == CCrash _ m2 = m1 == m2
+        _ == _ = False
+
+    export
+    Eq (CConAlt vars) where
+        MkConAlt n1 _ t1 a1 e1 == MkConAlt n2 _ t2 a2 e2 = t1 == t2 && n1 == n2 && case namesEq a1 a2 of
+            Just Refl => e1 == e2
+            Nothing => False
+
+    export
+    Eq (CConstAlt vars) where
+        MkConstAlt c1 e1 == MkConstAlt c2 e2 = c1 == c2 && e1 == e2
+
+mutual
+    export
+    Ord (CExp vars) where
+        CLocal {idx=x1} _ _ `compare` CLocal {idx=x2} _ _ = x1 `compare` x2
+        CRef _ n1 `compare` CRef _ n2 = n1 `compare` n2
+        CLam _ n1 e1 `compare` CLam _ n2 e2 = case nameEq n1 n2 of
+            Just Refl => compare e1 e2
+            Nothing => compare n1 n2
+        CLet _ n1 _ val1 sc1 `compare` CLet _ n2 _ val2 sc2 = case nameEq n1 n2 of
+            Just Refl => compare val1 val2 `thenCmp` compare sc1 sc2
+            Nothing => compare n1 n2
+        CApp _ f1 a1 `compare` CApp _ f2 a2 = compare f1 f2 `thenCmp` compare a1 a2
+        CCon _ n1 _ t1 a1 `compare` CCon _ n2 _ t2 a2 = compare t1 t2 `thenCmp` compare n1 n2 `thenCmp` compare a1 a2
+        COp _ f1 a1 `compare` COp _ f2 a2 = case primFnEq f1 f2 of
+            Just Refl => compare a1 a2
+            Nothing => primFnCmp f1 f2
+        CExtPrim _ f1 a1 `compare` CExtPrim _ f2 a2 = compare f1 f2 `thenCmp` compare a1 a2
+        CForce _ l1 e1 `compare` CForce _ l2 e2 = compare l1 l2 `thenCmp` compare e1 e2
+        CDelay _ l1 e1 `compare` CDelay _ l2 e2 = compare l1 l2 `thenCmp` compare e1 e2
+        CConCase _ s1 a1 d1 `compare` CConCase _ s2 a2 d2 = compare s1 s2 `thenCmp` compare a1 a2 `thenCmp` compare d1 d2
+        CConstCase _ s1 a1 d1 `compare` CConstCase _ s2 a2 d2 = compare s1 s2 `thenCmp` compare a1 a2 `thenCmp` compare d1 d2
+        CPrimVal _ c1 `compare` CPrimVal _ c2 = compare c1 c2
+        CErased _ `compare` CErased _ = EQ
+        CCrash _ m1 `compare` CCrash _ m2 = compare m1 m2
+        e1 `compare` e2 = compare (tag e1) (tag e2)
+          where
+            tag : forall vars . CExp vars -> Int
+            tag (CLocal _ _) = 0
+            tag (CRef _ _) = 1
+            tag (CLam _ _ _) = 2
+            tag (CLet _ _ _ _ _) = 3
+            tag (CApp _ _ _) = 4
+            tag (CCon _ _ _ _ _) = 5
+            tag (COp _ _ _) = 6
+            tag (CExtPrim _ _ _) = 7
+            tag (CForce _ _ _) = 8
+            tag (CDelay _ _ _) = 9
+            tag (CConCase _ _ _ _) = 10
+            tag (CConstCase _ _ _ _) = 11
+            tag (CPrimVal _ _) = 12
+            tag (CErased _) = 13
+            tag (CCrash _ _) = 14
+
+    export
+    Ord (CConAlt vars) where
+        MkConAlt n1 _ t1 a1 e1 `compare` MkConAlt n2 _ t2 a2 e2 =
+            compare t1 t2 `thenCmp` compare n1 n2 `thenCmp` case namesEq a1 a2 of
+                Just Refl => compare e1 e2
+                Nothing => compare a1 a2
+
+    export
+    Ord (CConstAlt vars) where
+        MkConstAlt c1 e1 `compare` MkConstAlt c2 e2 = compare c1 c2 `thenCmp` compare e1 e2

--- a/src/Core/Ord.idr
+++ b/src/Core/Ord.idr
@@ -1,3 +1,4 @@
+||| Courtesy of @z-snails
 module Core.Ord
 
 import Core.CompileExpr

--- a/src/Core/TTC.idr
+++ b/src/Core/TTC.idr
@@ -1109,10 +1109,10 @@ TTC GlobalDef where
                       sc <- fromBuf b
                       pure (MkGlobalDef loc name ty eargs seargs specargs iargs
                                         mul vars vis
-                                        tot fl refs refsR inv c True def cdef Nothing sc)
+                                        tot fl refs refsR inv c True def cdef sc)
               else pure (MkGlobalDef loc name (Erased loc False) [] [] [] []
                                      mul [] Public unchecked [] refs refsR
-                                     False False True def cdef Nothing [])
+                                     False False True def cdef [])
 
 export
 TTC Transform where

--- a/support/js/support.js
+++ b/support/js/support.js
@@ -16,13 +16,12 @@ function __prim_idris2js_array(x){
   return result;
 }
 
-function __lazy(creator) {
+function __lazy(thunk) {
   let res;
-  let processed = false;
   return function () {
-    if (processed) return res;
-    res = creator();
-    processed = true;
+    if (thunk === undefined) return res;
+    res = thunk();
+    thunk = undefined;
     return res;
   };
 };

--- a/support/js/support.js
+++ b/support/js/support.js
@@ -16,6 +16,17 @@ function __prim_idris2js_array(x){
   return result;
 }
 
+function __lazy(creator) {
+  let res;
+  let processed = false;
+  return function () {
+    if (processed) return res;
+    res = creator();
+    processed = true;
+    return res;
+  };
+};
+
 function __prim_stringIteratorNew(str) {
   return 0
 }


### PR DESCRIPTION
This PR introduces a simple form of CSE as a means of whole program optimization, mainly to reduce duplicate object definitions introduced during autosearch (see also #1614). This has a beneficial impact on the size of generated executables (for instance, `idris2.ss` is reduced from 11M to 7.9M, the compiled chez binary `idris2.so` from 6.1M to 4.6M), especially so in pathological cases (the notorious `node/integers` test is reduced from around 700KB to 76KB!).

In addition, this gives rise to some performance improvements as well: On the JS backends, I converted zero-argument toplevel functions to lazily evaluated constants. This increase performance in my idris2-json and idris2-webidl tests by about 30%. The same might be possible on scheme backends as well, as there too zero-argument toplevel definitions seem to be reevaluated on every invocation. Right now, I don't know enough scheme to do this myself, however.

I open this as a draft PR, since I still need help with a couple of things:

  * Should I introduce a new data constructor to `Name` for these newly generated toplevel definitions?
  * Should we hide this optimization behind a compiler flag? It's reasonably fast and therefore doesn't seem to impact overall compiler performance, so we might be safe to just enable it always?
  * I'm quite sure that I did not introduce this optimization correctly in `Compiler.Common` and `Compiler.CompileExpr`. For instance, I'm not sure other IRs than `NamedDef` are profiting from this right now. Someone help, please.
  * Finally, I'm quite sure my handling of file contexts (`FC`) is not correct. Again, someone review, please.

Edit: Forgot to mention and thank the amazing @Z-snails here, who got me started on this.