### PR TITLE
`invFin`: `export` ~> `public export` and `invFinSpec`

### DIFF
--- a/libs/contrib/Data/Fin/Extra.idr
+++ b/libs/contrib/Data/Fin/Extra.idr
@@ -51,6 +51,13 @@ invFin : {n : Nat} -> Fin n -> Fin n
 invFin FZ = last
 invFin (FS k) = weaken (invFin k)
 
+public export
+invFinSpec : {n : _} -> (i : Fin n) -> 1 + finToNat i + finToNat (invFin i) = n
+invFinSpec {n = S k} FZ = cong S finToNatLastIsBound
+invFinSpec (FS k) = let H = invFinSpec k in
+  let h = finToNatWeakenNeutral {n = invFin k} in
+  cong S (rewrite h in H)
+
 ||| The inverse of a weakened element is the successor of its inverse
 export
 invFinWeakenIsFS : {n : Nat} -> (m : Fin n) -> invFin (weaken m) = FS (invFin m)

--- a/libs/contrib/Data/Fin/Extra.idr
+++ b/libs/contrib/Data/Fin/Extra.idr
@@ -46,7 +46,7 @@ finToNatShift (S k) a = cong S (finToNatShift k a)
 -------------------------------------------------
 
 ||| Compute the Fin such that `k + invFin k = n - 1`
-export
+public export
 invFin : {n : Nat} -> Fin n -> Fin n
 invFin FZ = last
 invFin (FS k) = weaken (invFin k)

--- a/libs/contrib/Data/Fin/Extra.idr
+++ b/libs/contrib/Data/Fin/Extra.idr
@@ -51,7 +51,7 @@ invFin : {n : Nat} -> Fin n -> Fin n
 invFin FZ = last
 invFin (FS k) = weaken (invFin k)
 
-public export
+export
 invFinSpec : {n : _} -> (i : Fin n) -> 1 + finToNat i + finToNat (invFin i) = n
 invFinSpec {n = S k} FZ = cong S finToNatLastIsBound
 invFinSpec (FS k) = let H = invFinSpec k in


### PR DESCRIPTION
I don't have a good feel for when it's "good" or "bad" to publicly export a function.
This one is needed to prove properties about `invFin` which haven't yet been stated in the standard library.
Take for example the spec for `invFin` itself, which hasn't been there up until now.