### PR TITLE
Add Alternating List fst and snd functions

### DIFF
--- a/libs/contrib/Data/List/Alternating.idr
+++ b/libs/contrib/Data/List/Alternating.idr
@@ -214,6 +214,30 @@ Traversable (Odd a) where
 mutual
     namespace Odd
         public export
+        odds : Odd a b -> List a
+        odds (x :: xs) = x :: evens xs
+
+    namespace Even
+        public export
+        evens : Even a b -> List b
+        evens [] = []
+        evens (x :: xs) = odds xs
+
+mutual
+    namespace Odd
+        public export
+        evens : Odd a b -> List b
+        evens (x :: xs) = odds xs
+
+    namespace Even
+        public export
+        odds : Even a b -> List a
+        odds [] = []
+        odds (x :: xs) = x :: evens xs
+
+mutual
+    namespace Odd
+        public export
         forget : Odd a a -> List a
         forget (x :: xs) = x :: forget xs
 

--- a/tests/contrib/list_alternating/AlternatingList.idr
+++ b/tests/contrib/list_alternating/AlternatingList.idr
@@ -52,6 +52,8 @@ main = do
 
     ignore $ traverse printLn us
 
+    printLn $ odds xs
+    printLn $ evens xs
     printLn $ the (List String) $ forget $ mapFst show xs
   where
     avg : Double -> Double -> Double

--- a/tests/contrib/list_alternating/expected
+++ b/tests/contrib/list_alternating/expected
@@ -29,5 +29,7 @@ True
 ["Um,", 3.0, "Hello", 1.0, "Um,", 3.0, "world", 2.0, "Um,", 3.0, "!"]
 0.0
 1.0
+[1.0, 2.0, 3.0]
+["Hello", "world"]
 ["1.0", "Hello", "2.0", "world", "3.0"]
 Main> Bye for now!


### PR DESCRIPTION
Adds the Alternating List `fst` and `snd` functions, which take the sublists of alternating lists corresponding to the odd and even elements, respectively. Named for consistency with the `Bi...` interfaces, and by analogy with `Pair`.

That is, `fst` and `snd` are the obvious non-trivial functions of type:

```idris
fst : Odd a b -> List a
snd : Odd a b -> List b
```

Also adds tests for these functions.