### PR TITLE
Add List singleton function

### DIFF
--- a/libs/base/Data/List.idr
+++ b/libs/base/Data/List.idr
@@ -319,6 +319,10 @@ break : (a -> Bool) -> List a -> (List a, List a)
 break p xs = span (not . p) xs
 
 public export
+singleton : a -> List a
+singleton x = [x]
+
+public export
 split : (a -> Bool) -> List a -> List1 (List a)
 split p xs =
   case break p xs of

--- a/tests/idris2/reg047/QualifiedDoBang.idr
+++ b/tests/idris2/reg047/QualifiedDoBang.idr
@@ -1,3 +1,4 @@
+import Data.List
 import Data.Nat
 
 namespace MaybeList
@@ -7,7 +8,7 @@ namespace MaybeList
 
   public export
   pure : a -> (Maybe . List) a
-  pure = Just . (:: Nil)
+  pure = Just . singleton
 
   public export
   guard : Bool -> (Maybe . List) ()
@@ -25,7 +26,7 @@ namespace ListMaybe
 
   public export
   pure : a -> (List . Maybe) a
-  pure = (:: Nil) . Just
+  pure = singleton . Just
 
   public export
   guard : Bool -> (List . Maybe) ()


### PR DESCRIPTION
Adds the `List` singleton function. Honestly, I'm suprised it's not already in `base`.

We could use `pure` instead, but that's not always the semantic meaning we try to get across. Further, the presence of `singleton` for a variety of list-like types, but not `List` itself, could be confusing.