### PR TITLE
Save warnings to TTC

### DIFF
--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -747,7 +747,9 @@ record Defs where
      -- ^ for timing and checking timeouts; the maximum time after which a
      -- timeout should be thrown
   warnings : List Warning
-     -- ^ as yet unreported warnings
+     -- ^ warnings for this file and all imported
+  saveWarnings : List Warning
+     -- ^ warnings for this file
   schemeEvalLoaded : Bool
 
 -- Label for context references
@@ -796,6 +798,7 @@ initDefs
            , timings = empty
            , timer = Nothing
            , warnings = []
+           , saveWarnings = []
            , schemeEvalLoaded = False
            }
 
@@ -2242,7 +2245,7 @@ recordWarning : {auto c : Ref Ctxt Defs} -> Warning -> Core ()
 recordWarning w
     = do defs <- get Ctxt
          session <- getSession
-         put Ctxt $ record { warnings $= (w ::) } defs
+         put Ctxt $ record { warnings $= (w ::), saveWarnings $= (w ::) } defs
 
 export
 getTime : Core Integer

--- a/src/Idris/REPL/Common.idr
+++ b/src/Idris/REPL/Common.idr
@@ -161,7 +161,7 @@ emitWarnings : {auto c : Ref Ctxt Defs} ->
                Core (List Error)
 emitWarnings
     = do defs <- get Ctxt
-         let ws = reverse (warnings defs)
+         let ws = reverse (saveWarnings defs)
          session <- getSession
          if (session.warningsAsErrors)
            then let errs = WarningAsError <$> ws in


### PR DESCRIPTION
Exposes warnings to the LSP by saving them to TTC. Makes it so https://github.com/idris-community/idris2-lsp/pull/103 works.