### PR TITLE
update refc/buffer to check how many bytes have been read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,8 @@
 * Deprecates `base`'s `Data.Nat.Order.decideLTE` in favor of `Data.Nat.isLTE`.
 * Removes `base`'s deprecated `System.Directory.dirEntry`. Use `nextDirEntry` instead.
 * Removes `base`'s deprecated `Data.String.fastAppend`. Use `fastConcat` instead.
+* `System.File.Buffer.readBufferData` now returns the number of bytes that have
+   been read into the buffer.
 
 #### Contrib
 

--- a/tests/refc/buffer/TestBuffer.idr
+++ b/tests/refc/buffer/TestBuffer.idr
@@ -38,7 +38,8 @@ main = do
         | Nothing => pure ()
     Right f <- openFile "testRead.buf" Read
         | Left err => put $ pure err
-    Right ok <- readBufferData f readBuf 0 8
+    Right 8 <- readBufferData f readBuf 0 8
+        | Right size => put $ pure "\{show size} bytes have been read, 8 expected"
         | Left err => put $ pure err
     put $ bufferData readBuf
 


### PR DESCRIPTION
Just realized I missed this in #2274. This PR ensures that `readBufferData` returns the correct result.