### PR TITLE
Cumulativity preparation: Add field for universe level to TType

### DIFF
--- a/src/Compiler/CompileExpr.idr
+++ b/src/Compiler/CompileExpr.idr
@@ -351,7 +351,7 @@ mutual
                then pure $ CPrimVal fc c
                else pure $ CCon fc (UN $ Basic $ show c) TYCON Nothing []
   toCExpTm m n (Erased fc _) = pure $ CErased fc
-  toCExpTm m n (TType fc) = pure $ CCon fc (UN (Basic "Type")) TYCON Nothing []
+  toCExpTm m n (TType fc _) = pure $ CCon fc (UN (Basic "Type")) TYCON Nothing []
 
   toCExp : {vars : _} ->
            {auto c : Ref Ctxt Defs} ->
@@ -650,7 +650,7 @@ nfToCFType _ s (NTCon fc n_in _ _ args)
                 do narg <- evalClosure defs uarg
                    carg <- nfToCFType fc s narg
                    pure (CFIORes carg)
-nfToCFType _ s (NType _)
+nfToCFType _ s (NType _ _)
     = pure (CFUser (UN (Basic "Type")) [])
 nfToCFType _ s (NErased _ _)
     = pure (CFUser (UN (Basic "__")) [])

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -33,7 +33,7 @@ import public Libraries.Utils.Binary
 ||| (Increment this when changing anything in the data format)
 export
 ttcVersion : Int
-ttcVersion = 66
+ttcVersion = 67
 
 export
 checkTTCVersion : String -> Int -> Int -> Core ()

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -397,6 +397,10 @@ HasNames (Term vars) where
       = pure (TDelay fc x !(full gam t) !(full gam y))
   full gam (TForce fc r y)
       = pure (TForce fc r !(full gam y))
+  full gam (TType fc (Resolved i))
+      = do Just gdef <- lookupCtxtExact (Resolved i) gam
+                | Nothing => pure (TType fc (Resolved i))
+           pure (TType fc (fullname gdef))
   full gam tm = pure tm
 
   resolved gam (Ref fc x n)
@@ -420,6 +424,10 @@ HasNames (Term vars) where
       = pure (TDelay fc x !(resolved gam t) !(resolved gam y))
   resolved gam (TForce fc r y)
       = pure (TForce fc r !(resolved gam y))
+  resolved gam (TType fc n)
+      = do let Just i = getNameID n gam
+                | Nothing => pure (TType fc n)
+           pure (TType fc (Resolved i))
   resolved gam tm = pure tm
 
 export

--- a/src/Core/Context/Context.idr
+++ b/src/Core/Context/Context.idr
@@ -118,6 +118,8 @@ data Def : Type where
                                -- we guessed the term
             (constraints : List Int) -> Def
     ImpBind : Def -- global name temporarily standing for an implicitly bound name
+    -- a name standing for a universe level in a Type
+    UniverseLevel : Integer -> Def
     -- A delayed elaboration. The elaborators themselves are stored in the
     -- unification state
     Delayed : Def
@@ -135,6 +137,7 @@ defNameType (Hole {}) = Just Func
 defNameType (BySearch {}) = Nothing
 defNameType (Guess {}) = Nothing
 defNameType ImpBind = Just Bound
+defNameType (UniverseLevel {}) = Nothing
 defNameType Delayed = Nothing
 
 export
@@ -158,6 +161,7 @@ Show Def where
   show (Hole _ p) = "Hole" ++ if implbind p then " [impl]" else ""
   show (BySearch c depth def) = "Search in " ++ show def
   show (Guess tm _ cs) = "Guess " ++ show tm ++ " when " ++ show cs
+  show (UniverseLevel i) = "Universe level #" ++ show i
   show ImpBind = "Bound name"
   show Delayed = "Delayed"
 

--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -705,7 +705,7 @@ mapTermM f = goTerm where
     goTerm (TForce fc la t) = f =<< TForce fc la <$> goTerm t
     goTerm tm@(PrimVal _ _) = f tm
     goTerm tm@(Erased _ _) = f tm
-    goTerm tm@(TType _) = f tm
+    goTerm tm@(TType _ _) = f tm
 
 
 export

--- a/src/Core/Coverage.idr
+++ b/src/Core/Coverage.idr
@@ -38,10 +38,10 @@ conflictMatch ((x, tm) :: ms) = conflictArgs x tm ms || conflictMatch ms
       = c /= c'
     clash (Ref _ t _) (PrimVal _ _) = isJust (isCon t)
     clash (PrimVal _ _) (Ref _ t _) = isJust (isCon t)
-    clash (Ref _ t _) (TType _) = isJust (isCon t)
-    clash (TType _) (Ref _ t _) = isJust (isCon t)
-    clash (TType _) (PrimVal _ _) = True
-    clash (PrimVal _ _) (TType _) = True
+    clash (Ref _ t _) (TType _ _) = isJust (isCon t)
+    clash (TType _ _) (Ref _ t _) = isJust (isCon t)
+    clash (TType _ _) (PrimVal _ _) = True
+    clash (PrimVal _ _) (TType _ _) = True
     clash _ _ = False
 
     findN : Nat -> Term vars -> Bool
@@ -176,7 +176,7 @@ getMissingAlts fc defs (NPrimVal _ c) alts
                  pure []
          else pure [DefaultCase (Unmatched "Coverage check")]
 -- Similarly for types
-getMissingAlts fc defs (NType _) alts
+getMissingAlts fc defs (NType _ _) alts
     = do log "coverage.missing" 50 "Looking for missing alts at type Type"
          if any isDefault alts
            then do log "coverage.missing" 20 "Found default"
@@ -247,7 +247,7 @@ replaceDefaults : {auto c : Ref Ctxt Defs} ->
 -- Leave it alone if it's a primitive type though, since we need the catch
 -- all case there
 replaceDefaults fc defs (NPrimVal _ _) cs = pure cs
