### PR TITLE
[ prelude ] Give every `Show` type a default `Interpolation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,11 +43,14 @@
   concat [interpolate "hello ", interpolate world]
   ```
 
-  This allows you to write expressions within slices without having to call `show`
-  but for this you need to implement the `Interpolation` interface for each type
-  that you intend to use within an interpolation slice. The reason for not reusing
-  `Show` is that `Interpolation` and `Show` have conflicting semantics, typically
-  this is the case for `String` which adds double quotes around the string.
+  This allows you to write expressions within slices without having to call `show`.
+  The prelude provides a default `Interpolation` implementation for each type that
+  implments `Show`. The reason for not reusing `Show` is that `Interpolation` and
+  `Show` have conflicting semantics, typically this is the case for `String` which
+  adds double quotes around the string.
+
+  In case that you'd like to implement customized `Interpolation` to a type, you
+  may have to avoid ambiguous by `%hide interpDefault`.
 
 ### Compiler changes
 

--- a/libs/prelude/Prelude/Interpolation.idr
+++ b/libs/prelude/Prelude/Interpolation.idr
@@ -1,5 +1,7 @@
 module Prelude.Interpolation
 
+import Prelude.Show
+
 ||| Interpolated strings are of the form `"xxxx \{ expr } yyyy"`.
 ||| In this example the string `"xxxx "` is concatenated with `expr` and
 ||| `" yyyy"`, since `expr` is not necessarily a string, the generated
@@ -14,6 +16,17 @@ interface Interpolation a where
   interpolate : a -> String
 
 ||| The interpolation instance for Strings is the identity
-export
-Interpolation String where
+public export
+[interpId] Interpolation String where
   interpolate x = x
+
+public export
+[interpShow] Show a => Interpolation a where
+  interpolate x = show x
+
+%hint
+%inline
+public export
+interpDefault : {a : _} -> Show a => Interpolation a
+interpDefault {a = String} = interpId
+interpDefault {a = _} = interpShow

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -45,7 +45,7 @@ idrisTestsBasic = MkTestPool "Fundamental language features" [] Nothing
        "basic066", "basic067", "basic068",
        "idiom001",
        "interpolation001", "interpolation002", "interpolation003",
-       "interpolation004"]
+       "interpolation004", "interpolation005"]
 
 idrisTestsCoverage : TestPool
 idrisTestsCoverage = MkTestPool "Coverage checking" [] Nothing

--- a/tests/idris2/docs001/expected
+++ b/tests/idris2/docs001/expected
@@ -164,7 +164,6 @@ Hints:
   Cast String Nat
   Eq String
   FromString String
-  Interpolation String
   Monoid String
   Ord String
   Semigroup String

--- a/tests/idris2/interpolation003/Test.idr
+++ b/tests/idris2/interpolation003/Test.idr
@@ -1,5 +1,10 @@
 import Data.String
 
+%hide interpDefault
+
+Interpolation String where
+  interpolate x = x
+
 Interpolation Bool where
   interpolate True = "TT"
   interpolate False = "FF"
@@ -11,5 +16,10 @@ Interpolation Nat where
 Interpolation Integer where
   interpolate = show
 
-test : String
-test = "\{2}\{True}: \{True}\{True}"
+test : List String
+test = [
+    "This is \{True}",
+    "This is \{False}",
+    "This is a number : \{S (S (S Z))}",
+    "\{2}\{True}: \{True}\{True}"
+  ]

--- a/tests/idris2/interpolation003/expected
+++ b/tests/idris2/interpolation003/expected
@@ -1,8 +1,5 @@
 1/1: Building Test (Test.idr)
-Main> "This is TT"
-Main> "This is FF"
-Main> "This is a number : S S S 0"
-Main> "2TT: TTTT"
-Main> Main.test : String
-test = concat [interpolate 2, interpolate True, interpolate ": ", interpolate True, interpolate True]
+Main> ["This is TT", "This is FF", "This is a number : S S S 0", "2TT: TTTT"]
+Main> Main.test : List String
+test = [concat [interpolate "This is ", interpolate True], concat [interpolate "This is ", interpolate False], concat [interpolate "This is a number : ", interpolate 3], concat [interpolate 2, interpolate True, interpolate ": ", interpolate True, interpolate True]]
 Main> Bye for now!

--- a/tests/idris2/interpolation003/expected
+++ b/tests/idris2/interpolation003/expected
@@ -1,5 +1,5 @@
 1/1: Building Test (Test.idr)
 Main> ["This is TT", "This is FF", "This is a number : S S S 0", "2TT: TTTT"]
 Main> Main.test : List String
-test = [concat [interpolate "This is ", interpolate True], concat [interpolate "This is ", interpolate False], concat [interpolate "This is a number : ", interpolate 3], concat [interpolate 2, interpolate True, interpolate ": ", interpolate True, interpolate True]]
+test = [concat ["This is ", interpolate True], concat ["This is ", interpolate False], concat ["This is a number : ", interpolate 3], concat [interpolate 2, interpolate True, ": ", interpolate True, interpolate True]]
 Main> Bye for now!

--- a/tests/idris2/interpolation003/input
+++ b/tests/idris2/interpolation003/input
@@ -1,6 +1,3 @@
-"This is \{True}"
-"This is \{False}"
-"This is a number : \{S (S (S Z))}"
 test
 :printdef test
 :q

--- a/tests/idris2/interpolation005/Test.idr
+++ b/tests/idris2/interpolation005/Test.idr
@@ -1,0 +1,4 @@
+import Data.String
+
+test : String
+test = "\{2}\{True}: \{True}\{True}"

--- a/tests/idris2/interpolation005/expected
+++ b/tests/idris2/interpolation005/expected
@@ -1,0 +1,8 @@
+1/1: Building Test (Test.idr)
+Main> "This is True"
+Main> "This is False"
+Main> "This is a number : 3"
+Main> "2True: TrueTrue"
+Main> Main.test : String
+test = concat [interpolate 2, interpolate True, interpolate ": ", interpolate True, interpolate True]
+Main> Bye for now!

--- a/tests/idris2/interpolation005/expected
+++ b/tests/idris2/interpolation005/expected
@@ -4,5 +4,5 @@ Main> "This is False"
 Main> "This is a number : 3"
 Main> "2True: TrueTrue"
 Main> Main.test : String
-test = concat [interpolate 2, interpolate True, interpolate ": ", interpolate True, interpolate True]
+test = concat [interpolate 2, interpolate True, ": ", interpolate True, interpolate True]
 Main> Bye for now!

--- a/tests/idris2/interpolation005/input
+++ b/tests/idris2/interpolation005/input
@@ -1,0 +1,6 @@
+"This is \{True}"
+"This is \{False}"
+"This is a number : \{S (S (S Z))}"
+test
+:printdef test
+:q

--- a/tests/idris2/interpolation005/run
+++ b/tests/idris2/interpolation005/run
@@ -1,0 +1,4 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --no-banner Test.idr < input
+


### PR DESCRIPTION
Now every type implemented `Show` is allowed to be interpolated into strings without following a `show`.

Previous discussion on https://github.com/idris-lang/Idris2/pull/1967#issuecomment-1003534258