### PR TITLE
Thread the option of silencing output to stdout

### DIFF
--- a/src/Idris/Driver.idr
+++ b/src/Idris/Driver.idr
@@ -164,7 +164,7 @@ stMain cgs opts
 
          let ide = ideMode opts
          let ideSocket = ideModeSocket opts
-         let outmode = if ide then IDEMode 0 stdin stdout else REPL False
+         let outmode = if ide then IDEMode 0 stdin stdout else REPL InfoLvl
          let fname = findInput opts
          o <- newRef ROpts (REPL.Opts.defaultOpts fname outmode cgs)
          updateEnv
@@ -179,7 +179,7 @@ stMain cgs opts
                      | False => pure ()
 
                  when (checkVerbose opts) $ -- override Quiet if implicitly set
-                     setOutput (REPL False)
+                     setOutput (REPL InfoLvl)
                  u <- newRef UST initUState
                  origin <- maybe
                    (pure $ Virtual Interactive) (\fname => do

--- a/src/Idris/REPL/Opts.idr
+++ b/src/Idris/REPL/Opts.idr
@@ -20,10 +20,24 @@ import Libraries.Data.String.Extra
 
 %default total
 
+namespace VerbosityLvl
+  public export
+  data VerbosityLvl =
+   ||| Supress all message output to `stdout`.
+   NoneLvl |
+   ||| Keep only errors.
+   ErrorLvl |
+   ||| Keep everything.
+   InfoLvl
+
 public export
 data OutputMode
-  = IDEMode Integer File File
-  | REPL Bool -- quiet flag (ignore iputStrLn)
+  = IDEMode Integer File File |
+    ||| Given that we can divide elaboration messages into
+    ||| two categories: informational message and error message,
+    ||| `VerbosityLvl` applies a filter on the output,
+    |||  supressing writes to `stdout` if the level condition isn't met.
+    REPL VerbosityLvl
 
 public export
 record REPLOpts where

--- a/src/Idris/REPL/Opts.idr
+++ b/src/Idris/REPL/Opts.idr
@@ -23,7 +23,7 @@ import Libraries.Data.String.Extra
 namespace VerbosityLvl
   public export
   data VerbosityLvl =
-   ||| Supress all message output to `stdout`.
+   ||| Suppress all message output to `stdout`.
    NoneLvl |
    ||| Keep only errors.
    ErrorLvl |
@@ -36,7 +36,7 @@ data OutputMode
     ||| Given that we can divide elaboration messages into
     ||| two categories: informational message and error message,
     ||| `VerbosityLvl` applies a filter on the output,
-    |||  supressing writes to `stdout` if the level condition isn't met.
+    |||  suppressing writes to `stdout` if the level condition isn't met.
     REPL VerbosityLvl
 
 public export

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -328,7 +328,7 @@ preOptions (Profile :: opts)
     = do setSession (record { profile = True } !getSession)
          preOptions opts
 preOptions (Quiet :: opts)
-    = do setOutput (REPL True)
+    = do setOutput (REPL VerbosityLvl.ErrorLvl)
          preOptions opts
 preOptions (NoPrelude :: opts)
     = do setSession (record { noprelude = True } !getSession)
@@ -375,7 +375,7 @@ preOptions (AltErrorCount c :: opts)
     = do setSession (record { logErrorCount = c } !getSession)
          preOptions opts
 preOptions (RunREPL _ :: opts)
-    = do setOutput (REPL True)
+    = do setOutput (REPL VerbosityLvl.ErrorLvl)
          setSession (record { nobanner = True } !getSession)
          preOptions opts
 preOptions (FindIPKG :: opts)


### PR DESCRIPTION
The change helps to avoid the most commonly found dumps of elaboration error messages to stdout when in
quiet mode. That in turn keeps us safe from critical LSP failures due to unexpected writes to stdout.