### PR TITLE
[ re #238 ] Fix program error condition of `git diff` call in `Golden`

### DIFF
--- a/libs/test/Test/Golden.idr
+++ b/libs/test/Test/Golden.idr
@@ -253,6 +253,9 @@ runTest opts testPath = forkIO $ do
     expVsOut : String -> String -> List String
     expVsOut exp out = ["Expected:", maybeColored Green exp, "Given:", maybeColored Red out]
 
+    badSystemExitCode : Int -> Bool
+    badSystemExitCode code = code < 0 || code == 127 {- 127 means shell couldn't start -}
+
     mayOverwrite : Maybe String -> String -> IO ()
     mayOverwrite mexp out = do
       case mexp of
@@ -267,7 +270,7 @@ runTest opts testPath = forkIO $ do
             escapeArg testPath ++ "/expected " ++ escapeArg testPath ++ "/output"
           putStr . unlines $
             ["Golden value differs from actual value."] ++
-            (if (code < 0) then expVsOut exp out else []) ++
+            (if badSystemExitCode code then expVsOut exp out else []) ++
             ["Accept actual value as new golden value? [y/N]"]
       b <- getAnswer
       when b $ do Right _ <- writeFile (testPath ++ "/expected") out

--- a/support/c/idris_system.c
+++ b/support/c/idris_system.c
@@ -2,5 +2,10 @@
 #include "idris_system.h"
 
 int idris2_system(const char* command) {
-    return system(command);
+    int status = system(command);
+    #ifdef _WIN32
+      return status;
+    #else
+      return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+    #endif
 }


### PR DESCRIPTION
Manage the fact that `system()` can (and, actually, have to) use non-negative exit codes to mark an error, `127` in particular.

Also, manage the fact that some `libc` implementations (`glibc` in particular) do shift left the exit code by 8 bits for some reason:
- [how bad call is managed using `127` and `W_EXITCODE`](https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/posix/system.c;h=48668fb392e67d1a84bb8ffef480e4237b7b4645;hb=HEAD#l180)
- [how good call is managed, using `__waitpid`](https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/posix/system.c;h=48668fb392e67d1a84bb8ffef480e4237b7b4645;hb=HEAD#l171)
- [how `__waitpid` is implemented through `wait4`](https://sourceware.org/git/?p=glibc.git;a=blob;f=posix/waitpid.c;h=d46f57ea133454b5034473ba6a855494636f74cd;hb=HEAD#l38)
- [how `wait4` returns its code through `W_EXITCODE`](https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/wait4.c;h=c8f9d3d0c6af0d4347a3e54afcdf959232340c5b;hb=HEAD#l78)
- [how `W_EXITCODE` is defined through `__W_EXITCODE`](https://sourceware.org/git/?p=glibc.git;a=blob;f=posix/sys/wait.h;h=5325bfa4d2e5586739d7dc84878dc58c9feca50b;hb=HEAD#l68)
- [how `__W_EXITCODE` shifts by 8 bits](https://sourceware.org/git/?p=glibc.git;a=blob;f=bits/waitstatus.h;h=baaf96ac04490de6aea6719acdd27bfd88fded65;hb=HEAD#l56)

These treatments actually are needed when `--interactive` mode is used, but no `git` is available. The current exit code treatment does not show expected and existing values at all in this case.