### PR TITLE
Add function that checks whether a file handle points to a TTY device.

### DIFF
--- a/libs/base/System/File/Meta.idr
+++ b/libs/base/System/File/Meta.idr
@@ -24,7 +24,7 @@ prim__fileModifiedTime : FilePtr -> PrimIO Int
 prim__fileStatusTime : FilePtr -> PrimIO Int
 
 %foreign support "idris2_fileIsTTY"
-         "node:lambda:fp=>require('tty').isatty(fp.fd)"
+         "node:lambda:fp=>Number(require('tty').isatty(fp.fd))"
 prim__fileIsTTY : FilePtr -> PrimIO Int
 
 ||| Check if a file exists for reading.

--- a/libs/base/System/File/Meta.idr
+++ b/libs/base/System/File/Meta.idr
@@ -24,6 +24,7 @@ prim__fileModifiedTime : FilePtr -> PrimIO Int
 prim__fileStatusTime : FilePtr -> PrimIO Int
 
 %foreign support "idris2_fileIsTTY"
+         "node:lambda:fp=>require('tty').isatty(fp.fd)"
 prim__fileIsTTY : FilePtr -> PrimIO Int
 
 ||| Check if a file exists for reading.

--- a/libs/base/System/File/Meta.idr
+++ b/libs/base/System/File/Meta.idr
@@ -23,6 +23,9 @@ prim__fileModifiedTime : FilePtr -> PrimIO Int
 %foreign support "idris2_fileStatusTime"
 prim__fileStatusTime : FilePtr -> PrimIO Int
 
+%foreign support "idris2_fileIsTTY"
+prim__fileIsTTY : FilePtr -> PrimIO Int
+
 ||| Check if a file exists for reading.
 export
 exists : HasIO io => String -> io Bool
@@ -75,3 +78,9 @@ fPoll : HasIO io => File -> io Bool
 fPoll (FHandle f)
     = do p <- primIO (prim__fPoll f)
          pure (p > 0)
+
+||| Check whether the given File is a terminal device.
+export
+isTTY : HasIO io => (h : File) -> io Bool
+isTTY (FHandle f) = (/= 0) <$> primIO (prim__fileIsTTY f)
+

--- a/support/c/idris_file.c
+++ b/support/c/idris_file.c
@@ -30,6 +30,14 @@ void idris2_closeFile(FILE* f) {
     IDRIS2_VERIFY(fclose(f) == 0, "fclose failed: %s", strerror(errno));
 }
 
+int idris2_getFileNo(FILE* f) {
+#ifdef _WIN32
+    return win32_getFileNo(f);
+#else
+    return fileno(f);
+#endif
+}
+
 int idris2_fileError(FILE* f) {
     return ferror(f);
 }
