### PR TITLE
Add user hints to expression search

### DIFF
--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1832,7 +1832,8 @@ editCmd
          upd <- option False (symbol "!" $> True)
          line <- intLit
          n <- name
-         pure (ExprSearch upd (fromInteger line) n [])
+         hints <- sepBy (symbol ",") name
+         pure (ExprSearch upd (fromInteger line) n hints)
   <|> do replCmd ["psnext"]
          pure ExprSearchNext
   <|> do replCmd ["gd"]

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -461,7 +461,7 @@ processEdit (ExprSearch upd line name hints)
          let brack = elemBy (\x, y => dropNS x == dropNS y) name (bracketholes syn)
          case !(lookupDefName name (gamma defs)) of
               [(n, nidx, Hole locs _)] =>
-                  do let searchtm = exprSearch replFC name []
+                  do let searchtm = exprSearch replFC name hints
                      ropts <- get ROpts
                      put ROpts (record { psResult = Just (name, searchtm) } ropts)
                      defs <- get Ctxt

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -88,7 +88,7 @@ idrisTestsInteractive = MkTestPool "Interactive editing" [] Nothing
        "interactive025", "interactive026", "interactive027", "interactive028",
        "interactive029", "interactive030", "interactive031", "interactive032",
        "interactive033", "interactive034", "interactive035", "interactive036",
-       "interactive037"]
+       "interactive037", "interactive038"]
 
 idrisTestsInterface : TestPool
 idrisTestsInterface = MkTestPool "Interface" [] Nothing

--- a/tests/idris2/interactive038/IEdit.idr
+++ b/tests/idris2/interactive038/IEdit.idr
@@ -1,0 +1,11 @@
+data Vect : Nat -> Type -> Type where
+     Nil : Vect Z a
+     (::) : a -> Vect k a -> Vect (S k) a
+
+%name Vect xs, ys, zs
+
+replicate : {m : Nat} -> a -> Vect m a
+
+transpose : {m : Nat} -> Vect n (Vect m a) -> Vect m (Vect n a)
+transpose [] = ?transpose_rhs_1
+transpose (x :: xs) = ?transpose_rhs_2

--- a/tests/idris2/interactive038/expected
+++ b/tests/idris2/interactive038/expected
@@ -1,0 +1,4 @@
+1/1: Building IEdit (IEdit.idr)
+Main> No search results
+Main> replicate []
+Main> Bye for now!

--- a/tests/idris2/interactive038/input
+++ b/tests/idris2/interactive038/input
@@ -1,0 +1,3 @@
+:ps 10 transpose_rhs_1
+:ps 10 transpose_rhs_1 Main.replicate
+:q

--- a/tests/idris2/interactive038/run
+++ b/tests/idris2/interactive038/run
@@ -1,0 +1,4 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --no-banner IEdit.idr < input
+


### PR DESCRIPTION
The `ExprSearch` command has a field for user provided hints, beside functions annotated with the `%hint` pragma. However, names were not parsed and then they were not passed to the expression search machinery.