### PR TITLE
make Data.List1.length public

### DIFF
--- a/libs/base/Data/List1.idr
+++ b/libs/base/Data/List1.idr
@@ -65,7 +65,7 @@ export
 foldl1 : (func : a -> a -> a) -> (l : List1 a) -> a
 foldl1 f = foldl1By f id
 
-export
+public export
 length : List1 a -> Nat
 length (_ ::: xs) = S (length xs)
 


### PR DESCRIPTION
Following up from https://github.com/idris-lang/Idris2/pull/2125

I wanted to implement lengthMap for List1 but idris2 couldn't simplify the expression because the List1.length function isn't public export.

```
lengthMap : (xs : List1 a) -> length (map f xs) = length xs
lengthMap (head ::: tail) = ?lengthMap_rhs_1
```

Here `lengthMap_rhs_1 : length (f head ::: map f tail) = length (head ::: tail)`