### PR TITLE
Add 'tryParse' function to 'System.Path'

### DIFF
--- a/libs/contrib/System/Path.idr
+++ b/libs/contrib/System/Path.idr
@@ -244,6 +244,14 @@ parsePath =
                 (x::xs) => x :: delete CurDir xs
     pure $ MkPath vol (isJust root) body (isJust trailSep)
 
+export
+tryParse : String -> Maybe Path
+tryParse str =
+  case parse parsePath (lexPath str) of
+      Right (path, []) => Just path
+      _ => Nothing
+
+
 ||| Parses a String into Path.
 |||
 ||| The string is parsed as much as possible from left to right, and the invalid

--- a/libs/contrib/System/Path.idr
+++ b/libs/contrib/System/Path.idr
@@ -251,7 +251,6 @@ tryParse str =
       Right (path, []) => Just path
       _ => Nothing
 
-
 ||| Parses a String into Path.
 |||
 ||| The string is parsed as much as possible from left to right, and the invalid

--- a/libs/contrib/System/Path.idr
+++ b/libs/contrib/System/Path.idr
@@ -248,8 +248,8 @@ export
 tryParse : String -> Maybe Path
 tryParse str =
   case parse parsePath (lexPath str) of
-      Right (path, []) => Just path
-      _ => Nothing
+    Right (path, []) => Just path
+    _ => Nothing
 
 ||| Parses a String into Path.
 |||


### PR DESCRIPTION
Currently, the only function that `System.Path` provides to parse a `Path` from a `String` is `parse`, which silently fails by returning an empty path if the parsing fails. Often you want to know whether the parsing fails, so I've added a new function which returns a `Maybe` instead.