### PR TITLE
Make prim_js2idris_array iterative

### DIFF
--- a/support/js/support.js
+++ b/support/js/support.js
@@ -1,11 +1,12 @@
 class IdrisError extends Error { }
 
 function __prim_js2idris_array(x){
-  if(x.length === 0){
-    return {h:0}
-  } else {
-    return {a1:x[0],a2: __prim_js2idris_array(x.slice(1))}
+  let acc = { h:0 };
+
+  for (i = x.length-1; i>=0; i--) {
+      acc = { a1:x[i], a2:acc };
   }
+  return acc;
 }
 
 function __prim_idris2js_array(x){

--- a/tests/node/tailrec002/run
+++ b/tests/node/tailrec002/run
@@ -1,4 +1,4 @@
+rm -rf build
 $1 --no-color --console-width 0 --no-banner --cg node EvenOdd.idr -o app.js
 $1 --no-color --console-width 0 --no-banner Main.idr -x main
-rm -rf build
 


### PR DESCRIPTION
I was getting a stack overflow on the tailrec002 test, caused by this primitive being recursive. I've made it iterative. I'm no JS expert but I've tested its behaviour against the old version.