### PR TITLE
[ docs ]: fix typo

### DIFF
--- a/samples/ffi/smallc.c
+++ b/samples/ffi/smallc.c
@@ -1,4 +1,4 @@
-// To compile this file for the samples `sample/ffi/Small.dir` and `sample/ffi/Struct.idr`, you will
+// To compile this file for the samples `sample/ffi/Small.idr` and `sample/ffi/Struct.idr`, you will
 // need to manually compile and link it into a `.so` file, and place it in a location where the
 // resulting exectuable can find it. For example:
 //      gcc -c -fPIC smallc.c -o smallc.o


### PR DESCRIPTION
btw, im wondering whether i can use environment variables such as `${IDRIS_PREFIX}/lib` in %foreign statement?
namely `%foreign "C:f, ${PREFIX}/libmain.so"` or other proper ways