### PR TITLE
[ fix ] Detect OS as Darwin when running ARM version of Chez on a Mac

### DIFF
--- a/support/chez/support.ss
+++ b/support/chez/support.ss
@@ -4,7 +4,7 @@
     [(i3ob ti3ob a6ob ta6ob) "unix"]  ; OpenBSD
     [(i3fb ti3fb a6fb ta6fb) "unix"]  ; FreeBSD
     [(i3nb ti3nb a6nb ta6nb) "unix"]  ; NetBSD
-    [(i3osx ti3osx a6osx ta6osx) "darwin"]
+    [(i3osx ti3osx a6osx ta6osx tarm64osx) "darwin"]
     [(i3nt ti3nt a6nt ta6nt) "windows"]
     [else "unknown"]))
 


### PR DESCRIPTION
Hi! This change allows one to bootstrap and run idris2 on Macs using an ARM version of Chez (See more info below).

Similar error as #2078, but in this case the error was caused by `System.os` returning the wrong OS.
```
Exception: (while loading libidris2_support.so) dlopen(libidris2_support.so, 0x0002): tried: '/Users/USER/Idris/Idris2-main/build/exec/idris2_app/libidris2_support.so' (no such file), '/libidris2_support.so' (no such file), 'libidris2_support.so' (no such file), '/usr/local/lib/libidris2_support.so' (no such file), '/usr/lib/libidris2_support.so' (no such file), '/Users/USER/Idris/Idris2-main/build/exec/idris2_app/libidris2_support.so' (no such file), '/libidris2_support.so' (no such file), '/Users/USER/Idris/Idris2-main/libs/prelude/libidris2_support.so' (no such file), '/usr/local/lib/libidris2_support.so' (no such file), '/usr/lib/libidris2_support.so' 
```

Note that there is only a single line of change in `bootstrap/idris2_app/idris2.ss`.

---

For anyone interested:
The [Racket organization](http://github.com/racket) has a fork of Chez Scheme that supports ARM. I installed it by running the following commands:
1. `git clone https://github.com/racket/ChezScheme`
2. `cd ChezScheme`
3. `git submodule init`
4. `git submodule update`
5. `./configure --pb`
6. `make tarm64osx.bootquick`
7. `./configure --threads` (`--threads` is important to make it work with Idris 2)
8. `make`
9. `sudo make install`

This installs `scheme` to `/usr/local/bin`.