### PR TITLE
[ fix ] expose Data.Seq.Internal

### DIFF
--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -82,6 +82,7 @@ modules = Control.ANSI,
 
           Data.Rel.Complement,
 
+          Data.Seq.Internal,
           Data.Seq.Sized,
           Data.Seq.Unsized,
 


### PR DESCRIPTION
I get `Module Data.Seq.Internal not found` with `import Data.Seq.Unsized` if I do not have this change.