### PR TITLE
Fix #1946

### DIFF
--- a/tests/idris2/reflection011/CheckResolution.idr
+++ b/tests/idris2/reflection011/CheckResolution.idr
@@ -1,0 +1,13 @@
+import Language.Reflection
+
+%language ElabReflection
+
+checkWithoutLambda : Integer
+checkWithoutLambda = %runElab (do
+  x <- check (IPrimVal EmptyFC (BI 3))
+  pure x)
+
+checkWithLambda : Integer -> Integer
+checkWithLambda = %runElab (lambda Integer $ \v => do
+  x <- check (IPrimVal EmptyFC (BI 3))
+  pure $ v + x)

--- a/tests/idris2/reflection011/expected
+++ b/tests/idris2/reflection011/expected
@@ -1,0 +1,4 @@
+1/1: Building CheckResolution (CheckResolution.idr)
+Main> 3
+Main> 7
+Main> Bye for now!

--- a/tests/idris2/reflection011/input
+++ b/tests/idris2/reflection011/input
@@ -1,0 +1,3 @@
+checkWithoutLambda
+checkWithLambda 4
+:q

--- a/tests/idris2/reflection011/run
+++ b/tests/idris2/reflection011/run
@@ -1,0 +1,4 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --no-banner CheckResolution.idr < input
+


### PR DESCRIPTION
The patch removed a check that stops the resolution of functions by the evaluator in some corner cases (as the one mentioned in #1946).
It should be harmless: I worried at first that it could have stuck the compiler by introducing an endless loop, but such loops will be caught by `updateLimit`.
It will at worst slow down some evaluations, but it will allow the evaluation of valid `Elab`.

I have also added a test with the initial issue so that we can later try to reintroduce a better stop condition in the evaluator.