### PR TITLE
nix flake: make it more idiomatic

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,9 +35,7 @@
             inherit idris2-version chez;
             srcRev = self.shortRev or "dirty";
           };
-          buildIdris = { projectName, src, idrisLibraries }:
-            pkgs.callPackage ./nix/buildIdris.nix
-              { inherit src projectName idrisLibraries idris2-version; idris2 = idris2Pkg; };
+          buildIdris = pkgs.callPackage ./nix/buildIdris.nix { inherit idris2-version; idris2 = idris2Pkg; };
         in rec {
           checks = import ./nix/test.nix {
             inherit (pkgs) system stdenv runCommand lib;

--- a/nix/buildIdris.nix
+++ b/nix/buildIdris.nix
@@ -1,34 +1,44 @@
 { stdenv
 , lib
-, projectName
-, src
-, idris2
 , idris2-version
-, idrisLibraries
+, idris2
 }:
+{
+src
+, projectName
+, idrisLibraries
+, ...
+}@attrs:
 
 let
   ipkgName = projectName + ".ipkg";
   idrName = "idris2-${idris2-version}";
   libSuffix = "lib/${idrName}";
   lib-dirs = lib.strings.concatMapStringsSep ":" (p: "${p}/${libSuffix}") idrisLibraries;
+  drvAttrs = builtins.removeAttrs attrs [ "idrisLibraries" ];
 in
 rec {
-  build = stdenv.mkDerivation {
+  build = stdenv.mkDerivation (drvAttrs // {
     name = projectName;
     src = src;
     nativeBuildInputs = [ idris2 ];
     configurePhase = ''
+      runHook preConfigure
       export IDRIS2_PACKAGE_PATH=${lib-dirs}
+      runHook postConfigure
     '';
     buildPhase = ''
+      runHook preBuild
       idris2 --build ${ipkgName}
+      runHook postBuild
     '';
     installPhase = ''
+      runHook preInstall
       mkdir -p $out/bin
       mv build/exec/* $out/bin
+      runHook postInstall
     '';
-  };
+  });
   installLibrary = build.overrideAttrs (_: {
     buildPhase = "";
     installPhase = ''


### PR DESCRIPTION
While looking at https://github.com/ReplicaTest/REPLica/pull/62, I looked at this flake (I am no idris developer, yet) and think the flake could be more idiomatic/easier to use it if allowed to  pass attributes directly to `buildIdris` instead of the
convoluted `buildIdris (...).build.overrideAttrs(oldAttrs: {})`.
