### PR TITLE
[ cleanup ] Move left autos that are most likely to be passed explicitly

### DIFF
--- a/libs/base/Control/App/Console.idr
+++ b/libs/base/Control/App/Console.idr
@@ -27,9 +27,9 @@ putCharLn : Console e => Char -> App {l} e ()
 putCharLn c = putStrLn $ strCons c ""
 
 export
-print : (Console e, Show a) => a -> App {l} e ()
+print : Show a => Console e => a -> App {l} e ()
 print x = putStr $ show x
 
 export
-printLn : (Console e, Show a) => a -> App {l} e ()
+printLn : Show a => Console e => a -> App {l} e ()
 printLn x = putStrLn $ show x

--- a/libs/base/Control/Monad/Identity.idr
+++ b/libs/base/Control/Monad/Identity.idr
@@ -41,11 +41,11 @@ Ord a => Ord (Identity a) where
 --   pred (Id n) = Id $ pred n
 
 public export
-(Semigroup a) => Semigroup (Identity a) where
+Semigroup a => Semigroup (Identity a) where
   (<+>) x y = Id (runIdentity x <+> runIdentity y)
 
 public export
-(Monoid a) => Monoid (Identity a) where
+Monoid a => Monoid (Identity a) where
   neutral = Id (neutral)
 
 public export

--- a/libs/base/Control/Monad/RWS/CPS.idr
+++ b/libs/base/Control/Monad/RWS/CPS.idr
@@ -24,19 +24,19 @@ runRWST m r s = unRWST m r s neutral
 
 ||| Construct an RWST computation from a function. (The inverse of `runRWST`.)
 public export %inline
-rwsT : (Functor m, Semigroup w) => (r -> s -> m (a, s, w)) -> RWST r w s m a
+rwsT : Semigroup w => Functor m => (r -> s -> m (a, s, w)) -> RWST r w s m a
 rwsT f = MkRWST $ \r,s,w => (\(a,s',w') => (a,s',w <+> w')) <$> f r s
 
 ||| Evaluate a computation with the given initial state and environment,
 ||| returning the final value and output, discarding the final state.
 public export %inline
-evalRWST : (Functor m, Monoid w) => RWST r w s m a -> r -> s -> m (a,w)
+evalRWST : Monoid w => Functor m => RWST r w s m a -> r -> s -> m (a,w)
 evalRWST m r s = (\(a,_,w) => (a,w)) <$> runRWST m r s
 
 ||| Evaluate a computation with the given initial state and environment,
 ||| returning the final state and output, discarding the final value.
 public export %inline
-execRWST : (Functor m, Monoid w) => RWST r w s m a -> r -> s -> m (s,w)
+execRWST : Monoid w => Functor m => RWST r w s m a -> r -> s -> m (s,w)
 execRWST m r s = (\(_,s',w) => (s',w)) <$> runRWST m r s
 
 ||| Map the inner computation using the given function.

--- a/libs/base/Control/Monad/Writer/CPS.idr
+++ b/libs/base/Control/Monad/Writer/CPS.idr
@@ -25,7 +25,7 @@ record WriterT (w : Type) (m : Type -> Type) (a : Type) where
 ||| Construct an writer computation from a (result,output) computation.
 ||| (The inverse of `runWriterT`.)
 public export %inline
-writerT : (Functor m, Semigroup w) => m (a, w) -> WriterT w m a
+writerT : Semigroup w => Functor m => m (a, w) -> WriterT w m a
 writerT f = MkWriterT $ \w => (\(a,w') => (a,w <+> w')) <$> f
 
 ||| Unwrap a writer computation.
@@ -36,7 +36,7 @@ runWriterT m = unWriterT m neutral
 
 ||| Extract the output from a writer computation.
 public export %inline
-execWriterT : (Functor m, Monoid w) => WriterT w m a -> m w
+execWriterT : Monoid w => Functor m => WriterT w m a -> m w
 execWriterT = map snd . runWriterT
 
 ||| Map both the return value and output of a computation using

--- a/libs/base/Data/Bifoldable.idr
+++ b/libs/base/Data/Bifoldable.idr
@@ -5,11 +5,11 @@ module Data.Bifoldable
 
 ||| Left associative monadic bifold over a structure.
 public export
