### PR TITLE
Change default nf_metavar_threshold

### DIFF
--- a/src/Core/Options.idr
+++ b/src/Core/Options.idr
@@ -235,7 +235,7 @@ defaultSession = MkSessionOpts False CoveringOnly False False Chez [] 1000 False
 
 export
 defaultElab : ElabDirectives
-defaultElab = MkElabDirectives True True CoveringOnly 3 50 50 True
+defaultElab = MkElabDirectives True True CoveringOnly 3 50 25 True
 
 -- FIXME: This turns out not to be reliably portable, since different systems
 -- may have tools with the same name but different required arugments. We


### PR DESCRIPTION
We recently changed the meaning of this (calculated during 'quote' rather than after) and by experimentation it seemed to be too high. It is a somewhat arbitrary heuristic to decide when to fully normalise, but this seems to help as a better default in some cases and otherwise not hurt.