### PR TITLE
[cleanup] Small round of unused import culling.

### DIFF
--- a/libs/base/System/Escape.idr
+++ b/libs/base/System/Escape.idr
@@ -1,7 +1,6 @@
 module System.Escape
 
 import Data.List
-import Data.String
 
 import System.Info
 

--- a/libs/contrib/Search/Generator.idr
+++ b/libs/contrib/Search/Generator.idr
@@ -13,7 +13,6 @@ module Search.Generator
 import Data.Colist
 import Data.Colist1
 import Data.Fin
-import Data.List
 import Data.Stream
 import Data.Vect
 

--- a/libs/network/Network/Socket.idr
+++ b/libs/network/Network/Socket.idr
@@ -6,7 +6,6 @@ module Network.Socket
 
 import public Network.Socket.Data
 import Network.Socket.Raw
-import Data.List
 import Network.FFI
 
 -- ----------------------------------------------------- [ Network Socket API. ]

--- a/libs/test/Test/Golden.idr
+++ b/libs/test/Test/Golden.idr
@@ -82,7 +82,6 @@ import Data.String
 import System
 import System.Clock
 import System.Directory
-import System.File
 import System.Future
 import System.Info
 import System.Path

--- a/src/Compiler/RefC/CC.idr
+++ b/src/Compiler/RefC/CC.idr
@@ -7,9 +7,6 @@ import Core.Directory
 
 import System
 
-import Idris.Version
-import Libraries.Utils.Path
-
 %default total
 
 findCC : IO String

--- a/src/Idris/IDEMode/Parser.idr
+++ b/src/Idris/IDEMode/Parser.idr
@@ -5,8 +5,6 @@ module Idris.IDEMode.Parser
 
 import Idris.IDEMode.Commands
 import Core.Core
-import Core.Name
-import Core.Metadata
 import Core.FC
 
 import Data.List

--- a/src/Idris/IDEMode/SyntaxHighlight.idr
+++ b/src/Idris/IDEMode/SyntaxHighlight.idr
@@ -7,8 +7,6 @@ import Core.Metadata
 
 import Idris.REPL
 import Idris.Syntax
-import Idris.Pretty
-import Idris.Doc.String
 import Idris.IDEMode.Commands
 
 import Data.List

--- a/src/Idris/ProcessIdr.idr
+++ b/src/Idris/ProcessIdr.idr
@@ -39,8 +39,6 @@ import Idris.Doc.String
 
 import Data.List
 import Libraries.Data.SortedMap
-import Libraries.Utils.Path
-import Libraries.Data.SortedSet
 
 import System.File
 

--- a/src/Protocol/IDE.idr
+++ b/src/Protocol/IDE.idr
@@ -2,8 +2,6 @@
 module Protocol.IDE
 
 import Protocol.SExp
-import Data.List
-import Data.Maybe
 
 import public Libraries.Data.Span
 

--- a/src/Protocol/IDE/Formatting.idr
+++ b/src/Protocol/IDE/Formatting.idr
@@ -3,7 +3,6 @@ module Protocol.IDE.Formatting
 import Protocol.SExp
 import Protocol.IDE.Decoration
 
-import Data.Maybe
 import Data.List
 
 %default total

--- a/src/TTImp/Parser.idr
+++ b/src/TTImp/Parser.idr
@@ -1,7 +1,6 @@
 module TTImp.Parser
 
 import Core.Context
-import Core.Metadata
 import Core.TT
 import Parser.Source
 import TTImp.TTImp


### PR DESCRIPTION
I am getting close to ready to put my unused import warning PR up for review. Here's another (small) round of unused import culling before I do.

Culling these imports as a separate PR helps keep the size of the warning PR down and removes noise as I troubleshoot actual problems with the warning PR as well. Separately, there is of course a code cleanliness gain to removing these imports.