### PR TITLE
[ fix #2065 ] Use postfix projections if prefix ones are off

### DIFF
--- a/src/TTImp/ProcessRecord.idr
+++ b/src/TTImp/ProcessRecord.idr
@@ -205,12 +205,12 @@ elabRecord {vars} eopts fc env nest newns vis tn_in params conName_in fields
                    --
                    -- In upds, we use unNameNS (as opposed to rfNameNS or both)
                    -- because the field types will probably mention the UN versions of the projections;
-                   -- but only when prefix record projections are enabled, otherwise 
+                   -- but only when prefix record projections are enabled, otherwise
                    -- dependent records won't typecheck!
                    --
-                   -- With the braching on this flag, this change of using `rfNamesNS` remains backward compatible 
+                   -- With the braching on this flag, this change of using `rfNamesNS` remains backward compatible
                    -- (though the only difference I'm aware is in the output of the `:doc` command)
-                   prefix_flag <- isPrefixRecordProjections 
+                   prefix_flag <- isPrefixRecordProjections
                    let upds' = if prefix_flag
                          then (n, IApp bfc (IVar bfc unNameNS) (IVar bfc rname)) :: upds
                          else (n, IApp bfc (IVar bfc rfNameNS) (IVar bfc rname)) :: upds

--- a/src/TTImp/ProcessRecord.idr
+++ b/src/TTImp/ProcessRecord.idr
@@ -204,8 +204,17 @@ elabRecord {vars} eopts fc env nest newns vis tn_in params conName_in fields
                    -- Move on to the next getter.
                    --
                    -- In upds, we use unNameNS (as opposed to rfNameNS or both)
-                   -- because the field types will probably mention the UN versions of the projections.
-                   let upds' = (n, IApp bfc (IVar bfc unNameNS) (IVar bfc rname)) :: upds
+                   -- because the field types will probably mention the UN versions of the projections;
+                   -- but only when prefix record projections are enabled, otherwise 
+                   -- dependent records won't typecheck!
+                   --
+                   -- With the braching on this flag, this change of using `rfNamesNS` remains backward compatible 
+                   -- (though the only difference I'm aware is in the output of the `:doc` command)
+                   prefix_flag <- isPrefixRecordProjections 
+                   let upds' = if prefix_flag
+                         then (n, IApp bfc (IVar bfc unNameNS) (IVar bfc rname)) :: upds
+                         else (n, IApp bfc (IVar bfc rfNameNS) (IVar bfc rname)) :: upds
+
                    elabGetters tn con
                                (if imp == Explicit
                                    then S done else done)

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -144,7 +144,7 @@ idrisTestsData = MkTestPool "Data and record types" [] Nothing
        -- Records, access and dependent update
        "record001", "record002", "record003", "record004", "record005",
        "record006", "record007", "record008", "record009", "record010",
-       "record011"]
+       "record011", "record012" ]
 
 idrisTestsBuiltin : TestPool
 idrisTestsBuiltin = MkTestPool "Builtin types and functions" [] Nothing

--- a/tests/idris2/record012/Issue2065.idr
+++ b/tests/idris2/record012/Issue2065.idr
@@ -1,0 +1,9 @@
+
+%prefix_record_projections off
+
+data T : Nat -> Type where
+  MkT : (n : Nat) -> T n 
+
+record R where
+  n : Nat
+  x : T n

--- a/tests/idris2/record012/Issue2065.idr
+++ b/tests/idris2/record012/Issue2065.idr
@@ -2,7 +2,7 @@
 %prefix_record_projections off
 
 data T : Nat -> Type where
-  MkT : (n : Nat) -> T n 
+  MkT : (n : Nat) -> T n
 
 record R where
   n : Nat

--- a/tests/idris2/record012/expected
+++ b/tests/idris2/record012/expected
@@ -1,0 +1,1 @@
+1/1: Building Issue2065 (Issue2065.idr)

--- a/tests/idris2/record012/run
+++ b/tests/idris2/record012/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --no-banner --check Issue2065.idr


### PR DESCRIPTION
This should fix issue #2065 (turning off prefix record projections ruins dependent records), and hopefully not change anything else.