### PR TITLE
[WIP] Request for discussion: Remove coreLift_

### DIFF
--- a/idris2api.ipkg
+++ b/idris2api.ipkg
@@ -77,6 +77,7 @@ modules =
     Core.Primitives,
     Core.Reflect,
     Core.SchemeEval,
+    Core.System,
     Core.Termination,
     Core.Transform,
     Core.TT,

--- a/src/Compiler/ES/Node.idr
+++ b/src/Compiler/ES/Node.idr
@@ -9,6 +9,7 @@ import Compiler.Common
 
 import Core.Context
 import Core.Options
+import Core.System
 import Core.TT
 import Libraries.Utils.Path
 
@@ -50,7 +51,7 @@ executeExpr c tmpDir tm =
      Core.writeFile outn js
      node <- coreLift findNode
      quoted_node <- pure $ "\"" ++ node ++ "\"" -- Windows often have a space in the path.
-     coreLift_ $ system (quoted_node ++ " " ++ outn)
+     system_ (quoted_node ++ " " ++ outn)
      pure ()
 
 ||| Codegen wrapper for Node implementation.

--- a/src/Compiler/Interpreter/VMCode.idr
+++ b/src/Compiler/Interpreter/VMCode.idr
@@ -141,7 +141,7 @@ knownForeign = fromList
     ]
   where
     prim_putChar : Ref State InterpState => Stack -> Vect 2 Object -> Core Object
-    prim_putChar _ [Const (Ch c), Const WorldVal] = ioRes unit <$ coreLift_ (putChar c)
+    prim_putChar _ [Const (Ch c), Const WorldVal] = ioRes unit <$ coreLift (putChar c)
     prim_putChar stk as = argError stk as
     prim_getChar : Ref State InterpState => Stack -> Vect 1 Object -> Core Object
     prim_getChar _ [Const WorldVal] = ioRes . Const . Ch <$> coreLift getChar
@@ -150,7 +150,7 @@ knownForeign = fromList
     prim_getStr _ [Const WorldVal] = Const . Str <$> coreLift getLine
     prim_getStr stk as = argError stk as
     prim_putStr : Ref State InterpState => Stack -> Vect 2 Object -> Core Object
-    prim_putStr _ [Const (Str s), Const WorldVal] = ioRes unit <$ coreLift_ (putStr s)
+    prim_putStr _ [Const (Str s), Const WorldVal] = ioRes unit <$ coreLift (putStr s)
     prim_putStr stk as = argError stk as
 
 knownExtern : NameMap (ar ** (Ref State InterpState => Stack -> Vect ar Object -> Core Object))

--- a/src/Compiler/RefC/RefC.idr
+++ b/src/Compiler/RefC/RefC.idr
@@ -10,6 +10,7 @@ import Compiler.Generated
 import Core.Context
 import Core.Context.Log
 import Core.Directory
+import Core.System
 
 import Data.List
 import Libraries.Data.DList
@@ -1021,8 +1022,8 @@ footer = do
 export
 executeExpr : Ref Ctxt Defs -> (execDir : String) -> ClosedTerm -> Core ()
 executeExpr c _ tm
-    = do coreLift_ $ putStrLn "Execute expression not yet implemented for refc"
-         coreLift_ $ system "false"
+    = do coreLift $ putStrLn "Execute expression not yet implemented for refc"
+         system_ "false"
 
 export
 generateCSourceFile : {auto c : Ref Ctxt Defs}
@@ -1043,7 +1044,8 @@ generateCSourceFile defs outn =
      fileContent <- get OutfileText
      let code = fastConcat (map (++ "\n") (reify fileContent))
 
-     coreLift_ $ writeFile outn code
+     Right () <- coreLift $ writeFile outn code
+          | Left err => throw (FileErr outn err)
      log "compiler.refc" 10 $ "Generated C file " ++ outn
 
 export
@@ -1059,7 +1061,8 @@ compileExpr ANF c _ outputDir tm outfile =
      let outobj = outputDir </> outfile ++ ".o"
      let outexec = outputDir </> outfile
 
