### PR TITLE
[ syntax ] Namespaced idiom brackets

### DIFF
--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -151,17 +151,19 @@ bindBangs ((n, fc, btm) :: bs) ns tm
     $ bindFun fc ns btm
     $ ILam EmptyFC top Explicit (Just n) (Implicit fc False) tm
 
-idiomise : FC -> RawImp -> RawImp
-idiomise fc (IAlternative afc u alts)
-  = IAlternative afc (mapAltType (idiomise afc) u) (idiomise afc <$> alts)
-idiomise fc (IApp afc f a)
-    = let fc = virtualiseFC fc in
-      IApp fc (IApp fc (IVar fc (UN $ Basic "<*>"))
-                       (idiomise afc f))
-              a
-idiomise fc fn
-  = let fc = virtualiseFC fc in
-    IApp fc (IVar fc (UN $ Basic "pure")) fn
+idiomise : FC -> Maybe Namespace -> RawImp -> RawImp
+idiomise fc mns (IAlternative afc u alts)
+  = IAlternative afc (mapAltType (idiomise afc mns) u) (idiomise afc mns <$> alts)
+idiomise fc mns (IApp afc f a)
+  = let fc  = virtualiseFC fc
+        app = UN $ Basic "<*>"
+        nm  = maybe app (`NS` app) mns
+     in IApp fc (IApp fc (IVar fc nm) (idiomise afc mns f)) a
+idiomise fc mns fn
+  = let fc  = virtualiseFC fc
+        pur = UN $ Basic "pure"
+        nm  = maybe pur (`NS` pur) mns
+     in IApp fc (IVar fc nm) fn
 
 pairname : Name
 pairname = NS builtinNS (UN $ Basic "Pair")
@@ -353,10 +355,10 @@ mutual
                        bangNames $= ((bn, fc, itm) ::)
                      } bs)
            pure (IVar EmptyFC bn)
-  desugarB side ps (PIdiom fc term)
+  desugarB side ps (PIdiom fc ns term)
       = do itm <- desugarB side ps term
            logRaw "desugar.idiom" 10 "Desugaring idiom for" itm
-           let val = idiomise fc itm
+           let val = idiomise fc ns itm
            logRaw "desugar.idiom" 10 "Desugared to" val
            pure val
   desugarB side ps (PList fc nilFC args)

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -2252,10 +2252,3 @@ command
   <|> symbol ":?" $> Help -- special case, :? doesn't fit into above scheme
   <|> symbol ":" *> Editing <$> editCmd
   <|> eval
-
-testParser : String -> Either Error PTerm
-testParser str =
-  let origin = Virtual Interactive
-   in case runParser origin Nothing str (simplerExpr origin init) of
-        Left err       => Left err
-        Right (_,_,pt) => Right pt

--- a/src/Idris/Pretty.idr
+++ b/src/Idris/Pretty.idr
@@ -384,7 +384,8 @@ mutual
       go d (PMultiline _ indent xs) = "multiline" <++> (parenthesise (d > startPrec) $ hsep $ punctuate "++" (prettyString <$> concat xs))
       go d (PDoBlock _ ns ds) = parenthesise (d > startPrec) $ group $ align $ hang 2 $ do_ <++> (vsep $ punctuate semi (prettyDo <$> ds))
       go d (PBang _ tm) = "!" <+> go d tm
