### PR TITLE
Check the pre-options before the other options.

### DIFF
--- a/src/Idris/Driver.idr
+++ b/src/Idris/Driver.idr
@@ -171,14 +171,16 @@ stMain cgs opts
 
          finish <- showInfo opts
          when (not finish) $ do
+           -- start by going over the pre-options, and stop if we do not need to
+           -- continue
+           True <- preOptions opts
+              | False => pure ()
+
            -- If there's a --build or --install, just do that then quit
            done <- processPackageOpts opts
 
            when (not done) $ flip catch renderError $
-              do True <- preOptions opts
-                     | False => pure ()
-
-                 when (checkVerbose opts) $ -- override Quiet if implicitly set
+              do when (checkVerbose opts) $ -- override Quiet if implicitly set
                      setOutput (REPL InfoLvl)
                  u <- newRef UST initUState
                  origin <- maybe

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -288,7 +288,7 @@ setIncrementalCG failOnError cgn
                          coreLift $ exitWith (ExitFailure 1)
                  else pure ()
 
--- Options to be processed before type checking. Return whether to continue.
+||| Options to be processed before type checking. Return whether to continue.
 export
 preOptions : {auto c : Ref Ctxt Defs} ->
              {auto o : Ref ROpts REPLOpts} ->


### PR DESCRIPTION
This took slightly longer than it should have because I went down a rabbit hole thinking the problem was deeper nested than it actually was: We should run/check `preOptions`... _pre_ the other options.

Fixes #2066