### PR TITLE
[ re #1944 ] Allow toplevel aliases

### DIFF
--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -819,10 +819,11 @@ getFieldNames ctxt recNS
 
 -- Find similar looking names in the context
 export
-getSimilarNames : {auto c : Ref Ctxt Defs} -> Name -> Core (List String)
+getSimilarNames : {auto c : Ref Ctxt Defs} ->
+                   Name -> Core (Maybe (String, List (Name, Nat)))
 getSimilarNames nm = case show <$> userNameRoot nm of
-  Nothing => pure []
-  Just str => if length str <= 1 then pure [] else
+  Nothing => pure Nothing
+  Just str => if length str <= 1 then pure (Just (str, [])) else
     let threshold : Nat := max 1 (assert_total (divNat (length str) 3))
         test : Name -> IO (Maybe Nat) := \ nm => do
             let (Just str') = show <$> userNameRoot nm
@@ -831,9 +832,14 @@ getSimilarNames nm = case show <$> userNameRoot nm of
             pure (dist <$ guard (dist <= threshold))
     in do defs <- get Ctxt
           kept <- coreLift $ mapMaybeM test (resolvedAs (gamma defs))
-          let sorted = sortBy (\ x, y => compare (snd x) (snd y)) $ toList kept
-          let roots = mapMaybe (showNames nm str . fst) sorted
-          pure (nub roots)
+          pure $ Just (str, toList kept)
+
+export
+showSimilarNames : Name -> String -> List (Name, Nat) -> List String
+showSimilarNames nm str kept
+  = let sorted = sortBy (\ x, y => compare (snd x) (snd y)) kept
+        roots  = mapMaybe (showNames nm str . fst) sorted
+    in nub roots
 
   where
 
@@ -849,7 +855,9 @@ getSimilarNames nm = case show <$> userNameRoot nm of
 maybeMisspelling : {auto c : Ref Ctxt Defs} ->
                    Error -> Name -> Core a
 maybeMisspelling err nm = do
-  candidates <- getSimilarNames nm
+  Just (str, kept) <- getSimilarNames nm
+    | Nothing => throw err
+  let candidates = showSimilarNames nm str kept
   case candidates of
     [] => throw err
     (x::xs) => throw (MaybeMisspelling err (x ::: xs))

--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -24,6 +24,7 @@ import TTImp.Impossible
 import TTImp.PartialEval
 import TTImp.TTImp
 import TTImp.TTImp.Functor
+import TTImp.ProcessType
 import TTImp.Unelab
 import TTImp.Utils
 import TTImp.WithClause
@@ -889,6 +890,42 @@ warnUnreachable : {auto c : Ref Ctxt Defs} ->
 warnUnreachable (MkClause env lhs rhs)
     = recordWarning (UnreachableClause (getLoc lhs) env lhs)
 
+lookupOrAddAlias : {vars : _} ->
+                   {auto m : Ref MD Metadata} ->
+                   {auto c : Ref Ctxt Defs} ->
+                   {auto u : Ref UST UState} ->
+                   List ElabOpt -> NestedNames vars -> Env Term vars -> FC ->
+                   Name -> List ImpClause -> Core (Maybe GlobalDef)
+lookupOrAddAlias eopts nest env fc n [PatClause _ (IVar _ _) _]
+  = do defs <- get Ctxt
+       Nothing <- lookupCtxtExact n (gamma defs)
+         | Just gdef => pure (Just gdef)
+       -- No prior declaration: add one with a unification variable as its type
+       log "declare.def" 5 $
+         "Missing type declaration for the alias "
+         ++ show n
+         ++ ". Checking first whether it is a misspelling."
+       [] <- do -- get the candidates
+                Just (str, kept) <- getSimilarNames n
+                   | Nothing => pure []
+                -- only keep the ones that haven't been defined yet
+                decls <- for kept $ \ (cand, weight) => do
+                    Just gdef <- lookupCtxtExact cand (gamma defs)
+                      | Nothing => pure Nothing -- should be impossible
+                    let None = definition gdef
+                      | _ => pure Nothing
+                    pure (Just (cand, weight))
+                pure $ showSimilarNames n str $ catMaybes decls
+          | (x :: xs) => throw (MaybeMisspelling (NoDeclaration fc n) (x ::: xs))
+       log "declare.def" 5 "Not a misspelling: go ahead and declare it!"
+       processType eopts nest env fc top Public []
+          $ MkImpTy fc fc n $ Implicit fc False
+       defs <- get Ctxt
+       lookupCtxtExact n (gamma defs)
+lookupOrAddAlias _ _ _ fc n _
+  = do defs <- get Ctxt
+       lookupCtxtExact n (gamma defs)
+
 export
 processDef : {vars : _} ->
              {auto c : Ref Ctxt Defs} ->
@@ -899,8 +936,8 @@ processDef : {vars : _} ->
 processDef opts nest env fc n_in cs_in
     = do n <- inCurrentNS n_in
          defs <- get Ctxt
-         Just gdef <- lookupCtxtExact n (gamma defs)
-              | Nothing => noDeclaration fc n
+         Just gdef <- lookupOrAddAlias opts nest env fc n cs_in
+           | Nothing => noDeclaration fc n
          let None = definition gdef
               | _ => throw (AlreadyDefined fc n)
          let ty = type gdef

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -41,7 +41,7 @@ idrisTestsBasic = MkTestPool "Fundamental language features" [] Nothing
        "basic046", "basic047",             "basic049", "basic050",
        "basic051", "basic052", "basic053", "basic054", "basic055",
        "basic056", "basic057", "basic058", "basic059", "basic060",
-       "basic061",
+       "basic061", "basic063",
        "interpolation001", "interpolation002"]
 
 idrisTestsCoverage : TestPool

--- a/tests/idris2/basic063/NoDeclaration.idr
+++ b/tests/idris2/basic063/NoDeclaration.idr
@@ -1,0 +1,21 @@
+module NoDeclaration
+
+identity : (a : Type) -> a -> a
+identity _ x = x
+
+idNat = identity Nat
+
+double = (S 1 *)
+
+test : idNat (double 3) === 6
+test = Refl
+
+unwords : List String -> String
+unwords [] = ""
+unwords [x] = x
+unwords (x::xs) = x ++ " " ++ unwords xs
+
+helloWorld = unwords ["hello", "world"]
+
+test' : NoDeclaration.helloWorld === "hello world"
+test' = Refl

--- a/tests/idris2/basic063/expected
+++ b/tests/idris2/basic063/expected
@@ -1,0 +1,1 @@
+1/1: Building NoDeclaration (NoDeclaration.idr)

--- a/tests/idris2/basic063/run
+++ b/tests/idris2/basic063/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --no-banner --check NoDeclaration.idr

--- a/tests/idris2/error016/expected
+++ b/tests/idris2/error016/expected
@@ -8,7 +8,7 @@ Issue1230:9:1--9:15
  8 | mkRec2 : R
  9 | myRec2 = MkR 3
      ^^^^^^^^^^^^^^
-Did you mean any of: mkRec2, or myRec1?
+Did you mean: mkRec2?
 Main> Error: Undefined name nap. 
 
 (Interactive):1:4--1:7


### PR DESCRIPTION
Doesn't seem to work in `where` clauses at the moment.