### PR TITLE
[ fix ] missing idris2_popen/pclose decl in the C headers

### DIFF
--- a/support/c/idris_file.h
+++ b/support/c/idris_file.h
@@ -22,6 +22,9 @@ int idris2_fileSize(FILE* h);
 
 int idris2_fpoll(FILE* f);
 
+void *idris2_popen(const char *cmd, const char *mode);
+void idris2_pclose(void *stream);
+
 // Seek through the next newline without
 // saving anything along the way
 int idris2_seekLine(FILE* f);


### PR DESCRIPTION
i gave the `refc` backend a run, and it failed due to this.

random sidenote: the latest in git also fails with:

```ERROR: INTERNAL ERROR: FFI not found for Libraries_Utils_Scheme_unsafeVectorToList```

the commit that breaks it is this: https://github.com/idris-lang/Idris2/commit/a9ccf4db4f69677c5287a1278ab167247dac161d