### PR TITLE
Elab.Check don't need its parameter at runtime

### DIFF
--- a/libs/base/Language/Reflection.idr
+++ b/libs/base/Language/Reflection.idr
@@ -18,7 +18,7 @@ data Elab : Type -> Type where
      LogTerm : String -> Nat -> String -> TTImp -> Elab ()
 
      -- Elaborate a TTImp term to a concrete value
-     Check : {expected : Type} -> TTImp -> Elab expected
+     Check : TTImp -> Elab expected
      -- Quote a concrete expression back to a TTImp
      Quote : val -> Elab TTImp
 
@@ -91,7 +91,7 @@ logGoal str n msg
 ||| Check that some TTImp syntax has the expected type
 ||| Returns the type checked value
 export
-check : {expected : Type} -> TTImp -> Elab expected
+check : TTImp -> Elab expected
 check = Check
 
 ||| Return TTImp syntax of a given value


### PR DESCRIPTION
It makes sense, as `%runElab` consumes `Elab` at compile time.