### PR TITLE
[ totality ] Data.String.words should be total

### DIFF
--- a/libs/base/Data/String.idr
+++ b/libs/base/Data/String.idr
@@ -47,6 +47,11 @@ fastUnlines = fastConcat . unlines'
         unlines' [] = []
         unlines' (x :: xs) = x :: "\n" :: unlines' xs
 
+-- append a word to the list of words, only if it's non-empty
+wordsHelper : SnocList Char -> SnocList (List Char) -> SnocList (List Char)
+wordsHelper [<] css = css
+wordsHelper sc  css = css :< (sc <>> Nil)
+
 ||| Splits a character list into a list of whitespace separated character lists.
 |||
 ||| ```idris example
@@ -58,12 +63,9 @@ words' :  List Char
        -> List (List Char)
 words' (c :: cs) sc css =
   if isSpace c
-     then case sc of
-       [<] => words' cs [<] css
-       _   => words' cs [<] (css :< (sc <>> Nil))
+     then words' cs [<] (wordsHelper sc css)
      else words' cs (sc :< c) css
-words' [] [<] css = css <>> Nil
-words' [] sc  css = (css :< (sc <>> Nil)) <>> Nil
+words' [] sc css = wordsHelper sc css <>> Nil
 
 ||| Splits a string into a list of whitespace separated strings.
 |||

--- a/libs/base/Data/String.idr
+++ b/libs/base/Data/String.idr
@@ -51,9 +51,8 @@ fastUnlines = fastConcat . unlines'
 ||| ```idris example
 ||| words' (unpack " A B C  D E   ")
 ||| ```
-covering
 words' : List Char -> List (List Char)
-words' s = case dropWhile isSpace s of
+words' s = assert_total $ case dropWhile isSpace s of
             [] => []
             s' => let (w, s'') = break isSpace s'
                   in w :: words' s''
@@ -64,7 +63,6 @@ words' s = case dropWhile isSpace s of
 ||| words " A B C  D E   "
 ||| ```
 export
-covering
 words : String -> List String
 words s = map pack (words' (unpack s))
 


### PR DESCRIPTION
This looks like an oversight: `Data.String.words` is provably total, as all white space is dropped after each invocation of `break`. While it would be nice to actually have a proper proof of totality, this wasn't done for other functions like `Data.List.split` either, so I just went for the sledgehammer here.