### PR TITLE
Change associativity for System.Path operators

### DIFF
--- a/libs/contrib/System/Path.idr
+++ b/libs/contrib/System/Path.idr
@@ -13,7 +13,7 @@ import Text.Quantity
 
 import System.Info
 
-infixr 5 </>, />
+infixl 5 </>, />
 infixr 7 <.>
 
 

--- a/src/Libraries/Utils/Path.idr
+++ b/src/Libraries/Utils/Path.idr
@@ -19,7 +19,7 @@ import System.File
 
 %default total
 
-infixr 5 </>, />
+infixl 5 </>, />
 infixr 7 <.>
 
 


### PR DESCRIPTION
Currently the operators for combining paths associate to the right, but it would be more convenient if they associated to the left instead. For example, currently you cannot write:
```idris
root /> "usr" /> "lib"
```
As this is parsed as:
```idris
root /> ("usr" /> "lib")
```
But `/>` takes a `Path` on the LHS and so this is invalid.

By making the operators associate to the left, you can write this example without any extra brackets.