### PR TITLE
Add takeUntil Data.String.Parser parser

### DIFF
--- a/tests/chez/chez027/StringParser.idr
+++ b/tests/chez/chez027/StringParser.idr
@@ -40,6 +40,13 @@ maybeParser = do res <- optional (string "abc")
                  ignore $ string "def"
                  pure $ isJust res
 
+-- test takeUntil
+takeUntilParser : Parser String
+takeUntilParser = do ignore $ string "<!--"
+                     res <- takeUntil "-->"
+                     eos -- To check that takeUntil consumes the stop string itself
+                     pure res
+
 main : IO ()
 main = do
     res <- parseT parseStuff "abcdef"
@@ -56,6 +63,9 @@ main = do
     showRes $ pureParsing "63553"
     s <- parseT (takeWhile isDigit) "887abc8993"
     showRes s
+    showRes $ parse takeUntilParser "<!--XML Comment-->"
+    showRes $ parse takeUntilParser "<!--<- Complicated -- XML -- Comment ->-->"
+    showRes $ parse takeUntilParser "<!--Unclosed XML Comment"
     res <- parseT optParser "123def"
     showRes res
     res <- parseT optParser "def"

--- a/tests/chez/chez027/expected
+++ b/tests/chez/chez027/expected
@@ -6,6 +6,9 @@ Parse failed at position 0: Not good
 ['7', '6', '6', '7', '7', '5']
 ['6', '3', '5', '5', '3']
 "887"
+"XML Comment"
+"<- Complicated -- XML -- Comment ->"
+Parse failed at position 24: end of string reached - "-->" not found
 "123"
 ""
 True


### PR DESCRIPTION
Adds the `takeUntil` parser, which takes from the input until the "stop" string is found; and tests.