-     coreLift_ $ mkdirAll outputDir
+     Right () <- coreLift $ mkdirAll outputDir
+          | Left err => throw (FileErr outputDir err)
      cdata <- getCompileData False ANF tm
      let defs = anf cdata
 

--- a/src/Compiler/Scheme/Gambit.idr
+++ b/src/Compiler/Scheme/Gambit.idr
@@ -9,6 +9,7 @@ import Core.Context
 import Core.Directory
 import Core.Name
 import Core.Options
+import Core.System
 import Core.TT
 import Protocol.Hex
 import Libraries.Utils.Path
@@ -400,7 +401,7 @@ executeExpr : Ref Ctxt Defs -> (tmpDir : String) -> ClosedTerm -> Core ()
 executeExpr c tmpDir tm
     = do Just sh <- compileExpr c tmpDir tmpDir tm "_tmpgambit"
            | Nothing => throw (InternalError "compileExpr returned Nothing")
-         coreLift_ $ system sh -- TODO: on windows, should add exe extension
+         system_ sh -- TODO: on windows, should add exe extension
          pure ()
 
 export

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -1953,7 +1953,10 @@ export
 setWorkingDir : {auto c : Ref Ctxt Defs} -> String -> Core ()
 setWorkingDir dir
     = do defs <- get Ctxt
-         coreLift_ $ changeDir dir
+         when (dir /= "") $ do
+           True <- coreLift $ changeDir dir
+                | False => throw $ InternalError $ "setWorkingDir: Can't change to directory '" ++ dir ++ "'"
+           pure ()
          Just cdir <- coreLift $ currentDir
               | Nothing => throw (InternalError "Can't get current directory")
          put Ctxt ({ options->dirs->working_dir := cdir } defs)
@@ -1971,7 +1974,9 @@ withCtxt = wrapRef Ctxt resetCtxt
   where
     resetCtxt : Defs -> Core ()
     resetCtxt defs = do let dir = defs.options.dirs.working_dir
-                        coreLift_ $ changeDir dir
+                        True <- coreLift $ changeDir dir
+                             | False => throw $ InternalError $ "withCtxt: Can't change to directory '" ++ dir ++ "'"
+                        pure ()
 
 export
 setPrefix : {auto c : Ref Ctxt Defs} -> String -> Core ()

--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -499,12 +499,6 @@ export %inline
 ignore : Core a -> Core ()
 ignore = map (\ _ => ())
 
--- This would be better if we restrict it to a limited set of IO operations
-export
-%inline
-coreLift_ : IO a -> Core ()
-coreLift_ op = ignore (coreLift op)
-
 -- Monad (specialised)
 export %inline
 (>>=) : Core a -> (a -> Core b) -> Core b

--- a/src/Core/System.idr
+++ b/src/Core/System.idr
@@ -1,0 +1,32 @@
+module Core.System
+
+--import Core.Context
+--import Core.Context.Log
+import Core.Core
+--import Core.FC
+--import Core.Options
+--import Libraries.Utils.Path
+
+--import Data.List
+--import Data.Maybe
+
+import System
+import System.File.Permissions
+
+%default total
+
+export
+system_ : String -> Core ()
+system_ cmd = do
+  n <- coreLift $ system cmd
+  if n == -1
+     then throw $ InternalError $ cmd ++ ": failed with exit code " ++ show n
+     else pure ()
+
+export
+chmodRaw_ : String -> Int -> Core ()
+chmodRaw_ fname p = do
+  Right () <- coreLift $ chmodRaw fname p
+       | Left err => throw (FileErr fname err)
+  pure ()
+

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -373,7 +373,11 @@ installFrom builddir destdir ns
          traverse_ (\ (obj, dest) =>
                       do coreLift $ putStrLn $ "Installing " ++ obj ++ " to " ++ destPath
                          Right () <- coreLift $ copyFile obj dest
-                               | Left err => throw $ FileErr obj err
+                               | Left FileNotFound => pure ()
+                               | Left err => throw $ InternalError $ unlines
+                                               [ "Can't copy file " ++ obj ++ " to " ++ destPath
+                                               , show err
+                                               ]
                          pure ())
                    objPaths
 