-      go d (PIdiom _ tm) = enclose (pretty "[|") (pretty "|]") (go startPrec tm)
+      go d (PIdiom _ Nothing tm) = enclose (pretty "[|") (pretty "|]") (go startPrec tm)
+      go d (PIdiom _ (Just ns) tm) = enclose (pretty ns <+> pretty ".[|") (pretty "|]") (go startPrec tm)
       go d (PList _ _ xs) = brackets (group $ align $ vsep $ punctuate comma (go startPrec . snd <$> xs))
       go d (PSnocList _ _ xs)
         = brackets {ldelim = "[<"}

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -113,7 +113,7 @@ mutual
        PMultiline : FC -> (indent : Nat) -> List (List (PStr' nm)) -> PTerm' nm
        PDoBlock : FC -> Maybe Namespace -> List (PDo' nm) -> PTerm' nm
        PBang : FC -> PTerm' nm -> PTerm' nm
-       PIdiom : FC -> PTerm' nm -> PTerm' nm
+       PIdiom : FC -> Maybe Namespace -> PTerm' nm -> PTerm' nm
        PList : (full, nilFC : FC) -> List (FC, PTerm' nm) -> PTerm' nm
                                         -- ^   v location of the conses/snocs
        PSnocList : (full, nilFC : FC) -> SnocList ((FC, PTerm' nm)) -> PTerm' nm
@@ -177,7 +177,7 @@ mutual
   getPTermLoc (PMultiline fc _ _) = fc
   getPTermLoc (PDoBlock fc _ _) = fc
   getPTermLoc (PBang fc _) = fc
-  getPTermLoc (PIdiom fc _) = fc
+  getPTermLoc (PIdiom fc _ _) = fc
   getPTermLoc (PList fc _ _) = fc
   getPTermLoc (PSnocList fc _ _) = fc
   getPTermLoc (PPair fc _ _) = fc
@@ -775,7 +775,8 @@ parameters {0 nm : Type} (toName : nm -> Name)
   showPTermPrec d (PDoBlock _ ns ds)
         = "do " ++ showSep " ; " (map showDo ds)
   showPTermPrec d (PBang _ tm) = "!" ++ showPTermPrec d tm
-  showPTermPrec d (PIdiom _ tm) = "[|" ++ showPTermPrec d tm ++ "|]"
+  showPTermPrec d (PIdiom _ Nothing tm) = "[|" ++ showPTermPrec d tm ++ "|]"
+  showPTermPrec d (PIdiom _ (Just ns) tm) = show ns ++ ".[|" ++ showPTermPrec d tm ++ "|]"
   showPTermPrec d (PList _ _ xs)
         = "[" ++ showSep ", " (map (showPTermPrec d . snd) xs) ++ "]"
   showPTermPrec d (PSnocList _ _ xs)
@@ -1168,8 +1169,8 @@ mapPTermM f = goPTerm where
     goPTerm (PBang fc x) =
       PBang fc <$> goPTerm x
       >>= f
-    goPTerm (PIdiom fc x) =
-      PIdiom fc <$> goPTerm x
+    goPTerm (PIdiom fc ns x) =
+      PIdiom fc ns <$> goPTerm x
       >>= f
     goPTerm (PList fc nilFC xs) =
       PList fc nilFC <$> goPairedPTerms xs

--- a/src/Parser/Rule/Source.idr
+++ b/src/Parser/Rule/Source.idr
@@ -307,6 +307,14 @@ namespaceId = do
   pure (uncurry mkNestedNamespace nsid.val)
 
 export
+namespacedSymbol : String -> Rule (Maybe Namespace)
+namespacedSymbol req = do
+  (symbol req $> Nothing) <|> do
+    ns <- namespaceId
+    symbol ("." ++ req)
+    pure (Just ns)
+
+export
 moduleIdent : Rule ModuleIdent
 moduleIdent = nsAsModuleIdent <$> namespaceId
 

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -43,6 +43,7 @@ idrisTestsBasic = MkTestPool "Fundamental language features" [] Nothing
        "basic056", "basic057", "basic058", "basic059", "basic060",
        "basic061", "basic062", "basic063", "basic064", "basic065",
        "basic066", "basic067", "basic068",
+       "idiom001",
        "interpolation001", "interpolation002", "interpolation003",
        "interpolation004"]
 

--- a/tests/idris2/idiom001/Main.idr
+++ b/tests/idris2/idiom001/Main.idr
@@ -1,13 +1,35 @@
 module Main
 
-pure : Applicative f => Applicative g => a -> f (g a)
-pure = Prelude.pure . Prelude.pure
+namespace App2
+  public export
+  (<*>) : Applicative f => Applicative g =>
+          f (g $ a -> b) -> f (g a) -> f (g b)
+  fgf <*> fga = Prelude.[| fgf <*> fga |]
 
-(<*>) : Applicative f => Applicative g => f (g $ a -> b) -> f (g a) -> f (g b)
-fgf <*> fga = Prelude.[| fgf <*> fga |]
+  public export
+  pure : Applicative f => Applicative g =>
+         a -> f (g a)
+  pure = Prelude.pure . Prelude.pure
 
-test : List (Maybe Integer)
-test = Main.[| (map Just [1,2,3]) + [Just 4, Nothing] |]
+namespace App3
+  public export
+  (<*>) : Applicative f => Applicative g => Applicative h =>
+          f (g (h $ a -> b)) -> f (g (h a)) -> f (g (h b))
+  fgf <*> fga = App2.[| fgf <*> fga |]
+
+  public export
+  pure : Applicative f => Applicative g => Applicative h =>
+         a -> f (g (h a))
+  pure = App2.pure . Prelude.pure
+
+list : List (Maybe Integer)
+list = [Just 3, Just 7, Nothing, Just 0]
+
+test2 : List (Maybe Integer)
+test2 = App2.[| list + list |]
+
+test3 : Either String (List (Maybe Integer))
+test3 = App3.[| Right list + Right list |]
 
 main : IO ()
-main = printLn test
+main = printLn test2 >> printLn test3

--- a/tests/idris2/idiom001/Main.idr
+++ b/tests/idris2/idiom001/Main.idr
@@ -1,0 +1,13 @@
+module Main
+
+pure : Applicative f => Applicative g => a -> f (g a)
+pure = Prelude.pure . Prelude.pure
+
+(<*>) : Applicative f => Applicative g => f (g $ a -> b) -> f (g a) -> f (g b)
+fgf <*> fga = Prelude.[| fgf <*> fga |]
+
+test : List (Maybe Integer)
+test = Main.[| (map Just [1,2,3]) + [Just 4, Nothing] |]
+
+main : IO ()
+main = printLn test

--- a/tests/idris2/idiom001/expected
+++ b/tests/idris2/idiom001/expected
@@ -1,0 +1,3 @@
+1/1: Building Main (Main.idr)
+Main> [Just 5, Nothing, Just 6, Nothing, Just 7, Nothing]
+Main> Bye for now!

--- a/tests/idris2/idiom001/expected
+++ b/tests/idris2/idiom001/expected
@@ -1,3 +1,4 @@
 1/1: Building Main (Main.idr)
-Main> [Just 5, Nothing, Just 6, Nothing, Just 7, Nothing]
+Main> [Just 6, Just 10, Nothing, Just 3, Just 10, Just 14, Nothing, Just 7, Nothing, Nothing, Nothing, Nothing, Just 3, Just 7, Nothing, Just 0]
+Right [Just 6, Just 10, Nothing, Just 3, Just 10, Just 14, Nothing, Just 7, Nothing, Nothing, Nothing, Nothing, Just 3, Just 7, Nothing, Just 0]
 Main> Bye for now!

--- a/tests/idris2/idiom001/input
+++ b/tests/idris2/idiom001/input
@@ -1,0 +1,2 @@
+:exec main
+:q

--- a/tests/idris2/idiom001/run
+++ b/tests/idris2/idiom001/run
@@ -1,0 +1,4 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --cg node --no-banner Main.idr < input
+

--- a/tests/idris2/idiom001/run
+++ b/tests/idris2/idiom001/run
@@ -1,4 +1,4 @@
 rm -rf build
 
-$1 --no-color --console-width 0 --cg node --no-banner Main.idr < input
+$1 --no-color --console-width 0 --no-banner Main.idr < input
 

--- a/tests/idris2/perror007/expected
+++ b/tests/idris2/perror007/expected
@@ -15,7 +15,7 @@ StrError2:2:19--2:20
  1 | foo : String
  2 | foo = "nested: \{ " \{ 1 +  } " }"
                        ^
-... (29 others)
+... (30 others)
 1/1: Building StrError3 (StrError3.idr)
 Error: Couldn't parse any alternatives:
 1: Expected 'case', 'if', 'do', application or operator expression.
@@ -24,7 +24,7 @@ StrError3:2:7--2:8
  1 | foo : String
  2 | foo = "incomplete: \{ a <+> }"
            ^
-... (30 others)
+... (31 others)
 1/1: Building StrError4 (StrError4.idr)
 Error: Bracket is not properly closed.
 


### PR DESCRIPTION
This PR adds new syntax for prefixing idiom brackets with namespaces: `Foo.Bar.[| x + y|]`. This will be desugared just like regular idiom brackets, but in the desugared version `pure` and `(<*>)` will be prefixed with the given namespace as well.

There are several reasons why I consider this to be useful:

- Symmetry: Just like do blocks can be disambiguated by prefixing `do` with a namespace, this should be possible for idiom brackets as well.
- Usefulness: Applicative functors compose, and it is quite common to apply a function over a nesting of applicatives. As shown in the example below, this is now possible with very little syntactic overhead.

Example (see also the new test case in `idris2/idiom001`):
```idris
namespace App2
  public export
  (<*>) : Applicative f => Applicative g =>
          f (g $ a -> b) -> f (g a) -> f (g b)
  fgf <*> fga = Prelude.[| fgf <*> fga |]

  public export
  pure : Applicative f => Applicative g =>
         a -> f (g a)
  pure = Prelude.pure . Prelude.pure

list : List (Maybe Integer)
list = [Just 3, Just 7, Nothing, Just 0]

test : List (Maybe Integer)
test = App2.[| list + list |]
```

Future work: It might also be useful to allow prefixing of (Snoc)List literals and list comprehensions with namespaces for similar reasons.