-bifoldlM :  (Bifoldable p, Monad m)
-         => (f: a -> b -> m a)
-         -> (g: a -> c -> m a)
-         -> (init: a)
-         -> (input: p b c) -> m a
+bifoldlM : Monad m => Bifoldable p =>
+          (f: a -> b -> m a) ->
+          (g: a -> c -> m a) ->
+          (init: a) ->
+          (input: p b c) -> m a
 bifoldlM f g a0 = bifoldl (\ma,b => ma >>= flip f b)
                           (\ma,c => ma >>= flip g c)
                           (pure a0)
@@ -17,18 +17,18 @@ bifoldlM f g a0 = bifoldl (\ma,b => ma >>= flip f b)
 ||| Combines the elements of a structure,
 ||| given ways of mapping them to a common monoid.
 public export
-bifoldMap : (Bifoldable p, Monoid m) => (a -> m) -> (b -> m) -> p a b -> m
+bifoldMap : Monoid m => Bifoldable p => (a -> m) -> (b -> m) -> p a b -> m
 bifoldMap f g = bifoldr ((<+>) . f) ((<+>) . g) neutral
 
 ||| Combines the elements of a structure using a monoid.
 public export
-biconcat : (Bifoldable p, Monoid m) => p m m -> m
+biconcat : Monoid m => Bifoldable p => p m m -> m
 biconcat = bifoldr (<+>) (<+>) neutral
 
 ||| Combines the elements of a structure,
 ||| given ways of mapping them to a common monoid.
 public export
-biconcatMap : (Bifoldable p, Monoid m) => (a -> m) -> (b -> m) -> p a b -> m
+biconcatMap : Monoid m => Bifoldable p => (a -> m) -> (b -> m) -> p a b -> m
 biconcatMap f g = bifoldr ((<+>) . f) ((<+>) . g) neutral
 
 ||| The conjunction of all elements of a structure containing lazy boolean
@@ -59,24 +59,24 @@ biall f g = bifoldl (\x,y => x && f y) (\x,y => x && g y) True
 
 ||| Add together all the elements of a structure.
 public export
-bisum : (Bifoldable p, Num a) => p a a -> a
+bisum : Num a => Bifoldable p => p a a -> a
 bisum = bifoldr (+) (+) 0
 
 ||| Add together all the elements of a structure.
 ||| Same as `bisum` but tail recursive.
 export
-bisum' : (Bifoldable p, Num a) => p a a -> a
+bisum' : Num a => Bifoldable p => p a a -> a
 bisum' = bifoldl (+) (+) 0
 
 ||| Multiply together all elements of a structure.
 public export
-biproduct : (Bifoldable p, Num a) => p a a -> a
+biproduct : Num a => Bifoldable p => p a a -> a
 biproduct = bifoldr (*) (*) 1
 
 ||| Multiply together all elements of a structure.
 ||| Same as `product` but tail recursive.
 export
-biproduct' : (Bifoldable p, Num a) => p a a -> a
+biproduct' : Num a => Bifoldable p => p a a -> a
 biproduct' = bifoldl (*) (*) 1
 
 ||| Map each element of a structure to a computation, evaluate those
@@ -91,7 +91,7 @@ bitraverse_ f g = bifoldr ((*>) . f) ((*>) . g) (pure ())
 
 ||| Evaluate each computation in a structure and discard the results.
 public export
-bisequence_ : (Bifoldable p, Applicative f) => p (f a) (f b) -> f ()
+bisequence_ : Applicative f => Bifoldable p => p (f a) (f b) -> f ()
 bisequence_ = bifoldr (*>) (*>) (pure ())
 
 ||| Like `bitraverse_` but with the arguments flipped.
@@ -109,7 +109,7 @@ bifor_ p f g = bitraverse_ f g p
 ||| left-biased choice from a list of alternatives, which means that it
 ||| evaluates to the left-most non-`empty` alternative.
 public export
