### PR TITLE
[cleanup] Unhide string module

### DIFF
--- a/libs/base/Data/String.idr
+++ b/libs/base/Data/String.idr
@@ -112,7 +112,7 @@ lines' s = linesHelp [] s
 ||| Splits a string into a list of newline separated strings.
 |||
 ||| The emptry string becomes an empty list. The last newline, if not followed by
-||| any additional characters, is eaten (there will never be an empt string last element
+||| any additional characters, is eaten (there will never be an empty string last element
 ||| in the result).
 |||
 ||| ```idris example

--- a/libs/base/Data/String.idr
+++ b/libs/base/Data/String.idr
@@ -10,7 +10,7 @@ singleton : Char -> String
 singleton c = strCons c ""
 
 ||| Create a string by using n copies of a character
-export
+public export
 replicate : Nat -> Char -> String
 replicate n c = pack (replicate n c)
 
@@ -90,6 +90,10 @@ unwords = pack . unwords' . map unpack
 
 ||| Splits a character list into a list of newline separated character lists.
 |||
+||| The emptry string becomes an empty list. The last newline, if not followed by
+||| any additional characters, is eaten (there will never be an empt string last element
+||| in the result).
+|||
 ||| ```idris example
 ||| lines' (unpack "\rA BC\nD\r\nE\n")
 ||| ```
@@ -106,6 +110,10 @@ lines' s = linesHelp [] s
 
 
 ||| Splits a string into a list of newline separated strings.
+|||
+||| The emptry string becomes an empty list. The last newline, if not followed by
+||| any additional characters, is eaten (there will never be an empt string last element
+||| in the result).
 |||
 ||| ```idris example
 ||| lines  "\rA BC\nD\r\nE\n"

--- a/libs/base/Data/String.idr
+++ b/libs/base/Data/String.idr
@@ -91,7 +91,7 @@ unwords = pack . unwords' . map unpack
 ||| Splits a character list into a list of newline separated character lists.
 |||
 ||| The emptry string becomes an empty list. The last newline, if not followed by
-||| any additional characters, is eaten (there will never be an empt string last element
+||| any additional characters, is eaten (there will never be an empty string last element
 ||| in the result).
 |||
 ||| ```idris example

--- a/libs/base/Data/String.idr
+++ b/libs/base/Data/String.idr
@@ -111,7 +111,7 @@ lines' s = linesHelp [] s
 
 ||| Splits a string into a list of newline separated strings.
 |||
-||| The emptry string becomes an empty list. The last newline, if not followed by
+||| The empty string becomes an empty list. The last newline, if not followed by
 ||| any additional characters, is eaten (there will never be an empty string last element
 ||| in the result).
 |||

--- a/libs/base/Data/String.idr
+++ b/libs/base/Data/String.idr
@@ -90,7 +90,7 @@ unwords = pack . unwords' . map unpack
 
 ||| Splits a character list into a list of newline separated character lists.
 |||
-||| The emptry string becomes an empty list. The last newline, if not followed by
+||| The empty string becomes an empty list. The last newline, if not followed by
 ||| any additional characters, is eaten (there will never be an empty string last element
 ||| in the result).
 |||

--- a/src/Core/Case/CaseBuilder.idr
+++ b/src/Core/Case/CaseBuilder.idr
@@ -12,6 +12,7 @@ import Core.TT
 import Core.Value
 
 import Data.List
+import Data.String
 import Data.Vect
 import Libraries.Data.LengthMatch
 import Libraries.Data.SortedSet

--- a/src/Core/Coverage.idr
+++ b/src/Core/Coverage.idr
@@ -17,11 +17,6 @@ import Libraries.Data.NameMap
 import Libraries.Data.String.Extra
 import Libraries.Text.PrettyPrint.Prettyprinter
 
-%hide Data.String.lines
-%hide Data.String.lines'
-%hide Data.String.unlines
-%hide Data.String.unlines'
-
 %default covering
 
 -- Return whether any of the name matches conflict
@@ -347,7 +342,7 @@ getMissing fc n ctree
         patss <- buildArgs fc defs [] [] psIn ctree
         let pats = concat patss
         unless (null pats) $
-          logC "coverage.missing" 20 $ map unlines $
+          logC "coverage.missing" 20 $ map (join "\n") $
             flip traverse pats $ \ pat =>
               show <$> toFullNames pat
         pure (map (apply fc (Ref fc Func n)) patss)

--- a/src/Core/Name.idr
+++ b/src/Core/Name.idr
@@ -2,6 +2,7 @@ module Core.Name
 
 import Data.String
 import Decidable.Equality
+import Libraries.Data.String.Extra
 import Libraries.Text.PrettyPrint.Prettyprinter
 import Libraries.Text.PrettyPrint.Prettyprinter.Util
 import Libraries.Utils.String

--- a/src/Core/Name/Namespace.idr
+++ b/src/Core/Name/Namespace.idr
@@ -4,6 +4,7 @@ import Data.List
 import Data.List1
 import Data.String
 import Decidable.Equality
+import Libraries.Data.String.Extra
 import Libraries.Text.PrettyPrint.Prettyprinter
 import Libraries.Utils.Path
 

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -36,12 +36,6 @@ import Data.Maybe
 import Data.List
 import Data.List.Views
 import Data.String
-import Libraries.Data.String.Extra
-
-%hide Data.String.lines
-%hide Data.String.lines'
-%hide Data.String.unlines
-%hide Data.String.unlines'
 
 -- Convert high level Idris declarations (PDecl from Idris.Syntax) into
 -- TTImp, recording any high level syntax info on the way (e.g. infix

--- a/src/Idris/Doc/HTML.idr
+++ b/src/Idris/Doc/HTML.idr
@@ -166,7 +166,7 @@ htmlPreamble title root class =
     <nav><a href="\{root}index.html">Index</a>
 
     <select id="\{cssSelectID}">
-      \{String.unlines $ flip map cssFiles $ \ css =>
+      \{unlines $ flip map cssFiles $ \ css =>
          #"<option value="\#{css.filename}">\#{css.stylename}</option>"#
       }
     </select>

--- a/src/Idris/Doc/Keywords.idr
+++ b/src/Idris/Doc/Keywords.idr
@@ -9,6 +9,7 @@ import Idris.Doc.Annotations
 import Idris.Pretty
 
 import Libraries.Data.List.Quantifiers.Extra
+import Libraries.Data.String.Extra
 
 
 infix 10 ::=

--- a/src/Idris/Doc/String.idr
+++ b/src/Idris/Doc/String.idr
@@ -36,7 +36,6 @@ import Parser.Lexer.Source
 import public Idris.Doc.Annotations
 import Idris.Doc.Keywords
 
-
 %default covering
 
 -- Add a doc string for a module name
@@ -129,7 +128,7 @@ getHintsForType nty
     = do log "doc.data" 10 $ "Looking at \{show nty}"
          getImplDocs $ \ ty =>
            do let nms = allGlobals ty
-              log "doc.data" 10 $ String.unlines
+              log "doc.data" 10 $ unlines
                 [ "Candidate: " ++ show ty
                 , "Containing names: " ++ show nms
                 ]
@@ -143,7 +142,7 @@ getHintsForPrimitive c
     = do log "doc.data" 10 $ "Looking at \{show c}"
          getImplDocs $ \ ty =>
            do let nms = allConstants ty
-              log "doc.data" 10 $ String.unlines
+              log "doc.data" 10 $ unlines
                 [ "Candidate: " ++ show ty
                 , "Containing constants: " ++ show nms
                 ]
@@ -261,10 +260,8 @@ getDocsForName fc n config
 
     showDoc : Config -> (Name, String) -> Core (Doc IdrisDocAnn)
 
-    -- Avoid generating too much whitespace by not returning a single empty line
     reflowDoc : String -> List (Doc IdrisDocAnn)
-    reflowDoc "" = []
-    reflowDoc str = map (indent 2 . reflow) (forget $ Extra.lines str)
+    reflowDoc str = map (indent 2 . reflow) (lines str)
 
     showTotal : Name -> Totality -> Doc IdrisDocAnn
     showTotal n tot

--- a/src/Idris/Error.idr
+++ b/src/Idris/Error.idr
@@ -19,15 +19,10 @@ import Data.String
 
 import Libraries.Data.List.Extra
 import Libraries.Data.List1 as Lib
-import Libraries.Text.PrettyPrint.Prettyprinter.Util
 import Libraries.Data.String.Extra
+import Libraries.Text.PrettyPrint.Prettyprinter.Util
 
 import System.File
-
-%hide Data.String.lines
-%hide Data.String.lines'
-%hide Data.String.unlines
-%hide Data.String.unlines'
 
 %default covering
 
@@ -70,10 +65,10 @@ ploc fc = do
     let (er, ec) = mapHom (fromInteger . cast) e
     let nsize = length $ show (er + 1)
     let head = annotate FileCtxt (pretty fc)
-    source <- (forget . lines) <$> getCurrentElabSource
+    source <- lines <$> getCurrentElabSource
     if sr == er
        then do
-         let emph = spaces (cast $ nsize + sc + 4) <+> annotate Error (pretty (Extra.replicate (ec `minus` sc) '^'))
+         let emph = spaces (cast $ nsize + sc + 4) <+> annotate Error (pretty (replicate (ec `minus` sc) '^'))
          let firstr = er `minus` 4
          pure $ vsep ([emptyDoc, head] ++ (addLineNumbers nsize firstr (pretty <$> extractRange firstr er source)) ++ [emph]) <+> line
        else pure $ vsep (emptyDoc :: head :: addLineNumbers nsize sr (pretty <$> extractRange sr (Prelude.min er (sr + 5)) source)) <+> line
@@ -81,7 +76,7 @@ ploc fc = do
     extractRange : Nat -> Nat -> List String -> List String
     extractRange s e xs = take ((e `minus` s) + 1) (drop s xs)
     pad : Nat -> String -> String
-    pad size s = Extra.replicate (size `minus` length s) '0' ++ s
+    pad size s = replicate (size `minus` length s) '0' ++ s
     addLineNumbers : Nat -> Nat -> List (Doc IdrisAnn) -> List (Doc IdrisAnn)
     addLineNumbers size st xs =
       snd $ foldl (\(i, s), l => (S i, snoc s (space <+> annotate FileCtxt (pretty (pad size $ show $ i + 1) <++> pipe) <++> l))) (st, []) xs
@@ -103,18 +98,18 @@ ploc2 fc1 fc2 =
           else do let nsize = length $ show (er2 + 1)
                   let head = annotate FileCtxt (pretty $ MkFC fn1 s1 e2)
                   let firstRow = annotate FileCtxt (spaces (cast $ nsize + 2) <+> pipe)
-                  source <- (forget . lines) <$> getCurrentElabSource
+                  source <- lines <$> getCurrentElabSource
                   case (sr1 == er1, sr2 == er2, sr1 == sr2) of
                        (True, True, True) => do
                          let line = fileCtxt pipe <++> maybe emptyDoc pretty (elemAt source sr1)
-                         let emph = fileCtxt pipe <++> spaces (cast sc1) <+> error (pretty (Extra.replicate (ec1 `minus` sc1) '^'))
-                                      <+> spaces (cast $ sc2 `minus` ec1) <+> error (pretty (Extra.replicate (ec2 `minus` sc2) '^'))
+                         let emph = fileCtxt pipe <++> spaces (cast sc1) <+> error (pretty (replicate (ec1 `minus` sc1) '^'))
+                                      <+> spaces (cast $ sc2 `minus` ec1) <+> error (pretty (replicate (ec2 `minus` sc2) '^'))
                          pure $ vsep [emptyDoc, head, firstRow, fileCtxt (space <+> pretty (sr1 + 1)) <++> align (vsep [line, emph]), emptyDoc]
                        (True, True, False) => do
                          let line1 = fileCtxt pipe <++> maybe emptyDoc pretty (elemAt source sr1)
-                         let emph1 = fileCtxt pipe <++> spaces (cast sc1) <+> error (pretty (Extra.replicate (ec1 `minus` sc1) '^'))
+                         let emph1 = fileCtxt pipe <++> spaces (cast sc1) <+> error (pretty (replicate (ec1 `minus` sc1) '^'))
                          let line2 = fileCtxt pipe <++> maybe emptyDoc pretty (elemAt source sr2)
-                         let emph2 = fileCtxt pipe <++> spaces (cast sc2) <+> error (pretty (Extra.replicate (ec2 `minus` sc2) '^'))
+                         let emph2 = fileCtxt pipe <++> spaces (cast sc2) <+> error (pretty (replicate (ec2 `minus` sc2) '^'))
                          let numbered = if (sr2 `minus` er1) == 1
                                            then []
                                            else addLineNumbers nsize (sr1 + 1) (pretty <$> extractRange (sr1 + 1) er1 source)
@@ -123,27 +118,27 @@ ploc2 fc1 fc2 =
                             ++ [fileCtxt (space <+> pretty (sr2 + 1)) <++> align (vsep [line2, emph2]), emptyDoc]
                        (True, False, _) => do
                          let line = fileCtxt pipe <++> maybe emptyDoc pretty (elemAt source sr1)
-                         let emph = fileCtxt pipe <++> spaces (cast sc1) <+> error (pretty (Extra.replicate (ec1 `minus` sc1) '^'))
+                         let emph = fileCtxt pipe <++> spaces (cast sc1) <+> error (pretty (replicate (ec1 `minus` sc1) '^'))
                          pure $ vsep $ [emptyDoc, head, firstRow, fileCtxt (space <+> pretty (sr1 + 1)) <++> align (vsep [line, emph])]
                             ++ addLineNumbers nsize (sr1 + 1) (pretty <$> extractRange (sr1 + 1) (Prelude.max er1 er2) source)
                             ++ [emptyDoc]
                        (False, True, True) => do
                          let line = fileCtxt pipe <++> maybe emptyDoc pretty (elemAt source sr1)
-                         let emph = fileCtxt pipe <++> spaces (cast sc1) <+> error (pretty (Extra.replicate (ec1 `minus` sc1) '^'))
+                         let emph = fileCtxt pipe <++> spaces (cast sc1) <+> error (pretty (replicate (ec1 `minus` sc1) '^'))
                          pure $ vsep $ [emptyDoc, head, firstRow, fileCtxt (space <+> pretty (sr1 + 1)) <++> align (vsep [line, emph])]
                             ++ addLineNumbers nsize (sr1 + 1) (pretty <$> extractRange (sr1 + 1) (Prelude.max er1 er2) source)
                             ++ [emptyDoc]
                        (False, True, False) => do
                          let top = addLineNumbers nsize (sr1 + 1) (pretty <$> extractRange (sr1 + 1) er1 source)
                          let line = fileCtxt pipe <++> maybe emptyDoc pretty (elemAt source sr1)
-                         let emph = fileCtxt pipe <++> spaces (cast sc2) <+> error (pretty (Extra.replicate (ec2 `minus` sc2) '^'))
+                         let emph = fileCtxt pipe <++> spaces (cast sc2) <+> error (pretty (replicate (ec2 `minus` sc2) '^'))
                          pure $ vsep $ [emptyDoc, head, firstRow] ++ top ++ [fileCtxt (space <+> pretty (sr2 + 1)) <++> align (vsep [line, emph]), emptyDoc]
                        (_, _, _) => pure $ vsep (emptyDoc :: head :: addLineNumbers nsize sr1 (pretty <$> extractRange sr1 er2 source)) <+> line
   where
     extractRange : Nat -> Nat -> List String -> List String
     extractRange s e xs = take ((e `minus` s) + 1) (drop s xs)
     pad : Nat -> String -> String
-    pad size s = Extra.replicate (size `minus` length s) '0' ++ s
+    pad size s = replicate (size `minus` length s) '0' ++ s
     addLineNumbers : Nat -> Nat -> List (Doc IdrisAnn) -> List (Doc IdrisAnn)
     addLineNumbers size st xs =
       snd $ foldl (\(i, s), l => (S i, snoc s (space <+> annotate FileCtxt (pretty (pad size $ show $ i + 1) <++> pipe) <++> l))) (st, []) xs

--- a/src/Idris/IDEMode/CaseSplit.idr
+++ b/src/Idris/IDEMode/CaseSplit.idr
@@ -25,15 +25,9 @@ import Data.List1
 import Data.List.Views
 import Data.SnocList
 import Libraries.Data.List.Extra
-import Libraries.Data.String.Extra
 import Data.String
 import System.File
 import Data.Fin
-
-%hide Data.String.lines
-%hide Data.String.lines'
-%hide Data.String.unlines
-%hide Data.String.unlines'
 
 %default covering
 
@@ -238,7 +232,7 @@ parenTrim = Idris.IDEMode.CaseSplit.rtrim . fastPack . dropLast . fastUnpack
 ||| just after the `of`.
 onelineIndent : Nat -> String -> String
 onelineIndent indentation
-  = (Data.String.indent indentation) . fastPack . (drop indentation) . fastUnpack
+  = (indent indentation) . fastPack . (drop indentation) . fastUnpack
 
 ||| An unbracketed, oneline `case` block just needs to have the last updates
 ||| indented to lign up with the statement after the `of`.
@@ -296,7 +290,7 @@ updateCase splits line col
               Just f =>
                 do Right file <- coreLift $ readFile f
                        | Left err => throw (FileErr f err)
-                   let thisline = elemAt (forget $ lines file) (integerToNat (cast line))
+                   let thisline = elemAt (lines file) (integerToNat (cast line))
                    case thisline of
                         Nothing => throw (InternalError "File too short!")
                         Just l =>

--- a/src/Idris/IDEMode/Holes.idr
+++ b/src/Idris/IDEMode/Holes.idr
@@ -189,7 +189,7 @@ prettyHole defs env fn args ty
                             map (\premise => prettyRigHole premise.multiplicity
                                     <+> prettyImpBracket premise.isImplicit (prettyName premise.name <++> colon <++> prettyTerm premise.type))
                                     hdata.context) <+> hardline
-                    <+> (pretty $ L.replicate 30 '-') <+> hardline
+                    <+> (pretty $ replicate 30 '-') <+> hardline
                     <+> pretty (nameRoot $ hdata.name) <++> colon <++> prettyTerm hdata.type
 
 

--- a/src/Idris/ModTree.idr
+++ b/src/Idris/ModTree.idr
@@ -267,7 +267,7 @@ buildMod loc num len mod
         errs <- ifThenElse (not rebuild) (pure []) $
            do let pad = minus (length $ show len) (length $ show num)
               let msg : Doc IdrisAnn
-                  = pretty (Extra.replicate pad ' ') <+> pretty num
+                  = pretty (replicate pad ' ') <+> pretty num
                     <+> slash <+> pretty len <+> colon
                     <++> pretty "Building" <++> pretty mod.buildNS
                     <++> parens (pretty sourceFile)

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -796,7 +796,7 @@ processPackageOpts opts
     = do (MkPFR cmds@(_::_) opts' err) <- pure $ partitionOpts opts
              | (MkPFR Nil opts' _) => pure False
          if err
-           then coreLift $ putStrLn (errorMsg ++ "\n")
+           then coreLift $ putStrLn errorMsg
            else traverse_ (processPackage opts') cmds
          pure True
 

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -43,11 +43,6 @@ import Idris.Version
 import public Idris.Package.Types
 import Idris.Package.Init
 
-%hide Data.String.lines
-%hide Data.String.lines'
-%hide Data.String.unlines
-%hide Data.String.unlines'
-
 %default covering
 
 installDir : PkgDesc -> String

--- a/src/Idris/Pretty.idr
+++ b/src/Idris/Pretty.idr
@@ -6,6 +6,7 @@ import Data.SnocList
 import Data.Maybe
 import Data.String
 import Libraries.Control.ANSI.SGR
+import Libraries.Data.String.Extra
 
 import Parser.Lexer.Source
 

--- a/src/Idris/ProcessIdr.idr
+++ b/src/Idris/ProcessIdr.idr
@@ -38,6 +38,7 @@ import Idris.Pretty
 import Idris.Doc.String
 
 import Data.List
+import Data.String
 import Libraries.Data.SortedMap
 import Libraries.Utils.Path
 import Libraries.Data.SortedSet

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -60,19 +60,14 @@ import Libraries.Data.NameMap
 import Libraries.Data.PosMap
 import Data.Stream
 import Data.String
-import Libraries.Data.String.Extra
 import Libraries.Data.List.Extra
+import Libraries.Data.String.Extra
 import Libraries.Text.PrettyPrint.Prettyprinter.Util
 import Libraries.Utils.Path
 import Libraries.System.Directory.Tree
 
 import System
 import System.File
-
-%hide Data.String.lines
-%hide Data.String.lines'
-%hide Data.String.unlines
-%hide Data.String.unlines'
 
 %default covering
 
@@ -239,7 +234,7 @@ updateFile update
          Right content <- coreLift $ readFile f
                | Left err => throw (FileErr f err)
          coreLift_ $ writeFile (f ++ "~") content
-         coreLift_ $ writeFile f (unlines (update (forget $ lines content)))
+         coreLift_ $ writeFile f (unlines (update (lines content)))
          pure (DisplayEdit emptyDoc)
 
 rtrim : String -> String
@@ -547,7 +542,7 @@ processEdit (MakeCase upd line name)
          let Right l = unlit litStyle src
               | Left err => pure (EditError "Invalid literate Idris")
          let (markM, _) = isLitLine src
-         let c = forget $ lines $ makeCase brack name l
+         let c = lines $ makeCase brack name l
          if upd
             then updateFile (addMadeCase markM c (max 0 (integerToNat (cast (line - 1)))))
             else pure $ MadeCase markM c
@@ -558,7 +553,7 @@ processEdit (MakeWith upd line name)
          let Right l = unlit litStyle src
               | Left err => pure (EditError "Invalid literate Idris")
          let (markM, _) = isLitLine src
-         let w = forget $ lines $ makeWith name l
+         let w = lines $ makeWith name l
          if upd
             then updateFile (addMadeCase markM w (max 0 (integerToNat (cast (line - 1)))))
             else pure $ MadeWith markM w

--- a/src/Idris/REPL/Common.idr
+++ b/src/Idris/REPL/Common.idr
@@ -22,6 +22,7 @@ import Idris.Syntax
 import Idris.Version
 
 import Libraries.Data.ANameMap
+import Libraries.Data.String.Extra
 
 import Data.String
 import System.File

--- a/src/Idris/REPL/Opts.idr
+++ b/src/Idris/REPL/Opts.idr
@@ -11,12 +11,6 @@ import Data.List1
 import Libraries.Data.List.Extra
 import Data.String
 import System.File
-import Libraries.Data.String.Extra
-
-%hide Data.String.lines
-%hide Data.String.lines'
-%hide Data.String.unlines
-%hide Data.String.unlines'
 
 %default total
 
@@ -146,7 +140,7 @@ getSourceLine : {auto o : Ref ROpts REPLOpts} ->
                 Int -> Core (Maybe String)
 getSourceLine l
     = do src <- getSource
-         pure $ elemAt (forget $ lines src) (integerToNat (cast (l-1)))
+         pure $ elemAt (lines src) (integerToNat (cast (l-1)))
 
 export
 getLitStyle : {auto o : Ref ROpts REPLOpts} ->

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -28,8 +28,6 @@ import System.Directory
 
 %default covering
 
-%hide Libraries.Data.String.Extra.unlines
-
 ||| Dissected information about a package directory
 record PkgDir where
   constructor MkPkgDir

--- a/src/Libraries/Data/String/Extra.idr
+++ b/src/Libraries/Data/String/Extra.idr
@@ -5,11 +5,6 @@ import Data.List1
 import Data.Nat
 import Data.String
 
-%hide Data.String.lines
-%hide Data.String.lines'
-%hide Data.String.unlines
-%hide Data.String.unlines'
-
 %default total
 
 infixl 5 +>
@@ -93,62 +88,12 @@ index n str with (unpack str)
   index Z str | (x :: xs) = Just x
   index (S n) str | (x :: xs) = index n str | xs
 
-||| Produce a string by repeating the character `c` `n` times.
-public export
-replicate : (n : Nat) -> (c : Char) -> String
-replicate n c = pack $ replicate n c
-
--- lines and unlines are cloned from Data.String for compatible reason, should be removed
--- once v0.4.0 is released.
-
-||| Splits a character list into a list of newline separated character lists.
-|||
-||| ```idris example
-||| lines' (unpack "\rA BC\nD\r\nE\n")
-||| ```
-export
-lines' : List Char -> List1 (List Char)
-lines' [] = singleton []
-lines' s  = case break isNL s of
-                 (l, s') => l ::: case s' of
-                                       [] => []
-                                       _ :: s'' => forget $ lines' (assert_smaller s s'')
-
-||| Splits a string into a list of newline separated strings.
-|||
-||| ```idris example
-||| lines  "\rA BC\nD\r\nE\n"
-||| ```
-export
-lines : String -> List1 String
-lines s = map pack (lines' (unpack s))
-
-||| Joins the character lists by newlines into a single character list.
-|||
-||| ```idris example
-||| unlines' [['l','i','n','e'], ['l','i','n','e','2'], ['l','n','3'], ['D']]
-||| ```
-export
-unlines' : List (List Char) -> List Char
-unlines' [] = []
-unlines' [l] = l
-unlines' (l::ls) = l ++ '\n' :: unlines' ls
-
-||| Joins the strings by newlines into a single string.
-|||
-||| ```idris example
-||| unlines ["line", "line2", "ln3", "D"]
-||| ```
-export
-unlines : List String -> String
-unlines = pack . unlines' . map unpack
-
 ||| Indent a given string by `n` spaces.
 public export
 indent : (n : Nat) -> String -> String
-indent n x = Extra.replicate n ' ' ++ x
+indent n x = replicate n ' ' ++ x
 
 ||| Indent each line of a given string by `n` spaces.
 public export
 indentLines : (n : Nat) -> String -> String
-indentLines n str = unlines $ map (Extra.indent n) $ forget $ lines str
+indentLines n str = (join "\n") $ map (Extra.indent n) $ lines str

--- a/src/Libraries/Text/Literate.idr
+++ b/src/Libraries/Text/Literate.idr
@@ -28,12 +28,6 @@ import Libraries.Text.Lexer
 import Data.List1
 import Data.List.Views
 import Data.String
-import Libraries.Data.String.Extra
-
-%hide Data.String.lines
-%hide Data.String.lines'
-%hide Data.String.unlines
-%hide Data.String.unlines'
 
 %default total
 
@@ -85,11 +79,12 @@ reduce (MkBounded (CodeLine m src) _ _ :: rest) acc =
                       )::acc)
 
 reduce (MkBounded (CodeBlock l r src) _ _ :: rest) acc with (lines src) -- Strip the deliminators surrounding the block.
-  reduce (MkBounded (CodeBlock l r src) _ _ :: rest) acc | (s ::: ys) with (snocList ys)
-    reduce (MkBounded (CodeBlock l r src) _ _ :: rest) acc | (s ::: []) | Empty = reduce rest acc -- 2
-    reduce (MkBounded (CodeBlock l r src) _ _ :: rest) acc | (s ::: (srcs ++ [f])) | (Snoc f srcs rec) =
+  reduce (MkBounded (CodeBlock l r src) _ _ :: rest) acc | [] = reduce rest acc -- 1
+  reduce (MkBounded (CodeBlock l r src) _ _ :: rest) acc | (s :: ys) with (snocList ys)
+    reduce (MkBounded (CodeBlock l r src) _ _ :: rest) acc | (s :: []) | Empty = reduce rest acc -- 2
+    reduce (MkBounded (CodeBlock l r src) _ _ :: rest) acc | (s :: (srcs ++ [f])) | (Snoc f srcs rec) =
         -- the "\n" counts for the open deliminator; the closing deliminator should always be followed by a (Any "\n"), so we don't add a newline
-        reduce rest (((unlines srcs) ++ "\n") :: "\n" :: acc)
+        reduce rest ((unlines srcs) :: "\n" :: acc)
 
 -- [ NOTE ] 1 & 2 shouldn't happen as code blocks are well formed i.e. have two deliminators.
 

--- a/src/Libraries/Text/PrettyPrint/Prettyprinter/Doc.idr
+++ b/src/Libraries/Text/PrettyPrint/Prettyprinter/Doc.idr
@@ -5,19 +5,14 @@ import public Data.List1
 import Data.Maybe
 import Data.SnocList
 import Data.String
-import public Libraries.Data.String.Extra
 import public Libraries.Data.Span
-
-%hide Data.String.lines
-%hide Data.String.lines'
-%hide Data.String.unlines
-%hide Data.String.unlines'
+import Libraries.Data.String.Extra
 
 %default total
 
 export
 textSpaces : Int -> String
-textSpaces n = Extra.replicate (integerToNat $ cast n) ' '
+textSpaces n = String.replicate (integerToNat $ cast n) ' '
 
 ||| Maximum number of characters that fit in one line.
 public export
@@ -367,7 +362,7 @@ interface Pretty a where
 export
 Pretty String where
   pretty str = let str' = if "\n" `isSuffixOf` str then dropLast 1 str else str in
-                   vsep $ map unsafeTextWithoutNewLines $ forget $ lines str'
+                   vsep $ map unsafeTextWithoutNewLines $ lines str'
 
 public export
 FromString (Doc ann) where

--- a/src/Parser/Lexer/Source.idr
+++ b/src/Parser/Lexer/Source.idr
@@ -65,7 +65,7 @@ Show Token where
   show StringEnd = "string end"
   show InterpBegin = "string interp begin"
   show InterpEnd = "string interp end"
-  show (StringLit n x) = "string" ++ Extra.replicate n '#' ++ " " ++ show x
+  show (StringLit n x) = "string" ++ replicate n '#' ++ " " ++ show x
   -- Identifiers
   show (HoleIdent x) = "hole identifier " ++ x
   show (Ident x) = "identifier " ++ x
@@ -96,7 +96,7 @@ Pretty Token where
   pretty StringEnd = reflow "string end"
   pretty InterpBegin = reflow "string interp begin"
   pretty InterpEnd = reflow "string interp end"
-  pretty (StringLit n x) = pretty ("string" ++ Extra.replicate n '#') <++> dquotes (pretty x)
+  pretty (StringLit n x) = pretty ("string" ++ replicate n '#') <++> dquotes (pretty x)
   -- Identifiers
   pretty (HoleIdent x) = reflow "hole identifier" <++> pretty x
   pretty (Ident x) = pretty "identifier" <++> pretty x
@@ -184,14 +184,14 @@ stringBegin : Lexer
 stringBegin = many (is '#') <+> (is '"')
 
 stringEnd : Nat -> String
-stringEnd hashtag = "\"" ++ Extra.replicate hashtag '#'
+stringEnd hashtag = "\"" ++ replicate hashtag '#'
 
 multilineBegin : Lexer
 multilineBegin = many (is '#') <+> (exact "\"\"\"") <+>
                     manyUntil newline space <+> newline
 
 multilineEnd : Nat -> String
-multilineEnd hashtag = "\"\"\"" ++ Extra.replicate hashtag '#'
+multilineEnd hashtag = "\"\"\"" ++ replicate hashtag '#'
 
 -- Do this as an entire token, because the contents will be processed by
 -- a specific back end
@@ -319,7 +319,7 @@ fromOctLit str
 mutual
   stringTokens : Bool -> Nat -> Tokenizer Token
   stringTokens multi hashtag
-      = let escapeChars = "\\" ++ Extra.replicate hashtag '#'
+      = let escapeChars = "\\" ++ replicate hashtag '#'
             interpStart = escapeChars ++ "{"
             escapeLexer = escape (exact escapeChars) any
             charLexer = non $ exact (if multi then multilineEnd hashtag else stringEnd hashtag)

--- a/src/Parser/Rule/Source.idr
+++ b/src/Parser/Rule/Source.idr
@@ -9,12 +9,6 @@ import Core.Metadata
 import Data.List1
 import Data.String
 import Libraries.Data.List.Extra
-import Libraries.Data.String.Extra
-
-%hide Data.String.lines
-%hide Data.String.lines'
-%hide Data.String.unlines
-%hide Data.String.unlines'
 
 %default total
 

--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -36,12 +36,6 @@ import Libraries.Data.NameMap
 import Data.String
 import Data.Maybe
 import Libraries.Text.PrettyPrint.Prettyprinter
-import Libraries.Data.String.Extra
-
-%hide Data.String.lines
-%hide Data.String.lines'
-%hide Data.String.unlines
-%hide Data.String.unlines'
 
 %default covering
 


### PR DESCRIPTION
When the effect of the `base` `String.lines` and `String.unlines` functions changed subtly a while back, a compatibility layer was added to the compiler and these `String` module functions were hidden.

This PR unhides and switches back to the `String` module versions of these functions. It also removes `replicate` from `Libraries.Data.String.Extra` because that function has since been ported to `base`.