### PR TITLE
Rename `lp/loadpackage` to `package`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   the scheme based evaluator with `:set eval scheme`.
 * New option `evaltiming` to time how long an evaluation takes at the REPL,
   set with `:set evaltiming`.
+* Renames `:lp/loadpackage` to `:package`
 
 ### Language changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   the scheme based evaluator with `:set eval scheme`.
 * New option `evaltiming` to time how long an evaluation takes at the REPL,
   set with `:set evaltiming`.
-* Renames `:lp/loadpackage` to `:package`
+* Renames `:lp/loadpackage` to `:package`.
 
 ### Language changes
 

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -2173,6 +2173,7 @@ parserCommandsForHelp =
   , exprArgCmd (ParseREPLCmd ["s", "search"]) TypeSearch "Search for values by type"
   , nameArgCmd (ParseIdentCmd "di") DebugInfo "Show debugging information for a name"
   , moduleArgCmd (ParseKeywordCmd "module") ImportMod "Import an extra module"
+  , stringArgCmd (ParseREPLCmd ["package"]) ImportPackage "Import every module of the package"
   , noArgCmd (ParseREPLCmd ["q", "quit", "exit"]) Quit "Exit the Idris system"
   , noArgCmd (ParseREPLCmd ["cwd"]) CWD "Displays the current working directory"
   , stringArgCmd (ParseREPLCmd ["cd"]) CD "Change the current working directory"
@@ -2197,7 +2198,6 @@ parserCommandsForHelp =
   , noArgCmd (ParseREPLCmd ["version"]) ShowVersion "Display the Idris version"
   , noArgCmd (ParseREPLCmd ["?", "h", "help"]) Help "Display this help text"
   , declsArgCmd (ParseKeywordCmd "let") NewDefn "Define a new value"
-  , stringArgCmd (ParseREPLCmd ["lp", "loadpackage"]) ImportPackage "Load all modules of the package"
   , exprArgCmd (ParseREPLCmd ["fs", "fsearch"]) FuzzyTypeSearch "Search for global definitions by sketching the names distribution of the wanted type(s)."
   ]
 


### PR DESCRIPTION
In response to #2178

 I moved the doc-string up a few lines. Now it's right next to `module` which is close semantically to the command in question.
 Also renamed the command to `package` to dispel confusion about its semantics (Assuming the word 'import' conveys the intention better than 'load').