--- a/src/TTImp/ProcessDecls.idr
+++ b/src/TTImp/ProcessDecls.idr
@@ -188,5 +188,5 @@ processTTImpFile fname
                       Nothing <- checkDelayedHoles
                           | Just err => throw err
                       pure True)
-                  (\err => do coreLift_ (printLn err)
+                  (\err => do coreLift (printLn err)
                               pure False)

--- a/src/Yaffle/Main.idr
+++ b/src/Yaffle/Main.idr
@@ -46,16 +46,16 @@ yaffleMain sourceFileName args
          setLogTimings t
          addPrimitives
          case extension sourceFileName of
-              Just "ttc" => do coreLift_ $ putStrLn "Processing as TTC"
+              Just "ttc" => do coreLift $ putStrLn "Processing as TTC"
                                ignore $ readFromTTC {extra = ()} True emptyFC True sourceFileName (nsAsModuleIdent emptyNS) emptyNS
-                               coreLift_ $ putStrLn "Read TTC"
-              _ => do coreLift_ $ putStrLn "Processing as TTImp"
+                               coreLift $ putStrLn "Read TTC"
+              _ => do coreLift $ putStrLn "Processing as TTImp"
                       ok <- processTTImpFile sourceFileName
                       when ok $
                          do makeBuildDirectory modIdent
                             ttcFileName <- getTTCFileName sourceFileName "ttc"
                             writeToTTC () sourceFileName ttcFileName
-                            coreLift_ $ putStrLn "Written TTC"
+                            coreLift $ putStrLn "Written TTC"
          ust <- get UST
 
          repl {c} {u} {s}


### PR DESCRIPTION
Preface: I imagine there needs to be some discussion and consensus reached about these changes. I find having a concrete PR to point at helps with the discussion.

I was helping someone on the Discord server work through some build failures. What we noticed is that it seemed like the step that was failing was doing so silently despite having `set -x` in scripts and using `make`. Then a later step was failing because a file, `idris2.so`, was missing.

Looking at `src/Compiler/Scheme/Chez.idr`, I realized it's possible that the uses of `coreLift_` could be masking errors. Particularly when combined with `system` or file system operations. Then I discovered this related discussion: https://github.com/idris-lang/Idris2/issues/1244#issuecomment-856714168

I'm not sure if the space in the path was causing an exit code of `-1` or if the path was simply causing a file to be created in the wrong directory. So I can't say for sure that the changes I'm proposing would have made that failure more obvious, but it seems likely. And I think these changes will make it possible for us to report an error to the user as soon as something has failed instead of catching it later.

With all that out of the way, what I'm proposing is to avoid functions with a type like `m a -> n ()` that are implement in terms of `ignore` as much as possible. In this case, I decided to completely remove `coreLift_` so that I could easily find/audit all the uses. In the end, I decided to just leave it gone, but I could imagine adding it back and just being cautious about using it.

For functions with types like `system : String -> io Int` or `a -> io (Either Error ())` that are being used in the context of `Core`, it's probably better to wrap them in something that checks the error condition and `throws` the error. To that end, I created `system_` and `chmodRaw_`, that use `throw` and return `Core ()`. I just arbitrarily put them in `Core.System` and I haven't added their doc strings yet.

In other cases, it seemed better to check the result at the call site. I guess the main reason to do that is so that the error message can be customized to fit the use site. And maybe that implies I should be using some function like `Either a b -> (a -> Error) -> Core b` that `throw`s the `Error`. Although, idris makes it convenient to handle those cases right at the call site.

I started auditing uses of `ignore` too, but I decided I made a big enough mess for one day and that I should probably talk to others before spending a long time on it.

As an aside, I see that `coreLift_` was introduced when fixing #758 and I'm hope I'm not breaking anything by not ignoring return values. All the tests passed locally with these changes, so that is a good sign.