### PR TITLE
Update typedd.rst - Exercise 2 of 8.2.5

### DIFF
--- a/docs/source/typedd/typedd.rst
+++ b/docs/source/typedd/typedd.rst
@@ -149,6 +149,9 @@ In ``ReverseVec.idr``, add ``import Data.Nat`` for the ``Nat`` proofs.
 In ``Void.idr``, since functions must now be ``covering`` by default, add
 a ``partial`` annotation to ``nohead`` and its helper function ``getHead``.
 
+In Exercise 2 of 8.2.5, the definition of ``reverse'`` should be changed to
+``reverse' : Vect k a -> Vect m a -> Vect (k + m) a``
+
 Chapter 9
 ---------
 

--- a/docs/source/typedd/typedd.rst
+++ b/docs/source/typedd/typedd.rst
@@ -150,7 +150,8 @@ In ``Void.idr``, since functions must now be ``covering`` by default, add
 a ``partial`` annotation to ``nohead`` and its helper function ``getHead``.
 
 In Exercise 2 of 8.2.5, the definition of ``reverse'`` should be changed to
-``reverse' : Vect k a -> Vect m a -> Vect (k + m) a``
+``reverse' : Vect k a -> Vect m a -> Vect (k + m) a``, because the ``n`` in ``reverse'`` 
+is otherwise bound to the same value as the ``n`` in the signature of ``myReverse``.
 
 Chapter 9
 ---------


### PR DESCRIPTION
The skeleton code in exercise 2 of Chapter 8.2.5 no longer type-checks with idris2.

From ohad in the Discord:
"Idris2 treats unbound implicits in a more sophisticated way than idris1, and the n that appears in your code is constrained to be the same n as the n that appears in the type of myReverse.
You want a helper function that's more general, where the length of the accumulator changes with each call"