### PR TITLE
code-blocks missing in the docs

### DIFF
--- a/docs/source/reference/overloadedlit.rst
+++ b/docs/source/reference/overloadedlit.rst
@@ -38,7 +38,7 @@ the literal is suitable for the ``Fin n`` type. The restricted behaviour can be
 observed in the REPL, where the failure to construct a valid proof is caught during
 the type-checking phase and not at runtime:
 
-.. code-block:: repl
+.. code-block:: idris
 
     Main> the (Fin 3) 2
     FS (FS FZ)

--- a/docs/source/reference/overloadedlit.rst
+++ b/docs/source/reference/overloadedlit.rst
@@ -38,7 +38,7 @@ the literal is suitable for the ``Fin n`` type. The restricted behaviour can be
 observed in the REPL, where the failure to construct a valid proof is caught during
 the type-checking phase and not at runtime:
 
-.. code-block::
+.. code-block:: repl
 
     Main> the (Fin 3) 2
     FS (FS FZ)

--- a/docs/source/reference/strings.rst
+++ b/docs/source/reference/strings.rst
@@ -85,14 +85,14 @@ If you need to escape characters you still can by using a ``\\`` followed by the
 ``#`` that you used for your string delimiters. In the following example we are using two
 ``#`` characters as our escape sequence and want to print a line return:
 
-.. code-block::
+.. code-block:: idris
 
     markdownExample : String
     markdownExample = ##"markdown titles look like this: \##n"# Title \##n body""##
 
 This last example could be implemented by combining raw string literals with multiline strings:
 
-.. code-block::
+.. code-block:: idris
 
     markdownExample : String
     markdownExample = ##"""
@@ -111,7 +111,7 @@ programs that evaluate to strings with a string literals in order to avoid manua
 the concatenation of those expressions. To use interpolated strings, use ``\{`` to start an
 interpolation slice in which you can write an idris expression. Close it with ``}``
 
-.. code-block::
+.. code-block:: idris
 
     print : Expr -> String
     print (Var name expr) = "let \{name} = \{print expr}"


### PR DESCRIPTION
Some block codes in the docs are not rendered: the 'idris' language missed and somehow the rst compiler apparently discarded them instead of letting them withut syntax coloring.