### PR TITLE
[ performance ] CSE in linear space

### DIFF
--- a/src/Compiler/Common.idr
+++ b/src/Compiler/Common.idr
@@ -303,10 +303,7 @@ getCompileData doLazyAnnots phase_in tm_in
          logTime "++ Fix arity" $ traverse_ fixArityDef rcns
          compiledtm <- fixArityExp !(compileExp tm)
 
-         (cseDefs, csetm) <- logTime "++ CSE" $ do
-           um      <- analyzeNames rcns
-           defs    <- catMaybes <$> traverse (cseDef um) rcns
-           pure $ (cseNewToplevelDefs um ++ defs, adjust um compiledtm)
+         (cseDefs, csetm) <- logTime "++ CSE" $ cse rcns compiledtm
 
          namedDefs <- logTime "++ Forget names" $
            traverse getNamedDef cseDefs
@@ -359,6 +356,13 @@ compileTerm tm_in
     = do tm <- toFullNames tm_in
          fixArityExp !(compileExp tm)
 
+compDef : {auto c : Ref Ctxt Defs} -> Name -> Core (Maybe (Name, FC, CDef))
+compDef n = do
+  defs <- get Ctxt
+  Just def <- lookupCtxtExact n (gamma defs) | Nothing => pure Nothing
+  let Just cexpr =  compexpr def             | Nothing => pure Nothing
+  pure $ Just (n, location def, cexpr)
+
 export
 getIncCompileData : {auto c : Ref Ctxt Defs} -> (doLazyAnnots : Bool) ->
                     UsePhase -> Core CompileData
@@ -369,7 +373,7 @@ getIncCompileData doLazyAnnots phase
          let ns = keys (toIR defs)
          cns <- traverse toFullNames ns
          rcns <- filterM nonErased cns
-         cseDefs <- catMaybes <$> traverse (cseDef empty) rcns
+         cseDefs <- catMaybes <$> traverse compDef rcns
 
          namedDefs <- traverse getNamedDef cseDefs
 

--- a/src/Compiler/CompileExpr.idr
+++ b/src/Compiler/CompileExpr.idr
@@ -1,6 +1,5 @@
 module Compiler.CompileExpr
 
-import Compiler.Opts.CSE
 import Core.CaseTree
 import public Core.CompileExpr
 import Core.Context


### PR DESCRIPTION
The current CSE algorithm stores all closed sub-terms in their unmodified form in a `SortedMap`. This requires O(n^2) space w.r.t. term size and can lead to drastic amounts of memory consumption during CSE as mentioned on [discord](https://discord.com/channels/827106007712661524/827109190266257409/889134639480991764). @Z-snails had the idea to start the CSE analysis at the leaves, in which case it should be possible for the algorithm to consume a linear amount of space w.r.t. term size.

This PR adjusts the algorithm in such a way.