### PR TITLE
[ elab ] Implement `Alternative` for `Elab` using recently added `Try`

### DIFF
--- a/libs/base/Language/Reflection.idr
+++ b/libs/base/Language/Reflection.idr
@@ -74,6 +74,11 @@ Applicative Elab where
   f <*> a = Bind f (<$> a)
 
 export
+Alternative Elab where
+  empty = Fail EmptyFC ""
+  l <|> r = Try l r
+
+export
 Monad Elab where
   (>>=) = Bind
 


### PR DESCRIPTION
This enables standard `Alternative` combinators be applicable for `Elab`.

By the way, using the `Alternative` implementation from this PR, `findOp` function from frex-project/idris-frex#49 could be implemented easier, like this
```idris
findOp tm ops = choiceMap (\op => pure $ Just $ MkDPair op !(matchPrefix tm op)) ops
            <|> pure Nothing
```
instead of
```idris
findOp tm [] = pure Nothing
findOp tm $ op :: ops =
     try (do args <- matchPrefix tm op
￼            pure $ Just $ MkDPair op args)
￼        (findOp tm ops)
```