### PR TITLE
[ fix ] String casts on js backends

### DIFF
--- a/src/Compiler/ES/Codegen.idr
+++ b/src/Compiler/ES/Codegen.idr
@@ -202,12 +202,15 @@ jsBigIntOfString = callFun1 (esName "bigIntOfString")
 -- call _parseFloat from the preamble, which
 -- converts a string to a `Number`
 jsNumberOfString : Doc -> Doc
-jsNumberOfString = callFun1 "parseFloat"
+jsNumberOfString = callFun1 (esName "numberOfString")
 
 -- convert an string to an integral type based
 -- on its `IntKind`.
 jsIntOfString : IntKind -> Doc -> Doc
-jsIntOfString k = if useBigInt k then jsBigIntOfString else jsNumberOfString
+jsIntOfString k =
+  if useBigInt k
+     then jsBigIntOfString
+     else callFun1 (esName "intOfString")
 
 -- introduce a binary infix operation
 binOp : (symbol : String) -> (lhs : Doc) -> (rhs : Doc) -> Doc

--- a/support/js/support.js
+++ b/support/js/support.js
@@ -55,10 +55,21 @@ const _idrisworld = Symbol('idrisworld')
 
 const _crashExp = x=>{throw new IdrisError(x)}
 
-const _bigIntOfString = s=>{
-  const idx = s.indexOf('.')
-  return idx === -1 ? BigInt(s) : BigInt(s.slice(0, idx))
+const _bigIntOfString = s=> {
+  try {
+    const idx = s.indexOf('.')
+    return idx === -1 ? BigInt(s) : BigInt(s.slice(0, idx))
+  } catch (e) { return 0n }
 }
+
+const _numberOfString = s=> {
+  try {
+    const res = Number(s);
+    return isNaN(res) ? 0 : res;
+  } catch (e) { return 0 }
+}
+
+const _intOfString = s=> Math.trunc(_numberOfString(s))
 
 const _truncToChar = x=> String.fromCodePoint(
   (x >= 0 && x <= 55295) || (x >= 57344 && x <= 1114111) ? x : 0

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -265,6 +265,7 @@ nodeTests = MkTestPool "Node backend" [] (Just Node)
     , "memo"
     , "newints"
     , "reg001"
+    , "stringcast"
     , "syntax001"
     , "tailrec001"
     , "idiom001"

--- a/tests/node/stringcast/StringCast.idr
+++ b/tests/node/stringcast/StringCast.idr
@@ -1,0 +1,14 @@
+main : IO ()
+main = do
+  printLn $ cast {to = Integer} "end"
+  printLn $ cast {to = Nat} "end"
+  printLn $ cast {to = Double} "end"
+  printLn $ cast {to = Bits8} "end"
+  printLn $ cast {to = Bits16} "end"
+  printLn $ cast {to = Bits32} "end"
+  printLn $ cast {to = Bits64} "end"
+  printLn $ cast {to = Int8} "end"
+  printLn $ cast {to = Int16} "end"
+  printLn $ cast {to = Int32} "end"
+  printLn $ cast {to = Int64} "end"
+  printLn $ cast {to = Int} "end"

--- a/tests/node/stringcast/expected
+++ b/tests/node/stringcast/expected
@@ -1,0 +1,14 @@
+1/1: Building StringCast (StringCast.idr)
+Main> 0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+0
+Main> Bye for now!

--- a/tests/node/stringcast/input
+++ b/tests/node/stringcast/input
@@ -1,0 +1,2 @@
+:exec main
+:q

--- a/tests/node/stringcast/run
+++ b/tests/node/stringcast/run
@@ -1,0 +1,4 @@
+rm -rf build
+
+$1 --cg node --no-banner --no-color --console-width 0 StringCast.idr < input
+


### PR DESCRIPTION
On the Node backend, the following fails with an exception (the same code prints "0" with the default Chez backend):

```idris
main : IO ()
main = printLn $ cast {to = Integer} "end"
```

Likewise, the following version prints "NaN", while again printing "0" on Chez:

```idris
main : IO ()
main = printLn $ cast {to = Double} "end"
```

This PR adjusts the JS backends in such a way that they behave consistently w.r.t. to the default backend in the cases above. There might still be corner cases where the two backends differ, though.