### PR TITLE
Fixed problem where dirEntries leaks directory handles.

### DIFF
--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -67,7 +67,9 @@ dirEntries : String -> IO (List String)
 dirEntries dname =
     do Right d <- openDir dname
          | Left err => pure []
-       getFiles d []
+       entries <- getFiles d []
+       closeDir d
+       pure entries
   where
     getFiles : Directory -> List String -> IO (List String)
     getFiles d acc


### PR DESCRIPTION
dirEntries isn't closing its handle after use.