### PR TITLE
Remove unused imports

### DIFF
--- a/libs/base/Control/App/FileIO.idr
+++ b/libs/base/Control/App/FileIO.idr
@@ -2,8 +2,6 @@ module Control.App.FileIO
 
 import Control.App
 
-import Data.List
-import Data.String
 import System.File
 
 %default covering

--- a/libs/base/Control/WellFounded.idr
+++ b/libs/base/Control/WellFounded.idr
@@ -2,7 +2,6 @@ module Control.WellFounded
 
 import Control.Relation
 import Data.Nat
-import Data.List
 
 %default total
 

--- a/libs/base/Data/Colist.idr
+++ b/libs/base/Data/Colist.idr
@@ -1,6 +1,5 @@
 module Data.Colist
 
-import Data.Maybe
 import Data.List
 import Data.List1
 import public Data.Zippable

--- a/libs/base/Data/Fin/Order.idr
+++ b/libs/base/Data/Fin/Order.idr
@@ -7,7 +7,6 @@ import Data.Fin
 import Data.Fun
 import Data.Rel
 import Data.Nat
-import Data.Nat.Order
 import Decidable.Decidable
 
 %default total

--- a/libs/base/Data/IOArray.idr
+++ b/libs/base/Data/IOArray.idr
@@ -1,7 +1,6 @@
 module Data.IOArray
 
 import Data.IOArray.Prims
-import Data.List
 
 %default total
 

--- a/libs/base/Data/List/Quantifiers.idr
+++ b/libs/base/Data/List/Quantifiers.idr
@@ -2,7 +2,6 @@ module Data.List.Quantifiers
 
 import Data.DPair
 
-import Data.List
 import Data.List.Elem
 
 %default total

--- a/libs/base/Data/List/Views.idr
+++ b/libs/base/Data/List/Views.idr
@@ -4,7 +4,6 @@ import Control.Relation
 import Control.WellFounded
 import Data.List
 import Data.Nat
-import Data.Nat.Views
 
 %default total
 

--- a/libs/base/Data/Nat/Order.idr
+++ b/libs/base/Data/Nat/Order.idr
@@ -1,12 +1,10 @@
 ||| Implementation of ordering relations for `Nat`ural numbers
 module Data.Nat.Order
 
-import Control.Relation
 import Data.Nat
 import Data.Fun
 import Data.Rel
 import Decidable.Decidable
-import Decidable.Equality
 
 %default total
 

--- a/libs/base/Data/SnocList.idr
+++ b/libs/base/Data/SnocList.idr
@@ -1,7 +1,6 @@
 ||| A Reversed List
 module Data.SnocList
 
-import Decidable.Equality
 import Data.List
 import Data.Fin
 

--- a/libs/base/System.idr
+++ b/libs/base/System.idr
@@ -1,7 +1,6 @@
 module System
 
 import public Data.So
-import Data.List
 import Data.String
 
 import public System.Escape

--- a/libs/base/System/Concurrency.idr
+++ b/libs/base/System/Concurrency.idr
@@ -6,8 +6,6 @@
 ||| primitives that back ends should support.
 module System.Concurrency
 
-import Data.IORef
-
 %default total
 
 

--- a/libs/base/System/File/Permissions.idr
+++ b/libs/base/System/File/Permissions.idr
@@ -1,7 +1,6 @@
 module System.File.Permissions
 
 import public System.File.Error
-import System.File.Meta
 import System.File.Support
 import public System.File.Types
 

--- a/libs/base/System/File/ReadWrite.idr
+++ b/libs/base/System/File/ReadWrite.idr
@@ -2,7 +2,6 @@ module System.File.ReadWrite
 
 import public Data.Fuel
 
-import Data.List
 import Data.SnocList
 
 import System.File.Handle

--- a/libs/base/System/Signal.idr
+++ b/libs/base/System/Signal.idr
@@ -9,7 +9,6 @@ module System.Signal
 
 import Data.Fuel
 import Data.List
-import Data.List.Elem
 import System.Errno
 
 %default total

--- a/libs/contrib/Data/Binary.idr
+++ b/libs/contrib/Data/Binary.idr
@@ -1,6 +1,5 @@
 module Data.Binary
 
-import Data.Nat
 import Data.Nat.Properties
 import Data.Binary.Digit
 import Syntax.PreorderReasoning

--- a/libs/contrib/Data/Bool/Decidable.idr
+++ b/libs/contrib/Data/Bool/Decidable.idr
@@ -1,6 +1,5 @@
 module Data.Bool.Decidable
 
-import Decidable.Equality
 import Data.Void
 
 public export

--- a/libs/contrib/Data/List/Extra.idr
+++ b/libs/contrib/Data/List/Extra.idr
@@ -1,7 +1,5 @@
 module Data.List.Extra
 
-import Data.List
-
 %default total
 
 ||| Analogous to `map` for `List`, but the function is applied to the index of

--- a/libs/contrib/Data/List/Palindrome.idr
+++ b/libs/contrib/Data/List/Palindrome.idr
@@ -1,7 +1,6 @@
 module Data.List.Palindrome
 
 import Data.List
-import Data.List.Views
 import Data.List.Views.Extra
 import Data.List.Reverse
 import Data.List.Equalities

--- a/libs/contrib/Data/List/Reverse.idr
+++ b/libs/contrib/Data/List/Reverse.idr
@@ -3,7 +3,6 @@ module Data.List.Reverse
 
 import Data.Nat
 import Data.List