-bichoice : (Bifoldable p, Alternative f) => p (Lazy (f a)) (Lazy (f a)) -> f a
+bichoice : Alternative f => Bifoldable p => p (Lazy (f a)) (Lazy (f a)) -> f a
 bichoice t = bifoldr {a = Lazy (f a)} {b = Lazy (f a)} {acc = Lazy (f a)}
                  (\ x, xs => x <|> xs)
                  (\ x, xs => x <|> xs)

--- a/libs/base/Data/Contravariant.idr
+++ b/libs/base/Data/Contravariant.idr
@@ -16,7 +16,7 @@ interface Contravariant (0 f : Type -> Type) where
 ||| laws of each of those classes, it can't actually use its argument in any
 ||| meaningful capacity.
 public export %inline
-phantom : (Functor f, Contravariant f) => f a -> f b
+phantom : Contravariant f => Functor f => f a -> f b
 phantom fa = () >$ (fa $> ())
 
 ||| This is an infix alias for `contramap`.

--- a/libs/base/Data/List.idr
+++ b/libs/base/Data/List.idr
@@ -228,7 +228,7 @@ infix 7 \\
 ||| ```
 |||
 public export
-(\\) : (Eq a) => List a -> List a -> List a
+(\\) : Eq a => List a -> List a -> List a
 (\\) = foldl (flip delete)
 
 ||| The unionBy function returns the union of two lists by user-supplied equality predicate.

--- a/libs/base/Data/Maybe.idr
+++ b/libs/base/Data/Maybe.idr
@@ -60,7 +60,7 @@ lowerMaybe (Just x) = x
 
 ||| Returns `Nothing` when applied to `neutral`, and `Just` the value otherwise.
 export
-raiseToMaybe : (Monoid a, Eq a) => a -> Maybe a
+raiseToMaybe : Monoid a => Eq a => a -> Maybe a
 raiseToMaybe x = if x == neutral then Nothing else Just x
 
 public export

--- a/libs/base/Data/String.idr
+++ b/libs/base/Data/String.idr
@@ -301,7 +301,7 @@ parsePositive s = parsePosTrimmed (trim s)
 ||| parseInteger {a=Int} " -123"
 ||| ```
 public export
-parseInteger : (Num a, Neg a) => String -> Maybe a
+parseInteger : Num a => Neg a => String -> Maybe a
 parseInteger s = parseIntTrimmed (trim s)
   where
     parseIntTrimmed : String -> Maybe a

--- a/libs/base/Decidable/Decidable.idr
+++ b/libs/base/Decidable/Decidable.idr
@@ -43,7 +43,7 @@ interface Decidable k ts p where
 
 ||| Given a `Decidable` n-ary relation, provides a decision procedure for
 ||| this relation.
-decision : (ts : Vect k Type) -> (p : Rel ts) -> (Decidable k ts p) => liftRel ts p Dec
+decision : (ts : Vect k Type) -> (p : Rel ts) -> Decidable k ts p => liftRel ts p Dec
 decision ts p = decide {ts} {p}
 
 using (a : Type, x : a)

--- a/libs/contrib/Control/Linear/LIO.idr
+++ b/libs/contrib/Control/Linear/LIO.idr
@@ -85,7 +85,7 @@ runK (Bind {u_act = Unrestricted} act next) k = runK act (\x => runK (next x) k)
 ||| Run a linear program exactly once, with unrestricted return value in the
 ||| underlying context
 export
-run : (Applicative io, LinearBind io) =>
+run : Applicative io => LinearBind io =>
       (1 _ : L io a) -> io a
 run prog = runK prog pure
 

--- a/libs/contrib/Control/Validation.idr
+++ b/libs/contrib/Control/Validation.idr
@@ -146,7 +146,7 @@ natural = fromMaybe mkError parsePositive
 
 ||| Verify whether a String represents an Integer
 export
-integral : (Num a, Neg a, Monad m) => ValidatorT m String a
+integral : Num a => Neg a => Monad m => ValidatorT m String a
 integral = fromMaybe mkError parseInteger
     where
     mkError : String -> String
@@ -176,7 +176,7 @@ length l = MkValidator (validateVector l)
 
 ||| Verify that certain values are equal.
 export
