### PR TITLE
Make --prefix respect IDRIS2_PREFIX

### DIFF
--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -182,7 +182,7 @@ dirOption dirs LibDir
 dirOption dirs BlodwenPaths
     = iputStrLn $ pretty (toString dirs)
 dirOption dirs Prefix
-    = coreLift $ putStrLn yprefix
+    = coreLift $ putStrLn (prefix_dir dirs)
 
 --------------------------------------------------------------------------------
 --          Bash Autocompletions


### PR DESCRIPTION
Currently, `idris2 --prefix` only reports the string `yprefix` baked into the executable at build-time. For the [snap package](https://github.com/timsueberkrueb/idris2-snap) however, this location points to an invalid built-time only location at runtime (`/root/parts/idris2/install`) which is not useful and may break some scripts. Hence, this PR makes `idris2 --prefix` use `IDRIS2_PREFIX` and fall back to `yprefix` if the environment variable is not set.

Fixes #737.