### PR TITLE
Use escaped version of `system` internally

### DIFF
--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -33,7 +33,7 @@ on:
       - '.github/workflows/ci-super-linter.yml'
 
 env:
-  IDRIS2_VERSION: 0.5.1 # For previous-version build
+  IDRIS2_VERSION: 0.6.0 # For previous-version build
 
 jobs:
 

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -488,7 +488,7 @@ compileToSO prof chez appDirRel outSsAbs
          Right () <- coreLift $ writeFile tmpFileAbs build
             | Left err => throw (FileErr tmpFileAbs err)
          coreLift_ $ chmodRaw tmpFileAbs 0o755
-         coreLift_ $ system (chez ++ " --script \"" ++ tmpFileAbs ++ "\"")
+         coreLift_ $ system [chez, "--script", tmpFileAbs]
          pure ()
 
 ||| Compile a TT expression to Chez Scheme using incremental module builds
@@ -616,7 +616,7 @@ executeExpr :
 executeExpr c s tmpDir tm
     = do Just sh <- compileExpr False c s tmpDir tmpDir tm "_tmpchez"
             | Nothing => throw (InternalError "compileExpr returned Nothing")
-         coreLift_ $ system sh
+         coreLift_ $ system [sh]
 
 incCompile :
   Ref Ctxt Defs ->
@@ -655,7 +655,7 @@ incCompile c s sourceFile
                           show ssFile ++ "))"
                Right () <- coreLift $ writeFile tmpFileAbs build
                   | Left err => throw (FileErr tmpFileAbs err)
-               coreLift_ $ system (chez ++ " --script \"" ++ tmpFileAbs ++ "\"")
+               coreLift_ $ system [chez, "--script", tmpFileAbs]
                pure (Just (soFilename, mapMaybe fst fgndefs))
 
 ||| Codegen wrapper for Chez scheme implementation.

--- a/src/Compiler/Scheme/ChezSep.idr
+++ b/src/Compiler/Scheme/ChezSep.idr
@@ -141,9 +141,8 @@ chezLibraryName cu = chezNS (min1 cu.namespaces)
     min1 : List1 Namespace -> Namespace
     min1 (ns ::: nss) = foldl min ns nss
 
--- TODO: use a proper exec function without shell injection
 touch : String -> Core ()
-touch s = coreLift_ $ system ("touch \"" ++ s ++ "\"")
+touch s = coreLift_ $ system ["touch", s]
 
 record ChezLib where
   constructor MkChezLib
@@ -318,7 +317,7 @@ executeExpr :
 executeExpr c s tmpDir tm
     = do Just sh <- compileExpr False c s tmpDir tmpDir tm "_tmpchez"
             | Nothing => throw (InternalError "compileExpr returned Nothing")
-         coreLift_ $ system sh
+         coreLift_ $ system [sh]
 
 ||| Codegen wrapper for Chez scheme implementation.
 export

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -33,10 +33,10 @@ findRacket =
   do env <- idrisGetEnv "RACKET"
      pure $ fromMaybe "/usr/bin/env racket" env
 
-findRacoExe : IO String
+findRacoExe : IO (List String)
 findRacoExe =
   do env <- idrisGetEnv "RACKET_RACO"
-     pure $ (fromMaybe "/usr/bin/env raco" env) ++ " exe"
+     pure $ (maybe ["/usr/bin/env", "raco"] singleton env) ++ ["exe"]
 
 schHeader : Bool -> String -> String
 schHeader prof libs = """
@@ -448,8 +448,7 @@ compileExpr mkexec c s tmpDir outputDir tm outfile
 
          ok <- the (Core Int) $ if mkexec
                   then logTime 1 "Build racket" $
-                         coreLift $
-                           system (raco ++ " -o " ++ outBinAbs ++ " " ++ outRktAbs)
+                         coreLift $ system $ raco ++ ["-o", outBinAbs, outRktAbs]
                   else pure 0
          if ok == 0
             then do -- TODO: add launcher script
@@ -472,7 +471,7 @@ executeExpr :
 executeExpr c s tmpDir tm
     = do Just sh <- compileExpr False c s tmpDir tmpDir tm "_tmpracket"
             | Nothing => throw (InternalError "compileExpr returned Nothing")
-         coreLift_ $ system sh
+         coreLift_ $ system [sh]
 
 export
 codegenRacket : Codegen

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -965,8 +965,8 @@ process Edit
          case mainfile opts of
               Nothing => pure NoFileLoaded
               Just f =>
-                do let line = maybe "" (\i => " +" ++ show (i + 1)) (errorLine opts)
-                   coreLift_ $ system (editor opts ++ " \"" ++ f ++ "\"" ++ line)
+                do let line = maybe [] (\i => ["+" ++ show (i + 1)]) (errorLine opts)
+                   coreLift_ $ system $ [editor opts, f] ++ line
                    loadMainFile f
 process (Compile ctm outfile)
     = compileExp ctm outfile


### PR DESCRIPTION
Follow on from #2096. Use the new escaped version of `system` in the source of Idris itself.

This closes a couple of potential security holes, and makes the handling of these sorts of issues more uniform.

This PR will fail tests until the next version bump. I'm submitting the PR now, so that I don't forget about it.