-equal : (DecEq t, Monad m) => (a : t) -> PropValidator m t (\b => a = b)
+equal : Monad m => DecEq t => (a : t) -> PropValidator m t (\b => a = b)
 equal a = MkPropValidator $ \b => case decEq a b of
     Yes prf => pure prf
     No _ => left "Values are not equal."

--- a/libs/contrib/Data/Vect/Properties/Foldr.idr
+++ b/libs/contrib/Data/Vect/Properties/Foldr.idr
@@ -24,7 +24,7 @@ import Control.Order
 
 ||| Sum implemented with foldr
 public export
-sumR : (Foldable f, Num a) => f a -> a
+sumR : Num a => Foldable f => f a -> a
 sumR = foldr (+) 0
 
 %transform "sumR/sum" sumR = sum

--- a/libs/contrib/Data/Void.idr
+++ b/libs/contrib/Data/Void.idr
@@ -5,5 +5,5 @@ absurdity : Uninhabited t => (0 _ : t) -> s
 absurdity x = void (uninhabited x)
 
 export
-contradiction : (Uninhabited t) => (0 _ : x -> t) -> (x -> s)
+contradiction : Uninhabited t => (0 _ : x -> t) -> (x -> s)
 contradiction since x = absurdity (since x)

--- a/libs/contrib/Text/Parser.idr
+++ b/libs/contrib/Text/Parser.idr
@@ -13,7 +13,7 @@ import public Text.Token
 
 ||| Parse a terminal based on a kind of token.
 export
-match : (Eq k, TokenKind k) =>
+match : TokenKind k => Eq k =>
         (kind : k) ->
         Grammar state (Token k) True (TokType kind)
 match k = terminal "Unrecognised input" $

--- a/libs/contrib/Text/PrettyPrint/Prettyprinter/Doc.idr
+++ b/libs/contrib/Text/PrettyPrint/Prettyprinter/Doc.idr
@@ -282,7 +282,7 @@ punctuate _ [d] = [d]
 punctuate p (d :: ds) = (d <+> p) :: punctuate p ds
 
 export
-plural : (Num amount, Eq amount) => doc -> doc -> amount -> doc
+plural : Num amount => Eq amount => doc -> doc -> amount -> doc
 plural one multiple n = if n == 1 then one else multiple
 
 ||| Encloses the document between two other documents using `(<+>)`.

--- a/libs/prelude/Prelude/Interfaces.idr
+++ b/libs/prelude/Prelude/Interfaces.idr
@@ -291,13 +291,13 @@ interface Foldable t where
 
 ||| Combine each element of a structure into a monoid.
 public export
-concat : (Foldable t, Monoid a) => t a -> a
+concat : Monoid a => Foldable t => t a -> a
 concat = foldMap id
 
 ||| Combine into a monoid the collective results of applying a function to each
 ||| element of a structure.
 public export
-concatMap : (Foldable t, Monoid m) => (a -> m) -> t a -> m
+concatMap : Monoid m => Foldable t => (a -> m) -> t a -> m
 concatMap = foldMap
 
 namespace Bool.Lazy
@@ -324,14 +324,14 @@ namespace Bool.Lazy
 ||| element is `False` or no elements remain.
 public export
 and : Foldable t => t (Lazy Bool) -> Bool
-and = force . concat @{(%search, All)}
+and = force . concat @{All}
 
 ||| The disjunction of all elements of a structure containing lazy boolean
 ||| values.  `or` short-circuits from left to right, evaluating either until an
 ||| element is `True` or no elements remain.
 public export
 or : Foldable t => t (Lazy Bool) -> Bool
-or = force . concat @{(%search, Any)}
+or = force . concat @{Any}
 
 namespace Bool
   namespace Semigroup
@@ -388,40 +388,40 @@ namespace Num
 
 ||| Add together all the elements of a structure.
 public export
-sum : (Foldable t, Num a) => t a -> a
-sum = concat @{(%search, Additive)}
+sum : Num a => Foldable t => t a -> a
+sum = concat @{Additive}
 
 ||| Add together all the elements of a structure.
 ||| Same as `sum` but tail recursive.
 export
-sum' : (Foldable t, Num a) => t a -> a
+sum' : Num a => Foldable t => t a -> a
 sum' = sum
 
 ||| Multiply together all elements of a structure.
 public export
