### PR TITLE
[ mkdoc ] Wrap declaration part in <code> tag

### DIFF
--- a/src/Idris/Doc/HTML.idr
+++ b/src/Idris/Doc/HTML.idr
@@ -79,7 +79,7 @@ renderHtml (STText _ text) = pure $ htmlEscape text
 renderHtml (STLine _) = pure "<br>"
 renderHtml (STAnn Declarations rest)
   = pure $ "<dl class=\"decls\">" <+> !(renderHtml rest) <+> "</dl>"
-renderHtml (STAnn (Decl n) rest) = pure $ "<dt id=\"" ++ (htmlEscape $ show n) ++ "\">" <+> !(renderHtml rest) <+> "</dt>"
+renderHtml (STAnn (Decl n) rest) = pure $ "<dt id=\"" ++ (htmlEscape $ show n) ++ "\"><code>" <+> !(renderHtml rest) <+> "</code></dt>"
 renderHtml (STAnn DocStringBody rest)
   = pure $ "<dd>" <+> !(renderHtml rest) <+> "</dd>"
 renderHtml (STAnn UserDocString rest)


### PR DESCRIPTION
In this pull request, the declaration code in the HTML document generated by `--mkdoc` option will be changed to be enclosed in `<code>`.

This should improve the semantic meaning of the generated HTML markup.

The "declaration part" here means the area shown in the screenshot below:

![Screenshot 2021-11-14 at 22-47-41 Libraries Text PrettyPrint Prettyprinter SimpleDocTree](https://user-images.githubusercontent.com/29575029/141684178-0a53524d-00b6-48ff-b998-7308243cdad3.png)

## See also

* A very similar past example was found in Rustdoc.
  * Issue: [rustdoc, when I use google translate, that translate the doc as well as the code.](https://github.com/rust-lang/rust/issues/88020)
  * Pull request: [[rustdoc] Wrap code blocks in `<code>` tag](https://github.com/rust-lang/rust/pull/88093)
