### PR TITLE
Minor fix in documentation

### DIFF
--- a/docs/source/backends/custom.rst
+++ b/docs/source/backends/custom.rst
@@ -28,16 +28,16 @@ Now create a file containing
     import Compiler.Common
     import Idris.Driver
 
-    compile : Ref Ctxt Defs -> (tmpDir : String) -> (outputDir : String) ->
+    compile : Ref Ctxt Defs -> (tmpDir : String) -> (execDir : String) ->
             ClosedTerm -> (outfile : String) -> Core (Maybe String)
-    compile defs tmpDir outputDir term file = do coreLift $ putStrLn "I'd rather not."
-                                                 pure $ Nothing
+    compile defs tmp dir term file = do coreLift $ putStrLn "I'd rather not."
+                                        pure $ Nothing
 
-    execute : Ref Ctxt Defs -> (tmpDir : String) -> ClosedTerm -> Core ()
-    execute defs tmpDir term = do coreLift $ putStrLn "Maybe in an hour."
+    execute : Ref Ctxt Defs -> (execDir : String) -> ClosedTerm -> Core ()
+    execute defs dir term = do coreLift $ putStrLn "Maybe in an hour."
 
     lazyCodegen : Codegen
-    lazyCodegen = MkCG compile execute
+    lazyCodegen = MkCG compile execute Nothing Nothing
 
     main : IO ()
     main = mainWithCodegens [("lazy", lazyCodegen)]

--- a/tests/idris2/api001/LazyCodegen.idr
+++ b/tests/idris2/api001/LazyCodegen.idr
@@ -1,3 +1,5 @@
+||| NOTE: Please keep this file in sync with the example in docs/source/backends/custom.rst
+
 module Main
 
 import Core.Context


### PR DESCRIPTION
The example `lazy-idris2` was broken since PR https://github.com/idris-lang/Idris2/pull/1621. This PR fixes the example.