### PR TITLE
bump TTC version for nomangle additions.

### DIFF
--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -33,7 +33,7 @@ import public Libraries.Utils.Binary
 ||| (Increment this when changing anything in the data format)
 export
 ttcVersion : Int
-ttcVersion = 67
+ttcVersion = 68
 
 export
 checkTTCVersion : String -> Int -> Int -> Core ()


### PR DESCRIPTION
Bump TTC version. It's been 10 days and a number of commits since the last TTC version bump, so I'd argue it's worth applying this bump right after the TTC changes for `%nomangle` instead of pretending the version of TTC from 10 days ago and this one are the same.