### PR TITLE
[ elab ] Make `%runElab` expressions have unrestricted quantity

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -1,5 +1,7 @@
 
-This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELOG](./CHANGELOG.md) for changes to all previously released versions of Idris2. All new PRs should target this file (`CHANGELOG_NEXT`).
+This CHANGELOG describes the merged but unreleased changes.
+Please see [CHANGELOG](./CHANGELOG.md) for changes to all previously released versions of Idris2.
+All new PRs should target this file (`CHANGELOG_NEXT`).
 
 # Changelog
 
@@ -51,6 +53,9 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 
 * The compiler now parses `~x.fun` as unquoting `x` rather than `x.fun`
   and `~(f 5).fun` as unquoting `(f 5)` rather than `(f 5).fun`.
+
+* Elaborator script's expression under the `%runElab` is now typechecked in the context
+  of quantity `0`, because it is present and works only at the compile time
 
 ### Backend changes
 

--- a/src/Algebra/Preorder.idr
+++ b/src/Algebra/Preorder.idr
@@ -29,3 +29,9 @@ public export
 interface Preorder a => Top a where
   top : a
   topAbs : {x : a} -> x <= top = True
+
+||| The least bound of a bounded lattice
+public export
+interface Preorder a => Bot a where
+  bot : a
+  botAbs : {x : a} -> bot <= x = True

--- a/src/Algebra/ZeroOneOmega.idr
+++ b/src/Algebra/ZeroOneOmega.idr
@@ -72,6 +72,14 @@ Top ZeroOneOmega where
   topAbs {x = Rig1} = Refl
   topAbs {x = RigW} = Refl
 
+||| The bottom value of a lattice
+export
+Bot ZeroOneOmega where
+  bot = Rig0
+  botAbs {x = Rig0} = Refl
+  botAbs {x = Rig1} = Refl
+  botAbs {x = RigW} = Refl
+
 ----------------------------------------
 
 rigPlusAssociative : (x, y, z : ZeroOneOmega) ->

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -372,8 +372,8 @@ checkRunElab rig elabinfo nest env fc reqExt script exp
              throw (GenericMsg fc "%language ElabReflection not enabled")
          let n = NS reflectionNS (UN $ Basic "Elab")
          elabtt <- appCon fc defs n [expected]
-         (stm, sty) <- runDelays (const True) $
-                           check rig elabinfo nest env script (Just (gnf env elabtt))
+         (stm, _) <- runDelays (const True) $
+                           check bot elabinfo nest env script (Just (gnf env elabtt))
          solveConstraints inTerm Normal
          defs <- get Ctxt -- checking might have resolved some holes
          ntm <- elabScript rig fc nest env

--- a/src/TTImp/ProcessRunElab.idr
+++ b/src/TTImp/ProcessRunElab.idr
@@ -38,5 +38,6 @@ processRunElab eopts nest env fc tm
          unit <- getCon fc defs (builtin "Unit")
          exp <- appCon fc defs n [unit]
 
-         stm <- checkTerm tidx InExpr eopts nest env tm (gnf env exp)
+         e <- newRef EST $ initEStateSub tidx env Refl
+         (stm, _) <- check bot (initElabInfo InExpr) nest env tm $ Just $ gnf env exp
          ignore $ elabScript top fc nest env !(nfOpts withAll defs env stm) Nothing

--- a/tests/idris2/reflection/reflection029/NoEscape.idr
+++ b/tests/idris2/reflection/reflection029/NoEscape.idr
@@ -1,0 +1,16 @@
+module NoEscape
+
+import Language.Reflection
+
+%language ElabReflection
+
+0 n : Nat
+n = 3
+
+0 elabScript : Elab Nat
+elabScript = pure n
+
+failing "n is not accessible in this context"
+
+  m : Nat
+  m = %runElab elabScript

--- a/tests/idris2/reflection/reflection029/NoEscapePar.idr
+++ b/tests/idris2/reflection/reflection029/NoEscapePar.idr
@@ -1,0 +1,35 @@
+||| Check that we cannot implement function illegally escaping zero quantity using elaboration reflection
+module NoEscapePar
+
+import Language.Reflection
+
+%language ElabReflection
+
+escScr : Elab $ (0 _ : a) -> a
+escScr = check $ ILam EmptyFC M0 ExplicitArg (Just `{x}) `(a) `(x)
+
+failing "x is not accessible in this context"
+
+  esc : (0 _ : a) -> a
+  esc = %runElab escScr
+
+escd : (0 _ : a) -> a
+
+0 escd' : (0 _ : a) -> a
+
+escDecl : Name -> Elab Unit
+escDecl name = declare [
+                 IDef EmptyFC name [
+                   PatClause EmptyFC
+                     -- lhs
+                     (IApp EmptyFC (IVar EmptyFC name) (IBindVar EmptyFC "x"))
+                     -- rhs
+                     `(x)
+                 ]
+               ]
+
+%runElab escDecl `{escd'}
+
+failing "x is not accessible in this context"
+
+  %runElab escDecl `{escd}

--- a/tests/idris2/reflection/reflection029/RunElab0.idr
+++ b/tests/idris2/reflection/reflection029/RunElab0.idr
@@ -1,0 +1,13 @@
+module RunElab0
+
+import Language.Reflection
+
+%language ElabReflection
+
+0 elabScript : Elab Unit
+elabScript = pure ()
+
+x : Unit
+x = %runElab elabScript
+
+%runElab elabScript

--- a/tests/idris2/reflection/reflection029/expected
+++ b/tests/idris2/reflection/reflection029/expected
@@ -1,0 +1,3 @@
+1/1: Building RunElab0 (RunElab0.idr)
+1/1: Building NoEscape (NoEscape.idr)
+1/1: Building NoEscapePar (NoEscapePar.idr)

--- a/tests/idris2/reflection/reflection029/run
+++ b/tests/idris2/reflection/reflection029/run
@@ -1,0 +1,5 @@
+. ../../../testutils.sh
+
+check RunElab0.idr
+check NoEscape.idr
+check NoEscapePar.idr


### PR DESCRIPTION
According to #1436, we can't have a runtime-values of types like `forall a. List a -> Nat`. But consider we need to pass a list of types including one like above to an elaboration script. Now we don't have such an ability. This PR enables it.

Anyway, elaboration scripts work during compilation, why not them to have an access to erased values?