### PR TITLE
[ cleanup ] Remove unreachable match clauses

### DIFF
--- a/src/Compiler/RefC/RefC.idr
+++ b/src/Compiler/RefC/RefC.idr
@@ -80,8 +80,6 @@ cName (Nested i n) = "n__" ++ cCleanString (show i) ++ "_" ++ cName n
 cName (CaseBlock x y) = "case__" ++ cCleanString (show x) ++ "_" ++ cCleanString (show y)
 cName (WithBlock x y) = "with__" ++ cCleanString (show x) ++ "_" ++ cCleanString (show y)
 cName (Resolved i) = "fn__" ++ cCleanString (show i)
-cName n = assert_total $ idris_crash ("INTERNAL ERROR: Unsupported name in C backend " ++ show n)
--- not really total but this way this internal error does not contaminate everything else
 
 escapeChar : Char -> String
 escapeChar c = if isAlphaNum c || isNL c
@@ -135,8 +133,6 @@ cConstant Bits8Type = "Bits8"
 cConstant Bits16Type = "Bits16"
 cConstant Bits32Type = "Bits32"
 cConstant Bits64Type = "Bits64"
-cConstant n = assert_total $ idris_crash ("INTERNAL ERROR: Unknonw constant in C backend: " ++ show n)
--- not really total but this way this internal error does not contaminate everything else
 
 extractConstant : Constant -> String
 extractConstant (I x) = show x

--- a/src/TTImp/Elab/ImplicitBind.idr
+++ b/src/TTImp/Elab/ImplicitBind.idr
@@ -491,7 +491,6 @@ checkPolyConstraint (MkPolyConstraint fc env arg x y)
                                  throw (MatchTooSpecific fc env arg)
                          else pure ()
               _ => pure ()
-checkPolyConstraint _ = pure ()
 
 solvePolyConstraint :
             {auto c : Ref Ctxt Defs} ->

--- a/src/TTImp/Unelab.idr
+++ b/src/TTImp/Unelab.idr
@@ -268,9 +268,6 @@ mutual
   unelabTy' umode nest env (PrimVal fc c) = pure (IPrimVal fc c, gErased fc)
   unelabTy' umode nest env (Erased fc _) = pure (Implicit fc True, gErased fc)
   unelabTy' umode nest env (TType fc) = pure (IType fc, gType fc)
-  unelabTy' umode nest _ tm
-      = let fc = getLoc tm in
-            pure (Implicit fc False, gErased fc)
 
   unelabPi : {vars : _} ->
              {auto c : Ref Ctxt Defs} ->


### PR DESCRIPTION
#1942 shows that there are some unreachable clauses. Interestingly there was a non-trivial one in the `Unelab` module, but the `_` clause is really unreachable, I checked this by hand.

This must be a backward-compatible change, independent of #1942.