### PR TITLE
[base] add IsRight and IsLeft proofs to Data.Either

### DIFF
--- a/libs/base/Data/Either.idr
+++ b/libs/base/Data/Either.idr
@@ -31,6 +31,24 @@ isRight : Either a b -> Bool
 isRight (Left _)  = False
 isRight (Right _) = True
 
+||| Proof that an `Either` is actually a Right value
+public export
+data IsRight : Either a b -> Type where
+  ItIsRight : IsRight (Right x)
+
+export
+Uninhabited (IsRight (Left x)) where
+  uninhabited ItIsRight impossible
+
+||| Proof that an `Either` is actually a Left value
+public export
+data IsLeft : Either a b -> Type where
+  ItIsLeft : IsLeft (Left x)
+
+export
+Uninhabited (IsLeft (Right x)) where
+  uninhabited ItIsLeft impossible
+
 --------------------------------------------------------------------------------
 -- Grouping values
 


### PR DESCRIPTION
IsRight and IsLeft types, like IsJust and IsYes.

I have used IsRight instead of IsJust to provide more meaningful error messages, when the value is a Left.

I have no particular use case for IsLeft, it is included for the sake of completeness.