### PR TITLE
[ fix #2279 ] Racket bootstrap unsafe-fx

### DIFF
--- a/support/gambit/support.scm
+++ b/support/gambit/support.scm
@@ -46,7 +46,7 @@
 ; To match Chez
 (define (add1 x) (+ x 1))
 (define (sub1 x) (- x 1))
-(define (fxsub1 x) (fx- x 1))
+(define (fxadd1 x) (fx+ x 1))
 (define (fxsub1 x) (fx- x 1))
 
 (define (integer->bits8 x) (bitwise-and x #xff))


### PR DESCRIPTION
Patches the Racket bootstrap by adding `(require racket/unsafe/ops)` in `schHeader` (#2279).
Corrects a 🤦 mistake in Gambit support.scm (also from #2081).

I believe installing from a previous install works as is, so patching the bootstrap makes more sense than changing the support code.