### PR TITLE
Re-enable -Xcheck-hashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ idris2-exec: ${TARGET}
 
 ${TARGET}: src/IdrisPaths.idr
 	${IDRIS2_BOOT} --build ${IDRIS2_APP_IPKG}
+	install support/c/${IDRIS2_SUPPORT} ${TARGET}_app
 
 # We use FORCE to always rebuild IdrisPath so that the git SHA1 info is always up to date
 src/IdrisPaths.idr: FORCE

--- a/src/Core/Options.idr
+++ b/src/Core/Options.idr
@@ -201,7 +201,6 @@ record Options where
   primnames : PrimNames
   extensions : List LangExt
   additionalCGs : List (String, CG)
-  hashFn : Maybe String
 
 export
 availableCGs : Options -> List (String, CG)
@@ -237,31 +236,12 @@ export
 defaultElab : ElabDirectives
 defaultElab = MkElabDirectives True True CoveringOnly 3 50 50 True
 
--- FIXME: This turns out not to be reliably portable, since different systems
--- may have tools with the same name but different required arugments. We
--- probably need another way (perhaps our own internal hash function, although
--- that's not going to be as good as sha256).
-export
-defaultHashFn : Core (Maybe String)
-defaultHashFn
-    = do Nothing <- coreLift $ pathLookup ["sha256sum", "gsha256sum"]
-           | Just p => pure $ Just $ p ++ " --tag"
-         Nothing <- coreLift $ pathLookup ["sha256"]
-           | Just p => pure $ Just p
-         Nothing <- coreLift $ pathLookup ["openssl"]
-           | Just p => pure $ Just $ p ++ " sha256"
-         pure Nothing
-
 export
 defaults : Core Options
 defaults
-    = do -- hashFn <- defaultHashFn
-         -- Temporarily disabling the hash function until we have a more
-         -- portable way of working out what to call, and allowing a way for
-         -- it to fail gracefully.
-         pure $ MkOptions
+    = do pure $ MkOptions
            defaultDirs defaultPPrint defaultSession defaultElab Nothing Nothing
-           (MkPrimNs Nothing Nothing Nothing Nothing) [] [] Nothing
+           (MkPrimNs Nothing Nothing Nothing Nothing) [] []
 
 -- Reset the options which are set by source files
 export

--- a/src/Idris/ModTree.idr
+++ b/src/Idris/ModTree.idr
@@ -177,7 +177,7 @@ checkDepHashes : {auto c : Ref Ctxt Defs} ->
                  String -> Core Bool
 checkDepHashes depFileName
   = catch (do defs                   <- get Ctxt
-              Just depCodeHash       <- hashFileWith (defs.options.hashFn) depFileName
+              Just depCodeHash       <- coreLift $ hashFile depFileName
                     | _ => pure False
               depTTCFileName         <- getTTCFileName depFileName "ttc"
               (Just depStoredCodeHash, _) <- readHashes depTTCFileName
@@ -194,7 +194,7 @@ needsBuildingHash sourceFile ttcFile depFiles
   = do defs                <- get Ctxt
        -- If there's no hash available, either in the TTC or from the
        -- current source, then it needs building
-       Just codeHash       <- hashFileWith (defs.options.hashFn) sourceFile
+       Just codeHash       <- coreLift $ hashFile sourceFile
              | _ => pure True
        (Just storedCodeHash, _) <- readHashes ttcFile
              | _ => pure True

--- a/src/Idris/ProcessIdr.idr
+++ b/src/Idris/ProcessIdr.idr
@@ -237,9 +237,9 @@ unchangedTime sourceFileName ttcFileName
 
 
 ||| If the source file hash hasn't changed
-unchangedHash : (hashFn : Maybe String) -> (sourceFileName : String) -> (ttcFileName : String) -> Core Bool
-unchangedHash hashFn sourceFileName ttcFileName
-  = do Just sourceCodeHash        <- hashFileWith hashFn sourceFileName
+unchangedHash : (sourceFileName : String) -> (ttcFileName : String) -> Core Bool
+unchangedHash sourceFileName ttcFileName
+  = do Just sourceCodeHash        <- coreLift $ hashFile sourceFileName
              | _ => pure False
        (Just storedSourceHash, _) <- readHashes ttcFileName
              | _ => pure False
@@ -308,7 +308,7 @@ processMod sourceFileName ttcFileName msg sourcecode origin
           show (sort storedImportInterfaceHashes)
 
         sourceUnchanged <- (if session.checkHashesInsteadOfModTime
-          then unchangedHash (defs.options.hashFn) else unchangedTime) sourceFileName ttcFileName
+          then unchangedHash else unchangedTime) sourceFileName ttcFileName
 
         -- If neither the source nor the interface hashes of imports have changed then no rebuilding is needed
         if (sourceUnchanged && sort importInterfaceHashes == sort storedImportInterfaceHashes)

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -413,8 +413,7 @@ preOptions (IgnoreShadowingWarnings :: opts)
     = do updateSession (record { showShadowingWarning = False })
          preOptions opts
 preOptions (HashesInsteadOfModTime :: opts)
-    = do throw (InternalError "-Xcheck-hashes disabled (see issue #1935)")
-         updateSession (record { checkHashesInsteadOfModTime = True })
+    = do updateSession (record { checkHashesInsteadOfModTime = True })
          preOptions opts
 preOptions (CaseTreeHeuristics :: opts)
     = do updateSession (record { caseTreeHeuristics = True })

--- a/src/Libraries/Utils/String.idr
+++ b/src/Libraries/Utils/String.idr
@@ -31,9 +31,5 @@ escapeGeneric esc toEscape = pack . foldr escape [] . unpack
         else (c :: cs)
 
 export
-escapeStringUnix : String -> String
-escapeStringUnix = escapeGeneric '\\' ['"', '\\']
-
-export
 escapeStringChez : String -> String
 escapeStringChez = escapeGeneric '\\' ['\'', '\\']

--- a/support/c/idris_file.c
+++ b/support/c/idris_file.c
@@ -232,3 +232,26 @@ FILE* idris2_stdout() {
 FILE* idris2_stderr() {
     return stderr;
 }
+
+uint64_t idris2_hashFile(const char *path) {
+    FILE *fp;
+    char buf[16384];
+    size_t len = 0;
+    int c;
+    uint32_t hashA = 5381;
+    uint32_t hashB = 0;
+
+    if ((fp = fopen(path, "r")) == NULL) return 0;
+
+    while (len || ((len = fread(buf, 1, sizeof(buf), fp)) && !ferror(fp))) {
+        c = buf[--len];
+        hashA = (hashA << 5) + hashA + c;
+        hashB = c + (hashB << 6) + (hashB << 16) - hashB;
+    }
+
+    c = ferror(fp) || !feof(fp);
+    fclose(fp);
+    if (c) return 0;
+
+    return hashA | hashB ? (uint64_t)hashA << 32 | hashB : ~(uint64_t)0;
+}

--- a/support/c/idris_file.h
+++ b/support/c/idris_file.h
@@ -43,3 +43,5 @@ int idris2_fileIsTTY(FILE* f);
 FILE* idris2_stdin();
 FILE* idris2_stdout();
 FILE* idris2_stderr();
+
+uint64_t idris2_hashFile(const char* path);

--- a/tests/idris2/import001/expected
+++ b/tests/idris2/import001/expected
@@ -6,3 +6,5 @@ Test> Bye for now!
 2/3: Building Mult (Mult.idr)
 Test> S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S Z)))))))))))))))))
 Test> Bye for now!
