### PR TITLE
[ fix ] add let in JS array conversion

### DIFF
--- a/support/js/support.js
+++ b/support/js/support.js
@@ -3,7 +3,7 @@ class IdrisError extends Error { }
 function __prim_js2idris_array(x){
   let acc = { h:0 };
 
-  for (i = x.length-1; i>=0; i--) {
+  for (let i = x.length-1; i>=0; i--) {
       acc = { a1:x[i], a2:acc };
   }
   return acc;


### PR DESCRIPTION
This is a follow-up of #2267 . As noted correctly by @dunhamsteve, there should be a `let` in the `for` statement. While this is not strictly necessary, it can lead to nasty scoping bugs as described in [this stackoverflow reply](https://stackoverflow.com/questions/5717126/var-or-no-var-in-javascripts-for-in-loop).

Sorry, for not spotting this myself when I gave Edwin my OK on this.