### PR TITLE
[ re #2001 ] Make some prelude interfaces total

### DIFF
--- a/libs/contrib/Data/List/Alternating.idr
+++ b/libs/contrib/Data/List/Alternating.idr
@@ -6,6 +6,8 @@ import Data.List
 infixl 5 +>
 infixr 5 <+
 
+%default total
+
 mutual
     namespace Odd
         ||| Non-empty list, starting and ending with an a, where adjacent elements alternate
@@ -31,7 +33,7 @@ mutual
 mutual
     public export
     Eq a => Eq b => Eq (Odd a b) where
-        x :: xs == y :: ys = x == y && xs == ys
+        x :: xs == y :: ys = x == y && assert_total (xs == ys)
 
     public export
     Eq a => Eq b => Eq (Even a b) where
@@ -44,7 +46,7 @@ mutual
     Ord a => Ord b => Ord (Odd a b) where
         compare (x :: xs) (y ::ys)
            = case compare x y of
-                  EQ => compare xs ys
+                  EQ => assert_total (compare xs ys)
                   c => c
 
     public export
@@ -60,7 +62,7 @@ mutual
 mutual
     public export
     Bifunctor Odd where
-        bimap f g (x :: xs) = (f x) :: (bimap g f xs)
+        bimap f g (x :: xs) = (f x) :: assert_total (bimap g f xs)
 
     public export
     Bifunctor Even where
@@ -70,9 +72,9 @@ mutual
 mutual
     public export
     Bifoldable Odd where
-        bifoldr f g acc (x :: xs) = f x (bifoldr g f acc xs)
+        bifoldr f g acc (x :: xs) = f x (assert_total $ bifoldr g f acc xs)
 
-        bifoldl f g acc (x :: xs) = bifoldl g f (f acc x) xs
+        bifoldl f g acc (x :: xs) = assert_total $ bifoldl g f (f acc x) xs
 
     public export
     Bifoldable Even where
@@ -85,7 +87,7 @@ mutual
 mutual
     public export
     Bitraversable Odd where
-        bitraverse f g (x :: xs) = [| f x :: bitraverse g f xs |]
+        bitraverse f g (x :: xs) = [| f x :: assert_total (bitraverse g f xs) |]
 
     public export
     Bitraversable Even where
@@ -189,7 +191,7 @@ Monoid a => Alternative (Odd a) where
 namespace Snd
     public export
     [SndMonad] Monoid a => Monad (Odd a) where
-        x >>= f = biconcatMap singleton f x
+        x >>= f = assert_total $ biconcatMap singleton f x
 
     public export
     (>>=) : Monoid a => Odd a b -> (b -> Odd a c) -> Odd a c

--- a/libs/contrib/Data/SortedMap.idr
+++ b/libs/contrib/Data/SortedMap.idr
@@ -64,7 +64,7 @@ implementation Foldable (SortedMap k) where
   foldr f z = foldr f z . values
   foldl f z = foldl f z . values
 
-  null = delay . null . unM
+  null = null . unM
 
   foldMap f = foldMap f . values
 

--- a/libs/prelude/Prelude/EqOrd.idr
+++ b/libs/prelude/Prelude/EqOrd.idr
@@ -11,10 +11,13 @@ import Prelude.Ops
 ------------------------
 
 ||| The Eq interface defines inequality and equality.
+||| A minimal definition includes either `(==)` or `(/=)`.
 public export
 interface Eq ty where
   constructor MkEq
+  total
   (==) : ty -> ty -> Bool
+  total
   (/=) : ty -> ty -> Bool
 
   x == y = not (x /= y)
@@ -101,27 +104,35 @@ Eq Ordering where
   _  == _  = False
 
 ||| The Ord interface defines comparison operations on ordered data types.
+||| A minimal definition includes either `compare` or `(<)`.
 public export
 interface Eq ty => Ord ty where
   constructor MkOrd
+  total
   compare : ty -> ty -> Ordering
   compare x y = if x < y then LT else if x == y then EQ else GT
 
+  total
   (<) : ty -> ty -> Bool
   (<) x y = compare x y == LT
 
+  total
   (>) : ty -> ty -> Bool
   (>) x y = compare x y == GT
 
+  total
   (<=) : ty -> ty -> Bool
   (<=) x y = compare x y /= GT
 
+  total
   (>=) : ty -> ty -> Bool
   (>=) x y = compare x y /= LT
 
+  total
   max : ty -> ty -> ty
   max x y = if x > y then x else y
 
+  total
   min : ty -> ty -> ty
   min x y = if (x < y) then x else y
 

--- a/libs/prelude/Prelude/Show.idr
+++ b/libs/prelude/Prelude/Show.idr
@@ -40,11 +40,13 @@ Ord Prec where
   compare x        y        = compare (precCon x) (precCon y)
 
 ||| Things that have a canonical `String` representation.
+||| A minimal implementation includes either `show` or `showPrec`.
 public export
 interface Show ty where
   constructor MkShow
   ||| Convert a value to its `String` representation.
   ||| @ x the value to convert
+  total
   show : (x : ty) -> String
   show x = showPrec Open x
 
@@ -60,6 +62,7 @@ interface Show ty where
   ||| their own bracketing, like `Pair` and `List`.
   ||| @ d the precedence context.
   ||| @ x the value to convert
+  total
   showPrec : (d : Prec) -> (x : ty) -> String
   showPrec _ x = show x
 

--- a/src/Compiler/ANF.idr
+++ b/src/Compiler/ANF.idr
@@ -67,6 +67,7 @@ mutual
     show ANull = "[__]"
 
   export
+  covering
   Show ANF where
     show (AV _ v) = show v
     show (AAppName fc lazy n args)
@@ -95,6 +96,7 @@ mutual
     show (ACrash _ x) = "%CRASH(" ++ show x ++ ")"
 
   export
+  covering
   Show AConAlt where
     show (MkAConAlt n _ t args sc)
         = "%conalt " ++ show n ++
@@ -104,11 +106,13 @@ mutual
         showArg i = "v" ++ show i
 
   export
+  covering
   Show AConstAlt where
     show (MkAConstAlt c sc)
         = "%constalt(" ++ show c ++ ") => " ++ show sc
 
 export
+covering
 Show ANFDef where
   show (MkAFun args exp) = show args ++ ": " ++ show exp
   show (MkACon tag arity nt)

--- a/src/Compiler/LambdaLift.idr
+++ b/src/Compiler/LambdaLift.idr
@@ -79,6 +79,7 @@ showLazy = maybe "" $ (" " ++) . show
 
 mutual
   export
+  covering
   {vs : _} -> Show (Lifted vs) where
     show (LLocal {idx} _ p) = "!" ++ show (nameAt p)
     show (LAppName fc lazy n args)
@@ -107,17 +108,20 @@ mutual
     show (LCrash _ x) = "%CRASH(" ++ show x ++ ")"
 
   export
+  covering
   {vs : _} -> Show (LiftedConAlt vs) where
     show (MkLConAlt n _ t args sc)
         = "%conalt " ++ show n ++
              "(" ++ showSep ", " (map show args) ++ ") => " ++ show sc
 
   export
+  covering
   {vs : _} -> Show (LiftedConstAlt vs) where
     show (MkLConstAlt c sc)
         = "%constalt(" ++ show c ++ ") => " ++ show sc
 
 export
+covering
 Show LiftedDef where
   show (MkLFun args scope exp)
       = show args ++ show (reverse scope) ++ ": " ++ show exp

--- a/src/Compiler/VMCode.idr
+++ b/src/Compiler/VMCode.idr
@@ -69,6 +69,7 @@ Show Reg where
   show Discard = "DISCARD"
 
 export
+covering
 Show VMInst where
   show (DECLARE r) = "DECLARE " ++ show r
   show START = "START"
@@ -102,6 +103,7 @@ Show VMInst where
   show (ERROR str) = "ERROR " ++ show str
 
 export
+covering
 Show VMDef where
   show (MkVMFun args body) = show args ++ ": " ++ show body
   show (MkVMForeign ccs args ret)

--- a/src/Core/Case/CaseBuilder.idr
+++ b/src/Core/Case/CaseBuilder.idr
@@ -48,6 +48,7 @@ HasNames (ArgType vars) where
   resolved gam (Stuck ty) = Stuck <$> resolved gam ty
   resolved gam Unknown = pure Unknown
 
+covering
 {ns : _} -> Show (ArgType ns) where
   show (Known c t) = "Known " ++ show c ++ " " ++ show t
   show (Stuck t) = "Stuck " ++ show t
@@ -62,6 +63,7 @@ record PatInfo (pvar : Name) (vars : List Name) where
   argType : ArgType vars -- Type of the argument being inspected (i.e.
                          -- *not* refined by this particular pattern)
 
+covering
 {vars : _} -> Show (PatInfo n vars) where
   show pi = show (pat pi) ++ " : " ++ show (argType pi)
 
@@ -180,6 +182,7 @@ HasNames (NamedPats vars todo) where
   resolved gam [] = pure []
   resolved gam (x::xs) = [| (::) (resolved gam x) (resolved gam xs) |]
 
+covering
 {vars : _} -> {todo : _} -> Show (NamedPats vars todo) where
   show xs = "[" ++ showAll xs ++ "]"
     where
@@ -244,6 +247,7 @@ data PatClause : (vars : List Name) -> (todo : List Name) -> Type where
 getNPs : PatClause vars todo -> NamedPats vars todo
 getNPs (MkPatClause _ lhs pid rhs) = lhs
 
+covering
 {vars : _} -> {todo : _} -> Show (PatClause vars todo) where
   show (MkPatClause _ ps pid rhs)
      = show ps ++ " => " ++ show rhs
@@ -277,6 +281,7 @@ data Partitions : List (PatClause vars todo) -> Type where
                   Partitions ps -> Partitions (vs ++ ps)
      NoClauses : Partitions []
 
+covering
 {ps : _} -> Show (Partitions ps) where
   show (ConClauses cs rest)
     = unlines ("CON" :: map (("  " ++) . show) cs)
@@ -388,6 +393,7 @@ data Group : List Name -> -- variables in scope
      ConstGroup : Constant -> List (PatClause vars todo) ->
                   Group vars todo
 
+covering
 {vars : _} -> {todo : _} -> Show (Group vars todo) where
   show (ConGroup c t cs) = "Con " ++ show c ++ ": " ++ show cs
   show (DelayGroup cs) = "Delay: " ++ show cs

--- a/src/Core/Case/CaseTree.idr
+++ b/src/Core/Case/CaseTree.idr
@@ -132,14 +132,14 @@ showCA indent (DefaultCase sc)
         = "_ => " ++ showCT indent sc
 
 export
+covering
 {vars : _} -> Show (CaseTree vars) where
   show = showCT ""
 
 export
+covering
 {vars : _} -> Show (CaseAlt vars) where
   show = showCA ""
-
-
 
 mutual
   export
@@ -191,6 +191,7 @@ mutual
   eqAlt _ _ = False
 
 export
+covering
 Show Pat where
   show (PAs _ n p) = show n ++ "@(" ++ show p ++ ")"
   show (PCon _ n i _ args) = show n ++ " " ++ show i ++ " " ++ assert_total (show args)

--- a/src/Core/CompileExpr.idr
+++ b/src/Core/CompileExpr.idr
@@ -354,10 +354,12 @@ forgetDef (MkForeign ccs fargs ty) = MkNmForeign ccs fargs ty
 forgetDef (MkError err) = MkNmError (forget err)
 
 export
+covering
 {vars : _} -> Show (CExp vars) where
   show exp = show (forget exp)
 
 export
+covering
 Show CFType where
   show CFUnit = "Unit"
   show CFInt = "Int"
@@ -384,6 +386,7 @@ Show CFType where
   show (CFUser n args) = show n ++ " " ++ showSep " " (map show args)
 
 export
+covering
 Show CDef where
   show (MkFun args exp) = show args ++ ": " ++ show exp
   show (MkCon tag arity pos)
@@ -395,6 +398,7 @@ Show CDef where
   show (MkError exp) = "Error: " ++ show exp
 
 export
+covering
 Show NamedDef where
   show (MkNmFun args exp) = show args ++ ": " ++ show exp
   show (MkNmCon tag arity pos)

--- a/src/Core/Context/Context.idr
+++ b/src/Core/Context/Context.idr
@@ -141,6 +141,7 @@ defNameType (UniverseLevel {}) = Nothing
 defNameType Delayed = Nothing
 
 export
+covering
 Show Def where
   show None = "undefined"
   show (PMDef _ args ct rt pats)
@@ -185,6 +186,7 @@ data Clause : Type where
                 (lhs : Term vars) -> (rhs : Term vars) -> Clause
 
 export
+covering
 Show Clause where
   show (MkClause {vars} env lhs rhs)
       = show vars ++ ": " ++ show lhs ++ " = " ++ show rhs

--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -194,6 +194,7 @@ Show Warning where
 
 
 export
+covering
 Show Error where
   show (Fatal err) = show err
   show (CantConvert fc _ env x y)

--- a/src/Core/Metadata.idr
+++ b/src/Core/Metadata.idr
@@ -138,6 +138,7 @@ record Metadata where
        semanticAliases : PosMap (NonEmptyFC, NonEmptyFC)
        semanticDefaults : PosMap ASemanticDecoration
 
+covering
 Show Metadata where
   show (MkMetadata apps names tydecls currentLHS holeLHS nameLocMap
                    fname semanticHighlighting semanticAliases semanticDefaults)

--- a/src/Core/Ord.idr
+++ b/src/Core/Ord.idr
@@ -184,6 +184,7 @@ Ord (Var vars) where
 
 mutual
     export
+    covering
     Eq (CExp vars) where
         CLocal {idx=x1} _ _ == CLocal {idx=x2} _ _ = x1 == x2
         CRef _ n1 == CRef _ n2 = n1 == n2
@@ -209,17 +210,20 @@ mutual
         _ == _ = False
 
     export
+    covering
     Eq (CConAlt vars) where
         MkConAlt n1 _ t1 a1 e1 == MkConAlt n2 _ t2 a2 e2 = t1 == t2 && n1 == n2 && case namesEq a1 a2 of
             Just Refl => e1 == e2
             Nothing => False
 
     export
+    covering
     Eq (CConstAlt vars) where
         MkConstAlt c1 e1 == MkConstAlt c2 e2 = c1 == c2 && e1 == e2
 
 mutual
     export
+    covering
     Ord (CExp vars) where
         CLocal {idx=x1} _ _ `compare` CLocal {idx=x2} _ _ = x1 `compare` x2
         CRef _ n1 `compare` CRef _ n2 = n1 `compare` n2
@@ -262,6 +266,7 @@ mutual
             tag (CCrash _ _) = 14
 
     export
+    covering
     Ord (CConAlt vars) where
         MkConAlt n1 _ t1 a1 e1 `compare` MkConAlt n2 _ t2 a2 e2 =
             compare t1 t2 `thenCmp` compare n1 n2 `thenCmp` case namesEq a1 a2 of
@@ -269,5 +274,6 @@ mutual
                 Nothing => compare a1 a2
 
     export
+    covering
     Ord (CConstAlt vars) where
         MkConstAlt c1 e1 `compare` MkConstAlt c2 e2 = compare c1 c2 `thenCmp` compare e1 e2

--- a/src/Core/TT.idr
+++ b/src/Core/TT.idr
@@ -1723,6 +1723,7 @@ withPiInfo (DefImplicit t) tm = "{default " ++ show t ++ " " ++ tm ++ "}"
 
 
 export
+covering
 {vars : _} -> Show (Term vars) where
   show tm = let (fn, args) = getFnArgs tm in showApp fn args
     where

--- a/src/Core/Value.idr
+++ b/src/Core/Value.idr
@@ -137,6 +137,7 @@ Show (Closure free) where
   show _ = "[closure]"
 
 export
+covering
 {free : _} -> Show (NF free) where
   show (NBind _ x (Lam _ c info ty) _)
     = "\\" ++ withPiInfo info (showCount c ++ show x ++ " : " ++ show ty) ++

--- a/src/Idris/ModTree.idr
+++ b/src/Idris/ModTree.idr
@@ -40,6 +40,7 @@ record ModTree where
   sourceFile : Maybe String
   deps : List ModTree
 
+covering
 Show ModTree where
   show t = show (sourceFile t) ++ " " ++ show (nspace t) ++ "<-" ++ show (deps t)
 

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1903,6 +1903,7 @@ data CmdArg : Type where
      Args : List CmdArg -> CmdArg
 
 export
+covering
 Show CmdArg where
   show NoArg = ""
   show NameArg = "<name>"

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -825,10 +825,12 @@ parameters {0 nm : Type} (toName : nm -> Name)
     else "`" ++ showPrec d op ++ "`"
 
 export
+covering
 Show PTerm where
   showPrec = showPTermPrec id
 
 export
+covering
 Show IPTerm where
   showPrec = showPTermPrec rawName
 
@@ -841,6 +843,7 @@ record Method where
   type     : RawImp
 
 export
+covering
 Show Method where
   show (MkMethod n c treq ty)
     = "[" ++ show treq ++ "] " ++ show c ++ " " ++ show n ++ " : " ++ show ty

--- a/src/TTImp/Elab/Check.idr
+++ b/src/TTImp/Elab/Check.idr
@@ -68,6 +68,7 @@ data ImplBinding : List Name -> Type where
                  ImplBinding vars
 
 export
+covering
 Show (ImplBinding vars) where
   show (NameBinding c p tm ty) = show (tm, ty)
   show (AsBinding c p tm ty pat) = show (tm, ty) ++ "@" ++ show tm

--- a/src/TTImp/Elab/Record.idr
+++ b/src/TTImp/Elab/Record.idr
@@ -31,6 +31,7 @@ data Rec : Type where
      Constr : Maybe Name -> -- implicit argument name, if any
               Name -> List (String, Rec) -> Rec
 
+covering
 Show Rec where
   show (Field mn n ty)
       = "Field " ++ show mn ++ "; " ++ show n ++ " : " ++ show ty

--- a/src/TTImp/Interactive/CaseSplit.idr
+++ b/src/TTImp/Interactive/CaseSplit.idr
@@ -38,6 +38,7 @@ data ClauseUpdate : Type where
      Invalid : ClauseUpdate
 
 export
+covering
 Show ClauseUpdate where
   show (Valid lhs updates) = "Valid: " ++ show lhs ++ "\n" ++ "Updates: " ++ show updates
   show (Impossible lhs) = "Impossible: " ++ show lhs

--- a/src/TTImp/PartialEval.idr
+++ b/src/TTImp/PartialEval.idr
@@ -27,6 +27,7 @@ import Libraries.Data.NameMap
 
 data ArgMode = Static ClosedTerm | Dynamic
 
+covering
 Show ArgMode where
   show (Static tm) = "Static " ++ show tm
   show Dynamic = "Dynamic"

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -144,7 +144,8 @@ mutual
        UniqueDefault : RawImp' nm -> AltType' nm
 
   export
-    Show nm => Show (RawImp' nm) where
+  covering
+  Show nm => Show (RawImp' nm) where
       show (IVar fc n) = show n
       show (IPi fc c p n arg ret)
          = "(%pi " ++ show c ++ " " ++ show p ++ " " ++
@@ -202,6 +203,7 @@ mutual
       show (IWithUnambigNames fc ns rhs) = "(%with " ++ show ns ++ " " ++ show rhs ++ ")"
 
   export
+  covering
   Show nm => Show (IFieldUpdate' nm) where
     show (ISetField p val) = showSep "->" p ++ " = " ++ show val
     show (ISetFieldApp p val) = showSep "->" p ++ " $= " ++ show val
@@ -235,6 +237,7 @@ mutual
   isTotalityReq _ = False
 
   export
+  covering
   Show nm => Show (FnOpt' nm) where
     show Inline = "%inline"
     show NoInline = "%noinline"
@@ -274,6 +277,7 @@ mutual
        MkImpTy : FC -> (nameFC : FC) -> (n : Name) -> (ty : RawImp' nm) -> ImpTy' nm
 
   export
+  covering
   Show nm => Show (ImpTy' nm) where
     show (MkImpTy fc _ n ty) = "(%claim " ++ show n ++ " " ++ show ty ++ ")"
 
@@ -306,6 +310,7 @@ mutual
        MkImpLater : FC -> (n : Name) -> (tycon : RawImp' nm) -> ImpData' nm
 
   export
+  covering
   Show nm => Show (ImpData' nm) where
     show (MkImpData fc n tycon _ cons)
         = "(%data " ++ show n ++ " " ++ show tycon ++ " " ++
@@ -340,11 +345,13 @@ mutual
                      ImpRecord' nm
 
   export
+  covering
   Show nm => Show (IField' nm) where
     show (MkIField _ c Explicit n ty) = show n ++ " : " ++ show ty
     show (MkIField _ c _ n ty) = "{" ++ show n ++ " : " ++ show ty ++ "}"
 
   export
+  covering
   Show nm => Show (ImpRecord' nm) where
     show (MkImpRecord _ n params con fields)
         = "record " ++ show n ++ " " ++ show params ++
@@ -377,6 +384,7 @@ mutual
        ImpossibleClause : FC -> (lhs : RawImp' nm) -> ImpClause' nm
 
   export
+  covering
   Show nm => Show (ImpClause' nm) where
     show (PatClause fc lhs rhs)
        = show lhs ++ " = " ++ show rhs
@@ -417,6 +425,7 @@ mutual
        IBuiltin : FC -> BuiltinType -> Name -> ImpDecl' nm
 
   export
+  covering
   Show nm => Show (ImpDecl' nm) where
     show (IClaim _ c _ opts ty) = show opts ++ " " ++ show c ++ " " ++ show ty
     show (IData _ _ d) = show d
@@ -848,6 +857,7 @@ unIArg (Auto _ t) = t
 unIArg (Named _ _ t) = t
 
 export
+covering
 Show nm => Show (Arg' nm) where
   show (Explicit fc t) = show t
   show (Auto fc t) = "@{" ++ show t ++ "}"

--- a/tests/idris2/docs001/expected
+++ b/tests/idris2/docs001/expected
@@ -65,6 +65,7 @@ Main> data Prelude.List : Type -> Type
     Traversable List
 Main> interface Prelude.Show : Type -> Type
   Things that have a canonical `String` representation.
+  A minimal implementation includes either `show` or `showPrec`.
   Parameters: ty
   Constructor: MkShow
   Methods:
@@ -112,6 +113,9 @@ Main> Prelude.show : Show ty => ty -> String
   @ x the value to convert
   Totality: total
 Main> interface Prelude.Monad : (Type -> Type) -> Type
+  Monad
+  @m The underlying functor
+  A minimal definition includes either `(>>=)` or `join`.
   Parameters: m
   Constraints: Applicative m
   Constructor: MkMonad

--- a/tests/idris2/interactive030/expected
+++ b/tests/idris2/interactive030/expected
@@ -18,6 +18,9 @@ Main> Prelude.<$> : Functor f => (a -> b) -> f a -> f b
   Totality: total
   Fixity Declaration: infixr operator, level 4
 Main> interface Prelude.Monad : (Type -> Type) -> Type
+  Monad
+  @m The underlying functor
+  A minimal definition includes either `(>>=)` or `join`.
   Parameters: m
   Constraints: Applicative m
   Constructor: MkMonad

--- a/tests/idris2/reg033/DerivingEq.idr
+++ b/tests/idris2/reg033/DerivingEq.idr
@@ -47,5 +47,6 @@ genEq typeName = do
 data TreeOne a = BranchOne (TreeOne a) a (TreeOne a)
                | Leaf
 
+covering
 Eq a => Eq (TreeOne a) where
   (==) = %runElab genEq `{ TreeOne }

--- a/tests/idris2/reg033/test.idr
+++ b/tests/idris2/reg033/test.idr
@@ -8,5 +8,6 @@ import DerivingEq
 data TreeTwo a = BranchTwo (TreeTwo a) a (TreeTwo a)
                | Leaf
 
+covering
 Eq a => Eq (TreeTwo a) where
   (==) = %runElab genEq `{ TreeTwo }


### PR DESCRIPTION
The prelude interfaces that have default definitions for *all* of
their fields are declared total so that users are forced to think
about meeting the minimal requirements for an implementation to be
valid.