### PR TITLE
Made unifying error msg nicer.

### DIFF
--- a/src/Idris/Error.idr
+++ b/src/Idris/Error.idr
@@ -231,8 +231,9 @@ perror (CyclicMeta fc env n tm)
 perror (WhenUnifying _ gam env x y err)
     = do defs <- get Ctxt
          setCtxt gam
-         let res = errorDesc (reflow "When unifying" <++> code !(pshow env x) <++> "and"
-                      <++> code !(pshow env y)) <+> dot <+> line <+> !(perror err)
+         let res = errorDesc (reflow "When unifying:" <+> line
+                   <+> "    " <+> code !(pshow env x) <+> line <+> "and:" <+> line
+                   <+> "    " <+> code !(pshow env y)) <+> line <+> !(perror err)
          put Ctxt defs
          pure res
 perror (ValidCase fc env (Left tm))

--- a/tests/idris2/basic001/expected
+++ b/tests/idris2/basic001/expected
@@ -1,6 +1,9 @@
 1/1: Building Vect (Vect.idr)
 Main> Main> Cons (S Z) (Cons (S (S Z)) []) : Vect (S (S Z)) Nat
-Main> Error: When unifying Vect (S (S Z)) Nat and Vect (S Z) Nat.
+Main> Error: When unifying:
+    Vect (S (S Z)) Nat
+and:
+    Vect (S Z) Nat
 Mismatch between: S Z and Z.
 
 (Interactive):1:28--1:51

--- a/tests/idris2/basic016/expected
+++ b/tests/idris2/basic016/expected
@@ -1,5 +1,8 @@
 1/1: Building Eta (Eta.idr)
-Error: While processing right hand side of etaBad. When unifying \x, y => MkTest x y = \x, y => MkTest x y and MkTest = \x, y => MkTest x y.
+Error: While processing right hand side of etaBad. When unifying:
+    \x, y => MkTest x y = \x, y => MkTest x y
+and:
+    MkTest = \x, y => MkTest x y
 Mismatch between: Nat and Integer.
 
 Eta:14:10--14:14
@@ -11,7 +14,10 @@ Eta:14:10--14:14
                ^^^^
 
 1/1: Building Eta2 (Eta2.idr)
-Error: While processing right hand side of test. When unifying \x => S x = \x => S x and S = \x => S x.
+Error: While processing right hand side of test. When unifying:
+    \x => S x = \x => S x
+and:
+    S = \x => S x
 Mismatch between: a and Nat.
 
 Eta2:2:8--2:12
@@ -19,7 +25,10 @@ Eta2:2:8--2:12
  2 | test = Refl
             ^^^^
 
-Error: While processing right hand side of test2. When unifying \x => S x = \x => S x and S = \x => S x.
+Error: While processing right hand side of test2. When unifying:
+    \x => S x = \x => S x
+and:
+    S = \x => S x
 Mismatch between: a and Nat.
 
 Eta2:5:44--5:48

--- a/tests/idris2/basic030/expected
+++ b/tests/idris2/basic030/expected
@@ -1,5 +1,8 @@
 1/1: Building arity (arity.idr)
-Error: While processing right hand side of foo. When unifying Nat -> MyN and MyN.
+Error: While processing right hand side of foo. When unifying:
+    Nat -> MyN
+and:
+    MyN
 Mismatch between: Nat -> MyN and MyN.
 
 arity:4:16--4:21

--- a/tests/idris2/basic034/expected
+++ b/tests/idris2/basic034/expected
@@ -1,5 +1,8 @@
 1/1: Building lets (lets.idr)
-Error: While processing right hand side of dolet2. When unifying Maybe Int and Maybe String.
+Error: While processing right hand side of dolet2. When unifying:
+    Maybe Int
+and:
+    Maybe String
 Mismatch between: Int and String.
 
 lets:22:39--22:40

--- a/tests/idris2/error001/expected
+++ b/tests/idris2/error001/expected
@@ -1,5 +1,8 @@
 1/1: Building Error (Error.idr)
-Error: While processing right hand side of wrong. When unifying a and Vect ?k ?a.
+Error: While processing right hand side of wrong. When unifying:
+    a
+and:
+    Vect ?k ?a
 Mismatch between: a and Vect ?k ?a.
 
 Error:6:19--6:20

--- a/tests/idris2/error003/expected
+++ b/tests/idris2/error003/expected
@@ -1,6 +1,9 @@
 1/1: Building Error (Error.idr)
 Error: While processing right hand side of wrong. Sorry, I can't find any elaboration which works. All errors:
-If Main.length: When unifying Nat and Vect ?n ?a.
+If Main.length: When unifying:
+    Nat
+and:
+    Vect ?n ?a
 Mismatch between: Nat and Vect ?n ?a.
 
 Error:12:18--12:19
@@ -11,7 +14,10 @@ Error:12:18--12:19
  12 | wrong x = length x
                        ^
 
-If Prelude.List.length: When unifying Nat and List ?a.
+If Prelude.List.length: When unifying:
+    Nat
+and:
+    List ?a
 Mismatch between: Nat and List ?a.
 
 Error:12:18--12:19
@@ -22,7 +28,10 @@ Error:12:18--12:19
  12 | wrong x = length x
                        ^
 
-If Prelude.String.length: When unifying Nat and String.
+If Prelude.String.length: When unifying:
+    Nat
+and:
+    String
 Mismatch between: Nat and String.
 
 Error:12:18--12:19

--- a/tests/idris2/interface027/expected
+++ b/tests/idris2/interface027/expected
@@ -1,7 +1,10 @@
 1/1: Building params (params.idr)
 Main> False
 Main> True
