### PR TITLE
[ fix ] isImplicit now works for all binders

### DIFF
--- a/src/Core/TT.idr
+++ b/src/Core/TT.idr
@@ -430,6 +430,13 @@ Show (PrimFn arity) where
 public export
 data PiInfo t = Implicit | Explicit | AutoImplicit | DefImplicit t
 
+namespace PiInfo
+
+  export
+  isImplicit : PiInfo t -> Bool
+  isImplicit Explicit = False
+  isImplicit _ = True
+
 export
 eqPiInfoBy : (t -> u -> Bool) -> PiInfo t -> PiInfo u -> Bool
 eqPiInfoBy eqT = go where
@@ -487,14 +494,6 @@ isLet (Let _ _ _ _) = True
 isLet _ = False
 
 export
-isImplicit : Binder t -> Bool
-isImplicit (Pi _ _ Explicit _) = False
-isImplicit (Pi _ _ _ _) = True
-isImplicit (Lam _ _ Explicit _) = False
-isImplicit (Lam _ _ _ _) = True
-isImplicit _ = False
-
-export
 binderLoc : Binder tm -> FC
 binderLoc (Lam fc _ x ty) = fc
 binderLoc (Let fc _ val ty) = fc
@@ -529,6 +528,10 @@ piInfo (Pi _ c x ty) = x
 piInfo (PVar _ c p ty) = p
 piInfo (PLet _ c val ty) = Explicit
 piInfo (PVTy _ c ty) = Explicit
+
+export
+isImplicit : Binder tm -> Bool
+isImplicit = PiInfo.isImplicit . piInfo
 
 export
 setMultiplicity : Binder tm -> RigCount -> Binder tm


### PR DESCRIPTION
I set out to fix the display of implicitly bound values in goals but that seems a lot harder.

AFAIU for a definition `f` of type `f : a -> b -> a`, `f x y` is elaborated to `f {a = a@_} {b = b@_} x y`
and we should somehow find a way to ensure these `a` and `b` are marked as implicit.

In the meantime, may as well push this bug fix.