### PR TITLE
Check primitives (fromInteger etc) reduce on LHS

### DIFF
--- a/src/Core/CaseBuilder.idr
+++ b/src/Core/CaseBuilder.idr
@@ -1076,7 +1076,12 @@ mkPat args orig (Ref fc Func n)
   = do prims <- getPrimitiveNames
        mtm <- normalisePrims (const True) isPConst True prims n args orig []
        case mtm of
-         Just tm => mkPat [] tm tm
+         Just tm => if tm /= orig -- check we made progress; if there's an
+                                  -- unresolved interface, we might be stuck
+                                  -- and we'd loop forever
+                       then mkPat [] tm tm
+                       else -- Possibly this should be an error instead?
+                            pure $ PUnmatchable (getLoc orig) orig
          Nothing =>
            do log "compile.casetree" 10 $
                 "Unmatchable function: " ++ show n

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -130,7 +130,8 @@ idrisTestsRegression = MkTestPool "Various regressions" [] Nothing
        "reg022", "reg023", "reg024", "reg025", "reg026", "reg027", "reg028",
        "reg029", "reg030", "reg031", "reg032", "reg033", "reg034", "reg035",
        "reg036", "reg037", "reg038", "reg039", "reg040", "reg041", "reg042",
-       "reg043", "reg044", "reg045", "reg046", "reg047", "reg048", "reg049"]
+       "reg043", "reg044", "reg045", "reg046", "reg047", "reg048", "reg049",
+       "reg050"]
 
 idrisTestsData : TestPool
 idrisTestsData = MkTestPool "Data and record types" [] Nothing

--- a/tests/idris2/reg050/expected
+++ b/tests/idris2/reg050/expected
@@ -1,0 +1,11 @@
+1/1: Building loopy (loopy.idr)
+Error: While processing right hand side of eatBinary. While processing right hand side of eatBinary,firstDigit. Patterns for eatBinary,firstDigit,f require matching on different types.
+
+loopy:24:5--24:18
+ 20 |   firstDigit : List Char -> i
+ 21 |   firstDigit [] = 0
+ 22 |   firstDigit (d :: ds) = let
+ 23 |     f : Maybe i -> i
+ 24 |     f Nothing = 0
+          ^^^^^^^^^^^^^
+

--- a/tests/idris2/reg050/loopy.idr
+++ b/tests/idris2/reg050/loopy.idr
@@ -1,0 +1,27 @@
+
+toBit : Num i => Char -> Maybe i
+toBit '0' = Just 0
+toBit '1' = Just 1
+toBit _ = Nothing
+
+-- Return the number represented in binary as an initial segment of
+-- the string (remembering that if a number begins 0, it's zero).
+eatBinary : (Eq i, Num i) => String -> i
+eatBinary = firstDigit . unpack where
+
+  laterDigit : i -> List Char -> i
+  laterDigit n [] = n
+  laterDigit n (d :: ds) = let
+    f : Maybe i -> i
+    f Nothing = n
+    f (Just a) = laterDigit (2*n + a) ds
+    in f $ toBit d
+
+  firstDigit : List Char -> i
+  firstDigit [] = 0
+  firstDigit (d :: ds) = let
+    f : Maybe i -> i
+    f Nothing = 0
+    f (Just 0) = 0
+    f (Just a) = laterDigit a ds
+    in f $ toBit d

--- a/tests/idris2/reg050/run
+++ b/tests/idris2/reg050/run
@@ -1,0 +1,2 @@
+rm -rf build
+$1 --no-banner --no-color --console-width 0 loopy.idr --check -p contrib


### PR DESCRIPTION
If they don't, we can't turn them into patterns to match on, and we end up looping. Possibly we could throw a different and maybe more informative error instead of just making an unmatchable pattern.
Fixes #1895