-Main> Error: When unifying X 4 ?t and X 5 ?t.
+Main> Error: When unifying:
+    X 4 ?t
+and:
+    X 5 ?t
 Mismatch between: 0 and 1.
 
 (Interactive):1:1--1:12

--- a/tests/idris2/namespace002/expected
+++ b/tests/idris2/namespace002/expected
@@ -1,5 +1,8 @@
 1/1: Building Issue1313 (Issue1313.idr)
-Error: While processing right hand side of g. When unifying Int -> Int -> Int and Int.
+Error: While processing right hand side of g. When unifying:
+    Int -> Int -> Int
+and:
+    Int
 Mismatch between: Int -> Int -> Int and Int.
 
 Issue1313:9:17--9:18

--- a/tests/idris2/perf005/expected
+++ b/tests/idris2/perf005/expected
@@ -1,6 +1,9 @@
 1/2: Building NoRegression (NoRegression.idr)
 2/2: Building Lambda (Lambda.idr)
-Error: While processing right hand side of term. When unifying Term ?g (TyFunc ?tyA (TyFunc TyNat (TyFunc TyNat (TyFunc TyNat (TyFunc TyNat (TyFunc TyNat (TyFunc TyNat (TyFunc TyNat TyNat)))))))) and Term Empty (TyFunc TyNat (TyFunc TyNat (TyFunc TyNat (TyFunc TyNat (TyFunc TyNat (TyFunc TyNat (TyFunc TyNat TyNat))))))).
+Error: While processing right hand side of term. When unifying:
+    Term ?g (TyFunc ?tyA (TyFunc TyNat (TyFunc TyNat (TyFunc TyNat (TyFunc TyNat (TyFunc TyNat (TyFunc TyNat (TyFunc TyNat TyNat))))))))
+and:
+    Term Empty (TyFunc TyNat (TyFunc TyNat (TyFunc TyNat (TyFunc TyNat (TyFunc TyNat (TyFunc TyNat (TyFunc TyNat TyNat)))))))
 Mismatch between: TyFunc TyNat TyNat and TyNat.
 
 Lambda:62:3--88:9

--- a/tests/idris2/record004/expected
+++ b/tests/idris2/record004/expected
@@ -6,7 +6,10 @@ Main> 4.2
 Main> 4.2
 Main> 17.64
 Main> [1.1, 4.2]
-Main> Error: When unifying (?a -> ?b) -> ?f ?a -> ?f ?b and Point.
+Main> Error: When unifying:
+    (?a -> ?b) -> ?f ?a -> ?f ?b
+and:
+    Point
 Mismatch between: (?a -> ?b) -> ?f ?a -> ?f ?b and Point.
 
 (Interactive):1:1--1:4

--- a/tests/idris2/reflection001/expected
+++ b/tests/idris2/reflection001/expected
@@ -1,5 +1,8 @@
 1/1: Building quote (quote.idr)
-Error: While processing right hand side of bad. When unifying Int and TTImp.
+Error: While processing right hand side of bad. When unifying:
+    Int
+and:
+    TTImp
 Mismatch between: Int and TTImp.
 
 quote:25:19--25:22

--- a/tests/idris2/reflection005/expected
+++ b/tests/idris2/reflection005/expected
@@ -1,5 +1,8 @@
 1/1: Building refdecl (refdecl.idr)
-Error: While processing right hand side of bad. When unifying Elab () and Elab a.
+Error: While processing right hand side of bad. When unifying:
+    Elab ()
+and:
+    Elab a
 Mismatch between: () and a.
 
 refdecl:13:16--13:29

--- a/tests/idris2/reg007/expected
+++ b/tests/idris2/reg007/expected
@@ -1,5 +1,8 @@
 1/1: Building Main (Main.idr)
-Error: While processing right hand side of dpairWithExtraInfoBad. When unifying [MN 0, MN 0] and [MN 0].
+Error: While processing right hand side of dpairWithExtraInfoBad. When unifying:
+    [MN 0, MN 0]
+and:
+    [MN 0]
 Mismatch between: [MN 0] and [].
 
 Main:27:27--27:36

--- a/tests/idris2/with003/expected
+++ b/tests/idris2/with003/expected
@@ -23,7 +23,10 @@ Main> Error: Ambiguous elaboration. Possible results:
 
 Main> [] : Vect 0 ?elem
 Main> [] : List ?a
-Main> Error: When unifying Vect 0 ?elem and List ?a.
+Main> Error: When unifying:
+    Vect 0 ?elem
+and:
+    List ?a
 Mismatch between: Vect 0 ?elem and List ?a.
 
 (Interactive):1:40--1:41


### PR DESCRIPTION
Made unifying error msg nicer. ex.:

```
Error: While processing right hand side of foo3. When unifying:
    (Int, (String, (String, (Char, (Int, (String, Char))))))
and:
    (Int, (String, (String, (Char, (Int, (Int, Char))))))
Mismatch between: String and Int.
```
vs:
```
Error: While processing right hand side of foo3. When unifying (Int, (String, (String, (Char, (Int, (String, Char)))))) and (Int, (String, (String, (Char, (Int, (Int, Char))))))
Mismatch between: String and Int.
```

Code below:
```
foo : (Int,String,String,Char,Int,Int,Char) -> ()
foo x = ()


foo2 : (Int,String,String,Char,Int,String,Char)
foo2 = (1,"foo","x",'c',5,"fee",'d')

foo3 : ()
foo3 = foo foo2
```