### PR TITLE
Add chez-scheme to chez search path

### DIFF
--- a/libs/test/Test/Golden.idr
+++ b/libs/test/Test/Golden.idr
@@ -331,7 +331,7 @@ checkRequirement req
   where
     requirement : Requirement -> (String, List String)
     requirement C = ("CC", ["cc"])
-    requirement Chez = ("CHEZ", ["chez", "chezscheme9.5", "chezscheme", "scheme"])
+    requirement Chez = ("CHEZ", ["chez", "chezscheme9.5", "chezscheme", "chez-scheme", "scheme"])
     requirement Node = ("NODE", ["node"])
     requirement Racket = ("RACKET", ["racket"])
     requirement Gambit = ("GAMBIT", ["gsc"])

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -39,7 +39,7 @@ findChez : IO String
 findChez
     = do Nothing <- idrisGetEnv "CHEZ"
             | Just chez => pure chez
-         path <- pathLookup ["chez", "chezscheme", "chezscheme9.5", "scheme"]
+         path <- pathLookup ["chez", "chezscheme", "chez-scheme", "chezscheme9.5", "scheme"]
          pure $ fromMaybe "/usr/bin/env scheme" path
 
 ||| Returns the chez scheme version for given executable


### PR DESCRIPTION
According to repology, there are a few systems using `chez-scheme` as chez's name (including Alpine, Guix, Void, ASOC, Freebsd-ports, MacPorts, nix...)

https://repology.org/project/chez-scheme/versions

This small addition can eliminate time-wasting for those users. They will no longer have to change chez name or delegate with corresponding packagers.
