### PR TITLE
Only normalise a search goal if it's fast

### DIFF
--- a/src/Core/Normalise.idr
+++ b/src/Core/Normalise.idr
@@ -83,8 +83,6 @@ normaliseLHS defs env (Bind fc n b sc)
 normaliseLHS defs env tm
     = quote defs env !(nfOpts onLHS defs env tm)
 
--- The size limit here is the depth of stuck applications. If it gets past
--- that size, return the original
 export
 tryNormaliseSizeLimit : {auto c : Ref Ctxt Defs} ->
                      {free : _} ->
@@ -94,6 +92,8 @@ tryNormaliseSizeLimit defs limit env tm
     = do tm' <- nf defs env tm
          quoteOpts (MkQuoteOpts False False (Just limit)) defs env tm'
 
+-- The size limit here is the depth of stuck applications. If it gets past
+-- that size, return the original
 export
 normaliseSizeLimit : {auto c : Ref Ctxt Defs} ->
                      {free : _} ->


### PR DESCRIPTION
While we do end up normalising it anyway on success, there might be things blocking it that make the intermediate terms very big, so only do it speculatively to see if it's quick.