-replaceDefaults fc defs (NType _) cs = pure cs
+replaceDefaults fc defs (NType _ _) cs = pure cs
 replaceDefaults fc defs nfty cs
     = do cs' <- traverse rep cs
          pure (dropRep (concat cs'))
@@ -404,7 +404,7 @@ match (TForce _ _ t) (TForce _ _ t') = match t t'
 match (PrimVal _ c) (PrimVal _ c') = c == c'
 match (Erased _ _) _ = True
 match _ (Erased _ _) = True
-match (TType _) (TType _) = True
+match (TType _ _) (TType _ _) = True
 match _ _ = False
 
 -- Erase according to argument position

--- a/src/Core/GetType.idr
+++ b/src/Core/GetType.idr
@@ -47,7 +47,7 @@ mutual
                 _ => do fty' <- getTerm fty
                         throw (NotFunctionType fc env fty')
   chk env (As fc s n p) = chk env p
-  chk env (TDelayed fc r tm) = pure (gType fc)
+  chk env (TDelayed fc r tm) = pure (gType fc (MN "top" 0))
   chk env (TDelay fc r dty tm)
       = do gtm <- chk env tm
            tm' <- getNF gtm
@@ -61,7 +61,7 @@ mutual
                        pure $ glueBack defs env fty
                 _ => throw (GenericMsg fc "Not a delayed type")
   chk env (PrimVal fc x) = pure $ gnf env (chkConstant fc x)
-  chk env (TType fc) = pure (gType fc)
+  chk env (TType fc u) = pure (gType fc (MN "top" 0))
   chk env (Erased fc _) = pure (gErased fc)
 
   chkMeta : {vars : _} ->
@@ -115,7 +115,7 @@ mutual
   chkConstant fc (Ch x) = PrimVal fc CharType
   chkConstant fc (Db x) = PrimVal fc DoubleType
   chkConstant fc WorldVal = PrimVal fc WorldType
-  chkConstant fc _ = TType fc
+  chkConstant fc _ = TType fc (MN "top" 0)
 
 export
 getType : {vars : _} ->

--- a/src/Core/Hash.idr
+++ b/src/Core/Hash.idr
@@ -176,8 +176,8 @@ mutual
         = h `hashWithSalt` 9 `hashWithSalt` (show c)
     hashWithSalt h (Erased fc _)
         = hashWithSalt h 10
-    hashWithSalt h (TType fc)
-        = hashWithSalt h 11
+    hashWithSalt h (TType fc u)
+        = hashWithSalt h 11 `hashWithSalt` u
 
   export
   Hashable Pat where

--- a/src/Core/LinearCheck.idr
+++ b/src/Core/LinearCheck.idr
@@ -359,7 +359,7 @@ mutual
            pure (As fc s as' pat', pty, u)
   lcheck rig erase env (TDelayed fc r ty)
       = do (ty', _, u) <- lcheck rig erase env ty
-           pure (TDelayed fc r ty', gType fc, u)
+           pure (TDelayed fc r ty', gType fc (MN "top" 0), u)
   lcheck rig erase env (TDelay fc r ty val)
       = do (ty', _, _) <- lcheck erased erase env ty
            (val', gty, u) <- lcheck rig erase env val
@@ -377,8 +377,9 @@ mutual
       = pure (PrimVal fc c, gErased fc, [])
   lcheck rig erase env (Erased fc i)
       = pure (Erased fc i, gErased fc, [])
-  lcheck rig erase env (TType fc)
-      = pure (TType fc, gType fc, [])
+  lcheck rig erase env (TType fc u)
+      -- Not universe checking here, just use the top of the hierarchy
+      = pure (TType fc u, gType fc (MN "top" 0), [])
 
   lcheckBinder : {vars : _} ->
                  {auto c : Ref Ctxt Defs} ->

--- a/src/Core/Normalise/Convert.idr
+++ b/src/Core/Normalise/Convert.idr
@@ -87,7 +87,7 @@ tryUpdate ms (TDelay fc r ty tm) = pure $ TDelay fc r !(tryUpdate ms ty) !(tryUp
 tryUpdate ms (TForce fc r tm) = pure $ TForce fc r !(tryUpdate ms tm)
 tryUpdate ms (PrimVal fc c) = pure $ PrimVal fc c
 tryUpdate ms (Erased fc i) = pure $ Erased fc i
-tryUpdate ms (TType fc) = pure $ TType fc
+tryUpdate ms (TType fc u) = pure $ TType fc u
 
 mutual
   allConvNF : {auto c : Ref Ctxt Defs} ->
@@ -125,7 +125,7 @@ mutual
       quickConvArg (NDelay _ _ _ _) (NDelay _ _ _ _) = True
       quickConvArg (NForce _ _ t _) (NForce _ _ t' _) = quickConvArg t t'
       quickConvArg (NPrimVal _ c) (NPrimVal _ c') = c == c'
-      quickConvArg (NType _) (NType _) = True
+      quickConvArg (NType _ _) (NType _ _) = True
       quickConvArg (NErased _ _) _ = True
       quickConvArg _ (NErased _ _) = True
       quickConvArg _ _ = False
@@ -435,7 +435,9 @@ mutual
     convGen q i defs env (NPrimVal _ c) (NPrimVal _ c') = pure (c == c')
     convGen q i defs env (NErased _ _) _ = pure True
     convGen q i defs env _ (NErased _ _) = pure True
-    convGen q i defs env (NType _) (NType _) = pure True
+    convGen q i defs env (NType _ ul) (NType _ ur)
+        = -- TODO Cumulativity: Add constraint here
+          pure True
     convGen q i defs env x y = pure False
 
   export

--- a/src/Core/Normalise/Eval.idr
+++ b/src/Core/Normalise/Eval.idr
@@ -141,7 +141,7 @@ parameters (defs : Defs, topopts : EvalOpts)
                   _ => pure (NForce fc r tm' stk)
     eval env locs (PrimVal fc c) stk = pure $ NPrimVal fc c
     eval env locs (Erased fc i) stk = pure $ NErased fc i
-    eval env locs (TType fc) stk = pure $ NType fc
+    eval env locs (TType fc u) stk = pure $ NType fc u
 
     -- Apply an evaluated argument (perhaps cached from an earlier evaluation)
     -- to a stack
@@ -190,7 +190,7 @@ parameters (defs : Defs, topopts : EvalOpts)
                  _ => pure (NForce fc r tm' (args ++ stk))
     applyToStack env cont nf@(NPrimVal fc _) _ = pure nf
     applyToStack env cont nf@(NErased fc _) _ = pure nf
-    applyToStack env cont nf@(NType fc) _ = pure nf
+    applyToStack env cont nf@(NType fc _) _ = pure nf
 
     evalLocClosure : {auto c : Ref Ctxt Defs} ->
                      {free : _} ->
@@ -345,7 +345,7 @@ parameters (defs : Defs, topopts : EvalOpts)
                    else pure NoMatch
              _ => pure NoMatch
     -- Type of type matching, in typecase
-    tryAlt env loc opts fc stk (NType _) (ConCase (UN (Basic "Type")) tag [] sc)
+    tryAlt env loc opts fc stk (NType _ _) (ConCase (UN (Basic "Type")) tag [] sc)
          = evalTree env loc opts fc stk sc
     -- Arrow matching, in typecase
     tryAlt {more}
@@ -372,7 +372,7 @@ parameters (defs : Defs, topopts : EvalOpts)
         concrete (NTCon _ _ _ _ _) = True
         concrete (NPrimVal _ _) = True
         concrete (NBind _ _ _ _) = True
-        concrete (NType _) = True
+        concrete (NType _ _) = True
         concrete _ = False
     tryAlt _ _ _ _ _ _ _ = pure GotStuck
 
@@ -546,8 +546,8 @@ gnfOpts opts env tm
                        nfOpts opts defs env tm)
 
 export
-gType : FC -> Glued vars
-gType fc = MkGlue True (pure (TType fc)) (const (pure (NType fc)))
+gType : FC -> Name -> Glued vars
+gType fc u = MkGlue True (pure (TType fc u)) (const (pure (NType fc u)))
 
 export
 gErased : FC -> Glued vars

--- a/src/Core/Normalise/Quote.idr
+++ b/src/Core/Normalise/Quote.idr
@@ -240,7 +240,7 @@ mutual
                         pure $ applyWithFC (TForce fc r arg') args'
   quoteGenNF q opts defs bound env (NPrimVal fc c) = pure $ PrimVal fc c
   quoteGenNF q opts defs bound env (NErased fc i) = pure $ Erased fc i
-  quoteGenNF q opts defs bound env (NType fc) = pure $ TType fc
+  quoteGenNF q opts defs bound env (NType fc u) = pure $ TType fc u
 
 export
 Quote NF where

--- a/src/Core/Primitives.idr
+++ b/src/Core/Primitives.idr
@@ -500,7 +500,7 @@ believeMe : Vect 3 (NF vars) -> Maybe (NF vars)
 believeMe [_, _, val@(NDCon _ _ _ _ _)] = Just val
 believeMe [_, _, val@(NTCon _ _ _ _ _)] = Just val
 believeMe [_, _, val@(NPrimVal _ _)] = Just val
-believeMe [_, _, NType fc] = Just (NType fc)
+believeMe [_, _, NType fc u] = Just (NType fc u)
 believeMe [_, _, val] = Nothing
 
 constTy : Constant -> Constant -> Constant -> ClosedTerm
@@ -534,14 +534,14 @@ pi x rig plic ty sc = Bind emptyFC (UN (Basic x)) (Pi emptyFC rig plic ty) sc
 
 believeMeTy : ClosedTerm
 believeMeTy
-    = pi "a" erased Explicit (TType emptyFC) $
-      pi "b" erased Explicit (TType emptyFC) $
+    = pi "a" erased Explicit (TType emptyFC (MN "top" 0)) $
+      pi "b" erased Explicit (TType emptyFC (MN "top" 0)) $
       pi "x" top    Explicit (Local emptyFC Nothing _ (Later First)) $
       Local emptyFC Nothing _ (Later First)
 
 crashTy : ClosedTerm
 crashTy
-    = pi "a" erased Explicit (TType emptyFC) $
+    = pi "a" erased Explicit (TType emptyFC (MN "top" 0)) $
       pi "msg" top Explicit (PrimVal emptyFC StringType) $
       Local emptyFC Nothing _ (Later First)
 

--- a/src/Core/SchemeEval/Compile.idr
+++ b/src/Core/SchemeEval/Compile.idr
@@ -273,7 +273,7 @@ compileStk svs stk (TForce fc x tm)
                       Vector (-5) [toScheme x, toScheme fc, Lambda [] tm']]
 compileStk svs stk (PrimVal fc c) = pure $ compileConstant fc c
 compileStk svs stk (Erased fc imp) = pure $ Vector (-6) [toScheme fc, toScheme imp]
-compileStk svs stk (TType fc) = pure $ Vector (-7) [toScheme fc]
+compileStk svs stk (TType fc u) = pure $ Vector (-7) [toScheme fc, toScheme u]
 
 export
 compile : Ref Sym Integer =>
@@ -535,6 +535,7 @@ compileBody _ n (Hole numlocs x) = pure $ blockedMetaApp n
 compileBody _ n (BySearch x maxdepth defining) = pure $ blockedMetaApp n
 compileBody _ n (Guess guess envbind constraints) = pure $ blockedMetaApp n
 compileBody _ n ImpBind = pure $ blockedMetaApp n
+compileBody _ n (UniverseLevel _) = pure $ blockedMetaApp n
 compileBody _ n Delayed = pure $ blockedMetaApp n
 
 export

--- a/src/Core/SchemeEval/Evaluate.idr
+++ b/src/Core/SchemeEval/Evaluate.idr
@@ -42,7 +42,7 @@ mutual
        SForce   : FC -> LazyReason -> SNF vars -> SNF vars
        SPrimVal : FC -> Constant -> SNF vars
        SErased  : FC -> (imp : Bool) -> SNF vars
-       SType    : FC -> SNF vars
+       SType    : FC -> Name -> SNF vars
 
 getAllNames : {auto c : Ref Ctxt Defs} ->
               NameMap () -> List Name -> Core (NameMap ())
@@ -198,11 +198,14 @@ mutual
                           Just imp => imp
                           _ => False
            pure (Erased fc imp)
-  quoteVector svs (-7) [_, fc_in] -- Type
+  quoteVector svs (-7) [_, fc_in, u_in] -- Type
       = do let fc = case fromScheme (decodeObj fc_in) of
                          Just fc => fc
                          _ => emptyFC
-           pure (TType fc)
+           let u = case fromScheme (decodeObj u_in) of
+                        Just u => u
+                        _ => MN "top" 0
+           pure (TType fc u)
   quoteVector svs (-8) [_, proc_in, rig_in, pi_in, ty_in, name_in] -- Lambda
       = do let name = case fromScheme (decodeObj name_in) of
                            Nothing => UN (Basic "x")
@@ -491,11 +494,14 @@ mutual
                           Just imp => imp
                           _ => False
            pure (SErased fc imp)
-  snfVector svs (-7) [_, fc_in] -- Type
+  snfVector svs (-7) [_, fc_in, u_in] -- Type
       = do let fc = case fromScheme (decodeObj fc_in) of
                          Just fc => fc
                          _ => emptyFC
-           pure (SType fc)
+           let u = case fromScheme (decodeObj u_in) of
+                        Just u => u
+                        _ => MN "top" 0
+           pure (SType fc u)
   snfVector svs (-8) [_, proc_in, rig_in, pi_in, ty_in, name_in] -- Lambda
       = do let name = case fromScheme (decodeObj name_in) of
                            Nothing => UN (Basic "x")

--- a/src/Core/SchemeEval/Quote.idr
+++ b/src/Core/SchemeEval/Quote.idr
@@ -132,7 +132,7 @@ mutual
                      pure $ (TForce fc r arg')
   quoteGen q bound env (SPrimVal fc c) = pure $ PrimVal fc c
   quoteGen q bound env (SErased fc i) = pure $ Erased fc i
-  quoteGen q bound env (SType fc) = pure $ TType fc
+  quoteGen q bound env (SType fc u) = pure $ TType fc u
 
 export
 quote : {auto c : Ref Ctxt Defs} ->

--- a/src/Core/TT/Traversals.idr
+++ b/src/Core/TT/Traversals.idr
@@ -36,7 +36,7 @@ onPRefs f = go neutral where
   go acc (TForce fc x y) = go acc y
   go acc (PrimVal fc c) = acc
   go acc (Erased fc imp) = acc
-  go acc (TType fc) = acc
+  go acc (TType fc u) = acc
 
   gos acc [] = acc
   gos acc (x :: xs) = gos (go acc x) xs
@@ -65,7 +65,7 @@ onConstants f = go neutral where
   go acc (TForce fc x y) = go acc y
   go acc (PrimVal fc c) = acc <+> f c
   go acc (Erased fc imp) = acc
-  go acc (TType fc) = acc
+  go acc (TType fc u) = acc
 
   gos acc [] = acc
   gos acc (x :: xs) = gos (go acc x) xs
@@ -96,4 +96,4 @@ mapTermM f t = act t where
   go t@(TForce fc x y) = pure t
   go t@(PrimVal fc c) = pure t
   go t@(Erased fc imp) = pure t
-  go t@(TType fc) = pure t
+  go t@(TType fc u) = pure t

--- a/src/Core/TTC.idr
+++ b/src/Core/TTC.idr
@@ -333,8 +333,8 @@ mutual
              toBuf b c
     toBuf b (Erased fc _)
         = tag 10
-    toBuf b (TType fc)
-        = tag 11
+    toBuf b (TType fc u)
+        = do tag 11; toBuf b u
 
     fromBuf {vars} b
         = case !getTag of
@@ -366,7 +366,7 @@ mutual
                9 => do c <- fromBuf b
                        pure (PrimVal emptyFC c)
                10 => pure (Erased emptyFC False)
-               11 => pure (TType emptyFC)
+               11 => do u <- fromBuf b; pure (TType emptyFC u)
                12 => do fn <- fromBuf b
                         args <- fromBuf b
                         pure (apply emptyFC fn args)
@@ -966,6 +966,7 @@ TTC Def where
       = do tag 8; toBuf b guess; toBuf b envb; toBuf b constraints
   toBuf b ImpBind = tag 9
   toBuf b Delayed = tag 10
+  toBuf b (UniverseLevel i) = do tag 11; toBuf b i
 
   fromBuf b
       = case !getTag of
@@ -998,6 +999,8 @@ TTC Def where
                      pure (Guess g envb cs)
              9 => pure ImpBind
              10 => pure Context.Delayed
+             11 => do l <- fromBuf b
+                      pure (UniverseLevel l)
              _ => corrupt "Def"
 
 export

--- a/src/Core/Termination.idr
+++ b/src/Core/Termination.idr
@@ -105,7 +105,7 @@ scEq (TDelay _ _ t x) (TDelay _ _ t' x') = scEq t t' && scEq x x'
 scEq (TForce _ _ t) (TForce _ _ t') = scEq t t'
 scEq (PrimVal _ c) (PrimVal _ c') = c == c'
 scEq (Erased _ _) (Erased _ _) = True
-scEq (TType _) (TType _) = True
+scEq (TType _ _) (TType _ _) = True
 scEq _ _ = False
 
 data Guardedness = Toplevel | Unguarded | Guarded | InDelay
@@ -338,7 +338,7 @@ mutual
                   (updateRHS (map (\vt => (weaken (fst vt), weaken (snd vt))) ms) sc)
           urhs (PrimVal fc c) = PrimVal fc c
           urhs (Erased fc i) = Erased fc i
-          urhs (TType fc) = TType fc
+          urhs (TType fc u) = TType fc u
 
           lookupTm : Term vs -> List (Term vs, Term vs') -> Maybe (Term vs')
           lookupTm tm [] = Nothing

--- a/src/Core/Transform.idr
+++ b/src/Core/Transform.idr
@@ -81,7 +81,7 @@ tryReplace ms (TForce fc r tm)
          pure (TForce fc r tm')
 tryReplace ms (PrimVal fc c) = pure (PrimVal fc c)
 tryReplace ms (Erased fc i) = pure (Erased fc i)
-tryReplace ms (TType fc) = pure (TType fc)
+tryReplace ms (TType fc u) = pure (TType fc u)
 
 covering
 tryApply : Transform -> Term vs -> Maybe (Term vs)

--- a/src/Core/Unify.idr
+++ b/src/Core/Unify.idr
@@ -513,7 +513,7 @@ tryInstantiate {newvars} loc mode env mname mref num mdef locs otm tm
     noMeta (Local _ _ _ _) _ = True
     noMeta (Ref _ _ _) _ = True
     noMeta (PrimVal _ _) _ = True
-    noMeta (TType _) _ = True
+    noMeta (TType _ _) _ = True
     noMeta _ _ = False
 
     isSimple : Term vs -> Bool
@@ -585,7 +585,7 @@ tryInstantiate {newvars} loc mode env mname mref num mdef locs otm tm
         = Just (TForce fc r !(updateIVars ivs arg))
     updateIVars ivs (PrimVal fc c) = Just (PrimVal fc c)
     updateIVars ivs (Erased fc i) = Just (Erased fc i)
-    updateIVars ivs (TType fc) = Just (TType fc)
+    updateIVars ivs (TType fc u) = Just (TType fc u)
 
     mkDef : {vs, newvars : _} ->
             List (Var newvars) ->
@@ -959,7 +959,7 @@ mutual
       = convertErrorS swap loc env (NApp xfc (NLocal rx x xp) args) y
   unifyApp swap mode loc env xfc (NLocal rx x xp) args y@(NPrimVal _ _)
       = convertErrorS swap loc env (NApp xfc (NLocal rx x xp) args) y
-  unifyApp swap mode loc env xfc (NLocal rx x xp) args y@(NType _)
+  unifyApp swap mode loc env xfc (NLocal rx x xp) args y@(NType _ _)
       = convertErrorS swap loc env (NApp xfc (NLocal rx x xp) args) y
   -- If they're already convertible without metavariables, we're done,
   -- otherwise postpone

--- a/src/Core/Value.idr
+++ b/src/Core/Value.idr
@@ -101,11 +101,13 @@ mutual
        NForce   : FC -> LazyReason -> NF vars -> List (FC, Closure vars) -> NF vars
        NPrimVal : FC -> Constant -> NF vars
        NErased  : FC -> (imp : Bool) -> NF vars
-       NType    : FC -> NF vars
+       NType    : FC -> Name -> NF vars
 
 export
 ntCon : FC -> Name -> Int -> Nat -> List (FC, Closure vars) -> NF vars
-ntCon fc (UN (Basic "Type")) tag Z [] = NType fc
+-- Part of the machinery for matching on types - I believe this won't affect
+-- universe checking so put a dummy name.
+ntCon fc (UN (Basic "Type")) tag Z [] = NType fc (MN "top" 0)
 ntCon fc n tag Z [] = case isConstantType n of
   Just c => NPrimVal fc c
   Nothing => NTCon fc n tag Z []
@@ -123,7 +125,7 @@ getLoc (NDelay fc _ _ _) = fc
 getLoc (NForce fc _ _ _) = fc
 getLoc (NPrimVal fc _) = fc
 getLoc (NErased fc i) = fc
-getLoc (NType fc) = fc
+getLoc (NType fc _) = fc
 
 export
 {free : _} -> Show (NHead free) where
@@ -163,4 +165,4 @@ export
   show (NForce _ _ tm args) = "%Force " ++ show tm ++ " [" ++ show (length args) ++ " closures]"
   show (NPrimVal _ c) = show c
   show (NErased _ _) = "[__]"
-  show (NType _) = "Type"
+  show (NType _ _) = "Type"

--- a/src/Idris/REPL/FuzzySearch.idr
+++ b/src/Idris/REPL/FuzzySearch.idr
@@ -195,7 +195,7 @@ fuzzySearch expr = do
   doFind ns (PrimVal fc c) =
     fromMaybe [] ((:: []) <$> parseNameOrConst (PPrimVal fc c)) ++ ns
   doFind ns (Erased fc i) = ns
-  doFind ns (TType fc) = AType :: ns
+  doFind ns (TType fc _) = AType :: ns
 
   toFullNames' : NameOrConst -> Core NameOrConst
   toFullNames' (AName x) = AName <$> toFullNames x

--- a/src/TTImp/Elab/Ambiguity.idr
+++ b/src/TTImp/Elab/Ambiguity.idr
@@ -214,7 +214,7 @@ mutual
            else pure NoMatch
   mightMatch defs (NPrimVal _ x) (NPrimVal _ y)
       = if x == y then pure Concrete else pure NoMatch
-  mightMatch defs (NType _) (NType _) = pure Concrete
+  mightMatch defs (NType _ _) (NType _ _) = pure Concrete
   mightMatch defs (NApp _ _ _) _ = pure Poly
   mightMatch defs (NErased _ _) _ = pure Poly
   mightMatch defs _ (NApp _ _ _) = pure Poly
@@ -254,7 +254,7 @@ couldBe {vars} defs ty@(NPrimVal _ _) app
           Concrete => pure $ Just (True, app)
           Poly => pure $ Just (False, app)
           NoMatch => pure Nothing
-couldBe {vars} defs ty@(NType _) app
+couldBe {vars} defs ty@(NType _ _) app
    = case !(couldBeFn {vars} defs ty (getFn app)) of
           Concrete => pure $ Just (True, app)
           Poly => pure $ Just (False, app)
@@ -345,7 +345,8 @@ checkAlternative : {vars : _} ->
 checkAlternative rig elabinfo nest env fc (UniqueDefault def) alts mexpected
     = do checkAmbigDepth fc elabinfo
          expected <- maybe (do nm <- genName "altTy"
-                               ty <- metaVar fc erased env nm (TType fc)
+                               u <- uniVar fc
+                               ty <- metaVar fc erased env nm (TType fc u)
                                pure (gnf env ty))
                            pure mexpected
          let solvemode = case elabMode elabinfo of
@@ -398,7 +399,8 @@ checkAlternative rig elabinfo nest env fc uniq alts mexpected
            [alt] => checkImp rig elabinfo nest env alt mexpected
            _ =>
              do expected <- maybe (do nm <- genName "altTy"
-                                      ty <- metaVar fc erased env nm (TType fc)
+                                      u <- uniVar fc
+                                      ty <- metaVar fc erased env nm (TType fc u)
                                       pure (gnf env ty))
                                   pure mexpected
                 let solvemode = case elabMode elabinfo of

--- a/src/TTImp/Elab/App.idr
+++ b/src/TTImp/Elab/App.idr
@@ -691,11 +691,12 @@ mutual
            logTerm "elab.with" 10 "Function " tm
            argn <- genName "argTy"
            retn <- genName "retTy"
-           argTy <- metaVar fc erased env argn (TType fc)
+           u <- uniVar fc
+           argTy <- metaVar fc erased env argn (TType fc u)
            let argTyG = gnf env argTy
            retTy <- metaVar -- {vars = argn :: vars}
                             fc erased env -- (Pi RigW Explicit argTy :: env)
-                            retn (TType fc)
+                            retn (TType fc u)
            (argv, argt) <- check rig elabinfo
                                  nest env arg (Just argTyG)
            let fntm = App fc tm argv

--- a/src/TTImp/Elab/Case.idr
+++ b/src/TTImp/Elab/Case.idr
@@ -203,10 +203,12 @@ caseBlock {vars} rigc elabinfo fc nest env scr scrtm scrty caseRig alts expected
                            Just ty => getTerm ty
                            _ =>
                               do nmty <- genName "caseTy"
-                                 metaVar fc erased env nmty (TType fc)
+                                 u <- uniVar fc
+                                 metaVar fc erased env nmty (TType fc u)
 
+         u <- uniVar fc
          (caseretty, _) <- bindImplicits fc (implicitMode elabinfo) defs env
-                                         fullImps caseretty_in (TType fc)
+                                         fullImps caseretty_in (TType fc u)
          let casefnty
                = abstractFullEnvType fc (allow splitOn (explicitPi env))
                             (maybe (Bind fc scrn (Pi fc caseRig Explicit scrty)
@@ -388,8 +390,9 @@ checkCase rig elabinfo nest env fc scr scrty_in alts exp
         do scrty_exp <- case scrty_in of
                              Implicit _ _ => guessScrType alts
                              _ => pure scrty_in
+           u <- uniVar fc
            (scrtyv, scrtyt) <- check erased elabinfo nest env scrty_exp
-                                     (Just (gType fc))
+                                     (Just (gType fc u))
            logTerm "elab.case" 10 "Expected scrutinee type" scrtyv
            -- Try checking at the given multiplicity; if that doesn't work,
            -- try checking at Rig1 (meaning that we're using a linear variable

--- a/src/TTImp/Elab/Check.idr
+++ b/src/TTImp/Elab/Check.idr
@@ -315,7 +315,7 @@ concrete defs env (NBind fc _ (Pi _ _ _ _) sc)
 concrete defs env (NDCon _ _ _ _ _) = pure True
 concrete defs env (NTCon _ _ _ _ _) = pure True
 concrete defs env (NPrimVal _ _) = pure True
-concrete defs env (NType _) = pure True
+concrete defs env (NType _ _) = pure True
 concrete defs env _ = pure False
 
 export
@@ -410,6 +410,15 @@ argVar : {vars : _} ->
          Env Term vars -> Name -> Term vars -> Core (Int, Term vars)
 argVar fc rig env n ty
     = newMetaLets fc rig env n ty (Hole (length env) (holeInit False)) False True
+
+export
+uniVar : {auto c : Ref Ctxt Defs} ->
+         {auto u : Ref UST UState} ->
+         FC -> Core Name
+uniVar fc
+    = do n <- genName "u"
+         idx <- addDef n (newDef fc n erased [] (Erased fc False) Public None)
+         pure (Resolved idx)
 
 export
 searchVar : {vars : _} ->

--- a/src/TTImp/Elab/Delayed.idr
+++ b/src/TTImp/Elab/Delayed.idr
@@ -105,7 +105,8 @@ delayOnFailure fc rig env exp pred pri elab
     mkExpected (Just ty) = pure ty
     mkExpected Nothing
         = do nm <- genName "delayTy"
-             ty <- metaVar fc erased env nm (TType fc)
+             u <- uniVar fc
+             ty <- metaVar fc erased env nm (TType fc u)
              pure (gnf env ty)
 
 export
@@ -146,7 +147,8 @@ delayElab {vars} fc rig env exp pri elab
     mkExpected (Just ty) = pure ty
     mkExpected Nothing
         = do nm <- genName "delayTy"
-             ty <- metaVar fc erased env nm (TType fc)
+             u <- uniVar fc
+             ty <- metaVar fc erased env nm (TType fc u)
              pure (gnf env ty)
 
 export

--- a/src/TTImp/Elab/Hole.idr
+++ b/src/TTImp/Elab/Hole.idr
@@ -60,7 +60,8 @@ checkHole rig elabinfo nest env fc n_in (Just gexpty)
 checkHole rig elabinfo nest env fc n_in exp
     = do nmty <- genName ("type_of_" ++ show n_in)
          let env' = letToLam env
-         ty <- metaVar fc erased env' nmty (TType fc)
+         u <- uniVar fc
+         ty <- metaVar fc erased env' nmty (TType fc u)
          nm <- inCurrentNS (UN n_in)
          defs <- get Ctxt
          mkPrecise !(nf defs env' ty)

--- a/src/TTImp/Elab/Lazy.idr
+++ b/src/TTImp/Elab/Lazy.idr
@@ -29,7 +29,8 @@ checkDelayed : {vars : _} ->
                FC -> LazyReason -> RawImp -> Maybe (Glued vars) ->
                Core (Term vars, Glued vars)
 checkDelayed rig elabinfo nest env fc r tm exp
-    = do (tm', gty) <- check rig elabinfo nest env tm (Just (gType fc))
+    = do u <- uniVar fc
+         (tm', gty) <- check rig elabinfo nest env tm (Just (gType fc u))
          pure (TDelayed fc r tm', gty)
 
 export
@@ -45,7 +46,8 @@ checkDelay : {vars : _} ->
              Core (Term vars, Glued vars)
 checkDelay rig elabinfo nest env fc tm mexpected
     = do expected <- maybe (do nm <- genName "delayTy"
-                               ty <- metaVar fc erased env nm (TType fc)
+                               u <- uniVar fc
+                               ty <- metaVar fc erased env nm (TType fc u)
                                pure (gnf env ty))
                            pure mexpected
          let solvemode = case elabMode elabinfo of

--- a/src/TTImp/Elab/Prim.idr
+++ b/src/TTImp/Elab/Prim.idr
@@ -4,6 +4,9 @@ import Core.TT
 
 %default covering
 
+ttype : FC -> Term vars
+ttype fc = TType fc (MN "top" 0)
+
 export
 checkPrim : FC -> Constant -> (Term vars, Term vars)
 checkPrim fc (I i) = (PrimVal fc (I i), PrimVal fc IntType)
@@ -21,17 +24,17 @@ checkPrim fc (Ch c) = (PrimVal fc (Ch c), PrimVal fc CharType)
 checkPrim fc (Db d) = (PrimVal fc (Db d), PrimVal fc DoubleType)
 checkPrim fc WorldVal = (PrimVal fc WorldVal, PrimVal fc WorldType)
 
-checkPrim fc IntType = (PrimVal fc IntType, TType fc)
-checkPrim fc Int8Type = (PrimVal fc Int8Type, TType fc)
-checkPrim fc Int16Type = (PrimVal fc Int16Type, TType fc)
-checkPrim fc Int32Type = (PrimVal fc Int32Type, TType fc)
-checkPrim fc Int64Type = (PrimVal fc Int64Type, TType fc)
-checkPrim fc IntegerType = (PrimVal fc IntegerType, TType fc)
-checkPrim fc Bits8Type = (PrimVal fc Bits8Type, TType fc)
-checkPrim fc Bits16Type = (PrimVal fc Bits16Type, TType fc)
-checkPrim fc Bits32Type = (PrimVal fc Bits32Type, TType fc)
-checkPrim fc Bits64Type = (PrimVal fc Bits64Type, TType fc)
-checkPrim fc StringType = (PrimVal fc StringType, TType fc)
-checkPrim fc CharType = (PrimVal fc CharType, TType fc)
-checkPrim fc DoubleType = (PrimVal fc DoubleType, TType fc)
-checkPrim fc WorldType = (PrimVal fc WorldType, TType fc)
+checkPrim fc IntType = (PrimVal fc IntType, ttype fc)
+checkPrim fc Int8Type = (PrimVal fc Int8Type, ttype fc)
+checkPrim fc Int16Type = (PrimVal fc Int16Type, ttype fc)
+checkPrim fc Int32Type = (PrimVal fc Int32Type, ttype fc)
+checkPrim fc Int64Type = (PrimVal fc Int64Type, ttype fc)
+checkPrim fc IntegerType = (PrimVal fc IntegerType, ttype fc)
+checkPrim fc Bits8Type = (PrimVal fc Bits8Type, ttype fc)
+checkPrim fc Bits16Type = (PrimVal fc Bits16Type, ttype fc)
+checkPrim fc Bits32Type = (PrimVal fc Bits32Type, ttype fc)
+checkPrim fc Bits64Type = (PrimVal fc Bits64Type, ttype fc)
+checkPrim fc StringType = (PrimVal fc StringType, ttype fc)
+checkPrim fc CharType = (PrimVal fc CharType, ttype fc)
+checkPrim fc DoubleType = (PrimVal fc DoubleType, ttype fc)
+checkPrim fc WorldType = (PrimVal fc WorldType, ttype fc)

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -223,4 +223,5 @@ checkRunElab rig elabinfo nest env fc script exp
     mkExpected (Just ty) = pure !(getTerm ty)
     mkExpected Nothing
         = do nm <- genName "scriptTy"
-             metaVar fc erased env nm (TType fc)
+             u <- uniVar fc
+             metaVar fc erased env nm (TType fc u)

--- a/src/TTImp/Elab/Term.idr
+++ b/src/TTImp/Elab/Term.idr
@@ -172,7 +172,8 @@ checkTerm rig elabinfo nest env (ISearch fc depth) (Just gexpty)
 checkTerm rig elabinfo nest env (ISearch fc depth) Nothing
     = do est <- get EST
          nmty <- genName "searchTy"
-         ty <- metaVar fc erased env nmty (TType fc)
+         u <- uniVar fc
+         ty <- metaVar fc erased env nmty (TType fc u)
          nm <- genName "search"
          sval <- searchVar fc rig depth (Resolved (defining est)) env nest nm ty
          pure (sval, gnf env ty)
@@ -210,8 +211,8 @@ checkTerm {vars} rig elabinfo nest env (IPrimVal fc c) exp
     = do let (cval, cty) = checkPrim {vars} fc c
          checkExp rig elabinfo env fc cval (gnf env cty) exp
 checkTerm rig elabinfo nest env (IType fc) exp
-    = checkExp rig elabinfo env fc (TType fc) (gType fc) exp
-
+    = do u <- uniVar fc
+         checkExp rig elabinfo env fc (TType fc u) (gType fc u) exp
 checkTerm rig elabinfo nest env (IHole fc str) exp
     = checkHole rig elabinfo nest env fc (Basic str) exp
 checkTerm rig elabinfo nest env (IUnifyLog fc lvl tm) exp
@@ -230,7 +231,8 @@ checkTerm rig elabinfo nest env (Implicit fc b) (Just gexpty)
          pure (metaval, gexpty)
 checkTerm rig elabinfo nest env (Implicit fc b) Nothing
     = do nmty <- genName "implicit_type"
-         ty <- metaVar fc erased env nmty (TType fc)
+         u <- uniVar fc
+         ty <- metaVar fc erased env nmty (TType fc u)
          nm <- genName "_"
          metaval <- metaVar fc rig env nm ty
          -- Add to 'bindIfUnsolved' if 'b' set

--- a/src/TTImp/Impossible.idr
+++ b/src/TTImp/Impossible.idr
@@ -36,7 +36,7 @@ match nty (n, i, rty)
     sameRet (NErased _ _) _ = pure True
     sameRet (NTCon _ n _ _ _) (NTCon _ n' _ _ _) = pure (n == n')
     sameRet (NPrimVal _ c) (NPrimVal _ c') = pure (c == c')
-    sameRet (NType _) (NType _) = pure True
+    sameRet (NType _ _) (NType _ _) = pure True
     sameRet nf (NBind fc _ (Pi _ _ _ _) sc)
         = do defs <- get Ctxt
              sc' <- sc defs (toClosure defaultOpts [] (Erased fc False))

--- a/src/TTImp/Interactive/ExprSearch.idr
+++ b/src/TTImp/Interactive/ExprSearch.idr
@@ -436,7 +436,7 @@ tryRecursive fc rig opts hints env ty topty rdata
       argDiff (PrimVal _ c) (PrimVal _ c') = c /= c'
       argDiff (Erased _ _) _ = False
       argDiff _ (Erased _ _) = False
-      argDiff (TType _) (TType _) = False
+      argDiff (TType _ _) (TType _ _) = False
       argDiff (As _ _ _ x) y = argDiff x y
       argDiff x (As _ _ _ y) = argDiff x y
       argDiff _ _ = True
@@ -664,7 +664,8 @@ tryIntermediateWith fc rig opts hints env ((p, pty) :: rest) ty topty
                                                 (Erased fc False)))
                  | False => noResult
              intnty <- genVarName "cty"
-             letty <- metaVar fc' erased env intnty (TType fc)
+             u <- uniVar fc
+             letty <- metaVar fc' erased env intnty (TType fc u)
              let opts' = record { inUnwrap = True } opts
              locsearch <- searchLocalWith fc True rig opts' hints env [(p, pty)]
                                           letty topty
@@ -705,7 +706,8 @@ tryIntermediateRec fc rig opts hints env ty topty (Just rd)
          True <- isSingleCon defs !(nf defs [] rty)
               | _ => noResult
          intnty <- genVarName "cty"
-         letty <- metaVar fc erased env intnty (TType fc)
+         u <- uniVar fc
+         letty <- metaVar fc erased env intnty (TType fc u)
          let opts' = record { inUnwrap = True,
                               recData = Nothing } opts
          logTerm "interaction.search" 10 "Trying recursive search for" ty

--- a/src/TTImp/PartialEval.idr
+++ b/src/TTImp/PartialEval.idr
@@ -635,7 +635,7 @@ mutual
                         pure $ applyWithFC (TForce fc r arg') args'
   quoteGenNF q defs bound env (NPrimVal fc c) = pure $ PrimVal fc c
   quoteGenNF q defs bound env (NErased fc i) = pure $ Erased fc i
-  quoteGenNF q defs bound env (NType fc) = pure $ TType fc
+  quoteGenNF q defs bound env (NType fc u) = pure $ TType fc u
 
 evalRHS : {vars : _} ->
           {auto c : Ref Ctxt Defs} ->

--- a/src/TTImp/ProcessBuiltin.idr
+++ b/src/TTImp/ProcessBuiltin.idr
@@ -33,6 +33,7 @@ showDefType (Hole {}) = "hole"
 showDefType (BySearch {}) = "search"
 showDefType (Guess {}) = "guess"
 showDefType ImpBind = "bound name"
+showDefType (UniverseLevel {}) = "universe level"
 showDefType Delayed = "delayed"
 
 ||| Get the return type.
@@ -121,7 +122,7 @@ termConMatch (TForce _ _ tm0) tm1 = termConMatch tm0 tm1
 termConMatch tm0 (TForce _ _ tm1) = termConMatch tm0 tm1
 termConMatch (PrimVal _ _) (PrimVal _ _) = True -- no constructor to check.
 termConMatch (Erased _ _) (Erased _ _) = True -- return type can't erased?
-termConMatch (TType _) (TType _) = True
+termConMatch (TType _ _) (TType _ _) = True
 termConMatch _ _ = False
 
 ||| Check a type is strict.
@@ -137,7 +138,7 @@ isStrict (TDelay _ _ f x) = isStrict f && isStrict x
 isStrict (TForce _ _ tm) = isStrict tm
 isStrict (PrimVal _ _) = True
 isStrict (Erased _ _) = True
-isStrict (TType _) = True
+isStrict (TType _ _) = True
 
 ||| Get the name and definition of a list of names.
 getConsGDef :

--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -70,18 +70,18 @@ mutual
   mismatchNF defs (NBind _ _ _ _) (NPrimVal _ _) = pure True
   mismatchNF defs (NPrimVal _ _) (NTCon _ _ _ _ _) = pure True
   mismatchNF defs (NTCon _ _ _ _ _) (NPrimVal _ _) = pure True
-  mismatchNF defs (NPrimVal _ _) (NType _) = pure True
-  mismatchNF defs (NType _) (NPrimVal _ _) = pure True
+  mismatchNF defs (NPrimVal _ _) (NType _ _) = pure True
+  mismatchNF defs (NType _ _) (NPrimVal _ _) = pure True
 
 -- NTCon is apart from NBind, and NType
   mismatchNF defs (NTCon _ _ _ _ _) (NBind _ _ _ _) = pure True
   mismatchNF defs (NBind _ _ _ _) (NTCon _ _ _ _ _) = pure True
-  mismatchNF defs (NTCon _ _ _ _ _) (NType _) = pure True
-  mismatchNF defs (NType _) (NTCon _ _ _ _ _) = pure True
+  mismatchNF defs (NTCon _ _ _ _ _) (NType _ _) = pure True
+  mismatchNF defs (NType _ _) (NTCon _ _ _ _ _) = pure True
 
 -- NBind is apart from NType
-  mismatchNF defs (NBind _ _ _ _) (NType _) = pure True
-  mismatchNF defs (NType _) (NBind _ _ _ _) = pure True
+  mismatchNF defs (NBind _ _ _ _) (NType _ _) = pure True
+  mismatchNF defs (NType _ _) (NBind _ _ _ _) = pure True
 
   mismatchNF _ _ _ = pure False
 
@@ -116,18 +116,18 @@ impossibleOK defs (NPrimVal _ _) (NBind _ _ _ _) = pure True
 impossibleOK defs (NBind _ _ _ _) (NPrimVal _ _) = pure True
 impossibleOK defs (NPrimVal _ _) (NTCon _ _ _ _ _) = pure True
 impossibleOK defs (NTCon _ _ _ _ _) (NPrimVal _ _) = pure True
-impossibleOK defs (NPrimVal _ _) (NType _) = pure True
-impossibleOK defs (NType _) (NPrimVal _ _) = pure True
+impossibleOK defs (NPrimVal _ _) (NType _ _) = pure True
+impossibleOK defs (NType _ _) (NPrimVal _ _) = pure True
 
 -- NTCon is apart from NBind, and NType
 impossibleOK defs (NTCon _ _ _ _ _) (NBind _ _ _ _) = pure True
 impossibleOK defs (NBind _ _ _ _) (NTCon _ _ _ _ _) = pure True
-impossibleOK defs (NTCon _ _ _ _ _) (NType _) = pure True
-impossibleOK defs (NType _) (NTCon _ _ _ _ _) = pure True
+impossibleOK defs (NTCon _ _ _ _ _) (NType _ _) = pure True
+impossibleOK defs (NType _ _) (NTCon _ _ _ _ _) = pure True
 
 -- NBind is apart from NType
-impossibleOK defs (NBind _ _ _ _) (NType _) = pure True
-impossibleOK defs (NType _) (NBind _ _ _ _) = pure True
+impossibleOK defs (NBind _ _ _ _) (NType _ _) = pure True
+impossibleOK defs (NType _ _) (NBind _ _ _ _) = pure True
 
 impossibleOK defs x y = pure False
 
@@ -168,8 +168,8 @@ recoverable defs (NTCon _ xn xt xa xargs) (NTCon _ yn yt ya yargs)
 recoverable defs (NTCon _ _ _ _ _) (NPrimVal _ _) = pure False
 recoverable defs (NPrimVal _ _) (NTCon _ _ _ _ _) = pure False
 -- Type constructor vs. type
-recoverable defs (NTCon _ _ _ _ _) (NType _) = pure False
-recoverable defs (NType _) (NTCon _ _ _ _ _) = pure False
+recoverable defs (NTCon _ _ _ _ _) (NType _ _) = pure False
+recoverable defs (NType _ _) (NTCon _ _ _ _ _) = pure False
 -- Type constructor vs. binder
 recoverable defs (NTCon _ _ _ _ _) (NBind _ _ _ _) = pure False
 recoverable defs (NBind _ _ _ _) (NTCon _ _ _ _ _) = pure False

--- a/src/TTImp/ProcessParams.idr
+++ b/src/TTImp/ProcessParams.idr
@@ -45,8 +45,9 @@ processParams {vars} {c} {m} {u} nest env fc ps ds
          let pty_raw = mkParamTy ps
          pty_imp <- bindTypeNames fc [] vars (IBindHere fc (PI erased) pty_raw)
          log "declare.param" 10 $ "Checking " ++ show pty_imp
+         u <- uniVar fc
          pty <- checkTerm (-1) InType []
-                          nest env pty_imp (gType fc)
+                          nest env pty_imp (gType fc u)
          let (vs ** (prf, env', nest')) = extend env SubRefl nest pty
          logEnv "declare.param" 5 "Param env" env'
 

--- a/src/TTImp/ProcessType.idr
+++ b/src/TTImp/ProcessType.idr
@@ -289,11 +289,12 @@ processType {vars} eopts nest env fc rig vis opts (MkImpTy tfc nameFC n_in ty_ra
          Nothing <- lookupCtxtExact (Resolved idx) (gamma defs)
               | Just gdef => throw (AlreadyDefined fc n)
 
+         u <- uniVar fc
          ty <-
              wrapErrorC eopts (InType fc n) $
                    checkTerm idx InType (HolesOkay :: eopts) nest env
                              (IBindHere fc (PI erased) ty_raw)
-                             (gType fc)
+                             (gType fc u)
          logTermNF "declare.type" 3 ("Type of " ++ show n) [] (abstractFullEnvType tfc env ty)
 
          def <- initDef n env ty opts

--- a/src/TTImp/Unelab.idr
+++ b/src/TTImp/Unelab.idr
@@ -246,7 +246,7 @@ mutual
            pure (IForce fc tm', gErased fc)
   unelabTy' umode nest env (PrimVal fc c) = pure (IPrimVal fc c, gErased fc)
   unelabTy' umode nest env (Erased fc _) = pure (Implicit fc True, gErased fc)
-  unelabTy' umode nest env (TType fc) = pure (IType fc, gType fc)
+  unelabTy' umode nest env (TType fc _) = pure (IType fc, gType fc (MN "top" 0))
 
   unelabPi : {vars : _} ->
              {auto c : Ref Ctxt Defs} ->
@@ -287,7 +287,7 @@ mutual
                        else if rig /= top || isDefImp p
                                then Just (UN Underscore)
                                else Nothing
-           pure (IPi fc rig p' nm ty' sc, gType fc)
+           pure (IPi fc rig p' nm ty' sc, gType fc (MN "top" 0))
     where
       isNoSugar : UnelabMode -> Bool
       isNoSugar (NoSugar _) = True
@@ -305,7 +305,7 @@ mutual
                     gnf env (Bind fc x (PLet fc' rig val ty) scty))
   unelabBinder umode nest fc env x (PVTy _ rig ty) sctm sc scty
       = do (ty', _) <- unelabTy umode nest env ty
-           pure (sc, gType fc)
+           pure (sc, gType fc (MN "top" 0))
 
 export
 unelabNoSugar : {vars : _} ->

--- a/tests/idris2/basic005/expected
+++ b/tests/idris2/basic005/expected
@@ -1,6 +1,6 @@
 1/1: Building NoInfer (NoInfer.idr)
 Error: Unsolved holes:
-Main.{_:1} introduced at: 
+Main.{_:3} introduced at: 
 NoInfer:1:7--1:8
  1 | foo : ? -> Int
            ^

--- a/tests/idris2/basic049/expected
+++ b/tests/idris2/basic049/expected
@@ -151,7 +151,7 @@ Fld:226:1--226:10
 
 Error: While processing right hand side of r2_shouldNotTypecheck1. Ambiguous elaboration. Possible results:
     Main.R2.MkR
-    Main.R1.MkR Type
+    Main.R1.MkR ?field
 
 Fld:72:26--72:29
  68 | r1 : R1 -- explicit fields access

--- a/tests/idris2/error018/expected
+++ b/tests/idris2/error018/expected
@@ -30,7 +30,7 @@ Issue1031-3:4:6--4:7
 
 1/1: Building Issue1031-4 (Issue1031-4.idr)
 Error: While processing left hand side of nice. Unsolved holes:
-Main.{dotTm:373} introduced at: 
+Main.{dotTm:799} introduced at: 
 Issue1031-4:4:6--4:10
  1 | %default total
  2 | 

--- a/tests/idris2/interpreter008/expected
+++ b/tests/idris2/interpreter008/expected
@@ -1,6 +1,6 @@
 1/1: Building Issue2041 (Issue2041.idr)
 Error: Unsolved holes:
-Main.{n:377} introduced at: 
+Main.{n:804} introduced at: 
 Issue2041:5:17--5:19
  1 | ex : {n : Nat} -> String
  2 | ex {n} = "hello" ++ show n
@@ -9,8 +9,8 @@ Issue2041:5:17--5:19
  5 | main = putStrLn ex
                      ^^
 
-Main> Encountered unimplemented hole Main.{n:377}
-Warning: compiling hole Main.{n:377}
+Main> Encountered unimplemented hole Main.{n:804}
+Warning: compiling hole Main.{n:804}
 Main> Encountered unimplemented hole Main.{n:4}
 Warning: compiling hole Main.{n:4}
 Main> 

--- a/tests/ttimp/basic003/expected
+++ b/tests/ttimp/basic003/expected
@@ -1,8 +1,8 @@
 Processing as TTImp
 Written TTC
-Yaffle> Main.foo : (%pi Rig0 Explicit (Just m) Main.Nat (%pi Rig0 Explicit (Just a) %type (%pi Rig0 Explicit (Just {k:25}) Main.Nat (%pi RigW Explicit Nothing a (%pi RigW Explicit Nothing ((Main.Vect {k:25}) a) (%pi RigW Explicit Nothing ((Main.Vect m) a) (%pi Rig0 Explicit (Just _) Main.Nat ((Main.Vect ((Main.plus {k:25}) m)) a))))))))
+Yaffle> Main.foo : (%pi Rig0 Explicit (Just m) Main.Nat (%pi Rig0 Explicit (Just a) %type (%pi Rig0 Explicit (Just {k:63}) Main.Nat (%pi RigW Explicit Nothing a (%pi RigW Explicit Nothing ((Main.Vect {k:63}) a) (%pi RigW Explicit Nothing ((Main.Vect m) a) (%pi Rig0 Explicit (Just _) Main.Nat ((Main.Vect ((Main.plus {k:63}) m)) a))))))))
 Yaffle> Bye for now!
 Processing as TTC
 Read TTC
-Yaffle> Main.foo : (%pi Rig0 Explicit (Just m) Main.Nat (%pi Rig0 Explicit (Just a) %type (%pi Rig0 Explicit (Just {k:25}) Main.Nat (%pi RigW Explicit Nothing a (%pi RigW Explicit Nothing ((Main.Vect {k:25}) a) (%pi RigW Explicit Nothing ((Main.Vect m) a) (%pi Rig0 Explicit (Just _) Main.Nat ((Main.Vect ((Main.plus {k:25}) m)) a))))))))
+Yaffle> Main.foo : (%pi Rig0 Explicit (Just m) Main.Nat (%pi Rig0 Explicit (Just a) %type (%pi Rig0 Explicit (Just {k:63}) Main.Nat (%pi RigW Explicit Nothing a (%pi RigW Explicit Nothing ((Main.Vect {k:63}) a) (%pi RigW Explicit Nothing ((Main.Vect m) a) (%pi Rig0 Explicit (Just _) Main.Nat ((Main.Vect ((Main.plus {k:63}) m)) a))))))))
 Yaffle> Bye for now!

--- a/tests/ttimp/basic006/expected
+++ b/tests/ttimp/basic006/expected
@@ -2,5 +2,5 @@ Processing as TTImp
 Written TTC
 Yaffle> ((Main.Just [a = ((Main.Vect.Vect (Main.S Main.Z)) Integer)]) ((((Main.Vect.Cons [k = Main.Z]) [a = Integer]) 1) (Main.Vect.Nil [a = Integer])))
 Yaffle> ((Main.MkInfer [a = (Main.List.List Integer)]) (((Main.List.Cons [a = Integer]) 1) (Main.List.Nil [a = Integer])))
-Yaffle> (Interactive):1:9--1:12:Ambiguous elaboration [($resolved382 ?Main.{a:59}_[]), ($resolved363 ?Main.{a:59}_[])]
+Yaffle> (Interactive):1:9--1:12:Ambiguous elaboration [($resolved425 ?Main.{a:131}_[]), ($resolved385 ?Main.{a:131}_[])]
 Yaffle> Bye for now!

--- a/tests/ttimp/coverage002/expected
+++ b/tests/ttimp/coverage002/expected
@@ -2,6 +2,6 @@ Processing as TTImp
 Written TTC
 Yaffle> Main.lookup: All cases covered
 Yaffle> Main.lookup':
-($resolved410 [__] [__] ($resolved378 [__]) {_:60})
+($resolved466 [__] [__] ($resolved423 [__]) {_:123})
 Yaffle> Main.lookup'': Calls non covering function Main.lookup'
 Yaffle> Bye for now!

--- a/tests/ttimp/dot001/expected
+++ b/tests/ttimp/dot001/expected
@@ -3,13 +3,13 @@ Written TTC
 Yaffle> Bye for now!
 Processing as TTImp
 Dot2:15:1--16:1:When elaborating left hand side of Main.half:
-Dot2:15:28--15:30:Pattern variable {P:n:366} unifies with ?{P:m:366}_[]
+Dot2:15:28--15:30:Pattern variable {P:n:393} unifies with ?{P:m:393}_[]
 Yaffle> Bye for now!
 Processing as TTImp
 Dot3:18:1--19:1:When elaborating left hand side of Main.addBaz3:
-Dot3:18:10--18:15:Can't match on ($resolved358 ?{P:x:371}_[] ?{P:x:371}_[]) (Not a constructor application or primitive) - it elaborates to ($resolved358 ?Main.{_:13}_[] ?Main.{_:14}_[])
+Dot3:18:10--18:15:Can't match on ($resolved365 ?{P:x:404}_[] ?{P:x:404}_[]) (Not a constructor application or primitive) - it elaborates to ($resolved365 ?Main.{_:53}_[] ?Main.{_:54}_[])
 Yaffle> Bye for now!
 Processing as TTImp
 Dot4:17:1--18:1:When elaborating left hand side of Main.addBaz4:
-Dot4:17:33--17:34:Can't match on ?{P:x:373}_[] (Non linear pattern variable) - it elaborates to ?Main.{dotTm:15}_[]
+Dot4:17:33--17:34:Can't match on ?{P:x:406}_[] (Non linear pattern variable) - it elaborates to ?Main.{dotTm:55}_[]
 Yaffle> Bye for now!

--- a/tests/ttimp/eta001/expected
+++ b/tests/ttimp/eta001/expected
@@ -1,5 +1,5 @@
 Processing as TTImp
 Written TTC
-Yaffle> ((Main.Refl [{a:11} = Main.Nat]) [x = (Main.S (Main.S (Main.S (Main.S Main.Z))))])
+Yaffle> ((Main.Refl [{a:34} = Main.Nat]) [x = (Main.S (Main.S (Main.S (Main.S Main.Z))))])
 Yaffle> Main.etaGood1 : ((((Main.Eq [b = (%pi RigW Explicit Nothing Integer (%pi RigW Explicit Nothing Integer Main.Test))]) [a = (%pi RigW Explicit Nothing Integer (%pi RigW Explicit Nothing Integer Main.Test))]) Main.MkTest) (%lam RigW Explicit (Just x) Integer (%lam RigW Explicit (Just y) Integer ((Main.MkTest x) y))))
 Yaffle> Bye for now!


### PR DESCRIPTION
This doesn't do anything yet, other than introduce new universe variables whenever we introduce a new type, but it's the first step towards checking the universe hierarchy. Next step is to add constraints when checking pi, unifying/converting types, and when adding data constructors.

I'd like to at least merge this step now, without having completed the implementation, because it's a change to a core data type and I'm hoping it'll mean fewer merge conflicts later.