### PR TITLE
[ cleanup ] `mkdist.sh` script cleanup

### DIFF
--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'icons/**'
+      - 'Release/**'
       - '*.md'
       - 'CONTRIBUTORS'
       - 'LICENSE'

--- a/Release/mkdist.sh
+++ b/Release/mkdist.sh
@@ -20,7 +20,6 @@ git checkout tags/v"$1"
 rm -rf .git
 rm -rf .github
 rm .git*
-rm -f .travis*
 rm -rf Release
 rm -rf benchmark
 find . -type f -name '.gitignore' -exec rm -f {} \;


### PR DESCRIPTION
Since Travis CI is no longer used.