+Test> S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S Z)))))))))))))))))
+Test> Bye for now!

--- a/tests/idris2/import001/run
+++ b/tests/idris2/import001/run
@@ -5,8 +5,7 @@ sleep 1
 touch Mult.idr
 $1 --no-color --console-width 0 --no-banner --no-prelude Test.idr < input
 
-# Disabled until we have a portable way to do this
-#sleep 1
-#touch Mult.idr
-#$1 --no-color --console-width 0 --no-banner --no-prelude -Xcheck-hashes Test.idr < input
+sleep 1
+touch Mult.idr
+$1 --no-color --console-width 0 --no-banner --no-prelude -Xcheck-hashes Test.idr < input
 


### PR DESCRIPTION
This is using some supposedly good enough hash algorithms found on the web: http://www.cse.yorku.ca/~oz/hash.html

I've done a little testing and it seems to work well. I extracted every file from git's db (Idris 1 and 2) to run the function against. About 27k files, zero collisions. I also did `for x in **/*.idr; do echo '' >> $x; done` and all were recompiled them.

I haven't tested much with `Maybe Bit64`, since that is hot of the press. Seems just as good as Int or Integer so far.

One thing to note is that I've assumed the hash won't ever be `0` with text encoding, so zero gets folded in with the equally unlikely `~0`. I imagine the chances of IO errors are low, but it seems better to do it this way regardless. I've tested that part works too, but I'm no C pro.

**TL;DR**
`sed -i.bak ~/.idris2/bin/idris2 's/"\$@"/-Xcheck-hashes &/'`