### PR TITLE
[ base ] Introduce `.length` syntax for lists and vects

### DIFF
--- a/libs/base/Data/List.idr
+++ b/libs/base/Data/List.idr
@@ -32,6 +32,11 @@ drop Z     xs      = xs
 drop (S n) []      = []
 drop (S n) (_::xs) = drop n xs
 
+-- Nice syntax, very useful in complex types
+public export %inline
+(.length) : List a -> Nat
+xs.length = length xs
+
 ||| Satisfiable if `k` is a valid index into `xs`.
 |||
 ||| @ k  the potential index
@@ -71,7 +76,7 @@ index Z (x :: xs) {ok = InFirst} = x
 index (S k) (_ :: xs) {ok = InLater _} = index k xs
 
 public export
-index' : (xs : List a) -> Fin (length xs) -> a
+index' : (xs : List a) -> Fin xs.length -> a
 index' (x::_)  FZ     = x
 index' (_::xs) (FS i) = index' xs i
 
@@ -126,7 +131,7 @@ find p (x::xs) = if p x then Just x else find p xs
 ||| Find the index and proof of InBounds of the first element (if exists) of a
 ||| list that satisfies the given test, else `Nothing`.
 public export
-findIndex : (a -> Bool) -> (xs : List a) -> Maybe $ Fin (length xs)
+findIndex : (a -> Bool) -> (xs : List a) -> Maybe $ Fin xs.length
 findIndex _ [] = Nothing
 findIndex p (x :: xs) = if p x
   then Just FZ

--- a/libs/base/Data/SnocList.idr
+++ b/libs/base/Data/SnocList.idr
@@ -73,6 +73,10 @@ length : SnocList a -> Nat
 length Lin = Z
 length (sx :< x) = S $ length sx
 