-product : (Foldable t, Num a) => t a -> a
-product = concat @{(%search, Multiplicative)}
+product : Num a => Foldable t => t a -> a
+product = concat @{Multiplicative}
 
 ||| Multiply together all elements of a structure.
 ||| Same as `product` but tail recursive.
 export
-product' : (Foldable t, Num a) => t a -> a
+product' : Num a => Foldable t => t a -> a
 product' = product
 
 ||| Map each element of a structure to a computation, evaluate those
 ||| computations and discard the results.
 public export
-traverse_ : (Foldable t, Applicative f) => (a -> f b) -> t a -> f ()
+traverse_ : Applicative f => Foldable t => (a -> f b) -> t a -> f ()
 traverse_ f = foldr ((*>) . f) (pure ())
 
 ||| Evaluate each computation in a structure and discard the results.
 public export
-sequence_ : (Foldable t, Applicative f) => t (f a) -> f ()
+sequence_ : Applicative f => Foldable t => t (f a) -> f ()
 sequence_ = foldr (*>) (pure ())
 
 ||| Like `traverse_` but with the arguments flipped.
 public export
-for_ : (Foldable t, Applicative f) => t a -> (a -> f b) -> f ()
+for_ : Applicative f => Foldable t => t a -> (a -> f b) -> f ()
 for_ = flip traverse_
 
 namespace Lazy
@@ -462,12 +462,12 @@ public export
 |||
 ||| Note: In Haskell, `choice` is called `asum`.
 public export
-choice : (Foldable t, Alternative f) => t (Lazy (f a)) -> f a
-choice = force . concat @{(%search, Lazy.MonoidAlternative)}
+choice : Alternative f => Foldable t => t (Lazy (f a)) -> f a
+choice = force . concat @{Lazy.MonoidAlternative}
 
 ||| A fused version of `choice` and `map`.
 public export
-choiceMap : (Foldable t, Alternative f) => (a -> f b) -> t a -> f b
+choiceMap : Alternative f => Foldable t => (a -> f b) -> t a -> f b
 choiceMap = foldMap @{%search} @{MonoidAlternative}
 
 namespace Foldable
@@ -502,12 +502,12 @@ interface (Functor t, Foldable t) => Traversable t where
 
 ||| Evaluate each computation in a structure and collect the results.
 public export
-sequence : (Traversable t, Applicative f) => t (f a) -> f (t a)
+sequence : Applicative f => Traversable t => t (f a) -> f (t a)
 sequence = traverse id
 
 ||| Like `traverse` but with the arguments flipped.
 public export
-for : (Traversable t, Applicative f) => t a -> (a -> f b) -> f (t b)
+for : Applicative f => Traversable t => t a -> (a -> f b) -> f (t b)
 for = flip traverse
 
 public export
@@ -519,12 +519,12 @@ interface (Bifunctor p, Bifoldable p) => Bitraversable p where
 
 ||| Evaluate each computation in a structure and collect the results.
 public export
-bisequence : (Bitraversable p, Applicative f) => p (f a) (f b) -> f (p a b)
+bisequence : Applicative f => Bitraversable p => p (f a) (f b) -> f (p a b)
 bisequence = bitraverse id id
 
 ||| Like `bitraverse` but with the arguments flipped.
 public export
-bifor :  (Bitraversable p, Applicative f)
+bifor :  Applicative f => Bitraversable p
       => p a b
       -> (a -> f c)
       -> (b -> f d)

--- a/libs/prelude/Prelude/Types.idr
+++ b/libs/prelude/Prelude/Types.idr
@@ -105,7 +105,7 @@ natToInteger (S k) = 1 + natToInteger k
 
 ||| Counts the number of elements that satify a predicate.
 public export
-count : (Foldable t) => (predicate : a -> Bool) -> (t a) -> Nat
+count : Foldable t => (predicate : a -> Bool) -> t a -> Nat
 count predicate = foldMap @{%search} @{Additive} (\x => if predicate x then 1 else 0)
 
 -----------


### PR DESCRIPTION
Originally inspired by inconvenience of passing somewhat *main* auto-parameter to `concat`, `concatMap`, `choice` and `choiceMap`.