### PR TITLE
Make the (++) operator for lists tail-recursive. [breaks things; not necessarily a good idea]

### DIFF
--- a/libs/contrib/Data/List/Elem/Extra.idr
+++ b/libs/contrib/Data/List/Elem/Extra.idr
@@ -8,15 +8,19 @@ import Data.List.Elem
 ||| Proof that an element is still inside a list if we append to it.
 public export
 elemAppLeft : (xs, ys : List a) -> (prf : Elem x xs) -> Elem x (xs ++ ys)
-elemAppLeft (x :: xs) ys Here = Here
-elemAppLeft (x :: xs) ys (There prf2) = There $ elemAppLeft xs ys prf2
+elemAppLeft (x :: xs) ys Here = rewrite consAppend x xs ys in Here
+elemAppLeft (x :: xs) ys (There prf2)
+  = rewrite consAppend x xs ys in
+      There $ elemAppLeft xs ys prf2
 
 
 ||| Proof that an element is still inside a list if we prepend to it.
 public export
 elemAppRight :  (ys, xs : List a) -> (prf : Elem x xs) -> Elem x (ys ++ xs)
 elemAppRight [] xs prf = prf
-elemAppRight (y :: ys) xs prf = There $ elemAppRight ys xs prf
+elemAppRight (y :: ys) xs prf
+  = rewrite consAppend y ys xs in
+      There $ elemAppRight ys xs prf
 
 ||| Proof that membership on append implies membership in left or right sublist.
 public export
@@ -25,10 +29,12 @@ elemAppLorR : (xs, ys : List a)
            -> Either (Elem k xs) (Elem k ys)
 elemAppLorR [] [] prf = absurd prf
 elemAppLorR [] _ prf = Right prf
-elemAppLorR (x :: xs) [] prf =
-  Left $ rewrite sym $ appendNilRightNeutral xs in prf
-elemAppLorR (x :: xs) _ Here = Left Here
-elemAppLorR (x :: xs) ys (There prf) = mapFst There $ elemAppLorR xs ys prf
+elemAppLorR (x :: xs) [] prf
+  = Left $ rewrite sym $ appendNilRightNeutral (x :: xs) in prf
+elemAppLorR (x :: xs) ys prf
+  = case replace {p = \ t => Elem k t} (consAppend x xs ys) prf of
+      Here => Left Here
+      (There prf) => mapFst There $ elemAppLorR xs ys prf
 
 
 ||| Proof that x is not in (xs ++ ys) implies proof that x is not in xs.

--- a/libs/contrib/Data/List/HasLength.idr
+++ b/libs/contrib/Data/List/HasLength.idr
@@ -61,7 +61,9 @@ map f (S n) = S (map f n)
 export
 sucR : HasLength xs n -> HasLength (snoc xs x) (S n)
 sucR Z = S Z
-sucR (S n) = S (sucR n)
+sucR {xs = xsH :: xsT} (S n)
+  = rewrite consAppend xsH xsT [x] in
+      S (sucR n)
 
 ------------------------------------------------------------------------
 -- Views
@@ -118,9 +120,11 @@ namespace CurriedView
 -- /!\ Do NOT re-export these examples
 
 listTerminating : (p : Subset Nat (HasLength xs)) -> HasLength (xs ++ [x]) (S (fst p))
-listTerminating p = case view p of
-  Z => S Z
-  S p => S (listTerminating p)
+listTerminating p with (view p)
+  listTerminating {xs = []} (Element Z Z) | Z = S Z
+  listTerminating {xs = xsH :: xsT} _ | S p =
+    rewrite consAppend xsH xsT [x] in
+      S (listTerminating p)
 
 data P : List Nat -> Type where
   PNil : P []

--- a/libs/contrib/Data/List/Palindrome.idr
+++ b/libs/contrib/Data/List/Palindrome.idr
@@ -21,11 +21,10 @@ export
 palindromeReverse : (xs : List a) -> Palindrome xs -> reverse xs = xs
 palindromeReverse [] Empty = Refl
 palindromeReverse [_] Single = Refl
-palindromeReverse ([x] ++ ys ++ [x]) (Multi pf) =
-  rewrite sym $ revAppend ([x] ++ ys) [x] in
-    rewrite sym $ revAppend [x] ys in
-      rewrite palindromeReverse ys pf in
-        Refl
+palindromeReverse (x :: (ys ++ [x])) (Multi pf) =
+  rewrite sym $ consAppend x ys [x] in
+    rewrite palindromeReverse ys pf in
+      Refl
 
 private
 reversePalindromeEqualsLemma
