### PR TITLE
[ breaking, totality ] fGetLine should be covering

### DIFF
--- a/libs/base/System/File/ReadWrite.idr
+++ b/libs/base/System/File/ReadWrite.idr
@@ -41,6 +41,7 @@ prim__removeFile : String -> PrimIO Int
 |||
 ||| @ h the file handle to seek through
 export
+covering
 fSeekLine : HasIO io => (h : File) -> io (Either FileError ())
 fSeekLine (FHandle f)
     = do res <- primIO (prim__seekLine f)
@@ -53,6 +54,7 @@ fSeekLine (FHandle f)
 |||
 ||| @ h the file handle to get the line from
 export
+covering
 fGetLine : HasIO io => (h : File) -> io (Either FileError String)
 fGetLine (FHandle f)
     = do res <- primIO (prim__readLine f)


### PR DESCRIPTION
For the same reason as `fRead` is `covering`, `fGetLine` and `fSeekLine` should be `covering` instead of `total`. For instance, the following program will unavoidably and quickly fill a computer's memory:

```idris
import System.File

main : IO ()
main = do
  Right f <- openFile "/dev/zero" Read | Left e => pure ()
  Right s <- fGetLine f | Left e => pure ()
  closeFile f
  putStrLn s
```