### PR TITLE
Add some JSON cast interfaces

### DIFF
--- a/libs/contrib/Language/JSON/Data.idr
+++ b/libs/contrib/Language/JSON/Data.idr
@@ -96,6 +96,15 @@ export
 Show JSON where
   show = stringify
 
+export
+[Idris] Show JSON where
+  showPrec d JNull = "JNull"
+  showPrec d (JBoolean x) = showCon d "JBoolean" $ showArg x
+  showPrec d (JNumber x) = showCon d "JNumber" $ showArg x
+  showPrec d (JString x) = showCon d "JString" $ showArg x
+  showPrec d (JArray xs) = assert_total $ showCon d "JArray" $ showArg xs
+  showPrec d (JObject xs) = assert_total $ showCon d "JObject" $ showArg xs
+
 ||| Format a JSON value, indenting by `n` spaces per nesting level.
 |||
 ||| @curr The current indentation amount, measured in spaces.

--- a/libs/contrib/Language/JSON/Data.idr
+++ b/libs/contrib/Language/JSON/Data.idr
@@ -137,3 +137,23 @@ format {curr} n json = indent curr $ formatValue curr n json
                                      _ :: _ => ",\n" ++ formatProps xs
                                      [] => "\n"
     formatValue _ _ x = stringify x
+
+public export
+Cast () JSON where
+  cast () = JNull
+
+public export
+Cast Bool JSON where
+  cast = JBoolean
+
+public export
+Cast Double JSON where
+  cast = JNumber
+
+public export
+Cast String JSON where
+  cast = JString
+
+public export
+Cast a JSON => Cast (List a) JSON where
+  cast xs = JArray $ map cast xs

--- a/tests/contrib/json_002/ShowJSON.idr
+++ b/tests/contrib/json_002/ShowJSON.idr
@@ -1,0 +1,17 @@
+import Language.JSON
+
+someJSON : JSON
+someJSON = JObject [
+    ("a", JNull),
+    ("b", JBoolean True),
+    ("c", JNumber 1),
+    ("d", JString "Hello, world"),
+    ("e", JArray [JNull, JString "Lorem ipsum"]),
+    ("f", JObject [("key", JString "value")])
+  ]
+
+main : IO ()
+main = do
+    putStrLn $ show someJSON
+    putStrLn $ show @{Idris} someJSON
+    putStrLn $ format 4 someJSON

--- a/tests/contrib/json_002/expected
+++ b/tests/contrib/json_002/expected
@@ -1,0 +1,17 @@
+1/1: Building ShowJSON (ShowJSON.idr)
+Main> {"a":null,"b":true,"c":1.0,"d":"Hello, world","e":[null,"Lorem ipsum"],"f":{"key":"value"}}
+JObject [("a", JNull), ("b", JBoolean True), ("c", JNumber 1.0), ("d", JString "Hello, world"), ("e", JArray [JNull, JString "Lorem ipsum"]), ("f", JObject [("key", JString "value")])]
+{
+    "a": null,
+    "b": true,
+    "c": 1.0,
+    "d": "Hello, world",
+    "e": [
+        null,
+        "Lorem ipsum"
+    ],
+    "f": {
+        "key": "value"
+    }
+}
+Main> Bye for now!

--- a/tests/contrib/json_002/input
+++ b/tests/contrib/json_002/input
@@ -1,0 +1,2 @@
+:exec main
+:q

--- a/tests/contrib/json_002/run
+++ b/tests/contrib/json_002/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-banner --no-color --console-width 0 -p contrib ShowJSON.idr < input

--- a/tests/contrib/json_003/CastJSON.idr
+++ b/tests/contrib/json_003/CastJSON.idr
@@ -1,0 +1,11 @@
+import Language.JSON
+
+main : IO ()
+main = do
+    printLn $ JObject [
+        ("a", cast ()),
+        ("b", cast True),
+        ("c", cast 1.0),
+        ("d", cast "Hello, world"),
+        ("e", cast ["Lorem", "ipsum"])
+      ]

--- a/tests/contrib/json_003/expected
+++ b/tests/contrib/json_003/expected
@@ -1,0 +1,3 @@
+1/1: Building CastJSON (CastJSON.idr)
+Main> {"a":null,"b":true,"c":1.0,"d":"Hello, world","e":["Lorem","ipsum"]}
+Main> Bye for now!

--- a/tests/contrib/json_003/input
+++ b/tests/contrib/json_003/input
@@ -1,0 +1,2 @@
+:exec main
+:q

--- a/tests/contrib/json_003/run
+++ b/tests/contrib/json_003/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-banner --no-color --console-width 0 -p contrib CastJSON.idr < input


### PR DESCRIPTION
Adds some `Cast` to `JSON` implementations for `()`, `Bool`, `Double`, `String`, and `List`s.

Also adds another `Show JSON` implementation, for displaying the `JSON` as represented in Idris code.

Tests added for all of the above, as well as the existing `Show JSON` implemtation, and the `JSON` `format` function.