### PR TITLE
Make asHex take Bits64.

### DIFF
--- a/src/Compiler/ES/Codegen.idr
+++ b/src/Compiler/ES/Codegen.idr
@@ -49,7 +49,7 @@ jsString s = "'" ++ (concatMap okchar (unpack s)) ++ "'"
                             '"' => "\\\""
                             '\r' => "\\r"
                             '\n' => "\\n"
-                            other => "\\u{" ++ asHex (cast {to=Int} c) ++ "}"
+                            other => "\\u{" ++ asHex (cast c) ++ "}"
 
 ||| Alias for Text . jsString
 jsStringDoc : String -> Doc
@@ -69,7 +69,7 @@ jsIdent s = concatMap okchar (unpack s)
     okchar '_' = "_"
     okchar c = if isAlphaNum c
                   then cast c
-                  else "x" ++ the (String) (asHex (cast {to=Int} c))
+                  else "x" ++ asHex (cast c)
 
 keywordSafe : String -> String
 keywordSafe "var"    = "var$"
@@ -111,8 +111,8 @@ mainExpr = MN "__mainExpression" 0
 
 var : Var -> Doc
 var (VName x) = jsNameDoc x
-var (VLoc x)  = Text $ "$" ++ asHex x
-var (VRef x)  = Text $ "$R" ++ asHex x
+var (VLoc x)  = Text $ "$" ++ asHex (cast x)
+var (VRef x)  = Text $ "$R" ++ asHex (cast x)
 
 minimal : Minimal -> Doc
 minimal (MVar v)          = var v

--- a/src/Libraries/Utils/Hex.idr
+++ b/src/Libraries/Utils/Hex.idr
@@ -1,11 +1,12 @@
 module Libraries.Utils.Hex
 
+import Data.Bits
 import Data.List
 import Data.Primitives.Views
 
 %default total
 
-hexDigit : Int -> Char
+hexDigit : Bits64 -> Char
 hexDigit 0 = '0'
 hexDigit 1 = '1'
 hexDigit 2 = '2'
@@ -24,19 +25,15 @@ hexDigit 14 = 'e'
 hexDigit 15 = 'f'
 hexDigit _ = 'X' -- TMP HACK: Ideally we'd have a bounds proof, generated below
 
-||| Convert a positive integer into a list of (lower case) hexadecimal characters
+||| Convert a Bits64 value into a list of (lower case) hexadecimal characters
 export
-asHex : Int -> String
-asHex n =
-  if n > 0
-    then pack $ asHex' n []
-    else "0"
+asHex : Bits64 -> String
+asHex 0 = "0"
+asHex n = pack $ asHex' n []
   where
-    asHex' : Int -> List Char -> List Char
+    asHex' : Bits64 -> List Char -> List Char
     asHex' 0 hex = hex
-    asHex' n hex with (n `divides` 16)
-      asHex' (16 * div + rem) hex | DivBy div rem _ =
-        asHex' (assert_smaller n div) (hexDigit rem :: hex)
+    asHex' n hex = asHex' (assert_smaller n (n `shiftR` fromNat 4)) (hexDigit (n .&. 0xf) :: hex)
 
 export
 leftPad : Char -> Nat -> String -> String

--- a/src/TTImp/PartialEval.idr
+++ b/src/TTImp/PartialEval.idr
@@ -368,7 +368,7 @@ specialise {vars} fc env gdef fn stk
                let nhash = hash (mapMaybe getStatic (map snd sargs))
                               `hashWithSalt` fn -- add function name to hash to avoid namespace clashes
                let pename = NS partialEvalNS
-                            (UN $ Basic ("PE_" ++ nameRoot fnfull ++ "_" ++ asHex nhash))
+                            (UN $ Basic ("PE_" ++ nameRoot fnfull ++ "_" ++ asHex (cast nhash)))
                defs <- get Ctxt
                case lookup pename (peFailures defs) of
                     Nothing => Just <$> mkSpecDef fc gdef pename sargs fn stk


### PR DESCRIPTION
This PR changes the type from `Libraries.Utils.Hex.asHex` from `Int -> String` to `Bits64 -> String`. Before this change all negative `Int` values were translated to `"0"` which was not obvious from the type signature. With the new type, there will be less surprise, because `Bits64` is unsigned and every distinct argument value will result in a distinct `String`.
This PR is a lightweight version of the original https://github.com/idris-lang/Idris2/pull/1996 which additionally changed the type of the `hash` function to `Bits64`. This might be a good idea too, but is not directly required.