+public export %inline
+(.length) : SnocList a -> Nat
+xs.length = length xs
+
 export
 Show a => Show (SnocList a) where
   show xs = concat ("[< " :: intersperse ", " (show' [] xs) ++ ["]"])
@@ -155,7 +159,7 @@ data InBounds : (k : Nat) -> (xs : SnocList a) -> Type where
 ||| Find the index and proof of InBounds of the first element (if exists) of a
 ||| snoc-list that satisfies the given test, else `Nothing`.
 public export
-findIndex : (a -> Bool) -> (xs : SnocList a) -> Maybe $ Fin (length xs)
+findIndex : (a -> Bool) -> (xs : SnocList a) -> Maybe $ Fin xs.length
 findIndex _ Lin = Nothing
 findIndex p (xs :< x) = if p x
   then Just FZ

--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -26,6 +26,10 @@ length : (xs : Vect len elem) -> Nat
 length [] = 0
 length (_::xs) = 1 + length xs
 
+public export %inline
+(.length) : Vect n a -> Nat
+xs.length = length xs
+
 ||| Show that the length function on vectors in fact calculates the length
 export
 lengthCorrect : (xs : Vect len elem) -> length xs = len
@@ -285,7 +289,7 @@ public export
 fromList' : (xs : Vect len elem) -> (l : List elem) -> Vect (length l + len) elem
 fromList' ys [] = ys
 fromList' ys (x::xs) =
-  rewrite (plusSuccRightSucc (length xs) len) in
+  rewrite (plusSuccRightSucc xs.length len) in
   fromList' (x::ys) xs
 
 ||| Convert a list to a vector.
@@ -296,9 +300,9 @@ fromList' ys (x::xs) =
 ||| fromList [1,2,3,4]
 ||| ```
 public export
-fromList : (xs : List elem) -> Vect (length xs) elem
+fromList : (xs : List elem) -> Vect xs.length elem
 fromList l =
-  rewrite (sym $ plusZeroRightNeutral (length l)) in
+  rewrite sym $ plusZeroRightNeutral l.length in
   reverse $ fromList' [] l
 
 --------------------------------------------------------------------------------

--- a/libs/contrib/Data/List/AtIndex.idr
+++ b/libs/contrib/Data/List/AtIndex.idr
@@ -1,6 +1,7 @@
 module Data.List.AtIndex
 
 import Data.DPair
+import Data.List
 import Data.List.HasLength
 import Data.Nat
 import Decidable.Equality
@@ -81,7 +82,7 @@ lookup (S n) (x :: xs) = case lookup n xs of
 
 ||| An AtIndex proof implies that n is less than the length of the list indexed into
 public export
-inRange : (n : Nat) -> (xs : List a) -> (0 _ : AtIndex x xs n) -> LTE n (length xs)
+inRange : (n : Nat) -> (xs : List a) -> (0 _ : AtIndex x xs n) -> LTE n xs.length
 inRange n [] p = void (absurd p)
 inRange Z (x :: xs) p = LTEZero
 inRange (S n) (x :: xs) p = LTESucc (inRange n xs (inverseS p))

--- a/libs/contrib/Data/List/Equalities.idr
+++ b/libs/contrib/Data/List/Equalities.idr
@@ -72,7 +72,7 @@ lengthDistributesOverAppend (x :: xs) ys =
 
 ||| Length of a snoc'd list is the same as Succ of length list.
 export
-lengthSnoc : (x : _) -> (xs : List a) -> length (snoc xs x) = S (length xs)
+lengthSnoc : (x : _) -> (xs : List a) -> length (snoc xs x) = S xs.length
 lengthSnoc x [] = Refl
 lengthSnoc x (_ :: xs) = cong S (lengthSnoc x xs)
 

--- a/libs/contrib/Data/List/HasLength.idr
+++ b/libs/contrib/Data/List/HasLength.idr
@@ -46,7 +46,7 @@ hasLengthUnique (S p) (S q) = cong S (hasLengthUnique p q)
 
 ||| This specification corresponds to the length function
 export
-hasLength : (xs : List a) -> HasLength xs (length xs)
+hasLength : (xs : List a) -> HasLength xs xs.length
 hasLength [] = Z
 hasLength (_ :: xs) = S (hasLength xs)
 

--- a/libs/contrib/Data/List/Reverse.idr
+++ b/libs/contrib/Data/List/Reverse.idr
@@ -58,10 +58,10 @@ reverseSingletonId _ = Refl
 export
 reverseOntoLength : (xs, acc : List a) ->
   length (reverseOnto acc xs) = length acc + length xs
-reverseOntoLength [] acc = rewrite plusZeroRightNeutral (length acc) in Refl
+reverseOntoLength [] acc = rewrite plusZeroRightNeutral acc.length in Refl
 reverseOntoLength (x :: xs) acc =
   rewrite reverseOntoLength xs (x :: acc) in
-    plusSuccRightSucc (length acc) (length xs)
+    plusSuccRightSucc acc.length xs.length
 
 ||| Reversing preserves list length.
 export

--- a/libs/contrib/Data/List/Views/Extra.idr
+++ b/libs/contrib/Data/List/Views/Extra.idr
@@ -43,7 +43,7 @@ public export
 data SplitBalanced : List a -> Type where
   MkSplitBal
     : {xs, ys : List a}
-    -> Balanced (length xs) (length ys)
+    -> Balanced xs.length ys.length
     -> SplitBalanced (xs ++ ys)
 
 private
@@ -57,22 +57,22 @@ splitBalancedHelper revLs rs [] prf = MkSplitBal balancedLeftsAndRights
   where
     lengthsEqual : length rs = length revLs
     lengthsEqual =
-      rewrite sym (plusZeroRightNeutral (length revLs)) in prf
-    balancedLeftsAndRights : Balanced (length (reverse revLs)) (length rs)
+      rewrite sym $ plusZeroRightNeutral revLs.length in prf
+    balancedLeftsAndRights : Balanced (reverse revLs).length rs.length
     balancedLeftsAndRights =
       rewrite reverseLength revLs in
         rewrite lengthsEqual in
           mkBalancedEq Refl
 splitBalancedHelper revLs [] (x :: xs) prf =
   absurd $
-    the (0 = S (plus (length revLs) (length xs))) $
-      rewrite plusSuccRightSucc (length revLs) (length xs) in
+    the (0 = S (plus revLs.length xs.length)) $
+      rewrite plusSuccRightSucc revLs.length xs.length in
         prf
 splitBalancedHelper revLs (x :: rs) [lastItem] prf =
   rewrite appendAssociative (reverse revLs) [x] rs in
     rewrite sym (reverseCons x revLs) in
       MkSplitBal $
-        the (Balanced (length (reverseOnto [x] revLs)) (length rs)) $
+        the (Balanced (reverseOnto [x] revLs).length rs.length) $
           rewrite reverseCons x revLs in
             rewrite lengthSnoc x (reverse revLs) in
               rewrite reverseLength revLs in
@@ -82,16 +82,16 @@ splitBalancedHelper revLs (x :: rs) [lastItem] prf =
     lengthsEqual : length rs = length revLs
     lengthsEqual =
       cong pred $
-        the (S (length rs) = S (length revLs)) $
-          rewrite plusCommutative 1 (length revLs) in prf
+        the (S rs.length = S revLs.length) $
+          rewrite plusCommutative 1 revLs.length in prf
 splitBalancedHelper revLs (x :: oneFurther) (_ :: (_ :: twoFurther)) prf =
   rewrite appendAssociative (reverse revLs) [x] oneFurther in
     rewrite sym (reverseCons x revLs) in
       splitBalancedHelper (x :: revLs) oneFurther twoFurther $
         cong pred $
-          the (S (length oneFurther) = S (S (plus (length revLs) (length twoFurther)))) $
-          rewrite plusSuccRightSucc (length revLs) (length twoFurther) in
-            rewrite plusSuccRightSucc (length revLs) (S (length twoFurther)) in
+          the (S oneFurther.length = S (S (plus revLs.length twoFurther.length))) $
+          rewrite plusSuccRightSucc revLs.length twoFurther.length in
+            rewrite plusSuccRightSucc revLs.length (S twoFurther.length) in
               prf
 
 ||| Covering function for the `SplitBalanced`
@@ -113,13 +113,13 @@ private
 toVList
   : (xs : List a)
   -> SnocList ys
-  -> Balanced (length xs) (length ys)
+  -> Balanced xs.length ys.length
   -> VList (xs ++ ys)
 toVList [] Empty BalancedZ = VNil
 toVList [x] Empty BalancedL = VOne
 toVList [] (Snoc x zs rec) prf =
   absurd $
-    the (Balanced 0 (S (length zs))) $
+    the (Balanced 0 (S zs.length)) $
       rewrite sym (lengthSnoc x zs) in prf
 toVList (x :: xs) (Snoc y ys srec) prf =
   rewrite appendAssociative xs ys [y] in


### PR DESCRIPTION
I personally use this function a lot in my codebase, and I find it extremely simplifying when used in complex type signatures, so I suggest to have it in `base`.