### PR TITLE
[ fix #2032 ] Slow typechecking on `Int` operation when `Data.Fin.fromInteger` is in scope

### DIFF
--- a/libs/base/Data/Fin.idr
+++ b/libs/base/Data/Fin.idr
@@ -199,23 +199,23 @@ natFromInteger x = natToFinLt (fromInteger x)
 -- but we cannot convert the `Integer` to `Nat` either, because that slows down typechecking
 -- even when the function is unused (issue #2032)
 public export
-(<) : Integer -> Nat -> Bool
-(<) x n with (x < the Integer 0)
-  (<) _ _     | True  = True           -- if `x < 0` then `x < n` for any `n : Nat`
-  (<) x (S m) | False = (x-1) < m      -- recursive case
-  (<) x Z     | False = False          -- `x >= 0` contradicts `x < Z`
+integerLessThanNat : Integer -> Nat -> Bool
+integerLessThanNat x n with (x < the Integer 0)
+  integerLessThanNat _ _     | True  = True                            -- if `x < 0` then `x < n` for any `n : Nat`
+  integerLessThanNat x (S m) | False = integerLessThanNat (x-1) m      -- recursive case
+  integerLessThanNat x Z     | False = False                           -- `x >= 0` contradicts `x < Z`
 
 ||| Allow overloading of Integer literals for Fin.
 ||| @ x the Integer that the user typed
 ||| @ prf an automatically-constructed proof that `x` is in bounds
 public export
 fromInteger : (x : Integer) -> {n : Nat} ->
-              {auto 0 prf : So (x < n)} ->
+              {auto 0 prf : So (integerLessThanNat x n)} ->
               Fin n
 fromInteger x = natFromInteger x {prf = lemma prf} where
   -- to be minimally invasive, we just call the previous implementation.
   -- however, having a different proof obligation resolves #2032
-  0 lemma : {x : Integer} -> {n : Nat} -> So (x < n) -> So (fromInteger {ty=Nat} x < n)
+  0 lemma : {x : Integer} -> {n : Nat} -> So (integerLessThanNat x n) -> So (fromInteger {ty=Nat} x < n)
   lemma oh = believe_me oh
 
 -- %builtin IntegerToNatural Data.Fin.fromInteger

--- a/libs/base/Data/Fin.idr
+++ b/libs/base/Data/Fin.idr
@@ -189,10 +189,10 @@ maybeLT : (x : Nat) -> (y : Nat) -> Maybe (x `LT` y)
 maybeLT x y = maybeLTE (S x) y
 
 public export
-natFromInteger : (x : Integer) -> {n : Nat} ->
+finFromInteger : (x : Integer) -> {n : Nat} ->
                  {auto 0 prf : So (fromInteger x < n)} ->
                  Fin n
-natFromInteger x = natToFinLt (fromInteger x)
+finFromInteger x = natToFinLt (fromInteger x)
 
 -- Direct comparison between `Integer` and `Nat`.
 -- We cannot convert the `Nat` to `Integer`, because that will not work with open terms;
@@ -212,7 +212,7 @@ public export
 fromInteger : (x : Integer) -> {n : Nat} ->
               {auto 0 prf : So (integerLessThanNat x n)} ->
               Fin n
-fromInteger x = natFromInteger x {prf = lemma prf} where
+fromInteger x = finFromInteger x {prf = lemma prf} where
   -- to be minimally invasive, we just call the previous implementation.
   -- however, having a different proof obligation resolves #2032
   0 lemma : {x : Integer} -> {n : Nat} -> So (integerLessThanNat x n) -> So (fromInteger {ty=Nat} x < n)

--- a/libs/base/Data/Fin.idr
+++ b/libs/base/Data/Fin.idr
@@ -188,14 +188,35 @@ public export
 maybeLT : (x : Nat) -> (y : Nat) -> Maybe (x `LT` y)
 maybeLT x y = maybeLTE (S x) y
 
+public export
+natFromInteger : (x : Integer) -> {n : Nat} ->
+                 {auto 0 prf : So (fromInteger x < n)} ->
+                 Fin n
+natFromInteger x = natToFinLt (fromInteger x)
+
+-- Direct comparison between `Integer` and `Nat`.
+-- We cannot convert the `Nat` to `Integer`, because that will not work with open terms;
+-- but we cannot convert the `Integer` to `Nat` either, because that slows down typechecking
+-- even when the function is unused (issue #2032)
+public export
+(<) : Integer -> Nat -> Bool
+(<) x n with (x < the Integer 0)
+  (<) _ _     | True  = True           -- if `x < 0` then `x < n` for any `n : Nat`
+  (<) x (S m) | False = (x-1) < m      -- recursive case
+  (<) x Z     | False = False          -- `x >= 0` contradicts `x < Z`
+
 ||| Allow overloading of Integer literals for Fin.
 ||| @ x the Integer that the user typed
 ||| @ prf an automatically-constructed proof that `x` is in bounds
 public export
 fromInteger : (x : Integer) -> {n : Nat} ->
-              {auto 0 prf : So (fromInteger x < n)} ->
+              {auto 0 prf : So (x < n)} ->
               Fin n
-fromInteger x = natToFinLt (fromInteger x)
+fromInteger x = natFromInteger x {prf = lemma prf} where
+  -- to be minimally invasive, we just call the previous implementation.
+  -- however, having a different proof obligation resolves #2032
+  0 lemma : {x : Integer} -> {n : Nat} -> So (x < n) -> So (fromInteger {ty=Nat} x < n)
+  lemma oh = believe_me oh
 
 -- %builtin IntegerToNatural Data.Fin.fromInteger
 

--- a/tests/base/data_fin001/expected
+++ b/tests/base/data_fin001/expected
@@ -1,0 +1,1 @@
+1/1: Building fromInteger (fromInteger.idr)

--- a/tests/base/data_fin001/fromInteger.idr
+++ b/tests/base/data_fin001/fromInteger.idr
@@ -1,0 +1,22 @@
+
+-- this is to test that changes introduced for #2032 do not ruin other things
+-- (#2032 itself is a performance issue, I don't know how to properly test for that)
+
+import Data.Fin
+
+ex0 : {n : Nat} -> Fin (S n)
+ex0 = fromInteger 0
+
+ex1 : {n : Nat} -> Fin (S (S (S n)))
+ex1 = fromInteger 2
+
+eq0 : (===) {a=Fin 3} (fromInteger 2) (FS (FS FZ))
+eq0 = Refl
+
+eq1 : (===) {a=Fin (S (S (S k)))} (fromInteger 2) (FS (FS FZ))
+eq1 = Refl
+
+-- this will probably show up if issue #2032 is present
+-- and anybody measures the time it takes this test to run...
+addFourMillion : Int -> Int
+addFourMillion x = 4000000 + x

--- a/tests/base/data_fin001/run
+++ b/tests/base/data_fin001/run
@@ -1,0 +1,4 @@
+rm -rf build
+
+$1 --no-banner --no-color --console-width 0 --check fromInteger.idr
+

--- a/tests/idris2/basic042/expected
+++ b/tests/idris2/basic042/expected
@@ -15,7 +15,7 @@ Main> Zero
 Main> One
 Main> Omega
 Main> FS (FS FZ)
-Main> Error: Can't find an implementation for So (with block in < 6 False 3).
+Main> Error: Can't find an implementation for So (with block in integerLessThanNat 6 False 3).
 
 (Interactive):1:13--1:14
  1 | the (Fin 3) 6

--- a/tests/idris2/basic042/expected
+++ b/tests/idris2/basic042/expected
@@ -15,7 +15,7 @@ Main> Zero
 Main> One
 Main> Omega
 Main> FS (FS FZ)
-Main> Error: Can't find an implementation for So (== (compareNat 6 3) LT).
+Main> Error: Can't find an implementation for So (with block in < 6 False 3).
 
 (Interactive):1:13--1:14
  1 | the (Fin 3) 6


### PR DESCRIPTION
This PR fixes #2032 while being minimally invasive.

An example of the problem this is fixing is that following program typechecks very slowly (linear in the value of the constant):
```
import Data.Fin

addMillion : Int -> Int
addMillion x = 1000000 + x
```
The cause of the problem that even though `Data.Fin.fromInteger` is not called by this program, the typechecker tries to unify its type with the hole representing the type of `fromInteger` inserted before that literal constant. 

`Data.Fin.fromInteger` had the following type before this PR:
```
fromInteger : (x : Integer) -> {n : Nat} -> {auto 0 prf : So (fromInteger x < n)} -> Fin n
```
The problem is that `fromInteger x : Nat` in the proof obligation converts 1,000,000 to an unary `Nat` during typechecking, before finally rejecting it. That takes linear time (and memory) in the size of the constant.

This fix introduces a new comparison function which compares an `Integer` and a `Nat` directly. This way we can still pattern match on the `Nat` and things like `fromInteger 1 : Fin (S (S n))` still work. The new `fromInteger` then calls the old one (with a fake proof), so the rest of the conversion is unchanged.

One disadvantage of this change is that the error message when the auto proof search fails is a bit uglier (see test `basic042`).