### PR TITLE
Fix display of ambiguity errors

### DIFF
--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -102,7 +102,7 @@ data Error : Type where
                          FC -> Env Term vars -> Term vars -> Error
      AmbiguousName : FC -> List Name -> Error
      AmbiguousElab : {vars : _} ->
-                     FC -> Env Term vars -> List (Term vars) -> Error
+                     FC -> Env Term vars -> List (Context, Term vars) -> Error
      AmbiguousSearch : {vars : _} ->
                        FC -> Env Term vars -> Term vars -> List (Term vars) -> Error
      AmbiguityTooDeep : FC -> Name -> List Name -> Error
@@ -259,7 +259,7 @@ Show Error where
       = show fc ++ ":" ++ show t ++ " borrows, so must return a concrete type"
 
   show (AmbiguousName fc ns) = show fc ++ ":Ambiguous name " ++ show ns
-  show (AmbiguousElab fc env ts) = show fc ++ ":Ambiguous elaboration " ++ show ts
+  show (AmbiguousElab fc env ts) = show fc ++ ":Ambiguous elaboration " ++ show (map snd ts)
   show (AmbiguousSearch fc env tgt ts) = show fc ++ ":Ambiguous search " ++ show ts
   show (AmbiguityTooDeep fc n ns)
       = show fc ++ ":Ambiguity too deep in " ++ show n ++ " " ++ show ns

--- a/src/TTImp/Elab/Ambiguity.idr
+++ b/src/TTImp/Elab/Ambiguity.idr
@@ -440,4 +440,5 @@ checkAlternative rig elabinfo nest env fc uniq alts mexpected
                                   solveConstraints solvemode Normal
                                   solveConstraints solvemode Normal
                                   log "elab.ambiguous" 10 $ show (getName t) ++ " success"
+                                  logTermNF "elab.ambiguous" 10 "Result" env (fst res)
                                   pure res)) alts')

--- a/src/TTImp/Elab/Check.idr
+++ b/src/TTImp/Elab/Check.idr
@@ -627,8 +627,8 @@ exactlyOne' {vars} allowCons fc env all
                           [(_, res)] => Right res
                           _ => Left (map snd rs)
 
-    getRes : ((Term vars, Glued vars), st) -> Term vars
-    getRes ((tm, _), thisst) = tm
+    getRes : ((Term vars, Glued vars), Defs, st) -> (Context, Term vars)
+    getRes ((tm, _), defs, thisst) = (gamma defs, tm)
 
     getDepthError : Error -> Maybe Error
     getDepthError e@(AmbiguityTooDeep _ _ _) = Just e
@@ -642,7 +642,7 @@ exactlyOne' {vars} allowCons fc env all
     -- If they've all failed, collect all the errors
     -- If more than one succeeded, report the ambiguity
     altError : List (Maybe Name, Error) ->
-               List ((Term vars, Glued vars), st) ->
+               List ((Term vars, Glued vars), Defs, st) ->
                Error
     altError ls []
         = case depthError ls of

--- a/tests/idris2/basic003/expected
+++ b/tests/idris2/basic003/expected
@@ -2,8 +2,8 @@
 Main> Bye for now!
 1/1: Building Ambig2 (Ambig2.idr)
 Error: While processing right hand side of keepUnique. Ambiguous elaboration. Possible results:
-    Main.Set.toList ?arg
-    Main.Vect.toList ?arg
+    Main.Set.toList (Main.Set.fromList xs)
+    Main.Vect.toList (Main.Vect.fromList xs)
 
 Ambig2:26:21--26:27
  22 |   export

--- a/tests/idris2/basic049/expected
+++ b/tests/idris2/basic049/expected
@@ -151,7 +151,7 @@ Fld:226:1--226:10
 
 Error: While processing right hand side of r2_shouldNotTypecheck1. Ambiguous elaboration. Possible results:
     Main.R2.MkR
-    Main.R1.MkR Type
+    Main.R1.MkR (Prelude.the Prelude.Nat 22)
 
 Fld:72:26--72:29
  68 | r1 : R1 -- explicit fields access

--- a/tests/idris2/reg048/expected
+++ b/tests/idris2/reg048/expected
@@ -1,7 +1,7 @@
 1/1: Building inferror (inferror.idr)
 Error: While processing right hand side of g. Ambiguous elaboration. Possible results:
     Data.SortedMap.toList m
-    Prelude.toList ?arg
+    Prelude.toList m
 
 inferror:9:17--9:23
  5 | f m = case sortBy (\(x, _), (y, _) => compare x y) (SortedMap.toList m) of

--- a/tests/idris2/with003/expected
+++ b/tests/idris2/with003/expected
@@ -1,7 +1,7 @@
 1/1: Building Main (Main.idr)
 Main> Error: Ambiguous elaboration. Possible results:
-    Main.myPrintLn "foo" Prelude.>> ?arg
-    Main.myPrintLn "foo" Main.Other.>> ?arg
+    Main.myPrintLn "foo" Prelude.>> Delay (Main.myPrintLn "boo" Main.Other.>> (Prelude.map (\{arg:0} => {arg:0} Prelude.+ ?delayed) (Main.myPrintLn "woo") Main.Other.>> (Main.myPrintLn "goo" Main.Other.>> Main.myPrintLn "foo")))
+    Main.myPrintLn "foo" Main.Other.>> (Main.myPrintLn "boo" Main.Other.>> (Prelude.map (\{arg:0} => {arg:0} Prelude.+ ?delayed) (Main.myPrintLn "woo") Main.Other.>> (Main.myPrintLn "goo" Main.Other.>> Main.myPrintLn "foo")))
 
 (Interactive):1:4--1:19
  1 | do myPrintLn "foo"; myPrintLn "boo"; map (+1) (myPrintLn "woo"); myPrintLn "goo"; myPrintLn "foo"


### PR DESCRIPTION
We need to store the Context in errors at the point where the error occurs (or make sure the term has holes normalised before throwing the error), or we might get some nonsense in the message. There's still a couple of places in Error where we don't do this right. This fixes one of them, and improves a few messages in the process.