### PR TITLE
Rename RefC extension function stubs

### DIFF
--- a/docs/source/backends/refc.rst
+++ b/docs/source/backends/refc.rst
@@ -84,9 +84,10 @@ This will generate stub FFI function pointers in the generated C file, which
 your backend should set to the appropriate C functions before ``main`` is
 called.
 
-Each ``%foreign "lang: funcName, opts"`` definition will produce a stub whose
-name is given by ``cName (UN $ lang ++ "_" ++ funcName)``, of the appropriate
-function pointer type.
+Each ``%foreign "lang: foreignFuncName, opts"`` definition for a function
+will produce a stub, of the appropriate function pointer type. This stub will
+be called ``cName $ NS (mkNamespace lang) funcName``, where ``funcName`` is the
+fully qualified Idris name of that function.
 
 So the ``%foreign`` function
 
@@ -95,9 +96,9 @@ So the ``%foreign`` function
     %foreign "python: abs"
     abs : Int -> Int
 
-produces a stub ``python_abs``, which can be backpatched in Python by:
+produces a stub ``python_Main_abs``, which can be backpatched in Python by:
 
 .. code-block:: python
 
     abs_ptr = ctypes.CFUNCTYPE(ctypes.c_int64, ctypes.c_int64)(abs)
-    ctypes.c_void_p.in_dll(cdll, "python_abs").value = ctypes.cast(abs_ptr, ctypes.c_void_p).value
+    ctypes.c_void_p.in_dll(cdll, "python_Main_abs").value = ctypes.cast(abs_ptr, ctypes.c_void_p).value

--- a/src/Compiler/RefC/RefC.idr
+++ b/src/Compiler/RefC/RefC.idr
@@ -921,7 +921,7 @@ createCFunctions n (MkAForeign ccs fargs ret) = do
           let isStandardFFI = Prelude.elem lang ["RefC", "C"]
           let fctName = if isStandardFFI
                            then UN $ Basic $ fctForeignName
-                           else UN $ Basic $ lang ++ "_" ++ fctForeignName
+                           else NS (mkNamespace lang) n
           if isStandardFFI
              then case extLibOpts of
                       [lib, header] => addHeader header


### PR DESCRIPTION
Rename the functions stubs generated by RefC for RefC extensions.

This is a breaking change, but should only impact RefC extensions. To my knowledge, that is only the Python backend, which I already have a fix for.

This change reduces the chance of naming collisions. This is most obvious when two separate libraries bind the same foreign function, but can also occur between Idris functions and function stubs through a particularly poor choice of names.

This change also allows the use of special characters in the `%foreign` directive, that are not caught by `cName`. For example, `[` and `]`.