@@ -35,8 +34,11 @@ reversePalindromeEqualsLemma
   -> (reverse xs = xs, x = x')
 reversePalindromeEqualsLemma x x' xs prf = equateInnerAndOuter flipHeadX
   where
-    flipHeadX : reverse (xs ++ [x']) ++ [x] = x :: (xs ++ [x'])
-    flipHeadX = rewrite (sym (reverseCons x (xs ++ [x']))) in prf
+    flipHeadX : reverse (xs ++ [x']) ++ [x] = (x :: xs) ++ [x']
+    flipHeadX =
+      rewrite consAppend x xs [x'] in
+        rewrite (sym (reverseCons x (xs ++ [x']))) in
+          prf
     flipLastX' : reverse (xs ++ [x']) = x :: xs -> (x' :: reverse xs) = (x :: xs)
     flipLastX' prf = rewrite (revAppend xs [x']) in prf
     cancelOuter : (reverse (xs ++ [x'])) = x :: xs -> reverse xs = xs

--- a/libs/contrib/Data/List/Reverse.idr
+++ b/libs/contrib/Data/List/Reverse.idr
@@ -15,7 +15,9 @@ export
 reverseOntoAcc : (xs, ys, zs : List a) ->
   reverseOnto (ys ++ zs) xs = (reverseOnto ys xs) ++ zs
 reverseOntoAcc [] _ _ = Refl
-reverseOntoAcc (x :: xs) (ys) (zs) = reverseOntoAcc xs (x :: ys) zs
+reverseOntoAcc (x :: xs) (ys) (zs) =
+  rewrite sym $ consAppend x ys zs in
+    reverseOntoAcc xs (x :: ys) zs
 
 ||| Serves as a specification for reverseOnto.
 export

--- a/libs/contrib/Data/List/Views/Extra.idr
+++ b/libs/contrib/Data/List/Views/Extra.idr
@@ -122,11 +122,12 @@ toVList [] (Snoc x zs rec) prf =
     the (Balanced 0 (S (length zs))) $
       rewrite sym (lengthSnoc x zs) in prf
 toVList (x :: xs) (Snoc y ys srec) prf =
-  rewrite appendAssociative xs ys [y] in
-    VCons $
-      toVList xs srec $
-        balancedPred $
-          rewrite sym (lengthSnoc y ys) in prf
+  rewrite consAppend x xs (ys ++ [y]) in
+    rewrite appendAssociative xs ys [y] in
+      VCons $
+        toVList xs srec $
+          balancedPred $
+            rewrite sym (lengthSnoc y ys) in prf
 
 ||| Covering function for `VList`
 ||| Constructs the view in linear time.

--- a/libs/prelude/Prelude/Types.idr
+++ b/libs/prelude/Prelude/Types.idr
@@ -380,9 +380,17 @@ Ord a => Ord (List a) where
 
 namespace List
   public export
+  reverseOnto : List a -> List a -> List a
+  reverseOnto acc [] = acc
+  reverseOnto acc (x::xs) = reverseOnto (x::acc) xs
+
+  public export
+  reverse : List a -> List a
+  reverse = reverseOnto []
+
+  public export
   (++) : (xs, ys : List a) -> List a
-  [] ++ ys = ys
-  (x :: xs) ++ ys = x :: xs ++ ys
+  xs ++ ys = reverseOnto ys (reverse xs)
 
   public export
   length : List a -> Nat


### PR DESCRIPTION
This PR does three things:
* Makes `(++)` tail-recursive. (More precisely, it turns it into two calls to `reverseOnto`, which is tail-recursive.)
* Moves reverse and reverseOnto into prelude, since (++) uses them.
* Updates a bunch of proofs to work with the new (++) (and adds a new theorem to `Data.List`).

Here are two reasons to make `(++)` tail-recursive:
* It should be faster. A preliminary benchmark confirms this; see below.
* It should help prevent stack overflows. See [my recent thread](https://groups.google.com/g/idris-lang/c/zD751y1AUOI/m/jcrw0Tw-AQAJ) about the javascript backend. Even if stack overflows aren't an issue, it seems better to avoid allocating unnecessary stack frames.

Unfortunately it looks like a lot of things depend on the implementation being what it is. This PR fixes the libraries, but presumably external libraries will break.

I would have preferred to hide the implementation (i.e. use `export` instead of `public export`) and provide lemmas instead, so that future implementation changes won't break everything again. However I [ran into trouble](https://groups.google.com/g/idris-lang/c/_W_6fQnD4KU/m/JxhrXVCEAQAJ) trying to move one of the necessary lemmas into the prelude.

On the whole, I don't know if this change is a good idea. Personally my vote would be for it, because it's more efficient and I don't think it's good to depend on how functions are implemented. But from fixing all the proofs, I do see that it's mighty convenient in proofs to define `(++)` the old way, and expose the implementation. In the worst case, I've learned a bunch about how to prove things in Idris2 :)

## Benchmark

Here's a silly benchmark. I haven't tried anything real, like building Idris.

(EDIT to add: this is with the racket backend, because chez isn't currently ported to OpenBSD.)

The program:

```
import Data.List

%default total

slowReverse : List a -> List a
slowReverse [] = []
slowReverse (x :: xs) = slowReverse xs ++ [x]

main : IO ()
main = putStrLn $ show $ length $ slowReverse $ replicate 100000 ()
```

Before the change (at commit 4a9f0007):
```
falsifian moth tmp $ idris2 -o f f.idr && echo running... && time build/exec/f 
running...
100000
    1m15.56s real     1m15.25s user     0m00.26s system
falsifian moth tmp $ 
I-search: 
falsifian moth tmp $ time build/exec/f                                         
100000
    1m15.17s real     1m14.74s user     0m00.38s system
falsifian moth tmp $ time build/exec/f 
100000
    1m19.07s real     1m18.69s user     0m00.36s system
```

After the change (at this commit):
```
falsifian moth tmp $ idris2 -o f f.idr && echo running... && time build/exec/f 
running...
100000
    0m37.06s real     0m36.75s user     0m00.25s system
falsifian moth tmp $ time build/exec/f
100000
    0m37.40s real     0m36.92s user     0m00.43s system
falsifian moth tmp $ time build/exec/f 
100000
    0m37.12s real     0m36.72s user     0m00.35s system
```
