### PR TITLE
make readBufferData return the number of bytes that have been read

### DIFF
--- a/libs/base/System/File/Buffer.idr
+++ b/libs/base/System/File/Buffer.idr
@@ -30,11 +30,11 @@ export
 readBufferData : HasIO io => (fh : File) -> (buf : Buffer) ->
                  (offset : Int) ->
                  (maxbytes : Int) ->
-                 io (Either FileError ())
+                 io (Either FileError Int)
 readBufferData (FHandle h) buf offset max
     = do read <- primIO (prim__readBufferData h buf offset max)
          if read >= 0
-            then pure (Right ())
+            then pure (Right read)
             else pure (Left FileReadError)
 
 ||| Write the data from the buffer to the given `File`.

--- a/tests/refc/buffer/TestBuffer.idr
+++ b/tests/refc/buffer/TestBuffer.idr
@@ -38,7 +38,7 @@ main = do
         | Nothing => pure ()
     Right f <- openFile "testRead.buf" Read
         | Left err => put $ pure err
-    Right () <- readBufferData f readBuf 0 8
+    Right ok <- readBufferData f readBuf 0 8
         | Left err => put $ pure err
     put $ bufferData readBuf
 


### PR DESCRIPTION
This commits make `readBufferData` return the number of bytes that have been read. Without it, you cannot read the content of a file by chunks.

An example of how returning the number of read bytes can be used:
```haskell
||| Construct a `Stream` reading from a File
export
fromFile : HasIO m => File -> Stream (Of Bits8) m (Either FileError ())
fromFile file = (newBuffer 1024) >>= loop where
  loop : Maybe Buffer -> Stream (Of Bits8) m (Either FileError ())
  loop (Just buffer) = do
    False <- liftIO $ fEOF file
    | True => pure (Right ())
    Right cap <- liftIO (rawSize buffer >>= Test.readBufferData file buffer 0)
    | Left err => pure (Left err)
    data' <- traverse (getBits8 buffer) [0..(cap-1)]
    fromList_ data' *> loop (Just buffer)
``` 