### PR TITLE
[ fix #2176 ] Records in where-blocks are in the wrong namespace (unlike similar data definitions) 

### DIFF
--- a/src/TTImp/Elab/Local.idr
+++ b/src/TTImp/Elab/Local.idr
@@ -123,6 +123,39 @@ localHelper {vars} nest env nestdecls_in func
     updateDataName nest (MkImpLater loc' n tycons)
         = MkImpLater loc' (newName nest n) tycons
 
+--    -- ??? I have no idea if something like this is the right thing to do or not ???
+--    updateRawImp : NestedNames vars -> RawImp -> RawImp
+--    updateRawImp nest (IVar fc n) = IVar fc (newName nest n)
+--    updateRawImp nest rawimp      = rawimp
+
+    -- recall that ImpParameter' nm = (Name, RigCount, PiInfo (RawImp' nm), RawImp' nm)
+    updateImpParameter : NestedNames vars -> ImpParameter -> ImpParameter
+    updateImpParameter nest (nm, rigc, piinfo, rawimp)
+        = ( newName nest nm
+          , rigc
+          , piinfo -- map (updateRawImp nest) piinfo
+          , rawimp -- updateRawImp nest rawimp
+          )
+
+    updateFieldName : NestedNames vars -> IField -> IField
+    updateFieldName nest (MkIField fc rigc piinfo n rawimp)
+        = MkIField fc rigc piinfo -- (map (updateRawImp nest) piinfo)
+                           (newName nest n)
+                           rawimp -- (updateRawImp nest rawimp)
+
+    updateRecordName : NestedNames vars -> ImpRecord -> ImpRecord
+    updateRecordName nest (MkImpRecord fc n params conName fields)
+        = MkImpRecord fc (newName nest n)
+                         (map (updateImpParameter nest) params)
+                         (newName nest conName)
+                         (map (updateFieldName nest) fields)
+
+    -- I'm not sure about this implementation...
+    -- The whole record thing is a mess and should be refactored though...
+    updateRecordNS : NestedNames vars -> Maybe String -> Maybe String
+    updateRecordNS _    Nothing   = Nothing
+    updateRecordNS nest (Just ns) = Just $ show $ newName nest (UN $ mkUserName ns)
+
     updateName : NestedNames vars -> ImpDecl -> ImpDecl
     updateName nest (IClaim loc' r vis fnopts ty)
          = IClaim loc' r vis fnopts (updateTyName nest ty)
@@ -130,6 +163,8 @@ localHelper {vars} nest env nestdecls_in func
          = IDef loc' (newName nest n) cs
     updateName nest (IData loc' vis mbt d)
          = IData loc' vis mbt (updateDataName nest d)
+    updateName nest (IRecord loc' ns vis mbt imprecord)
+         = IRecord loc' (updateRecordNS nest ns) vis mbt (updateRecordName nest imprecord)
     updateName nest i = i
 
     setPublic : ImpDecl -> ImpDecl

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -346,6 +346,10 @@ mutual
        MkIField : FC -> RigCount -> PiInfo (RawImp' nm) -> Name -> RawImp' nm ->
                   IField' nm
 
+  public export
+  ImpParameter : Type
+  ImpParameter = ImpParameter' Name
+
   -- TODO: turn into a proper datatype
   public export
   ImpParameter' : Type -> Type

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -145,7 +145,7 @@ idrisTestsData = MkTestPool "Data and record types" [] Nothing
        -- Records, access and dependent update
        "record001", "record002", "record003", "record004", "record005",
        "record006", "record007", "record008", "record009", "record010",
-       "record011", "record012", "record013", "record014" ]
+       "record011", "record012", "record013", "record014", "record015" ]
 
 idrisTestsBuiltin : TestPool
 idrisTestsBuiltin = MkTestPool "Builtin types and functions" [] Nothing

--- a/tests/idris2/record015/Issue2176.idr
+++ b/tests/idris2/record015/Issue2176.idr
@@ -1,0 +1,115 @@
+
+--------------------------------------------------------------------------------
+-- data (this worked before)
+
+fd : Int
+fd = 5 where
+  data X : Type where
+    MkX : Int -> X
+
+gd : Int
+gd = 5 where
+  data X : Type where
+    MkX : Int -> X
+
+--------------------------------------------------------------------------------
+-- record without fields or constructor
+
+fr0 : Int
+fr0 = 5 where
+  record X where
+
+gr0 : Int
+gr0 = 5 where
+  record X where
+
+--------------------------------------------------------------------------------
+-- record without fields but with constructor
+
+fr1 : Int
+fr1 = 5 where
+  record X where
+    constructor MkX
+
+gr1 : Int
+gr1 = 5 where
+  record X where
+    constructor MkX
+
+--------------------------------------------------------------------------------
+-- record with a field and constructor
+
+fr2 : Int
+fr2 = 5 where
+  record X where
+    constructor MkX
+    field1 : Int
+
+gr2 : Int
+gr2 = 5 where
+  record X where
+    constructor MkX
+    field1 : Int
+
+--------------------------------------------------------------------------------
+-- record with two fields and constructor
+
+fr3 : Int
+fr3 = 5 where
+  record X where
+    constructor MkX
+    field1 : Int
+    field2 : Bool
+
+gr3 : Int
+gr3 = 5 where
+  record X where
+    constructor MkX
+    field1 : Char
+    field2 : String
+
+--------------------------------------------------------------------------------
+-- complex example
+
+fr4 : List Int
+fr4 = fun k where
+
+  k : Int
+  k = 5
+
+  record X where
+    constructor MkX
+    xfield1 : Int
+    xfield2 : (X -> Int)
+
+  rec : X
+  rec = MkX (k+1) (const (k+2))
+
+  fun : Int -> List Int
+  fun n = n :: rec.xfield1 :: rec.xfield2 rec :: []
+
+gr4 : List Int
+gr4 = fun k where
+
+  k : Int
+  k = 5
+
+  record X where
+    constructor MkX
+    xfield1 : Int
+    xfield2 : (X -> Int)
+
+  rec : X
+  rec = MkX (k+3) (const (k+4))
+
+  fun : Int -> List Int
+  fun n = n :: rec.xfield1 :: rec.xfield2 rec :: []
+
+--------------------------------------------------------------------------------
+
+main : IO ()
+main = do
+  printLn $ fr4
+  printLn $ gr4
+
+--------------------------------------------------------------------------------

--- a/tests/idris2/record015/expected
+++ b/tests/idris2/record015/expected
@@ -1,0 +1,1 @@
+1/1: Building Issue2176 (Issue2176.idr)

--- a/tests/idris2/record015/run
+++ b/tests/idris2/record015/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --no-banner --check Issue2176.idr


### PR DESCRIPTION
This is an attemp to fix #2176.

It seems to work, but I'm not at all confident about some of details, so this needs a thorough review and quite possibly some refinements.
