### PR TITLE
[ build ] Simplify bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ TEST_PREFIX ?= ${IDRIS2_CURDIR}/build/env
 IDRIS2_BOOT_PREFIX := ${IDRIS2_CURDIR}/bootstrap-build
 
 # These are the library path in the build dir to be used during build
-export IDRIS2_BOOT_PATH := "${IDRIS2_CURDIR}/libs/prelude/build/ttc${SEP}${IDRIS2_CURDIR}/libs/base/build/ttc${SEP}${IDRIS2_CURDIR}/libs/contrib/build/ttc${SEP}${IDRIS2_CURDIR}/libs/network/build/ttc${SEP}${IDRIS2_CURDIR}/libs/test/build/ttc"
+IDRIS2_BOOT_PATH := "${IDRIS2_CURDIR}/libs/prelude/build/ttc${SEP}${IDRIS2_CURDIR}/libs/base/build/ttc${SEP}${IDRIS2_CURDIR}/libs/contrib/build/ttc${SEP}${IDRIS2_CURDIR}/libs/network/build/ttc${SEP}${IDRIS2_CURDIR}/libs/test/build/ttc"
 
 export SCHEME
 

--- a/bootstrap-stage2.sh
+++ b/bootstrap-stage2.sh
@@ -3,33 +3,18 @@
 set -e # exit on any error
 
 BOOTSTRAP_PREFIX=$PWD/bootstrap-build
-
-if [ "$OS" = "windows" ]; then
-    # IDRIS_PREFIX is only used to build IDRIS2_BOOT_PATH
-    IDRIS_PREFIX=$(cygpath -m "$BOOTSTRAP_PREFIX")
-    SEP=";"
-else
-    IDRIS_PREFIX=$BOOTSTRAP_PREFIX
-    SEP=":"
-fi
-
 IDRIS2_CG="${IDRIS2_CG-"chez"}"
-
-BOOT_PATH_BASE=$IDRIS_PREFIX/idris2-$IDRIS2_VERSION
-IDRIS2_BOOT_PATH="$BOOT_PATH_BASE/prelude$SEP	$BOOT_PATH_BASE/base$SEP	$BOOT_PATH_BASE/contrib$SEP	$BOOT_PATH_BASE/network	$BOOT_PATH_BASE/test"
 
 # BOOTSTRAP_PREFIX must be the "clean" build root, without cygpath -m
 # Otherwise, we get 'git: Bad address'
 echo "$BOOTSTRAP_PREFIX"
-DYLIB_PATH="$BOOTSTRAP_PREFIX/lib"
 
-$MAKE libs IDRIS2_CG="$IDRIS2_CG" LD_LIBRARY_PATH="$DYLIB_PATH" \
+$MAKE libs IDRIS2_CG="$IDRIS2_CG" \
     PREFIX="$BOOTSTRAP_PREFIX" SCHEME="$SCHEME"
-$MAKE install IDRIS2_CG="$IDRIS2_CG" LD_LIBRARY_PATH="$DYLIB_PATH" \
+$MAKE install IDRIS2_CG="$IDRIS2_CG" \
     PREFIX="$BOOTSTRAP_PREFIX" SCHEME="$SCHEME"
 
 # Now rebuild everything properly
 $MAKE clean-libs IDRIS2_BOOT="$BOOTSTRAP_PREFIX/bin/idris2"
 $MAKE all IDRIS2_BOOT="$BOOTSTRAP_PREFIX/bin/idris2" IDRIS2_CG="$IDRIS2_CG" \
-    IDRIS2_PATH="$IDRIS2_BOOT_PATH" LD_LIBRARY_PATH="$DYLIB_PATH" \
     SCHEME="$SCHEME"


### PR DESCRIPTION
Delete a whole lot of things from `bootstrap-stage2.sh` that doesn't seem to be needed.

Reasoning: `LD_LYBRARY_PATH` is already handled by the wrapper scripts. `IDRIS2_PATH` is not exported and is not propagated anywhere in the `Makefile`.

It causes no visible harm when testing it on Linux using:

`make SCHEME=chez-scheme clean bootstrap test`

----

the CI also seems to be clear (besides some seemingly unrelated issues).

i'm working on a better build system, and i'm trying to understand what's happening in the current setup. in the process i came to the above realization, but i'm still not sure... am i missing here something?

it would be nice if someone reviewed this who understands the bootstrap process.