### PR TITLE
[ fix ] Use right reflection constructor name for unambiguing with

### DIFF
--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -711,11 +711,6 @@ parameters {0 nm : Type} (toName : nm -> Name)
         = "let " ++ showCount rig ++ showPTermPrec d n ++ " : " ++ showPTermPrec d ty ++ " = "
                  ++ showPTermPrec d val ++ concatMap showAlt alts ++
                  " in " ++ showPTermPrec d sc
-      where
-        showAlt : PClause' nm -> String
-        showAlt (MkPatClause _ lhs rhs _) = " | " ++ showPTerm lhs ++ " => " ++ showPTerm rhs ++ ";"
-        showAlt (MkWithClause _ lhs rhs prf flags _) = " | <<with alts not possible>>"
-        showAlt (MkImpossible _ lhs) = " | " ++ showPTerm lhs ++ " impossible;"
   showPTermPrec _ (PCase _ tm cs)
         = "case " ++ showPTerm tm ++ " of { " ++
             showSep " ; " (map showCase cs) ++ " }"

--- a/src/TTImp/Reflect.idr
+++ b/src/TTImp/Reflect.idr
@@ -609,7 +609,7 @@ mutual
     reflect fc defs lhs env (IUnquote tfc t)
         = throw (InternalError "Can't reflect an unquote: escapes should be lifted out")
     reflect fc defs lhs env (IRunElab tfc t)
-        = throw (InternalError "Can't reflect a %runelab")
+        = throw (InternalError "Can't reflect a %runElab")
     reflect fc defs lhs env (IPrimVal tfc t)
         = do fc' <- reflect fc defs lhs env tfc
              t' <- reflect fc defs lhs env t

--- a/src/TTImp/Reflect.idr
+++ b/src/TTImp/Reflect.idr
@@ -633,7 +633,7 @@ mutual
         = do fc' <- reflect fc defs lhs env tfc
              ns' <- reflect fc defs lhs env ns
              t' <- reflect fc defs lhs env t
-             appCon fc defs (reflectionttimp "WithUnambigNames") [fc', ns', t']
+             appCon fc defs (reflectionttimp "IWithUnambigNames") [fc', ns', t']
 
   export
   Reflect IFieldUpdate where

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -215,6 +215,7 @@ idrisTests = MkTestPool "Misc" [] Nothing
        "reflection001", "reflection002", "reflection003", "reflection004",
        "reflection005", "reflection006", "reflection007", "reflection008",
        "reflection009", "reflection010", "reflection011", "reflection012",
+       "reflection013",
        -- The 'with' rule
        "with001", "with002", "with004", "with005", "with006",
        -- with-disambiguation

--- a/tests/idris2/reflection013/WithUnambig.idr
+++ b/tests/idris2/reflection013/WithUnambig.idr
@@ -1,0 +1,12 @@
+import Language.Reflection
+
+x : TTImp
+x = `(with Prelude.Nil [])
+
+%language ElabReflection
+
+x' : Elab (List Nat)
+x' = check x
+
+l : List Nat
+l = 1 :: %runElab x'

--- a/tests/idris2/reflection013/expected
+++ b/tests/idris2/reflection013/expected
@@ -1,0 +1,1 @@
+1/1: Building WithUnambig (WithUnambig.idr)

--- a/tests/idris2/reflection013/run
+++ b/tests/idris2/reflection013/run
@@ -1,0 +1,4 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --no-banner --check WithUnambig.idr
+


### PR DESCRIPTION
+ also a cleanup and a cosmetic fix that do not worth their own PRs

This fixes a bug of unability to use `with <Constructor> <expression>` expressions under quotes (see added test for particular example).