### PR TITLE
[ new ] Add fixities' FC to the syntax info.

### DIFF
--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -28,7 +28,7 @@ import public Libraries.Utils.Binary
 ||| (Increment this when changing anything in the data format)
 export
 ttcVersion : Int
-ttcVersion = 71
+ttcVersion = 72
 
 export
 checkTTCVersion : String -> Int -> Int -> Core ()

--- a/src/Idris/Doc/String.idr
+++ b/src/Idris/Doc/String.idr
@@ -308,7 +308,7 @@ getDocsForName fc n config
     getInfixDoc n
         = do let Just (Basic n) = userNameRoot n
                     | _ => pure []
-             let Just (fixity, assoc) = S.lookup n (infixes !(get Syn))
+             let Just (_, fixity, assoc) = S.lookup n (infixes !(get Syn))
                     | Nothing => pure []
              pure $ pure $ hsep
                   [ pretty (show fixity)
@@ -321,7 +321,7 @@ getDocsForName fc n config
     getPrefixDoc n
         = do let Just (Basic n) = userNameRoot n
                     | _ => pure []
-             let Just assoc = S.lookup n (prefixes !(get Syn))
+             let Just (_, assoc) = S.lookup n (prefixes !(get Syn))
                     | Nothing => pure []
              pure $ ["prefix operator, level" <++> pretty (show assoc)]
 

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -900,8 +900,12 @@ record SyntaxInfo where
   constructor MkSyntax
   -- Keep infix/prefix, then we can define operators which are both
   -- (most obviously, -)
-  infixes : StringMap (Fixity, Nat)
-  prefixes : StringMap Nat
+  ||| Infix operators as a map from their names to their fixity,
+  ||| precedence, and the file context where that fixity was defined.
+  infixes : StringMap (FC, Fixity, Nat)
+  ||| Prefix operators as a map from their names to their precedence
+  ||| and the file context where their fixity was defined.
+  prefixes : StringMap (FC, Nat)
   -- info about modules
   saveMod : List ModuleIdent -- current module name
   modDocstrings : SortedMap ModuleIdent String
@@ -1019,13 +1023,13 @@ initSyntax
 
   where
 
-    initInfix : StringMap (Fixity, Nat)
-    initInfix = insert "=" (Infix, 0) empty
+    initInfix : StringMap (FC, Fixity, Nat)
+    initInfix = insert "=" (EmptyFC, Infix, 0) empty
 
-    initPrefix : StringMap Nat
+    initPrefix : StringMap (FC, Nat)
     initPrefix = fromList
-      [ ("-", 10)
-      , ("negate", 10) -- for documentation purposes
+      [ ("-", (EmptyFC, 10))
+      , ("negate", (EmptyFC, 10)) -- for documentation purposes
       ]
 
     initDocStrings : ANameMap String


### PR DESCRIPTION
This small change retains origin information for the fixity declaration for an operator.

I think this could be generally useful for various things, but it is specifically useful for the unused warning import feature I am working on -- modules like prelude's `Prelude.Ops` (declares nothing but fixities) can be imported and indeed required for an operator to be fully defined but without knowing that the operator's fixity came from that module it is not possible to determine the module has been "used."