### PR TITLE
idris_system: include sys wait

### DIFF
--- a/support/c/idris_system.c
+++ b/support/c/idris_system.c
@@ -1,4 +1,9 @@
 #include <stdlib.h>
+
+#ifndef _WIN32
+#include <sys/wait.h>
+#endif
+
 #include "idris_system.h"
 
 int idris2_system(const char* command) {


### PR DESCRIPTION
I need to add this include on FreeBSD (probably also needed on other BSDs). I'm not sure why linux/macos build without it.