@@ -61,11 +69,7 @@ int idris2_removeFile(const char *filename) {
 }
 
 int idris2_fileSize(FILE* f) {
-#ifdef _WIN32
-    int fd = win32_getFileNo(f);
-#else
-    int fd = fileno(f);
-#endif
+    int fd = idris2_getFileNo(f);
 
     struct stat buf;
     if (fstat(fd, &buf) == 0) {
@@ -84,11 +88,7 @@ int idris2_fpoll(FILE* f)
     struct timeval timeout;
     timeout.tv_sec = 1;
     timeout.tv_usec = 0;
-#ifdef _WIN32
-    int fd = win32_getFileNo(f);
-#else
-    int fd = fileno(f);
-#endif
+    int fd = idris2_getFileNo(f);
 
     FD_ZERO(&x);
     FD_SET(fd, &x);
@@ -180,11 +180,7 @@ int idris2_eof(FILE* f) {
 }
 
 int idris2_fileAccessTime(FILE* f) {
-#ifdef _WIN32
-    int fd = win32_getFileNo(f);
-#else
-    int fd = fileno(f);
-#endif
+    int fd = idris2_getFileNo(f);
 
     struct stat buf;
     if (fstat(fd, &buf) == 0) {
@@ -195,11 +191,7 @@ int idris2_fileAccessTime(FILE* f) {
 }
 
 int idris2_fileModifiedTime(FILE* f) {
-#ifdef _WIN32
-    int fd = win32_getFileNo(f);
-#else
-    int fd = fileno(f);
-#endif
+    int fd = idris2_getFileNo(f);
 
     struct stat buf;
     if (fstat(fd, &buf) == 0) {
@@ -210,11 +202,7 @@ int idris2_fileModifiedTime(FILE* f) {
 }
 
 int idris2_fileStatusTime(FILE* f) {
-#ifdef _WIN32
-    int fd = win32_getFileNo(f);
-#else
-    int fd = fileno(f);
-#endif
+    int fd = idris2_getFileNo(f);
 
     struct stat buf;
     if (fstat(fd, &buf) == 0) {
@@ -225,11 +213,10 @@ int idris2_fileStatusTime(FILE* f) {
 }
 
 int idris2_fileIsTTY(FILE* f) {
+    int fd = idris2_getFileNo(f);
 #ifdef _WIN32
-    int fd = win32_getFileNo(f);
     return win32_isTTY(fd);
 #else
-    int fd = fileno(f);
     return isatty(fd);
 #endif
 }

--- a/support/c/idris_file.c
+++ b/support/c/idris_file.c
@@ -61,7 +61,11 @@ int idris2_removeFile(const char *filename) {
 }
 
 int idris2_fileSize(FILE* f) {
+#ifdef _WIN32
+    int fd = win32_getFileNo(f);
+#else
     int fd = fileno(f);
+#endif
 
     struct stat buf;
     if (fstat(fd, &buf) == 0) {
@@ -80,7 +84,11 @@ int idris2_fpoll(FILE* f)
     struct timeval timeout;
     timeout.tv_sec = 1;
     timeout.tv_usec = 0;
+#ifdef _WIN32
+    int fd = win32_getFileNo(f);
+#else
     int fd = fileno(f);
+#endif
 
     FD_ZERO(&x);
     FD_SET(fd, &x);
@@ -172,7 +180,11 @@ int idris2_eof(FILE* f) {
 }
 
 int idris2_fileAccessTime(FILE* f) {
+#ifdef _WIN32
+    int fd = win32_getFileNo(f);
+#else
     int fd = fileno(f);
+#endif
 
     struct stat buf;
     if (fstat(fd, &buf) == 0) {
@@ -183,7 +195,11 @@ int idris2_fileAccessTime(FILE* f) {
 }
 
 int idris2_fileModifiedTime(FILE* f) {
+#ifdef _WIN32
+    int fd = win32_getFileNo(f);
+#else
     int fd = fileno(f);
+#endif
 
     struct stat buf;
     if (fstat(fd, &buf) == 0) {
@@ -194,7 +210,11 @@ int idris2_fileModifiedTime(FILE* f) {
 }
 
 int idris2_fileStatusTime(FILE* f) {
+#ifdef _WIN32
+    int fd = win32_getFileNo(f);
+#else
     int fd = fileno(f);
+#endif
 
     struct stat buf;
     if (fstat(fd, &buf) == 0) {
@@ -202,6 +222,16 @@ int idris2_fileStatusTime(FILE* f) {
     } else {
         return -1;
     }
+}
+
+int idris2_fileIsTTY(FILE* f) {
+#ifdef _WIN32
+    int fd = win32_getFileNo(f);
+    return win32_isTTY(fd);
+#else
+    int fd = fileno(f);
+    return isatty(fd);
+#endif
 }
 
 FILE* idris2_stdin() {

--- a/support/c/idris_file.h
+++ b/support/c/idris_file.h
@@ -38,6 +38,7 @@ int idris2_eof(FILE* f);
 int idris2_fileAccessTime(FILE* f);
 int idris2_fileModifiedTime(FILE* f);
 int idris2_fileStatusTime(FILE* f);
+int idris2_fileIsTTY(FILE* f);
 
 FILE* idris2_stdin();
 FILE* idris2_stdout();

--- a/support/c/windows/win_utils.c
+++ b/support/c/windows/win_utils.c
@@ -179,3 +179,11 @@ long win32_getNProcessors() {
                                                  ;
 }
 
+int win32_getFileNo(FILE* f) {
+    return _fileno(f);
+}
+
+int win32_isTTY(int fd) {
+    return _isatty(fd);
+}
+

--- a/support/c/windows/win_utils.h
+++ b/support/c/windows/win_utils.h
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include <stdio.h>
+#include <io.h>
 
 #pragma once
 
@@ -13,4 +14,7 @@ int win32_modenv(const char* name, const char* value, int overwrite);
 int win32_getErrno();
 int win32_getPID();
 long win32_getNProcessors();
+
+int win32_getFileNo(FILE*);
+int win32_isTTY(int fd);
 


### PR DESCRIPTION
This feels a bit more robust (and subtly different) than checking whether the `$TERM` environment variable is set to "dumb". It also theoretically opens the door for an app to pipe data to non-`stdout` TTY handles that it opens.

I also swapped out uses of `fileno()` for `_fileno()` when in a Windows environment because the former is a deprecated alias of the latter.

If this PR gets merged, I will submit a (good first issue) follow-up ticket that after the next Idris 2 release we can start using this function either in addition to- or instead of checking for "dumb" terminals when determining if colors are supported in the Idris 2 compiler source code.