-import Data.List.Equalities
 
 -- Additional properties coming out of base's Data.List
 --  - revAppend (i.e. reverse xs ++ reverse ys = reverse (ys ++ xs)

--- a/libs/contrib/Data/List/TailRec.idr
+++ b/libs/contrib/Data/List/TailRec.idr
@@ -21,8 +21,6 @@ import Syntax.WithProof
 
 import Data.List
 import Data.List1
-import Data.Vect
-import Data.Nat
 
 total
 lengthAcc : List a -> Nat -> Nat

--- a/libs/contrib/Data/Monoid/Exponentiation.idr
+++ b/libs/contrib/Data/Monoid/Exponentiation.idr
@@ -1,6 +1,5 @@
 module Data.Monoid.Exponentiation
 
-import Control.Algebra
 import Data.Nat.Views
 import Syntax.PreorderReasoning
 

--- a/libs/contrib/Data/Nat/Division.idr
+++ b/libs/contrib/Data/Nat/Division.idr
@@ -6,7 +6,6 @@ import Syntax.PreorderReasoning
 import Syntax.PreorderReasoning.Generic
 import Data.Nat
 import Data.Nat.Equational
-import Data.Nat.Order
 import Data.Nat.Order.Strict
 import Data.Nat.Order.Properties
 import Decidable.Order.Strict

--- a/libs/contrib/Data/Nat/Exponentiation.idr
+++ b/libs/contrib/Data/Nat/Exponentiation.idr
@@ -3,8 +3,6 @@ module Data.Nat.Exponentiation
 import Data.Nat as Nat
 import Data.Nat.Properties
 import Data.Monoid.Exponentiation as Mon
-import Data.Nat.Views
-import Data.Nat.Order
 import Syntax.PreorderReasoning
 import Syntax.PreorderReasoning.Generic
 

--- a/libs/contrib/Data/Nat/Factor.idr
+++ b/libs/contrib/Data/Nat/Factor.idr
@@ -5,7 +5,6 @@ import Data.Fin
 import Data.Fin.Extra
 import Data.Nat
 import Data.Nat.Equational
-import Syntax.PreorderReasoning
 
 %default total
 

--- a/libs/contrib/Data/Nat/Order/Properties.idr
+++ b/libs/contrib/Data/Nat/Order/Properties.idr
@@ -1,13 +1,8 @@
 ||| Additional properties/lemmata of Nats involving order
 module Data.Nat.Order.Properties
 
-import Syntax.PreorderReasoning
 import Syntax.PreorderReasoning.Generic
 import Data.Nat
-import Data.Nat.Order
-import Data.Nat.Order.Strict
-import Decidable.Equality
-import Decidable.Order.Strict
 import Data.Bool.Decidable
 
 

--- a/libs/contrib/Data/Nat/Order/Strict.idr
+++ b/libs/contrib/Data/Nat/Order/Strict.idr
@@ -3,8 +3,6 @@ module Data.Nat.Order.Strict
 
 import Data.Nat
 import Decidable.Order.Strict
-import Decidable.Equality
-import Data.Nat.Order
 
 %default total
 

--- a/libs/contrib/Data/String/Extra.idr
+++ b/libs/contrib/Data/String/Extra.idr
@@ -1,7 +1,5 @@
 module Data.String.Extra
 
-import Data.List
-import Data.List1
 import Data.Nat
 import Data.String
 

--- a/libs/contrib/Data/String/Interpolation.idr
+++ b/libs/contrib/Data/String/Interpolation.idr
@@ -2,8 +2,6 @@
 ||| Not as fancy
 module Data.String.Interpolation
 
-import Data.String
-
 namespace Data.String.Interpolation.Basic
   %inline
   public export

--- a/libs/contrib/Data/String/Parser/Expression.idr
+++ b/libs/contrib/Data/String/Parser/Expression.idr
@@ -3,7 +3,6 @@
 
 module Data.String.Parser.Expression
 
-import Control.Monad.Identity
 import Data.String.Parser
 
 public export

--- a/libs/contrib/Data/Telescope/Congruence.idr
+++ b/libs/contrib/Data/Telescope/Congruence.idr
@@ -1,7 +1,6 @@
 ||| N-ary congruence for reasoning
 module Data.Telescope.Congruence
 
-import Data.Fin
 import Data.Telescope.Telescope
 import Data.Telescope.Segment
 import Data.Telescope.SimpleFun

--- a/libs/contrib/Data/Telescope/Telescope.idr
+++ b/libs/contrib/Data/Telescope/Telescope.idr
@@ -7,7 +7,6 @@ module Data.Telescope.Telescope
 import Data.DPair
 import Data.Nat
 import Data.Fin
-import Syntax.PreorderReasoning
 
 %default total
 

--- a/libs/contrib/Data/Tree/Perfect.idr
+++ b/libs/contrib/Data/Tree/Perfect.idr
@@ -1,15 +1,11 @@
 module Data.Tree.Perfect
 
 import Control.WellFounded
-import Decidable.Order.Strict
 import Data.Monoid.Exponentiation
 import Data.Nat.Views
 import Data.Nat
-import Data.Nat.Order
-import Data.Nat.Order.Strict
 import Data.Nat.Order.Properties
 import Data.Nat.Exponentiation
-import Data.DPair
 import Syntax.WithProof
 import Syntax.PreorderReasoning.Generic
 

--- a/libs/contrib/Data/Vect/Binary.idr
+++ b/libs/contrib/Data/Vect/Binary.idr
@@ -8,7 +8,6 @@ import Data.Binary
 import Data.IMaybe
 import Data.Nat
 import Data.Nat.Exponentiation
-import Data.Nat.Properties
 import Data.Tree.Perfect
 
 %default total

--- a/libs/contrib/Data/Vect/Properties/Foldr.idr
+++ b/libs/contrib/Data/Vect/Properties/Foldr.idr
@@ -15,12 +15,9 @@ import Data.Vect
 import Data.Vect.Elem
 import Data.Fin
 import Data.Nat
-import Data.Nat.Order
 
 import Syntax.PreorderReasoning
 import Syntax.PreorderReasoning.Generic
-
-import Control.Order
 
 ||| Sum implemented with foldr
 public export

--- a/libs/contrib/Data/Vect/Properties/Map.idr
+++ b/libs/contrib/Data/Vect/Properties/Map.idr
@@ -3,7 +3,6 @@ module Data.Vect.Properties.Map
 
 import Data.Vect.Properties.Tabulate
 import Data.Vect.Properties.Index
-import Data.Vect.Properties.Foldr
 
 import Data.Vect
 import Data.Vect.Elem

--- a/libs/contrib/Language/JSON/Data.idr
+++ b/libs/contrib/Language/JSON/Data.idr
@@ -2,7 +2,6 @@ module Language.JSON.Data
 
 import Data.Bits
 import Data.List
-import Data.Nat
 import Data.String.Extra
 import Data.String
 

--- a/libs/contrib/Language/JSON/Lexer.idr
+++ b/libs/contrib/Language/JSON/Lexer.idr
@@ -2,7 +2,6 @@ module Language.JSON.Lexer
 
 import Language.JSON.String
 import Text.Lexer
-import Text.Token
 
 import public Language.JSON.Tokens
 

--- a/libs/contrib/Language/JSON/Parser.idr
+++ b/libs/contrib/Language/JSON/Parser.idr
@@ -2,7 +2,6 @@ module Language.JSON.Parser
 
 import Language.JSON.Data
 import Text.Parser
-import Text.Token
 import Data.List
 
 import public Language.JSON.Tokens

--- a/libs/contrib/Language/JSON/String/Tokens.idr
+++ b/libs/contrib/Language/JSON/String/Tokens.idr
@@ -1,7 +1,6 @@
 module Language.JSON.String.Tokens
 
 import Data.List
-import Data.String
 import Data.String.Extra
 import Text.Token
 

--- a/libs/contrib/System/Console/GetOpt.idr
+++ b/libs/contrib/System/Console/GetOpt.idr
@@ -4,12 +4,8 @@
 ||| (http://hackage.haskell.org/package/base-4.14.1.0/docs/System-Console-GetOpt.html)).
 module System.Console.GetOpt
 
-import Control.Monad.Reader
-import Control.Monad.State
-
 import Data.List
 import Data.List1
-import Data.Maybe
 import Data.String
 
 %default total

--- a/libs/contrib/System/Directory/Tree.idr
+++ b/libs/contrib/System/Directory/Tree.idr
@@ -4,7 +4,6 @@ import Control.Monad.Either
 import Data.DPair
 import Data.List
 import Data.Nat
-import Data.String
 import System.Directory
 import System.File
 import System.Path

--- a/libs/contrib/System/Path.idr
+++ b/libs/contrib/System/Path.idr
@@ -1,7 +1,6 @@
 module System.Path
 
 import Data.List
-import Data.List1
 import Data.Maybe
 import Data.Nat
 import Data.String

--- a/libs/contrib/Text/Lexer/Core.idr
+++ b/libs/contrib/Text/Lexer/Core.idr
@@ -2,8 +2,6 @@ module Text.Lexer.Core
 
 import Data.List
 import Data.Maybe
-import Data.Nat
-import Data.String
 
 import public Control.Delayed
 import public Text.Bounded

--- a/libs/contrib/Text/Lexer/Tokenizer.idr
+++ b/libs/contrib/Text/Lexer/Tokenizer.idr
@@ -1,15 +1,10 @@
 module Text.Lexer.Tokenizer
 
 import Data.List
-import Data.Either
-import Data.Nat
-import Data.String
 
-import Data.String.Extra
 import Text.Lexer.Core
 import Text.Lexer
 import Text.PrettyPrint.Prettyprinter
-import Text.PrettyPrint.Prettyprinter.Util
 
 import public Control.Delayed
 import public Text.Bounded

--- a/libs/contrib/Text/Literate.idr
+++ b/libs/contrib/Text/Literate.idr
@@ -29,7 +29,6 @@ import Data.List
 import Data.List1
 import Data.List.Views
 import Data.String
-import Data.String.Extra
 
 %default total
 

--- a/libs/contrib/Text/Parser.idr
+++ b/libs/contrib/Text/Parser.idr
@@ -1,7 +1,6 @@
 module Text.Parser
 
 import Data.Bool
-import Data.List
 import Data.Nat
 import public Data.List1
 

--- a/libs/contrib/Text/Parser/Expression.idr
+++ b/libs/contrib/Text/Parser/Expression.idr
@@ -1,7 +1,6 @@
 module Text.Parser.Expression
 
 import Text.Parser
-import Data.List1
 
 public export
 data Assoc

--- a/libs/contrib/Text/PrettyPrint/Prettyprinter/Render/HTML.idr
+++ b/libs/contrib/Text/PrettyPrint/Prettyprinter/Render/HTML.idr
@@ -1,6 +1,5 @@
 module Text.PrettyPrint.Prettyprinter.Render.HTML
 
-import Data.List
 import Data.String
 
 %default covering

--- a/libs/contrib/Text/PrettyPrint/Prettyprinter/Render/String.idr
+++ b/libs/contrib/Text/PrettyPrint/Prettyprinter/Render/String.idr
@@ -1,7 +1,6 @@
 module Text.PrettyPrint.Prettyprinter.Render.String
 
 import Data.String
-import Data.String.Extra
 import Text.PrettyPrint.Prettyprinter.Doc
 
 %default total

--- a/libs/contrib/Text/PrettyPrint/Prettyprinter/SimpleDocTree.idr
+++ b/libs/contrib/Text/PrettyPrint/Prettyprinter/SimpleDocTree.idr
@@ -1,7 +1,6 @@
 module Text.PrettyPrint.Prettyprinter.SimpleDocTree
 
 import Text.PrettyPrint.Prettyprinter.Doc
-import Text.Parser
 
 %default total
 

--- a/libs/contrib/Text/PrettyPrint/Prettyprinter/Util.idr
+++ b/libs/contrib/Text/PrettyPrint/Prettyprinter/Util.idr
@@ -1,7 +1,6 @@
 module Text.PrettyPrint.Prettyprinter.Util
 
 import Data.List
-import Data.String
 import Text.PrettyPrint.Prettyprinter.Doc
 import Text.PrettyPrint.Prettyprinter.Render.String
 

--- a/libs/prelude/Prelude/Cast.idr
+++ b/libs/prelude/Prelude/Cast.idr
@@ -1,6 +1,5 @@
 module Prelude.Cast
 
-import Builtin
 import Prelude.Basics
 import Prelude.Num
 import Prelude.Types

--- a/libs/prelude/Prelude/EqOrd.idr
+++ b/libs/prelude/Prelude/EqOrd.idr
@@ -2,7 +2,6 @@ module Prelude.EqOrd
 
 import Builtin
 import Prelude.Basics
-import Prelude.Ops
 
 %default total
 

--- a/libs/prelude/Prelude/Interfaces.idr
+++ b/libs/prelude/Prelude/Interfaces.idr
@@ -4,7 +4,6 @@ import Builtin
 import Prelude.Basics
 import Prelude.EqOrd
 import Prelude.Num
-import Prelude.Ops
 
 %default total
 

--- a/libs/prelude/Prelude/Interpolation.idr
+++ b/libs/prelude/Prelude/Interpolation.idr
@@ -1,8 +1,5 @@
 module Prelude.Interpolation
 
-import Prelude.Ops
-import Prelude.Types
-
 ||| Interpolated strings are of the form `"xxxx \{ expr } yyyy"`.
 ||| In this example the string `"xxxx "` is concatenated with `expr` and
 ||| `" yyyy"`, since `expr` is not necessarily a string, the generated

--- a/libs/prelude/Prelude/Num.idr
+++ b/libs/prelude/Prelude/Num.idr
@@ -1,9 +1,7 @@
 module Prelude.Num
 
-import Builtin
 import Prelude.Basics
 import Prelude.EqOrd
-import Prelude.Ops
 
 %default total
 

--- a/libs/prelude/Prelude/Show.idr
+++ b/libs/prelude/Prelude/Show.idr
@@ -5,7 +5,6 @@ import Prelude.Basics
 import Prelude.EqOrd
 import Prelude.Num
 import Prelude.Types
-import Prelude.Interpolation
 
 %default total
 

--- a/libs/prelude/Prelude/Types.idr
+++ b/libs/prelude/Prelude/Types.idr
@@ -1,7 +1,6 @@
 module Prelude.Types
 
 import Builtin
-import PrimIO
 import Prelude.Basics
 import Prelude.EqOrd
 import Prelude.Interfaces

--- a/src/Compiler/CaseOpts.idr
+++ b/src/Compiler/CaseOpts.idr
@@ -6,7 +6,6 @@ import Compiler.CompileExpr
 
 import Core.CompileExpr
 import Core.Context
-import Core.Context.Log
 import Core.FC
 import Core.TT
 

--- a/src/Compiler/Common.idr
+++ b/src/Compiler/Common.idr
@@ -14,12 +14,9 @@ import Core.Context
 import Core.Context.Log
 import Core.Directory
 import Core.Options
-import Core.Ord
 import Core.TT
 import Core.TTC
 import Libraries.Data.IOArray
-import Libraries.Data.SortedMap
-import Libraries.Utils.Path
 import Libraries.Utils.Scheme
 
 import Data.List
@@ -31,7 +28,6 @@ import Idris.Env
 
 import System.Directory
 import System.Info
-import System.File
 
 %default covering
 

--- a/src/Compiler/CompileExpr.idr
+++ b/src/Compiler/CompileExpr.idr
@@ -12,7 +12,6 @@ import Core.Value
 
 import Data.List
 import Data.Maybe
-import Libraries.Data.NameMap
 import Data.Vect
 
 %default covering

--- a/src/Compiler/ES/Ast.idr
+++ b/src/Compiler/ES/Ast.idr
@@ -2,9 +2,7 @@ module Compiler.ES.Ast
 
 import Core.CompileExpr
 import Core.Context
-import Compiler.Common
 import Data.List1
-import Data.Nat
 import Data.Vect
 
 %default total

--- a/src/Compiler/ES/Codegen.idr
+++ b/src/Compiler/ES/Codegen.idr
@@ -16,7 +16,6 @@ import Compiler.NoMangle
 import Libraries.Data.SortedMap
 import Libraries.Utils.Hex
 import Libraries.Data.String.Extra
-import Libraries.Data.NameMap
 
 import Data.Vect
 

--- a/src/Compiler/ES/Javascript.idr
+++ b/src/Compiler/ES/Javascript.idr
@@ -4,19 +4,13 @@ module Compiler.ES.Javascript
 import Compiler.ES.Codegen
 
 import Compiler.Common
-import Compiler.CompileExpr
 
 import Core.Context
 import Core.TT
 import Core.Options
 import Libraries.Utils.Path
 
-import System
-import System.File
-
-import Data.Maybe
 import Data.String
-import Libraries.Data.String.Extra
 
 %default covering
 

--- a/src/Compiler/ES/Node.idr
+++ b/src/Compiler/ES/Node.idr
@@ -6,7 +6,6 @@ import Idris.Env
 import Compiler.ES.Codegen
 
 import Compiler.Common
-import Compiler.CompileExpr
 
 import Core.Context
 import Core.Options
@@ -14,7 +13,6 @@ import Core.TT
 import Libraries.Utils.Path
 
 import System
-import System.File
 
 import Data.Maybe
 

--- a/src/Compiler/ES/TailRec.idr
+++ b/src/Compiler/ES/TailRec.idr
@@ -116,10 +116,8 @@
 ||| where the things described above can be expressed.
 module Compiler.ES.TailRec
 
-import Data.Maybe
 import Data.List
 import Data.List1
-import Data.String
 import Libraries.Data.Graph
 import Libraries.Data.SortedSet
 import Libraries.Data.List.Extra as L

--- a/src/Compiler/ES/ToAst.idr
+++ b/src/Compiler/ES/ToAst.idr
@@ -2,16 +2,11 @@
 ||| to a sequence of imperative statements.
 module Compiler.ES.ToAst
 
-import Data.DPair
-import Data.Nat
-import Data.List1
 import Data.Vect
-import Compiler.Common
 import Core.CompileExpr
 import Core.Context
 import Compiler.ES.Ast
 import Compiler.ES.State
-import Libraries.Data.SortedMap
 
 --------------------------------------------------------------------------------
 --          Converting NamedCExp

--- a/src/Compiler/LambdaLift.idr
+++ b/src/Compiler/LambdaLift.idr
@@ -7,7 +7,6 @@ import Core.TT
 
 import Data.List
 import Data.Vect
-import Data.Maybe
 
 %default covering
 

--- a/src/Compiler/Opts/CSE.idr
+++ b/src/Compiler/Opts/CSE.idr
@@ -35,11 +35,9 @@ import Core.TT
 
 import Core.Ord
 import Data.List
-import Data.Nat
 import Data.String
 import Data.Vect
 import Libraries.Data.SortedMap
-import Libraries.Data.NameMap
 
 ||| Maping from a pairing of closed terms together with
 ||| their size (for efficiency) to the number of

--- a/src/Compiler/RefC/RefC.idr
+++ b/src/Compiler/RefC/RefC.idr
@@ -14,7 +14,6 @@ import Core.Directory
 import Data.List
 import Libraries.Data.DList
 import Data.Nat
-import Data.String
 import Libraries.Data.SortedSet
 import Data.Vect
 

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -3,7 +3,6 @@ module Compiler.Scheme.Chez
 import Compiler.Common
 import Compiler.CompileExpr
 import Compiler.Generated
-import Compiler.Inline
 import Compiler.Scheme.Common
 
 import Core.Context
@@ -25,10 +24,8 @@ import Idris.Env
 
 import System
 import System.Directory
-import System.File
 import System.Info
 
-import Libraries.Data.NameMap
 import Libraries.Data.Version
 import Libraries.Utils.String
 

--- a/src/Compiler/Scheme/ChezSep.idr
+++ b/src/Compiler/Scheme/ChezSep.idr
@@ -3,7 +3,6 @@ module Compiler.Scheme.ChezSep
 import Compiler.Common
 import Compiler.CompileExpr
 import Compiler.Generated
-import Compiler.Inline
 import Compiler.Scheme.Common
 import Compiler.Scheme.Chez
 import Compiler.Separate
@@ -13,26 +12,20 @@ import Core.Hash
 import Core.Context
 import Core.Context.Log
 import Core.Directory
-import Core.Name
 import Core.Options
 import Core.TT
-import Libraries.Utils.Hex
 import Libraries.Utils.Path
 
 import Data.List
 import Data.List1
-import Data.Maybe
 import Data.String
-import Data.Vect
 
 import Idris.Env
 
 import System
 import System.Directory
-import System.File
 import System.Info
 
-import Libraries.Data.NameMap
 import Libraries.Data.Version
 import Libraries.Utils.String
 

--- a/src/Compiler/Scheme/Common.idr
+++ b/src/Compiler/Scheme/Common.idr
@@ -2,16 +2,12 @@ module Compiler.Scheme.Common
 
 import Compiler.Common
 import Compiler.CompileExpr
-import Compiler.Inline
 
 import Core.Context
 import Core.Name
 import Core.TT
 
-import Data.List
 import Data.Vect
-
-import System.Info
 
 %default covering
 

--- a/src/Compiler/Scheme/Gambit.idr
+++ b/src/Compiler/Scheme/Gambit.idr
@@ -3,7 +3,6 @@ module Compiler.Scheme.Gambit
 import Compiler.Common
 import Compiler.CompileExpr
 import Compiler.Generated
-import Compiler.Inline
 import Compiler.Scheme.Common
 
 import Core.Context
@@ -16,16 +15,12 @@ import Libraries.Utils.Path
 
 import Data.List
 import Data.Maybe
-import Libraries.Data.NameMap
-import Data.String
 import Data.Vect
 
 import Idris.Env
 
 import System
 import System.Directory
-import System.File
-import System.Info
 
 %default covering
 

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -3,7 +3,6 @@ module Compiler.Scheme.Racket
 import Compiler.Common
 import Compiler.CompileExpr
 import Compiler.Generated
-import Compiler.Inline
 import Compiler.Scheme.Common
 
 import Core.Options
@@ -17,8 +16,6 @@ import Libraries.Utils.Path
 
 import Data.List
 import Data.Maybe
-import Libraries.Data.NameMap
-import Data.Nat
 import Data.String
 import Data.Vect
 
@@ -26,7 +23,6 @@ import Idris.Env
 
 import System
 import System.Directory
-import System.File
 import System.Info
 
 %default covering

--- a/src/Compiler/VMCode.idr
+++ b/src/Compiler/VMCode.idr
@@ -4,7 +4,6 @@ import Compiler.ANF
 
 import Core.CompileExpr
 import Core.Context
-import Core.Core
 import Core.TT
 
 import Libraries.Data.IntMap

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -4,25 +4,20 @@
 module Core.Binary
 
 import public Core.Binary.Prims
-import Core.Case.CaseTree
 import Core.Context
 import Core.Context.Log
 import Core.Core
-import Core.Hash
 import Core.Name.Namespace
-import Core.Normalise
 import Core.Options
 import Core.TT
 import Core.TTC
 import Core.UnifyState
 
-import Data.Buffer
 import Data.List
 import Data.String
 
 import System.File
 
-import Libraries.Data.IntMap
 import Libraries.Data.NameMap
 
 import public Libraries.Utils.Binary

--- a/src/Core/Case/CaseTree.idr
+++ b/src/Core/Case/CaseTree.idr
@@ -2,7 +2,6 @@ module Core.Case.CaseTree
 
 import Core.TT
 
-import Data.Bool
 import Data.List
 
 import Libraries.Data.NameMap

--- a/src/Core/Case/Util.idr
+++ b/src/Core/Case/Util.idr
@@ -2,8 +2,6 @@ module Core.Case.Util
 
 import Core.Case.CaseTree
 import Core.Context
-import Core.Env
-import Core.Normalise
 import Core.Value
 
 public export

--- a/src/Core/CompileExpr.idr
+++ b/src/Core/CompileExpr.idr
@@ -7,7 +7,6 @@ import Core.Name
 import Core.TT
 
 import Data.List
-import Libraries.Data.NameMap
 import Data.Vect
 
 %default covering

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -27,7 +27,6 @@ import Libraries.Data.StringMap
 import Libraries.Data.UserNameMap
 import Libraries.Text.Distance.Levenshtein
 
-import System
 import System.Clock
 import System.Directory
 

--- a/src/Core/Context/Context.idr
+++ b/src/Core/Context/Context.idr
@@ -3,17 +3,11 @@ module Core.Context.Context
 import        Core.Case.CaseTree
 import        Core.CompileExpr
 import        Core.Env
-import        Core.Hash
 import public Core.Name
 import public Core.Options.Log
 import public Core.TT
 
-import Data.Fin
 import Data.IORef
-import Data.List
-import Data.List1
-import Data.Maybe
-import Data.Nat
 
 import Libraries.Data.IntMap
 import Libraries.Data.IOArray

--- a/src/Core/Context/Log.idr
+++ b/src/Core/Context/Log.idr
@@ -2,7 +2,6 @@ module Core.Context.Log
 
 import Core.Context
 import Core.Options
-import Data.String
 
 import Libraries.Data.StringMap
 

--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -4,18 +4,14 @@ import Core.Context.Context
 import Core.Env
 import Core.TT
 
-import Data.List
 import Data.List1
-import Data.String
 import Data.Vect
 
 import Libraries.Data.IMaybe
 import Libraries.Text.PrettyPrint.Prettyprinter
 import Libraries.Text.PrettyPrint.Prettyprinter.Util
-import Libraries.Utils.Binary
 
 import public Data.IORef
-import System
 import System.File
 
 %default covering

--- a/src/Core/Directory.idr
+++ b/src/Core/Directory.idr
@@ -4,17 +4,13 @@ import Core.Context
 import Core.Context.Log
 import Core.Core
 import Core.FC
-import Core.Name
 import Core.Options
 import Libraries.Utils.Path
 
 import Data.List
-import Data.String
 import Data.Maybe
 
 import System.Directory
-import System.File
-import System.Info
 
 %default total
 

--- a/src/Core/GetType.idr
+++ b/src/Core/GetType.idr
@@ -1,6 +1,5 @@
 module Core.GetType
 
-import Core.Case.CaseTree
 import Core.Context
 import Core.Env
 import Core.Normalise

--- a/src/Core/Hash.idr
+++ b/src/Core/Hash.idr
@@ -4,10 +4,7 @@ import Core.Case.CaseTree
 import Core.CompileExpr
 import Core.TT
 
-import Data.List
 import Data.List1
-import Libraries.Data.List.Lazy
-import Data.String
 import Libraries.Data.String.Iterator
 import Data.Vect
 

--- a/src/Core/InitPrimitives.idr
+++ b/src/Core/InitPrimitives.idr
@@ -4,7 +4,6 @@ import Compiler.CompileExpr
 
 import Core.Context
 import Core.Primitives
-import Core.TT
 
 %default covering
 

--- a/src/Core/Metadata.idr
+++ b/src/Core/Metadata.idr
@@ -4,11 +4,9 @@ import Core.Binary
 import Core.Context
 import Core.Context.Log
 import Core.Core
-import Core.Directory
 import Core.Env
 import Core.FC
 import Core.Normalise
-import Core.Options
 import Core.TT
 import Core.TTC
 

--- a/src/Core/Name.idr
+++ b/src/Core/Name.idr
@@ -1,8 +1,6 @@
 module Core.Name
 
-import Data.List
 import Data.String
-import Data.Maybe
 import Decidable.Equality
 import Libraries.Text.PrettyPrint.Prettyprinter
 import Libraries.Text.PrettyPrint.Prettyprinter.Util

--- a/src/Core/Name/Namespace.idr
+++ b/src/Core/Name/Namespace.idr
@@ -5,7 +5,6 @@ import Data.List1
 import Data.String
 import Decidable.Equality
 import Libraries.Text.PrettyPrint.Prettyprinter
-import Libraries.Text.PrettyPrint.Prettyprinter.Util
 import Libraries.Utils.Path
 
 %default total

--- a/src/Core/Normalise.idr
+++ b/src/Core/Normalise.idr
@@ -4,21 +4,13 @@ import public Core.Normalise.Convert
 import public Core.Normalise.Eval
 import public Core.Normalise.Quote
 
-import Core.Case.CaseTree
 import Core.Context
 import Core.Context.Log
 import Core.Core
 import Core.Env
 import Core.Options
-import Core.Primitives
 import Core.TT
 import Core.Value
-
-import Libraries.Data.IntMap
-import Data.List
-import Data.Maybe
-import Data.Nat
-import Data.Vect
 
 %default covering
 

--- a/src/Core/Normalise/Convert.idr
+++ b/src/Core/Normalise/Convert.idr
@@ -5,19 +5,12 @@ import public Core.Normalise.Quote
 
 import Core.Case.CaseTree
 import Core.Context
-import Core.Context.Log
 import Core.Core
 import Core.Env
-import Core.Options
-import Core.Primitives
 import Core.TT
 import Core.Value
 
-import Libraries.Data.IntMap
 import Data.List
-import Data.Maybe
-import Data.Nat
-import Data.Vect
 
 %default covering
 

--- a/src/Core/Normalise/Eval.idr
+++ b/src/Core/Normalise/Eval.idr
@@ -5,12 +5,10 @@ import Core.Context
 import Core.Context.Log
 import Core.Core
 import Core.Env
-import Core.Options
 import Core.Primitives
 import Core.TT
 import Core.Value
 
-import Libraries.Data.IntMap
 import Data.List
 import Data.Maybe
 import Data.Nat

--- a/src/Core/Normalise/Quote.idr
+++ b/src/Core/Normalise/Quote.idr
@@ -1,21 +1,11 @@
 module Core.Normalise.Quote
 
-import Core.Case.CaseTree
 import Core.Context
-import Core.Context.Log
 import Core.Core
 import Core.Env
 import Core.Normalise.Eval
-import Core.Options
-import Core.Primitives
 import Core.TT
 import Core.Value
-
-import Libraries.Data.IntMap
-import Data.List
-import Data.Maybe
-import Data.Nat
-import Data.Vect
 
 %default covering
 

--- a/src/Core/Options.idr
+++ b/src/Core/Options.idr
@@ -5,14 +5,11 @@ import Core.Name
 import public Core.Options.Log
 import Core.TT
 
-import Libraries.Utils.Binary
 import Libraries.Utils.Path
 
 import Data.List
 import Data.Maybe
 import Data.String
-
-import System.Info
 
 %default total
 

--- a/src/Core/Options/Log.idr
+++ b/src/Core/Options/Log.idr
@@ -9,7 +9,6 @@ import Data.String
 import Data.These
 import Libraries.Text.PrettyPrint.Prettyprinter
 import Libraries.Text.PrettyPrint.Prettyprinter.Util
-import Libraries.Text.PrettyPrint.Prettyprinter.Render.String
 
 %default total
 

--- a/src/Core/Primitives.idr
+++ b/src/Core/Primitives.idr
@@ -1,6 +1,5 @@
 module Core.Primitives
 
-import Core.Core
 import Core.Context
 import Core.TT
 import Core.Value

--- a/src/Core/SchemeEval.idr
+++ b/src/Core/SchemeEval.idr
@@ -4,7 +4,6 @@ module Core.SchemeEval
 -- Drops back to the default slow evaluator if scheme isn't available
 
 import Core.Context
-import Core.Context.Log
 import Core.Core
 import Core.Env
 import Core.Normalise
@@ -13,9 +12,6 @@ import public Core.SchemeEval.Evaluate
 import public Core.SchemeEval.Quote
 import public Core.SchemeEval.ToScheme
 import Core.TT
-
-import Libraries.Data.NameMap
-import Libraries.Utils.Scheme
 
 {-
 

--- a/src/Core/SchemeEval/Compile.idr
+++ b/src/Core/SchemeEval/Compile.idr
@@ -11,8 +11,6 @@ Advanced TODO (possibly not worth it...):
 
 -}
 
-import Algebra.ZeroOneOmega
-
 import Core.Case.CaseTree
 import Core.Context
 import Core.Core

--- a/src/Core/SchemeEval/Quote.idr
+++ b/src/Core/SchemeEval/Quote.idr
@@ -1,15 +1,11 @@
 module Core.SchemeEval.Quote
 
 import Core.Context
-import Core.Context.Log
 import Core.Core
 import Core.Env
 import Core.SchemeEval.Compile
 import Core.SchemeEval.Evaluate
 import Core.TT
-
-import Libraries.Data.NameMap
-import Libraries.Utils.Scheme
 
 mutual
   quoteArgs : {auto c : Ref Ctxt Defs} ->

--- a/src/Core/TTC.idr
+++ b/src/Core/TTC.idr
@@ -12,7 +12,6 @@ import Core.Options
 import Core.TT
 
 import Libraries.Data.NameMap
-import Libraries.Data.PosMap
 
 import Libraries.Data.IOArray
 import Data.Vect

--- a/src/Core/Termination.idr
+++ b/src/Core/Termination.idr
@@ -1,14 +1,11 @@
 module Core.Termination
 
-import Core.Case.CaseTree
 import Core.Context
 import Core.Context.Log
 import Core.Env
 import Core.Normalise
 import Core.TT
 import Core.Value
-
-import Control.Monad.State
 
 import Libraries.Data.NameMap
 import Libraries.Data.SortedMap

--- a/src/Core/Transform.idr
+++ b/src/Core/Transform.idr
@@ -2,7 +2,6 @@ module Core.Transform
 
 import Core.Context
 import Core.Env
-import Core.Normalise
 import Core.TT
 
 import Libraries.Data.NameMap

--- a/src/Core/Unify.idr
+++ b/src/Core/Unify.idr
@@ -13,7 +13,6 @@ import public Core.UnifyState
 import Core.Value
 
 import Data.List
-import Data.List.Views
 import Data.Maybe
 
 import Libraries.Data.IntMap

--- a/src/Core/UnifyState.idr
+++ b/src/Core/UnifyState.idr
@@ -1,7 +1,6 @@
 
 module Core.UnifyState
 
-import Core.Case.CaseTree
 import Core.Context
 import Core.Context.Log
 import Core.Core
@@ -16,8 +15,6 @@ import Core.Value
 import Data.List
 import Libraries.Data.IntMap
 import Libraries.Data.NameMap
-import Libraries.Data.StringMap
-import Libraries.Utils.Binary
 
 %default covering
 

--- a/src/Core/Value.idr
+++ b/src/Core/Value.idr
@@ -5,9 +5,6 @@ import Core.Core
 import Core.Env
 import Core.TT
 
-import Libraries.Data.IntMap
-import Libraries.Data.NameMap
-
 %default covering
 
 public export

--- a/src/Idris/CommandLine.idr
+++ b/src/Idris/CommandLine.idr
@@ -1,15 +1,11 @@
 module Idris.CommandLine
 
-import IdrisPaths
-
 import Idris.Env
 import Idris.Version
 
-import Core.Name.Namespace
 import Core.Options
 
 import Data.List
-import Data.List1
 import Data.Maybe
 import Data.String
 import Data.Either

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -1,6 +1,5 @@
 module Idris.Desugar
 
-import Core.Binary
 import Core.Context
 import Core.Context.Log
 import Core.Core
@@ -10,11 +9,8 @@ import Core.Options
 import Core.TT
 import Core.Unify
 
-import Data.Maybe
-
 import Libraries.Data.List.Extra
 import Libraries.Data.StringMap
-import Libraries.Data.String.Extra
 import Libraries.Data.ANameMap
 import Libraries.Data.SortedMap
 
@@ -36,11 +32,9 @@ import TTImp.Utils
 import Libraries.Data.IMaybe
 import Libraries.Utils.Shunting
 
-import Control.Monad.State
 import Data.Maybe
 import Data.List
 import Data.List.Views
-import Data.List1
 import Data.String
 import Libraries.Data.String.Extra
 

--- a/src/Idris/Doc/Annotations.idr
+++ b/src/Idris/Doc/Annotations.idr
@@ -5,9 +5,6 @@ import Core.Name
 
 import Idris.Pretty
 
-import Libraries.Control.ANSI.SGR
-import Libraries.Text.PrettyPrint.Prettyprinter
-
 %default total
 
 public export

--- a/src/Idris/Doc/HTML.idr
+++ b/src/Idris/Doc/HTML.idr
@@ -6,8 +6,6 @@ import Core.Directory
 
 import Data.String
 
-import Parser.Lexer.Source
-
 import Libraries.Text.PrettyPrint.Prettyprinter
 import Libraries.Text.PrettyPrint.Prettyprinter.Render.HTML
 import Libraries.Text.PrettyPrint.Prettyprinter.SimpleDocTree

--- a/src/Idris/Doc/Keywords.idr
+++ b/src/Idris/Doc/Keywords.idr
@@ -9,7 +9,6 @@ import Idris.Doc.Annotations
 import Idris.Pretty
 
 import Libraries.Data.List.Quantifiers.Extra
-import Libraries.Text.PrettyPrint.Prettyprinter
 
 
 infix 10 ::=

--- a/src/Idris/Doc/String.idr
+++ b/src/Idris/Doc/String.idr
@@ -4,12 +4,10 @@ import Core.Context
 import Core.Context.Log
 import Core.Core
 import Core.Env
-import Core.Metadata
 import Core.TT
 import Core.TT.Traversals
 
 import Idris.Pretty
-import Idris.Pretty.Render
 import Idris.REPL.Opts
 import Idris.Resugar
 import Idris.Syntax
@@ -30,7 +28,6 @@ import Libraries.Data.SortedMap
 import Libraries.Data.StringMap as S
 import Libraries.Data.String.Extra
 
-import Libraries.Control.ANSI.SGR
 import public Libraries.Text.PrettyPrint.Prettyprinter
 import public Libraries.Text.PrettyPrint.Prettyprinter.Util
 

--- a/src/Idris/Driver.idr
+++ b/src/Idris/Driver.idr
@@ -12,7 +12,6 @@ import Core.Unify
 import Idris.CommandLine
 import Idris.Env
 import Idris.IDEMode.REPL
-import Idris.ModTree
 import Idris.Package
 import Idris.ProcessIdr
 import Idris.REPL
@@ -25,12 +24,9 @@ import Idris.Error
 import IdrisPaths
 
 import Data.List
-import Data.List1
-import Data.So
 import Data.String
 import System
 import System.Directory
-import System.File
 import Libraries.Utils.Path
 import Libraries.Utils.Term
 

--- a/src/Idris/Elab/Implementation.idr
+++ b/src/Idris/Elab/Implementation.idr
@@ -19,8 +19,8 @@ import TTImp.Unelab
 import TTImp.Utils
 
 import Control.Monad.State
-import Libraries.Data.ANameMap
 import Data.List
+import Libraries.Data.ANameMap
 import Libraries.Data.NameMap
 
 %default covering

--- a/src/Idris/Elab/Implementation.idr
+++ b/src/Idris/Elab/Implementation.idr
@@ -1,6 +1,5 @@
 module Idris.Elab.Implementation
 
-import Core.Binary
 import Core.Context
 import Core.Context.Log
 import Core.Core
@@ -9,11 +8,9 @@ import Core.Metadata
 import Core.TT
 import Core.Unify
 
-import Idris.Resugar
 import Idris.Syntax
 
 import TTImp.BindImplicits
-import TTImp.Elab
 import TTImp.Elab.Check
 import TTImp.ProcessDecls
 import TTImp.TTImp

--- a/src/Idris/Elab/Interface.idr
+++ b/src/Idris/Elab/Interface.idr
@@ -1,6 +1,5 @@
 module Idris.Elab.Interface
 
-import Core.Binary
 import Core.Context
 import Core.Context.Log
 import Core.Core
@@ -9,23 +8,18 @@ import Core.Env
 import Core.Metadata
 import Core.TT
 import Core.Unify
-import Core.Value
 
-import Idris.Resugar
 import Idris.Syntax
 
 import TTImp.BindImplicits
 import TTImp.ProcessDecls
-import TTImp.Elab
 import TTImp.Elab.Check
-import TTImp.Unelab
 import TTImp.TTImp
 import TTImp.Utils
 
 import Libraries.Data.ANameMap
 import Libraries.Data.List.Extra
 import Data.List
-import Data.Maybe
 
 %default covering
 

--- a/src/Idris/Error.idr
+++ b/src/Idris/Error.idr
@@ -1,12 +1,9 @@
 module Idris.Error
 
-import Core.Case.CaseTree
 import Core.Core
 import Core.Context
 import Core.Env
-import Core.Metadata
 import Core.Options
-import Core.Value
 
 import Idris.REPL.Opts
 import Idris.Resugar
@@ -17,16 +14,11 @@ import Parser.Source
 
 import Data.List
 import Data.List1
-import Data.Maybe
-import Data.Stream
 import Data.String
 
 import Libraries.Data.List.Extra
 import Libraries.Data.List1 as Lib
-import Libraries.Data.String.Extra
-import Libraries.Text.PrettyPrint.Prettyprinter
 import Libraries.Text.PrettyPrint.Prettyprinter.Util
-import Libraries.Utils.String
 import Libraries.Data.String.Extra
 
 import System.File

--- a/src/Idris/IDEMode/Holes.idr
+++ b/src/Idris/IDEMode/Holes.idr
@@ -12,7 +12,6 @@ import Idris.Pretty
 import Idris.IDEMode.Commands
 
 import Libraries.Data.String.Extra as L
-import Libraries.Utils.Term
 
 %default covering
 

--- a/src/Idris/IDEMode/Parser.idr
+++ b/src/Idris/IDEMode/Parser.idr
@@ -9,16 +9,13 @@ import Core.Name
 import Core.Metadata
 import Core.FC
 
-import Data.Maybe
 import Data.List
-import Data.String
 import Parser.Lexer.Source
 import Parser.Source
 import Parser.Support
 import Libraries.Text.Lexer
 import Libraries.Text.Lexer.Tokenizer
 import Libraries.Text.Parser
-import Libraries.Utils.String
 
 %default total
 

--- a/src/Idris/IDEMode/REPL.idr
+++ b/src/Idris/IDEMode/REPL.idr
@@ -1,32 +1,15 @@
 module Idris.IDEMode.REPL
 
-import Compiler.Scheme.Chez
-import Compiler.Scheme.Racket
-import Compiler.Scheme.Gambit
-import Compiler.Common
-
-import Core.AutoSearch
-import Core.CompileExpr
 import Core.Context
 import Core.Directory
-import Core.InitPrimitives
 import Core.Metadata
-import Core.Normalise
 import Core.Options
-import Core.TT
 import Core.Unify
 
-import Data.List
-import Data.So
-import Data.String
-
-import Idris.Desugar
 import Idris.Error
-import Idris.ModTree
 import Idris.Package
 import Idris.Parser
 import Idris.Pretty
-import Idris.Resugar
 import Idris.REPL
 import Idris.Syntax
 import Idris.Version
@@ -36,11 +19,6 @@ import Idris.IDEMode.Commands
 import Idris.IDEMode.Holes
 import Idris.IDEMode.Parser
 import Idris.IDEMode.SyntaxHighlight
-
-import TTImp.Interactive.CaseSplit
-import TTImp.Elab
-import TTImp.TTImp
-import TTImp.ProcessDecls
 
 import Libraries.Utils.Hex
 import Libraries.Utils.Path

--- a/src/Idris/IDEMode/SyntaxHighlight.idr
+++ b/src/Idris/IDEMode/SyntaxHighlight.idr
@@ -3,9 +3,7 @@ module Idris.IDEMode.SyntaxHighlight
 import Core.Context
 import Core.Context.Log
 import Core.Directory
-import Core.InitPrimitives
 import Core.Metadata
-import Core.TT
 
 import Idris.REPL
 import Idris.Syntax
@@ -14,7 +12,6 @@ import Idris.Doc.String
 import Idris.IDEMode.Commands
 
 import Data.List
-import Data.Maybe
 
 import Libraries.Data.PosMap
 

--- a/src/Idris/ModTree.idr
+++ b/src/Idris/ModTree.idr
@@ -7,12 +7,9 @@ import Core.Core
 import Core.Directory
 import Core.Metadata
 import Core.Options
-import Core.Primitives
 import Core.InitPrimitives
 import Core.UnifyState
 
-import Idris.Desugar
-import Idris.Error
 import Idris.Parser
 import Idris.ProcessIdr
 import Idris.REPL.Common
@@ -23,14 +20,10 @@ import Data.List
 import Data.Either
 import Data.String
 
-import System
 import System.Directory
-import System.File
 
 import Libraries.Data.StringMap
 import Libraries.Data.String.Extra as Extra
-
-import Debug.Trace
 
 %default covering
 

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -6,7 +6,6 @@ import Core.Context
 import Core.Context.Log
 import Core.Core
 import Core.Directory
-import Core.Env
 import Core.Metadata
 import Core.Name.Namespace
 import Core.Options
@@ -27,8 +26,6 @@ import Libraries.Data.SortedMap
 import Libraries.Data.StringMap
 import Libraries.Data.StringTrie
 import Libraries.Text.Parser
-import Libraries.Text.PrettyPrint.Prettyprinter
-import Libraries.Utils.String
 import Libraries.Utils.Path
 
 import Idris.CommandLine
@@ -42,7 +39,6 @@ import Idris.REPL.Opts
 import Idris.SetOptions
 import Idris.Syntax
 import Idris.Version
-import IdrisPaths
 
 import public Idris.Package.Types
 import Idris.Package.Init

--- a/src/Idris/Package/Init.idr
+++ b/src/Idris/Package/Init.idr
@@ -12,7 +12,6 @@ import System.Directory
 
 import Libraries.Utils.Path
 import Libraries.System.Directory.Tree
-import Libraries.Text.PrettyPrint.Prettyprinter
 
 %default total
 

--- a/src/Idris/Package/Types.idr
+++ b/src/Idris/Package/Types.idr
@@ -3,8 +3,6 @@ module Idris.Package.Types
 import Core.FC
 import Core.Name.Namespace
 import Data.Maybe
-import Data.String
-import Idris.CommandLine
 import Idris.Version
 import Libraries.Text.PrettyPrint.Prettyprinter
 import Libraries.Text.PrettyPrint.Prettyprinter.Util

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -4,14 +4,12 @@ import Core.Options
 import Core.Metadata
 import Idris.Syntax
 import public Parser.Source
-import Parser.Lexer.Source
 import TTImp.TTImp
 
 import public Libraries.Text.Parser
 import Data.Either
 import Libraries.Data.IMaybe
 import Data.List
-import Data.List.Views
 import Data.List1
 import Data.Maybe
 import Data.Nat

--- a/src/Idris/Parser/Let.idr
+++ b/src/Idris/Parser/Let.idr
@@ -6,8 +6,6 @@ import Libraries.Text.Bounded
 import Data.Either
 import Data.List1
 
-import Libraries.Utils.String
-
 %default total
 
 ------------------------------------------------------------------------

--- a/src/Idris/Pretty/Render.idr
+++ b/src/Idris/Pretty/Render.idr
@@ -5,7 +5,6 @@ import Core.Core
 
 import Idris.REPL.Opts
 
-import Libraries.Control.ANSI.SGR
 import Libraries.Text.PrettyPrint.Prettyprinter
 import public Libraries.Text.PrettyPrint.Prettyprinter.Render.Terminal
 import Libraries.Utils.Term

--- a/src/Idris/ProcessIdr.idr
+++ b/src/Idris/ProcessIdr.idr
@@ -38,11 +38,10 @@ import Idris.Pretty
 import Idris.Doc.String
 
 import Data.List
-import Libraries.Data.NameMap
 import Libraries.Data.SortedMap
 import Libraries.Utils.Path
+import Libraries.Data.SortedSet
 
-import System
 import System.File
 
 %default covering

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -1,16 +1,8 @@
 module Idris.REPL
 
-import Compiler.Scheme.Chez
-import Compiler.Scheme.ChezSep
-import Compiler.Scheme.Racket
-import Compiler.Scheme.Gambit
-import Compiler.ES.Node
-import Compiler.ES.Javascript
 import Compiler.Common
-import Compiler.RefC.RefC
 import Compiler.Inline
 
-import Core.AutoSearch
 import Core.Case.CaseTree
 import Core.CompileExpr
 import Core.Context
@@ -18,7 +10,6 @@ import Core.Context.Log
 import Core.Directory
 import Core.Env
 import Core.FC
-import Core.InitPrimitives
 import Core.LinearCheck
 import Core.Metadata
 import Core.Normalise
@@ -65,23 +56,18 @@ import TTImp.ProcessDecls
 import Data.List
 import Data.List1
 import Data.Maybe
-import Libraries.Data.ANameMap
 import Libraries.Data.NameMap
 import Libraries.Data.PosMap
 import Data.Stream
 import Data.String
-import Data.DPair
 import Libraries.Data.String.Extra
 import Libraries.Data.List.Extra
-import Libraries.Text.PrettyPrint.Prettyprinter
 import Libraries.Text.PrettyPrint.Prettyprinter.Util
-import Libraries.Text.PrettyPrint.Prettyprinter.Render.Terminal
 import Libraries.Utils.Path
 import Libraries.System.Directory.Tree
 
 import System
 import System.File
-import System.Directory
 
 %hide Data.String.lines
 %hide Data.String.lines'

--- a/src/Idris/REPL/Common.idr
+++ b/src/Idris/REPL/Common.idr
@@ -5,7 +5,6 @@ import Core.Directory
 import Core.Env
 import Core.InitPrimitives
 import Core.Metadata
-import Core.Primitives
 import Core.TT
 import Core.Unify
 import Core.UnifyState
@@ -15,7 +14,6 @@ import Idris.Doc.String
 
 import Idris.Error
 import Idris.IDEMode.Commands
-import Idris.IDEMode.Holes
 import Idris.Pretty
 import public Idris.REPL.Opts
 import Idris.Resugar
@@ -23,9 +21,7 @@ import Idris.Syntax
 import Idris.Version
 
 import Libraries.Data.ANameMap
-import Libraries.Text.PrettyPrint.Prettyprinter
 
-import Data.List
 import Data.String
 import System.File
 

--- a/src/Idris/REPL/FuzzySearch.idr
+++ b/src/Idris/REPL/FuzzySearch.idr
@@ -1,57 +1,20 @@
 module Idris.REPL.FuzzySearch
 
-import Core.AutoSearch
-import Core.Case.CaseTree
-import Core.CompileExpr
 import Core.Context
-import Core.Context.Log
-import Core.Env
-import Core.InitPrimitives
-import Core.LinearCheck
 import Core.Metadata
-import Core.Normalise
-import Core.Options
 import Core.TT
-import Core.Termination
 import Core.Unify
 
-import Idris.Desugar
 import Idris.Doc.String
-import Idris.Error
-import Idris.IDEMode.CaseSplit
 import Idris.IDEMode.Commands
-import Idris.IDEMode.MakeClause
-import Idris.IDEMode.Holes
-import Idris.ModTree
-import Idris.Parser
 import Idris.Pretty
-import Idris.ProcessIdr
-import Idris.Resugar
 import Idris.Syntax
-import Idris.Version
 
 import public Idris.REPL.Common
 
 import Data.List
-import Data.List1
 import Data.Maybe
-import Libraries.Data.ANameMap
-import Libraries.Data.NameMap
-import Libraries.Data.PosMap
-import Data.Stream
-import Data.String
-import Data.DPair
-import Libraries.Data.String.Extra
 import Libraries.Data.List.Extra
-import Libraries.Text.PrettyPrint.Prettyprinter
-import Libraries.Text.PrettyPrint.Prettyprinter.Util
-import Libraries.Text.PrettyPrint.Prettyprinter.Render.Terminal
-import Libraries.Utils.Path
-import Libraries.System.Directory.Tree
-
-import System
-import System.File
-import System.Directory
 
 %default covering
 

--- a/src/Idris/Resugar.idr
+++ b/src/Idris/Resugar.idr
@@ -13,7 +13,6 @@ import TTImp.Unelab
 import TTImp.Utils
 
 import Data.List
-import Data.List1
 import Data.Maybe
 import Data.String
 import Libraries.Data.StringMap

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -3,7 +3,6 @@ module Idris.SetOptions
 import Compiler.Common
 
 import Core.Context
-import Core.Directory
 import Core.Metadata
 import Core.Options
 import Core.Unify
@@ -18,11 +17,8 @@ import Idris.REPL
 import Idris.Syntax
 import Idris.Version
 
-import IdrisPaths
-
 import Data.List
 import Data.List1
-import Data.So
 import Data.String
 
 import Libraries.Data.List1 as Lib

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -15,14 +15,11 @@ import TTImp.TTImp
 import Libraries.Data.ANameMap
 import Data.List
 import Data.Maybe
-import Data.String
 import Libraries.Data.NameMap
 import Libraries.Data.SortedMap
 import Libraries.Data.String.Extra
 import Libraries.Data.StringMap
 import Libraries.Text.PrettyPrint.Prettyprinter
-import Libraries.Text.PrettyPrint.Prettyprinter.Util
-import Libraries.Text.PrettyPrint.Prettyprinter.Render.String
 
 import Parser.Lexer.Source
 

--- a/src/Libraries/Data/IOArray.idr
+++ b/src/Libraries/Data/IOArray.idr
@@ -1,7 +1,6 @@
 module Libraries.Data.IOArray
 
 import Data.IOArray.Prims
-import Data.List
 
 %default total
 

--- a/src/Libraries/Data/List/Extra.idr
+++ b/src/Libraries/Data/List/Extra.idr
@@ -1,6 +1,6 @@
 module Libraries.Data.List.Extra
 
-import Data.List
+import public Data.List
 import Data.List1
 
 %default total

--- a/src/Libraries/Data/PosMap.idr
+++ b/src/Libraries/Data/PosMap.idr
@@ -7,7 +7,6 @@
 module Libraries.Data.PosMap
 
 import Core.FC
-import Core.Name.Namespace
 
 import Data.List
 

--- a/src/Libraries/System/Directory/Tree.idr
+++ b/src/Libraries/System/Directory/Tree.idr
@@ -1,11 +1,9 @@
 module Libraries.System.Directory.Tree
 
 import Control.Monad.Either
-import Data.Buffer
 import Data.DPair
 import Data.List
 import Data.Nat
-import Data.String
 import System.Directory
 import System.File
 import Libraries.Utils.Path

--- a/src/Libraries/Text/Distance/Levenshtein.idr
+++ b/src/Libraries/Text/Distance/Levenshtein.idr
@@ -1,7 +1,5 @@
 module Libraries.Text.Distance.Levenshtein
 
-import Data.List
-import Data.Maybe
 import Data.String
 import Libraries.Data.IOMatrix
 import Libraries.Data.List.Extra

--- a/src/Libraries/Text/Lexer/Core.idr
+++ b/src/Libraries/Text/Lexer/Core.idr
@@ -2,8 +2,6 @@ module Libraries.Text.Lexer.Core
 
 import Data.List
 import Data.Maybe
-import Data.Nat
-import Data.String
 
 import public Libraries.Control.Delayed
 import public Libraries.Text.Bounded

--- a/src/Libraries/Text/Lexer/Tokenizer.idr
+++ b/src/Libraries/Text/Lexer/Tokenizer.idr
@@ -1,15 +1,10 @@
 module Libraries.Text.Lexer.Tokenizer
 
 import Data.List
-import Data.Either
-import Data.Nat
-import Data.String
 
-import Libraries.Data.String.Extra
 import Libraries.Text.Lexer.Core
 import Libraries.Text.Lexer
 import Libraries.Text.PrettyPrint.Prettyprinter
-import Libraries.Text.PrettyPrint.Prettyprinter.Util
 
 import public Libraries.Control.Delayed
 import public Libraries.Text.Bounded

--- a/src/Libraries/Text/Literate.idr
+++ b/src/Libraries/Text/Literate.idr
@@ -25,7 +25,6 @@ module Libraries.Text.Literate
 
 import Libraries.Text.Lexer
 
-import Data.List
 import Data.List1
 import Data.List.Views
 import Data.String

--- a/src/Libraries/Text/Parser.idr
+++ b/src/Libraries/Text/Parser.idr
@@ -1,7 +1,6 @@
 module Libraries.Text.Parser
 
 import Data.Bool
-import Data.List
 import Data.Nat
 import public Data.List1
 

--- a/src/Libraries/Text/PrettyPrint/Prettyprinter/Render/HTML.idr
+++ b/src/Libraries/Text/PrettyPrint/Prettyprinter/Render/HTML.idr
@@ -1,6 +1,5 @@
 module Libraries.Text.PrettyPrint.Prettyprinter.Render.HTML
 
-import Data.List
 import Data.String
 
 %default covering

--- a/src/Libraries/Text/PrettyPrint/Prettyprinter/Render/String.idr
+++ b/src/Libraries/Text/PrettyPrint/Prettyprinter/Render/String.idr
@@ -1,7 +1,6 @@
 module Libraries.Text.PrettyPrint.Prettyprinter.Render.String
 
 import Data.String
-import Libraries.Data.String.Extra
 import Libraries.Text.PrettyPrint.Prettyprinter.Doc
 
 %default total

--- a/src/Libraries/Text/PrettyPrint/Prettyprinter/SimpleDocTree.idr
+++ b/src/Libraries/Text/PrettyPrint/Prettyprinter/SimpleDocTree.idr
@@ -1,7 +1,6 @@
 module Libraries.Text.PrettyPrint.Prettyprinter.SimpleDocTree
 
 import Libraries.Text.PrettyPrint.Prettyprinter.Doc
-import Libraries.Text.Parser
 
 %default total
 

--- a/src/Libraries/Text/PrettyPrint/Prettyprinter/Util.idr
+++ b/src/Libraries/Text/PrettyPrint/Prettyprinter/Util.idr
@@ -1,7 +1,6 @@
 module Libraries.Text.PrettyPrint.Prettyprinter.Util
 
 import Data.List
-import Data.String
 import Libraries.Text.PrettyPrint.Prettyprinter.Doc
 import Libraries.Text.PrettyPrint.Prettyprinter.Render.String
 

--- a/src/Libraries/Utils/Binary.idr
+++ b/src/Libraries/Utils/Binary.idr
@@ -5,8 +5,6 @@ import Data.List
 
 import System.File
 
-import Libraries.Utils.String
-
 -- Serialising data as binary. Provides an interface TTC which allows
 -- reading and writing to chunks of memory, "Binary", which can be written
 -- to and read from files.

--- a/src/Libraries/Utils/Hex.idr
+++ b/src/Libraries/Utils/Hex.idr
@@ -2,7 +2,6 @@ module Libraries.Utils.Hex
 
 import Data.Bits
 import Data.List
-import Data.Primitives.Views
 
 %default total
 

--- a/src/Libraries/Utils/Term.idr
+++ b/src/Libraries/Utils/Term.idr
@@ -1,7 +1,5 @@
 module Libraries.Utils.Term
 
-import System.FFI
-
 %default total
 
 libterm : String -> String

--- a/src/Parser/Lexer/Package.idr
+++ b/src/Parser/Lexer/Package.idr
@@ -7,7 +7,6 @@ import public Libraries.Text.Bounded
 import Libraries.Text.PrettyPrint.Prettyprinter
 
 import Data.List
-import Data.List1
 import Data.String
 import Libraries.Data.String.Extra
 import Libraries.Utils.String

--- a/src/Parser/Lexer/Source.idr
+++ b/src/Parser/Lexer/Source.idr
@@ -3,7 +3,6 @@ module Parser.Lexer.Source
 import public Parser.Lexer.Common
 
 import Data.Either
-import Data.List1
 import Data.List
 import Data.Maybe
 import Data.String

--- a/src/Parser/Package.idr
+++ b/src/Parser/Package.idr
@@ -8,7 +8,6 @@ import public Parser.Support
 
 import Core.Core
 import Core.FC
-import Core.Name.Namespace
 import System.File
 
 %default total

--- a/src/Parser/Rule/Package.idr
+++ b/src/Parser/Rule/Package.idr
@@ -2,7 +2,6 @@ module Parser.Rule.Package
 
 import public Parser.Lexer.Package
 
-import Data.List
 import Data.List1
 
 import Core.Name.Namespace

--- a/src/Parser/Support.idr
+++ b/src/Parser/Support.idr
@@ -5,15 +5,11 @@ import public Libraries.Text.Lexer
 import public Libraries.Text.Parser
 import Libraries.Data.String.Extra
 import public Libraries.Text.PrettyPrint.Prettyprinter
-import Libraries.Text.PrettyPrint.Prettyprinter.Util
 
 import Core.TT
 import Core.Core
 import Data.List
-import Data.List.Views
-import Data.String
 import Parser.Unlit
-import System.File
 
 %default total
 

--- a/src/TTImp/Elab.idr
+++ b/src/TTImp/Elab.idr
@@ -9,7 +9,6 @@ import Core.Metadata
 import Core.Normalise
 import Core.UnifyState
 import Core.Unify
-import Core.Value
 
 import Idris.Syntax
 
@@ -17,7 +16,6 @@ import TTImp.Elab.Check
 import TTImp.Elab.Delayed
 import TTImp.Elab.Term
 import TTImp.TTImp
-import TTImp.Unelab
 
 import Data.List
 import Data.Maybe

--- a/src/TTImp/Elab/App.idr
+++ b/src/TTImp/Elab/App.idr
@@ -1,6 +1,5 @@
 module TTImp.Elab.App
 
-import Core.Case.CaseTree
 import Core.Context
 import Core.Context.Log
 import Core.Core
@@ -18,7 +17,6 @@ import TTImp.Elab.Dot
 import TTImp.TTImp
 
 import Data.List
-import Data.List1
 import Data.Maybe
 
 %default covering

--- a/src/TTImp/Elab/As.idr
+++ b/src/TTImp/Elab/As.idr
@@ -8,7 +8,6 @@ import Core.Metadata
 import Core.Normalise
 import Core.Unify
 import Core.TT
-import Core.Value
 
 import Idris.Syntax
 
@@ -17,7 +16,6 @@ import TTImp.Elab.ImplicitBind
 import TTImp.TTImp
 
 import Data.List
-import Libraries.Data.NameMap
 
 %default covering
 

--- a/src/TTImp/Elab/Case.idr
+++ b/src/TTImp/Elab/Case.idr
@@ -1,6 +1,5 @@
 module TTImp.Elab.Case
 
-import Core.Case.CaseTree
 import Core.Context
 import Core.Context.Log
 import Core.Core

--- a/src/TTImp/Elab/Delayed.idr
+++ b/src/TTImp/Elab/Delayed.idr
@@ -12,7 +12,6 @@ import Core.TT
 import Core.Value
 
 import TTImp.Elab.Check
-import TTImp.TTImp
 
 import Libraries.Data.IntMap
 import Libraries.Data.NameMap

--- a/src/TTImp/Elab/Dot.idr
+++ b/src/TTImp/Elab/Dot.idr
@@ -7,15 +7,11 @@ import Core.Metadata
 import Core.Normalise
 import Core.Unify
 import Core.TT
-import Core.Value
 
 import Idris.Syntax
 
 import TTImp.Elab.Check
-import TTImp.Elab.ImplicitBind
 import TTImp.TTImp
-
-import Libraries.Data.NameMap
 
 %default covering
 

--- a/src/TTImp/Elab/Local.idr
+++ b/src/TTImp/Elab/Local.idr
@@ -1,6 +1,5 @@
 module TTImp.Elab.Local
 
-import Core.Case.CaseTree
 import Core.Context
 import Core.Context.Log
 import Core.Core
@@ -9,12 +8,10 @@ import Core.Metadata
 import Core.Normalise
 import Core.Unify
 import Core.TT
-import Core.Value
 
 import Idris.Syntax
 
 import TTImp.Elab.Check
-import TTImp.Elab.Utils
 import TTImp.TTImp
 
 import Libraries.Data.NameMap

--- a/src/TTImp/Elab/Quote.idr
+++ b/src/TTImp/Elab/Quote.idr
@@ -8,7 +8,6 @@ import Core.Normalise
 import Core.Reflect
 import Core.Unify
 import Core.TT
-import Core.Value
 
 import Idris.Syntax
 

--- a/src/TTImp/Elab/Record.idr
+++ b/src/TTImp/Elab/Record.idr
@@ -17,7 +17,6 @@ import TTImp.Elab.Delayed
 import TTImp.TTImp
 
 import Data.List
-import Data.Maybe
 
 %default covering
 

--- a/src/TTImp/Elab/Rewrite.idr
+++ b/src/TTImp/Elab/Rewrite.idr
@@ -17,8 +17,6 @@ import TTImp.Elab.Check
 import TTImp.Elab.Delayed
 import TTImp.TTImp
 
-import Data.List
-
 %default covering
 
 -- TODO: Later, we'll get the name of the lemma from the type, if it's one

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -4,7 +4,6 @@ import Core.Context
 import Core.Context.Log
 import Core.Core
 import Core.Env
-import Core.GetType
 import Core.Metadata
 import Core.Normalise
 import Core.Options
@@ -22,7 +21,6 @@ import TTImp.Reflect
 import TTImp.TTImp
 import TTImp.TTImp.Functor
 import TTImp.Unelab
-import TTImp.Utils
 
 %default covering
 

--- a/src/TTImp/Elab/Term.idr
+++ b/src/TTImp/Elab/Term.idr
@@ -7,8 +7,6 @@ import Core.Core
 import Core.Env
 import Core.Metadata
 import Core.Normalise
-import Core.Options
-import Core.Reflect
 import Core.Unify
 import Core.TT
 import Core.Value
@@ -31,7 +29,6 @@ import TTImp.Elab.Quote
 import TTImp.Elab.Record
 import TTImp.Elab.Rewrite
 import TTImp.Elab.RunElab
-import TTImp.Reflect
 import TTImp.TTImp
 
 %default covering

--- a/src/TTImp/Impossible.idr
+++ b/src/TTImp/Impossible.idr
@@ -10,7 +10,6 @@ import TTImp.TTImp
 import TTImp.Elab.App
 
 import Data.List
-import Data.List1
 
 %default covering
 

--- a/src/TTImp/Interactive/CaseSplit.idr
+++ b/src/TTImp/Interactive/CaseSplit.idr
@@ -6,7 +6,6 @@ import Core.Core
 import Core.Env
 import Core.Metadata
 import Core.Normalise
-import Core.Options
 import Core.TT
 import Core.UnifyState
 import Core.Value

--- a/src/TTImp/Interactive/ExprSearch.idr
+++ b/src/TTImp/Interactive/ExprSearch.idr
@@ -32,7 +32,6 @@ import TTImp.TTImp.Functor
 import TTImp.Unelab
 import TTImp.Utils
 
-import Data.Either
 import Data.List
 
 %default covering

--- a/src/TTImp/Interactive/GenerateDef.idr
+++ b/src/TTImp/Interactive/GenerateDef.idr
@@ -21,7 +21,6 @@ import TTImp.Interactive.ExprSearch
 import TTImp.ProcessDecls
 import TTImp.ProcessDef
 import TTImp.TTImp
-import TTImp.Unelab
 import TTImp.Utils
 
 import Data.List

--- a/src/TTImp/Interactive/MakeLemma.idr
+++ b/src/TTImp/Interactive/MakeLemma.idr
@@ -5,7 +5,6 @@ import Core.Env
 import Core.Metadata
 import Core.Normalise
 import Core.TT
-import Core.Value
 
 import TTImp.Unelab
 import TTImp.TTImp

--- a/src/TTImp/Parser.idr
+++ b/src/TTImp/Parser.idr
@@ -1,19 +1,14 @@
 module TTImp.Parser
 
 import Core.Context
-import Core.Core
 import Core.Metadata
-import Core.Env
 import Core.TT
 import Parser.Source
 import TTImp.TTImp
 
 import public Libraries.Text.Parser
 import Data.List
-import Data.List.Views
 import Data.List1
-import Data.Maybe
-import Data.String
 
 topDecl : OriginDesc -> IndentInfo -> Rule ImpDecl
 -- All the clauses get parsed as one-clause definitions. Collect any

--- a/src/TTImp/PartialEval.idr
+++ b/src/TTImp/PartialEval.idr
@@ -1,6 +1,5 @@
 module TTImp.PartialEval
 
-import Core.Case.CaseTree
 import Core.Context
 import Core.Context.Log
 import Core.Core

--- a/src/TTImp/ProcessBuiltin.idr
+++ b/src/TTImp/ProcessBuiltin.idr
@@ -4,18 +4,12 @@ module TTImp.ProcessBuiltin
 
 import Data.List
 
-import Libraries.Data.Fin as Libs
-import Libraries.Data.NameMap
-
-import Core.Case.CaseTree
 import Core.Core
 import Core.Context
 import Core.Context.Log
 import Core.CompileExpr
 import Core.Env
-import Core.Metadata
 import Core.TT
-import Core.UnifyState
 
 import TTImp.TTImp
 

--- a/src/TTImp/ProcessData.idr
+++ b/src/TTImp/ProcessData.idr
@@ -19,7 +19,6 @@ import TTImp.Elab.Check
 import TTImp.Elab.Utils
 import TTImp.Elab
 import TTImp.TTImp
-import TTImp.Utils
 
 import Data.DPair
 import Data.List

--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -28,7 +28,6 @@ import TTImp.TTImp
 import TTImp.TTImp.Functor
 import TTImp.ProcessType
 import TTImp.Unelab
-import TTImp.Utils
 import TTImp.WithClause
 
 import Data.Either

--- a/src/TTImp/ProcessParams.idr
+++ b/src/TTImp/ProcessParams.idr
@@ -15,8 +15,6 @@ import TTImp.Elab
 import TTImp.Elab.Check
 import TTImp.TTImp
 
-import Data.List
-
 %default covering
 
 extend : {extvs : _} ->

--- a/src/TTImp/ProcessRecord.idr
+++ b/src/TTImp/ProcessRecord.idr
@@ -5,14 +5,11 @@ import Core.Context.Log
 import Core.Core
 import Core.Env
 import Core.Metadata
-import Core.Normalise
 import Core.UnifyState
-import Core.Value
 
 import Idris.Syntax
 
 import TTImp.BindImplicits
-import TTImp.Elab
 import TTImp.Elab.Check
 import TTImp.TTImp
 import TTImp.TTImp.Functor

--- a/src/TTImp/ProcessType.idr
+++ b/src/TTImp/ProcessType.idr
@@ -13,15 +13,12 @@ import Core.Value
 
 import Idris.Syntax
 
-import TTImp.BindImplicits
 import TTImp.Elab.Check
 import TTImp.Elab.Utils
 import TTImp.Elab
 import TTImp.TTImp
-import TTImp.Utils
 
 import Data.List
-import Data.List1
 import Data.String
 import Libraries.Data.NameMap
 

--- a/src/TTImp/Unelab.idr
+++ b/src/TTImp/Unelab.idr
@@ -5,12 +5,10 @@ import Core.Context
 import Core.Context.Log
 import Core.Env
 import Core.Normalise
-import Core.Options
 import Core.Value
 import Core.TT
 
 import TTImp.TTImp
-import TTImp.Utils
 
 import Data.List
 import Data.String

--- a/src/Yaffle/Main.idr
+++ b/src/Yaffle/Main.idr
@@ -1,31 +1,20 @@
 module Yaffle.Main
 
-import Parser.Source
-
 import Core.Binary
 import Core.Context
 import Core.Directory
-import Core.Env
 import Core.FC
 import Core.InitPrimitives
 import Core.Metadata
-import Core.Normalise
-import Core.Options
-import Core.TT
 import Core.UnifyState
 import Libraries.Utils.Path
 
 import Idris.Syntax
 
-import TTImp.Parser
 import TTImp.ProcessDecls
-import TTImp.TTImp
 
 import Yaffle.REPL
 
-import Data.List
-import Data.So
-import Data.String
 import System
 
 %default covering

--- a/src/Yaffle/REPL.idr
+++ b/src/Yaffle/REPL.idr
@@ -11,7 +11,6 @@ import Core.Normalise
 import Core.Termination
 import Core.TT
 import Core.Unify
-import Core.Value
 
 import Idris.Syntax
 


### PR DESCRIPTION
I'm working on a PR that will introduce a warning for when an import is not used in a module. That work is not done, but in the meantime I thought it would be smart to open a PR that removes the majority of those unused imports.

If others think this kind of cleanup is beneficial, it is nice to have a standalone PR removing the imports because there are so many of them -- this way, reviewing the PR is actually manageable because beyond making sure CI still passes you just need to skim the removals to verify no fishy changes are being made.

A couple of questions:
1. Is this a desirable thing to do? I personally like removing unused imports from my own code because I find it makes the import list easier to work with and comprehend. But should it be forced upon the compiler codebase?
2. Does it make things faster? I would have thought so, but it turns out to be negligible with respect to speed. The current `main` branch compiles (using version 0.5.1 of the compiler) in 3 minutes 20 seconds on my machine. This branch, by contrast, compiles in 3 minutes 19 seconds. A whopping 1 second improvement! These durations were _very_ consistent, so the 1 second does appear to be _real_, just not very significant.

I strongly suggest that review of this PR takes the form of skimming the changes to make sure they are all removed imports (except for the 1 import that is made public to make it more ergonomic to use `List.NonEmpty` without requiring explicit import of `Data.List` when only `Data.List.Extra` is needed). It would be a massive endeavor with no clear benefit to try to reason about whether the imports I removed make sense to remove. That's the whole reason for a warning after all -- let the computer figure out what imports aren't needed.