### PR TITLE
[ fix ] Forbid "." as namespace identifier

### DIFF
--- a/src/Core/Directory.idr
+++ b/src/Core/Directory.idr
@@ -125,7 +125,7 @@ mbPathToNS wdir sdir fname =
     sdir = fromMaybe "" $ filter (/= ".") sdir
     base = if isAbsolute fname then wdir </> sdir else sdir
   in
-    unsafeFoldModuleIdent . reverse . splitPath . Path.dropExtension
+    unsafeFoldModuleIdent . filter (/= ".") . reverse . splitPath . Path.dropExtension
       <$> Path.dropBase base fname
 
 export


### PR DESCRIPTION
#2124 allowed `idris2 --find-ipkg <srcfile>` when `sourcedir  =  "."`, but broke `idris2 --build <ipkg>`. This allows both.