### PR TITLE
[ fix ] fastConcat for JS backends

### DIFF
--- a/libs/prelude/Prelude/Types.idr
+++ b/libs/prelude/Prelude/Types.idr
@@ -464,7 +464,7 @@ Traversable List where
 %foreign
   "scheme:string-concat"
   "RefC:fastConcat"
-  "javascript:lambda:(xs)=>''.concat(...__prim_idris2js_array(xs))"
+  "javascript:lambda:(xs)=>__prim_idris2js_array(xs).join('')"
 export
 fastConcat : List String -> String
 
@@ -592,7 +592,7 @@ pack (x :: xs) = strCons x (pack xs)
 %foreign
     "scheme:string-pack"
     "RefC:fastPack"
-    "javascript:lambda:(xs)=>''.concat(...__prim_idris2js_array(xs))"
+    "javascript:lambda:(xs)=>__prim_idris2js_array(xs).join('')"
 export
 fastPack : List Char -> String
 

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -271,6 +271,7 @@ nodeTests = MkTestPool "Node backend" [] (Just Node)
     , "bitops"
     , "casts"
     , "memo"
+    , "fastConcat"
     , "newints"
     , "reg001", "reg002"
     , "stringcast"

--- a/tests/node/fastConcat/FastConcat.idr
+++ b/tests/node/fastConcat/FastConcat.idr
@@ -1,0 +1,9 @@
+replicateTR : Nat -> a -> List a
+replicateTR n v = go n Nil
+  where go : Nat -> List a -> List a
+        go 0     as = as
+        go (S k) as = go k (v :: as)
+
+main : IO ()
+main =  printLn (length $ fastPack $ replicateTR 1000000 '0')
+     >> putStrLn (fastConcat $ replicateTR 1000000 "")

--- a/tests/node/fastConcat/expected
+++ b/tests/node/fastConcat/expected
@@ -1,0 +1,4 @@
+1/1: Building FastConcat (FastConcat.idr)
+Main> 1000000
+
+Main> Bye for now!

--- a/tests/node/fastConcat/input
+++ b/tests/node/fastConcat/input
@@ -1,0 +1,2 @@
+:exec main
+:q

--- a/tests/node/fastConcat/run
+++ b/tests/node/fastConcat/run
@@ -1,0 +1,4 @@
+rm -rf build
+
+$1 --cg node --no-banner --no-color --console-width 0 FastConcat.idr < input
+


### PR DESCRIPTION
The current implementations of `fastPack` and `fastConcat` on the JS backends crash for large list inputs. This PR fixes the implementations and adds a new test case.