### PR TITLE
[ cleanup ] Remove unused `get`'s, replace `get+put` with `update`

### DIFF
--- a/src/Compiler/ES/Codegen.idr
+++ b/src/Compiler/ES/Codegen.idr
@@ -672,7 +672,7 @@ mutual
     as <- traverse (map (insertBreak r) . alt) alts
     d  <- traverseOpt stmt def
     nm <- get NoMangleMap
-    pure $  switch (minimal nm sc <+> ".h") as d
+    pure $ switch (minimal nm sc <+> ".h") as d
     where
         alt : {r : _} -> EConAlt r -> Core (Doc,Doc)
         alt (MkEConAlt _ RECORD b)  = ("undefined",) <$> stmt b

--- a/src/Compiler/LambdaLift.idr
+++ b/src/Compiler/LambdaLift.idr
@@ -234,8 +234,7 @@ mutual
                unused = getUnused unusedContracted
                scl' = dropUnused {outer=bound} unused scl
            n <- genName
-           ldefs <- get Lifts
-           put Lifts ({ defs $= ((n, MkLFun (dropped vars unused) bound scl') ::) } ldefs)
+           update Lifts { defs $= ((n, MkLFun (dropped vars unused) bound scl') ::) }
            pure $ LUnderApp fc n (length bound) (allVars fc vars unused)
     where
         allPrfs : (vs : List Name) -> (unused : Vect (length vs) Bool) -> List (Var vs)

--- a/src/Compiler/RefC/RefC.idr
+++ b/src/Compiler/RefC/RefC.idr
@@ -366,9 +366,7 @@ freeTmpVars = do
 addHeader : {auto h : Ref HeaderFiles (SortedSet String)}
          -> String
          -> Core ()
-addHeader header = do
-    headerFiles <- get HeaderFiles
-    put HeaderFiles $ insert header headerFiles
+addHeader = update HeaderFiles . insert
 
 
 
@@ -885,8 +883,7 @@ createCFunctions : {auto c : Ref Ctxt Defs}
 createCFunctions n (MkAFun args anf) = do
     fn <- functionDefSignature n args
     fn' <- functionDefSignatureArglist n
-    otherDefs <- get FunctionDefinitions
-    put FunctionDefinitions ((fn ++ ";\n") :: (fn' ++ ";\n") :: otherDefs)
+    update FunctionDefinitions $ \otherDefs => (fn ++ ";\n") :: (fn' ++ ";\n") :: otherDefs
     newTemporaryVariableLevel
     let argsNrs = getArgsNrList args Z
     emit EmptyFC fn
@@ -936,10 +933,9 @@ createCFunctions n (MkAForeign ccs fargs ret) = do
                       [lib, header] => addHeader header
                       _ => pure ()
              else emit EmptyFC $ additionalFFIStub fctName fargs ret
-          otherDefs <- get FunctionDefinitions
           let fnDef = "Value *" ++ (cName n) ++ "(" ++ showSep ", " (replicate (length fargs) "Value *") ++ ");"
           fn_arglist <- functionDefSignatureArglist n
-          put FunctionDefinitions ((fnDef ++ "\n") :: (fn_arglist ++ ";\n") :: otherDefs)
+          update FunctionDefinitions $ \otherDefs => (fnDef ++ "\n") :: (fn_arglist ++ ";\n") :: otherDefs
           typeVarNameArgList <- createFFIArgList fargs
 
           emit EmptyFC fn_arglist

--- a/src/Core/AutoSearch.idr
+++ b/src/Core/AutoSearch.idr
@@ -569,12 +569,10 @@ searchType {vars} fc rigc defaults trying depth def checkdets top env target
 --          (defining : Name) -> (topTy : Term vars) -> Env Term vars ->
 --          Core (Term vars)
 Core.Unify.search fc rigc defaults depth def top env
-    = do defs <- get Ctxt
-         logTermNF "auto" 3 "Initial target: " env top
+    = do logTermNF "auto" 3 "Initial target: " env top
          log "auto" 3 $ "Running search with defaults " ++ show defaults
          tm <- searchType fc rigc defaults [] depth def
                           True (abstractEnvType fc env top) env
                           top
          logTermNF "auto" 3 "Result" env tm
-         defs <- get Ctxt
          pure tm

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -202,7 +202,6 @@ readTTCFile : TTC extra =>
               Ref Bin Binary -> Core (TTCFile extra)
 readTTCFile readall file as b
       = do hdr <- fromBuf b
-           chunk <- get Bin
            when (hdr /= "TT2") $
              corrupt ("TTC header in " ++ file ++ " " ++ show hdr)
            ver <- fromBuf @{Wasteful} b
@@ -349,60 +348,44 @@ addTypeHint fc (tyn, hintn, d)
                             show !(getFullName tyn)))
         addHintFor fc tyn hintn d True
 
-addAutoHint : {auto c : Ref Ctxt Defs} ->
-              (Name, Bool) -> Core ()
+addAutoHint : {auto c : Ref Ctxt Defs} -> (Name, Bool) -> Core ()
 addAutoHint (hintn_in, d)
-    = do defs <- get Ctxt
-         hintn <- toResolvedNames hintn_in
-
-         put Ctxt ({ autoHints $= insert hintn d } defs)
+    = do hintn <- toResolvedNames hintn_in
+         update Ctxt { autoHints $= insert hintn d }
 
 export
-updatePair : {auto c : Ref Ctxt Defs} ->
-             Maybe PairNames -> Core ()
-updatePair p
-    = do defs <- get Ctxt
-         put Ctxt ({ options->pairnames $= (p <+>) } defs)
+updatePair : {auto c : Ref Ctxt Defs} -> Maybe PairNames -> Core ()
+updatePair p = update Ctxt { options->pairnames $= (p <+>) }
 
 export
-updateRewrite : {auto c : Ref Ctxt Defs} ->
-                Maybe RewriteNames -> Core ()
-updateRewrite r
-    = do defs <- get Ctxt
-         put Ctxt ({ options->rewritenames $= (r <+>) } defs)
+updateRewrite : {auto c : Ref Ctxt Defs} -> Maybe RewriteNames -> Core ()
+updateRewrite r = update Ctxt { options->rewritenames $= (r <+>) }
 
 export
 updatePrimNames : PrimNames -> PrimNames -> PrimNames
 updatePrimNames p
-    = { fromIntegerName $= ((fromIntegerName p) <+>),
-        fromStringName $= ((fromStringName p) <+>),
-        fromCharName $= ((fromCharName p) <+>),
-        fromDoubleName $= ((fromDoubleName p) <+>)
+    = { fromIntegerName $= (p.fromIntegerName <+>),
+        fromStringName  $= (p.fromStringName  <+>),
+        fromCharName    $= (p.fromCharName    <+>),
+        fromDoubleName  $= (p.fromDoubleName  <+>)
       }
 
 export
-updatePrims : {auto c : Ref Ctxt Defs} ->
-              PrimNames -> Core ()
-updatePrims p
-    = do defs <- get Ctxt
-         put Ctxt ({ options->primnames $= updatePrimNames p } defs)
+updatePrims : {auto c : Ref Ctxt Defs} -> PrimNames -> Core ()
+updatePrims p = update Ctxt { options->primnames $= updatePrimNames p }
 
 export
 updateNameDirectives : {auto c : Ref Ctxt Defs} ->
                        List (Name, List String) -> Core ()
 updateNameDirectives [] = pure ()
 updateNameDirectives ((t, ns) :: nds)
-    = do defs <- get Ctxt
-         put Ctxt ({ namedirectives $= insert t ns } defs)
+    = do update Ctxt { namedirectives $= insert t ns }
          updateNameDirectives nds
 
 export
 updateCGDirectives : {auto c : Ref Ctxt Defs} ->
                      List (CG, String) -> Core ()
-updateCGDirectives cgs
-    = do defs <- get Ctxt
-         let cgs' = nub (cgs ++ cgdirectives defs)
-         put Ctxt ({ cgdirectives := cgs' } defs)
+updateCGDirectives cgs = update Ctxt { cgdirectives $= nub . (cgs ++) }
 
 export
 updateTransforms : {auto c : Ref Ctxt Defs} ->
@@ -480,7 +463,6 @@ readFromTTC nestedns loc reexp fname modNS importAs
                  do traverse_ (addTypeHint loc) (typeHints ttc)
                     traverse_ addAutoHint (autoHints ttc)
                     addImportedInc modNS (incData ttc)
-                    defs <- get Ctxt
                     -- Set up pair/rewrite etc names
                     updatePair (pairnames ttc)
                     updateRewrite (rewritenames ttc)
@@ -494,8 +476,7 @@ readFromTTC nestedns loc reexp fname modNS importAs
 
                -- Finally, update the unification state with the holes from the
                -- ttc
-               ust <- get UST
-               put UST ({ nextName := nextVar ttc } ust)
+               update UST { nextName := nextVar ttc }
                pure (Just (ex, ifaceHash ttc, imported ttc))
   where
     alreadyDone : ModuleIdent -> Namespace ->

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -996,34 +996,23 @@ aliasName fulln
 -- it'll be better to use addHashWithNames to make the hash independent
 -- of the internal numbering of names.
 export
-addHash : {auto c : Ref Ctxt Defs} ->
-          Hashable a => a -> Core ()
-addHash x
-    = do defs <- get Ctxt
-         put Ctxt ({ ifaceHash := hashWithSalt (ifaceHash defs) x } defs)
+addHash : {auto c : Ref Ctxt Defs} -> Hashable a => a -> Core ()
+addHash x = update Ctxt { ifaceHash $= flip hashWithSalt x }
 
 export
-initHash : {auto c : Ref Ctxt Defs} ->
-           Core ()
-initHash
-    = do defs <- get Ctxt
-         put Ctxt ({ ifaceHash := 5381 } defs)
+initHash : {auto c : Ref Ctxt Defs} -> Core ()
+initHash = update Ctxt { ifaceHash := 5381 }
 
 export
 addUserHole : {auto c : Ref Ctxt Defs} ->
               Bool -> -- defined in another module?
               Name -> -- hole name
               Core ()
-addUserHole ext n
-    = do defs <- get Ctxt
-         put Ctxt ({ userHoles $= insert n ext } defs)
+addUserHole ext n = update Ctxt { userHoles $= insert n ext }
 
 export
-clearUserHole : {auto c : Ref Ctxt Defs} ->
-                Name -> Core ()
-clearUserHole n
-    = do defs <- get Ctxt
-         put Ctxt ({ userHoles $= delete n } defs)
+clearUserHole : {auto c : Ref Ctxt Defs} -> Name -> Core ()
+clearUserHole n = update Ctxt { userHoles $= delete n }
 
 export
 getUserHoles : {auto c : Ref Ctxt Defs} ->
@@ -1153,9 +1142,7 @@ setLinearCheck i chk
 
 export
 setCtxt : {auto c : Ref Ctxt Defs} -> Context -> Core ()
-setCtxt gam
-  = do defs <- get Ctxt
-       put Ctxt ({ gamma := gam } defs)
+setCtxt gam = update Ctxt { gamma := gam }
 
 export
 resolveName : {auto c : Ref Ctxt Defs} ->
@@ -1500,16 +1487,12 @@ setMutWith fc tn tns
 export
 addMutData : {auto c : Ref Ctxt Defs} ->
              Name -> Core ()
-addMutData n
-    = do defs <- get Ctxt
-         put Ctxt ({ mutData $= (n ::) } defs)
+addMutData n = update Ctxt { mutData $= (n ::) }
 
 export
 dropMutData : {auto c : Ref Ctxt Defs} ->
               Name -> Core ()
-dropMutData n
-    = do defs <- get Ctxt
-         put Ctxt ({ mutData $= filter (/= n) } defs)
+dropMutData n = update Ctxt { mutData $= filter (/= n) }
 
 export
 setDetermining : {auto c : Ref Ctxt Defs} ->
@@ -1597,39 +1580,32 @@ export
 addGlobalHint : {auto c : Ref Ctxt Defs} ->
                 Name -> Bool -> Core ()
 addGlobalHint hintn_in isdef
-    = do defs <- get Ctxt
-         hintn <- toResolvedNames hintn_in
-
-         put Ctxt ({ autoHints $= insert hintn isdef,
-                     saveAutoHints $= ((hintn, isdef) ::) } defs)
+    = do hintn <- toResolvedNames hintn_in
+         update Ctxt { autoHints $= insert hintn isdef,
+                       saveAutoHints $= ((hintn, isdef) ::) }
 
 export
 addLocalHint : {auto c : Ref Ctxt Defs} ->
                Name -> Core ()
 addLocalHint hintn_in
-    = do defs <- get Ctxt
-         hintn <- toResolvedNames hintn_in
-         put Ctxt ({ localHints $= insert hintn () } defs)
+    = do hintn <- toResolvedNames hintn_in
+         update Ctxt { localHints $= insert hintn () }
 
 export
 addOpenHint : {auto c : Ref Ctxt Defs} -> Name -> Core ()
 addOpenHint hintn_in
-    = do defs <- get Ctxt
-         hintn <- toResolvedNames hintn_in
-         put Ctxt ({ openHints $= insert hintn () } defs)
+    = do hintn <- toResolvedNames hintn_in
+         update Ctxt { openHints $= insert hintn () }
 
 export
 dropOpenHint : {auto c : Ref Ctxt Defs} -> Name -> Core ()
 dropOpenHint hintn_in
-    = do defs <- get Ctxt
-         hintn <- toResolvedNames hintn_in
-         put Ctxt ({ openHints $= delete hintn } defs)
+    = do hintn <- toResolvedNames hintn_in
+         update Ctxt { openHints $= delete hintn }
 
 export
 setOpenHints : {auto c : Ref Ctxt Defs} -> NameMap () -> Core ()
-setOpenHints hs
-    = do d <- get Ctxt
-         put Ctxt ({ openHints := hs } d)
+setOpenHints hs = update Ctxt { openHints := hs }
 
 export
 addTransform : {auto c : Ref Ctxt Defs} ->
@@ -1653,26 +1629,18 @@ addTransform fc t_in
 
 export
 clearSavedHints : {auto c : Ref Ctxt Defs} -> Core ()
-clearSavedHints
-    = do defs <- get Ctxt
-         put Ctxt ({ saveTypeHints := [],
-                     saveAutoHints := [] } defs)
+clearSavedHints = update Ctxt { saveTypeHints := [], saveAutoHints := [] }
 
 -- Set the default namespace for new definitions
 export
-setNS : {auto c : Ref Ctxt Defs} ->
-        Namespace -> Core ()
-setNS ns
-    = do defs <- get Ctxt
-         put Ctxt ({ currentNS := ns } defs)
+setNS : {auto c : Ref Ctxt Defs} -> Namespace -> Core ()
+setNS ns = update Ctxt { currentNS := ns }
 
 -- Set the nested namespaces we're allowed to look inside
 export
 setNestedNS : {auto c : Ref Ctxt Defs} ->
               List Namespace -> Core ()
-setNestedNS ns
-    = do defs <- get Ctxt
-         put Ctxt ({ nestedNS := ns } defs)
+setNestedNS ns = update Ctxt { nestedNS := ns }
 
 -- Get the default namespace for new definitions
 export
@@ -1697,9 +1665,7 @@ getNestedNS
 export
 addImported : {auto c : Ref Ctxt Defs} ->
               (ModuleIdent, Bool, Namespace) -> Core ()
-addImported mod
-    = do defs <- get Ctxt
-         put Ctxt ({ imported $= (mod ::) } defs)
+addImported mod = update Ctxt { imported $= (mod ::) }
 
 export
 getImported : {auto c : Ref Ctxt Defs} ->
@@ -1743,11 +1709,8 @@ getNextTypeTag
 -- current namespace of "Prelude.List.Data"
 -- Inner namespaces go first, for ease of name lookup
 export
-extendNS : {auto c : Ref Ctxt Defs} ->
-           Namespace -> Core ()
-extendNS ns
-    = do defs <- get Ctxt
-         put Ctxt ({ currentNS $= (<.> ns) } defs)
+extendNS : {auto c : Ref Ctxt Defs} -> Namespace -> Core ()
+extendNS ns = update Ctxt { currentNS $= (<.> ns) }
 
 export
 withExtendedNS : {auto c : Ref Ctxt Defs} ->
@@ -1792,9 +1755,7 @@ inCurrentNS n = pure n
 export
 setVisible : {auto c : Ref Ctxt Defs} ->
              Namespace -> Core ()
-setVisible nspace
-    = do defs <- get Ctxt
-         put Ctxt ({ gamma->visibleNS $= (nspace ::) } defs)
+setVisible nspace = update Ctxt { gamma->visibleNS $= (nspace ::) }
 
 export
 getVisible : {auto c : Ref Ctxt Defs} ->
@@ -1809,9 +1770,7 @@ getVisible
 export
 setAllPublic : {auto c : Ref Ctxt Defs} ->
                (pub : Bool) -> Core ()
-setAllPublic pub
-    = do defs <- get Ctxt
-         put Ctxt ({ gamma->allPublic := pub } defs)
+setAllPublic pub = update Ctxt { gamma->allPublic := pub }
 
 export
 isAllPublic : {auto c : Ref Ctxt Defs} ->
@@ -1849,9 +1808,7 @@ getNextEntry
 export
 setNextEntry : {auto c : Ref Ctxt Defs} ->
                Int -> Core ()
-setNextEntry i
-    = do defs <- get Ctxt
-         put Ctxt ({ gamma->nextEntry := i } defs)
+setNextEntry i = update Ctxt { gamma->nextEntry := i }
 
 -- Set the 'first entry' index (i.e. the first entry in the current file)
 -- to the place we currently are in the context
@@ -1882,18 +1839,12 @@ getPPrint
          pure (printing (options defs))
 
 export
-setPPrint : {auto c : Ref Ctxt Defs} ->
-            PPrinter -> Core ()
-setPPrint ppopts
-    = do defs <- get Ctxt
-         put Ctxt ({ options->printing := ppopts } defs)
+setPPrint : {auto c : Ref Ctxt Defs} -> PPrinter -> Core ()
+setPPrint ppopts = update Ctxt { options->printing := ppopts }
 
 export
-setCG : {auto c : Ref Ctxt Defs} ->
-        CG -> Core ()
-setCG cg
-    = do defs <- get Ctxt
-         put Ctxt ({ options->session->codegen := cg } defs)
+setCG : {auto c : Ref Ctxt Defs} -> CG -> Core ()
+setCG cg = update Ctxt { options->session->codegen := cg }
 
 export
 getDirs : {auto c : Ref Ctxt Defs} -> Core Dirs
@@ -1903,60 +1854,43 @@ getDirs
 
 export
 addExtraDir : {auto c : Ref Ctxt Defs} -> String -> Core ()
-addExtraDir dir
-    = do defs <- get Ctxt
-         put Ctxt ({ options->dirs->extra_dirs $= (++ [dir]) } defs)
+addExtraDir dir = update Ctxt { options->dirs->extra_dirs $= (++ [dir]) }
 
 export
 addPackageDir : {auto c : Ref Ctxt Defs} -> String -> Core ()
-addPackageDir dir
-    = do defs <- get Ctxt
-         put Ctxt ({ options->dirs->package_dirs $= (++ [dir]) } defs)
+addPackageDir dir = update Ctxt { options->dirs->package_dirs $= (++ [dir]) }
 
 export
 addDataDir : {auto c : Ref Ctxt Defs} -> String -> Core ()
-addDataDir dir
-    = do defs <- get Ctxt
-         put Ctxt ({ options->dirs->data_dirs $= (++ [dir]) } defs)
+addDataDir dir = update Ctxt { options->dirs->data_dirs $= (++ [dir]) }
 
 export
 addLibDir : {auto c : Ref Ctxt Defs} -> String -> Core ()
-addLibDir dir
-    = do defs <- get Ctxt
-         put Ctxt ({ options->dirs->lib_dirs $= (++ [dir]) } defs)
+addLibDir dir = update Ctxt { options->dirs->lib_dirs $= (++ [dir]) }
 
 export
 setBuildDir : {auto c : Ref Ctxt Defs} -> String -> Core ()
-setBuildDir dir
-    = do defs <- get Ctxt
-         put Ctxt ({ options->dirs->build_dir := dir } defs)
+setBuildDir dir = update Ctxt { options->dirs->build_dir := dir }
 
 export
 setDependsDir : {auto c : Ref Ctxt Defs} -> String -> Core ()
-setDependsDir dir
-    = do defs <- get Ctxt
-         put Ctxt ({ options->dirs->depends_dir := dir } defs)
+setDependsDir dir = update Ctxt { options->dirs->depends_dir := dir }
 
 export
 setOutputDir : {auto c : Ref Ctxt Defs} -> Maybe String -> Core ()
-setOutputDir dir
-    = do defs <- get Ctxt
-         put Ctxt ({ options->dirs->output_dir := dir } defs)
+setOutputDir dir = update Ctxt { options->dirs->output_dir := dir }
 
 export
 setSourceDir : {auto c : Ref Ctxt Defs} -> Maybe String -> Core ()
-setSourceDir mdir
-    = do defs <- get Ctxt
-         put Ctxt ({ options->dirs->source_dir := mdir } defs)
+setSourceDir mdir = update Ctxt { options->dirs->source_dir := mdir }
 
 export
 setWorkingDir : {auto c : Ref Ctxt Defs} -> String -> Core ()
 setWorkingDir dir
-    = do defs <- get Ctxt
-         coreLift_ $ changeDir dir
+    = do coreLift_ $ changeDir dir
          Just cdir <- coreLift $ currentDir
               | Nothing => throw (InternalError "Can't get current directory")
-         put Ctxt ({ options->dirs->working_dir := cdir } defs)
+         update Ctxt { options->dirs->working_dir := cdir }
 
 export
 getWorkingDir : Core String
@@ -1975,15 +1909,11 @@ withCtxt = wrapRef Ctxt resetCtxt
 
 export
 setPrefix : {auto c : Ref Ctxt Defs} -> String -> Core ()
-setPrefix dir
-    = do defs <- get Ctxt
-         put Ctxt ({ options->dirs->prefix_dir := dir } defs)
+setPrefix dir = update Ctxt { options->dirs->prefix_dir := dir }
 
 export
 setExtension : {auto c : Ref Ctxt Defs} -> LangExt -> Core ()
-setExtension e
-    = do defs <- get Ctxt
-         put Ctxt ({ options $= setExtension e } defs)
+setExtension e = update Ctxt { options $= setExtension e }
 
 export
 isExtension : LangExt -> Defs -> Bool
@@ -1999,59 +1929,41 @@ checkUnambig fc n
               ns => ambiguousName fc n (map fst ns)
 
 export
-lazyActive : {auto c : Ref Ctxt Defs} ->
-             Bool -> Core ()
-lazyActive a
-    = do defs <- get Ctxt
-         put Ctxt ({ options->elabDirectives->lazyActive := a } defs)
+lazyActive : {auto c : Ref Ctxt Defs} -> Bool -> Core ()
+lazyActive a = update Ctxt { options->elabDirectives->lazyActive := a }
 
 export
-setUnboundImplicits : {auto c : Ref Ctxt Defs} ->
-                Bool -> Core ()
-setUnboundImplicits a
-    = do defs <- get Ctxt
-         put Ctxt ({ options->elabDirectives->unboundImplicits := a } defs)
+setUnboundImplicits : {auto c : Ref Ctxt Defs} -> Bool -> Core ()
+setUnboundImplicits a = update Ctxt { options->elabDirectives->unboundImplicits := a }
 
 export
 setPrefixRecordProjections : {auto c : Ref Ctxt Defs} -> Bool -> Core ()
-setPrefixRecordProjections b = do
-  defs <- get Ctxt
-  put Ctxt ({ options->elabDirectives->prefixRecordProjections := b } defs)
+setPrefixRecordProjections b = update Ctxt { options->elabDirectives->prefixRecordProjections := b }
 
 export
 setDefaultTotalityOption : {auto c : Ref Ctxt Defs} ->
                            TotalReq -> Core ()
-setDefaultTotalityOption tot
-    = do defs <- get Ctxt
-         put Ctxt ({ options->elabDirectives->totality := tot } defs)
+setDefaultTotalityOption tot = update Ctxt { options->elabDirectives->totality := tot }
 
 export
 setAmbigLimit : {auto c : Ref Ctxt Defs} ->
                 Nat -> Core ()
-setAmbigLimit max
-    = do defs <- get Ctxt
-         put Ctxt ({ options->elabDirectives->ambigLimit := max } defs)
+setAmbigLimit max = update Ctxt { options->elabDirectives->ambigLimit := max }
 
 export
 setAutoImplicitLimit : {auto c : Ref Ctxt Defs} ->
                        Nat -> Core ()
-setAutoImplicitLimit max
-    = do defs <- get Ctxt
-         put Ctxt ({ options->elabDirectives->autoImplicitLimit := max } defs)
+setAutoImplicitLimit max = update Ctxt { options->elabDirectives->autoImplicitLimit := max }
 
 export
 setNFThreshold : {auto c : Ref Ctxt Defs} ->
                  Nat -> Core ()
-setNFThreshold max
-    = do defs <- get Ctxt
-         put Ctxt ({ options->elabDirectives->nfThreshold := max } defs)
+setNFThreshold max = update Ctxt { options->elabDirectives->nfThreshold := max }
 
 export
 setSearchTimeout : {auto c : Ref Ctxt Defs} ->
                    Integer -> Core ()
-setSearchTimeout t
-    = do defs <- get Ctxt
-         put Ctxt ({ options->session->searchTimeout := t } defs)
+setSearchTimeout t = update Ctxt { options->session->searchTimeout := t }
 
 export
 isLazyActive : {auto c : Ref Ctxt Defs} ->
@@ -2098,57 +2010,46 @@ setPair : {auto c : Ref Ctxt Defs} ->
           FC -> (pairType : Name) -> (fstn : Name) -> (sndn : Name) ->
           Core ()
 setPair fc ty f s
-    = do defs <- get Ctxt
-         ty' <- checkUnambig fc ty
+    = do ty' <- checkUnambig fc ty
          f' <- checkUnambig fc f
          s' <- checkUnambig fc s
-         put Ctxt ({ options $= setPair ty' f' s' } defs)
+         update Ctxt { options $= setPair ty' f' s' }
 
 export
 setRewrite : {auto c : Ref Ctxt Defs} ->
              FC -> (eq : Name) -> (rwlemma : Name) -> Core ()
 setRewrite fc eq rw
-    = do defs <- get Ctxt
-         rw' <- checkUnambig fc rw
+    = do rw' <- checkUnambig fc rw
          eq' <- checkUnambig fc eq
-         put Ctxt ({ options $= setRewrite eq' rw' } defs)
+         update Ctxt { options $= setRewrite eq' rw' }
 
 -- Don't check for ambiguity here; they're all meant to be overloadable
 export
 setFromInteger : {auto c : Ref Ctxt Defs} ->
                  Name -> Core ()
-setFromInteger n
-    = do defs <- get Ctxt
-         put Ctxt ({ options $= setFromInteger n } defs)
+setFromInteger n = update Ctxt { options $= setFromInteger n }
 
 export
 setFromString : {auto c : Ref Ctxt Defs} ->
                 Name -> Core ()
-setFromString n
-    = do defs <- get Ctxt
-         put Ctxt ({ options $= setFromString n } defs)
+setFromString n = update Ctxt { options $= setFromString n }
 
 export
 setFromChar : {auto c : Ref Ctxt Defs} ->
               Name -> Core ()
-setFromChar n
-    = do defs <- get Ctxt
-         put Ctxt ({ options $= setFromChar n } defs)
+setFromChar n = update Ctxt { options $= setFromChar n }
 
 export
 setFromDouble : {auto c : Ref Ctxt Defs} ->
               Name -> Core ()
-setFromDouble n
-    = do defs <- get Ctxt
-         put Ctxt ({ options $= setFromDouble n } defs)
+setFromDouble n = update Ctxt { options $= setFromDouble n }
 
 export
 addNameDirective : {auto c : Ref Ctxt Defs} ->
                    FC -> Name -> List String -> Core ()
 addNameDirective fc n ns
-    = do defs <- get Ctxt
-         n' <- checkUnambig fc n
-         put Ctxt ({ namedirectives $= insert n' ns  } defs)
+    = do n' <- checkUnambig fc n
+         update Ctxt { namedirectives $= insert n' ns  }
 
 -- Checking special names from Options
 
@@ -2241,13 +2142,8 @@ isPrimName prims given = let (ns, nm) = splitNS given in go ns nm prims where
 export
 addLogLevel : {auto c : Ref Ctxt Defs} ->
               Maybe LogLevel -> Core ()
-addLogLevel lvl
-    = do defs <- get Ctxt
-         case lvl of
-           Nothing => put Ctxt ({ options->session->logEnabled := True,
-                                  options->session->logLevel := defaultLogLevel } defs)
-           Just l  => put Ctxt ({ options->session->logEnabled := True,
-                                  options->session->logLevel $= insertLogLevel l } defs)
+addLogLevel Nothing  = update Ctxt { options->session->logEnabled := True, options->session->logLevel := defaultLogLevel }
+addLogLevel (Just l) = update Ctxt { options->session->logEnabled := True, options->session->logLevel $= insertLogLevel l }
 
 export
 withLogLevel : {auto c : Ref Ctxt Defs} ->
@@ -2262,18 +2158,12 @@ withLogLevel l comp = do
   pure r
 
 export
-setLogTimings : {auto c : Ref Ctxt Defs} ->
-                Bool -> Core ()
-setLogTimings b
-    = do defs <- get Ctxt
-         put Ctxt ({ options->session->logTimings := b } defs)
+setLogTimings : {auto c : Ref Ctxt Defs} -> Bool -> Core ()
+setLogTimings b = update Ctxt { options->session->logTimings := b }
 
 export
-setDebugElabCheck : {auto c : Ref Ctxt Defs} ->
-                    Bool -> Core ()
-setDebugElabCheck b
-    = do defs <- get Ctxt
-         put Ctxt ({ options->session->debugElabCheck := b } defs)
+setDebugElabCheck : {auto c : Ref Ctxt Defs} -> Bool -> Core ()
+setDebugElabCheck b = update Ctxt { options->session->debugElabCheck := b }
 
 export
 getSession : {auto c : Ref Ctxt Defs} ->
@@ -2283,11 +2173,8 @@ getSession
          pure (session (options defs))
 
 export
-setSession : {auto c : Ref Ctxt Defs} ->
-             Session -> Core ()
-setSession sopts
-    = do defs <- get Ctxt
-         put Ctxt ({ options->session := sopts } defs)
+setSession : {auto c : Ref Ctxt Defs} -> Session -> Core ()
+setSession sopts = update Ctxt { options->session := sopts }
 
 %inline
 export
@@ -2297,10 +2184,7 @@ updateSession f = setSession (f !getSession)
 
 export
 recordWarning : {auto c : Ref Ctxt Defs} -> Warning -> Core ()
-recordWarning w
-    = do defs <- get Ctxt
-         session <- getSession
-         put Ctxt $ { warnings $= (w ::) } defs
+recordWarning w = update Ctxt { warnings $= (w ::) }
 
 export
 getTime : Core Integer
@@ -2324,15 +2208,12 @@ startTimer : {auto c : Ref Ctxt Defs} ->
              Integer -> String -> Core ()
 startTimer tmax action
     = do t <- getTime
-         defs <- get Ctxt
-         put Ctxt $ { timer := Just (t + tmax * 1000000, action) } defs
+         update Ctxt { timer := Just (t + tmax * 1000000, action) }
 
 ||| Clear the timer
 export
 clearTimer : {auto c : Ref Ctxt Defs} -> Core ()
-clearTimer
-    = do defs <- get Ctxt
-         put Ctxt $ { timer := Nothing } defs
+clearTimer = update Ctxt { timer := Nothing }
 
 ||| If the timer was started more than t milliseconds ago, throw an exception
 export
@@ -2387,9 +2268,7 @@ addImportedInc modNS inc
 export
 setIncData : {auto c : Ref Ctxt Defs} ->
              CG -> (String, List String) -> Core ()
-setIncData cg res
-    = do defs <- get Ctxt
-         put Ctxt ({ incData $= ((cg, res) :: )} defs)
+setIncData cg res = update Ctxt { incData $= ((cg, res) :: )}
 
 -- Set a name as Private that was previously visible (and, if 'everywhere' is
 -- set, hide in any modules imported by this one)

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -2142,7 +2142,7 @@ isPrimName prims given = let (ns, nm) = splitNS given in go ns nm prims where
 export
 addLogLevel : {auto c : Ref Ctxt Defs} ->
               Maybe LogLevel -> Core ()
-addLogLevel Nothing  = update Ctxt { options->session->logEnabled := True, options->session->logLevel := defaultLogLevel }
+addLogLevel Nothing  = update Ctxt { options->session->logEnabled := False, options->session->logLevel := defaultLogLevel }
 addLogLevel (Just l) = update Ctxt { options->session->logEnabled := True, options->session->logLevel $= insertLogLevel l }
 
 export

--- a/src/Core/LinearCheck.idr
+++ b/src/Core/LinearCheck.idr
@@ -262,7 +262,6 @@ mutual
                               _ => env
                          else env
            (sc', sct, usedsc) <- lcheck rig erase (b' :: env') sc
-           defs <- get Ctxt
 
            let used_in = count 0 usedsc
            holeFound <- if not erase && isLinear (multiplicity b)

--- a/src/Core/Metadata.idr
+++ b/src/Core/Metadata.idr
@@ -228,18 +228,12 @@ addNameLoc loc n
            put MD $ { nameLocMap $= insert (neloc, n') } meta
 
 export
-setHoleLHS : {auto m : Ref MD Metadata} ->
-             ClosedTerm -> Core ()
-setHoleLHS tm
-    = do meta <- get MD
-         put MD ({ currentLHS := Just tm } meta)
+setHoleLHS : {auto m : Ref MD Metadata} -> ClosedTerm -> Core ()
+setHoleLHS tm = update MD { currentLHS := Just tm }
 
 export
-clearHoleLHS : {auto m : Ref MD Metadata} ->
-               Core ()
-clearHoleLHS
-    = do meta <- get MD
-         put MD ({ currentLHS := Nothing } meta)
+clearHoleLHS : {auto m : Ref MD Metadata} -> Core ()
+clearHoleLHS = update MD { currentLHS := Nothing }
 
 export
 withCurrentLHS : {auto c : Ref Ctxt Defs} ->
@@ -289,16 +283,12 @@ findHoleLHS hn
 export
 addSemanticDefault : {auto m : Ref MD Metadata} ->
                      ASemanticDecoration -> Core ()
-addSemanticDefault asem
-  = do meta <- get MD
-       put MD $ { semanticDefaults $= insert asem } meta
+addSemanticDefault asem = update MD { semanticDefaults $= insert asem }
 
 export
 addSemanticAlias : {auto m : Ref MD Metadata} ->
                    NonEmptyFC -> NonEmptyFC -> Core ()
-addSemanticAlias from to
-  = do meta <- get MD
-       put MD $ { semanticAliases $= insert (from, to) } meta
+addSemanticAlias from to = update MD { semanticAliases $= insert (from, to) }
 
 export
 addSemanticDecorations : {auto m : Ref MD Metadata} ->
@@ -306,7 +296,6 @@ addSemanticDecorations : {auto m : Ref MD Metadata} ->
    SemanticDecorations -> Core ()
 addSemanticDecorations decors
     = do meta <- get MD
-         defs <- get Ctxt
          let posmap = meta.semanticHighlighting
          let (newDecors,droppedDecors) =
                span

--- a/src/Core/SchemeEval/Quote.idr
+++ b/src/Core/SchemeEval/Quote.idr
@@ -95,8 +95,7 @@ mutual
              Ref Sym Integer -> Bounds bound ->
              Env Term vars -> SNF vars -> Core (Term (bound ++ vars))
   quoteGen q bound env (SBind fc n b sc)
-      = do i <- get Sym
-           put Sym (i + 1)
+      = do i <- nextName
            let var = UN (Basic ("b-" ++ show (fromInteger i)))
            -- Ref Bound gets turned directly into a symbol by seval, which
            -- we can then read back when quoting the scope

--- a/src/Core/Transform.idr
+++ b/src/Core/Transform.idr
@@ -114,8 +114,7 @@ trans env stk (Ref fc Func fn)
               Nothing => pure (unload stk (Ref fc Func fn))
               Just ts => do let fullapp = unload stk (Ref fc Func fn)
                             let (u, tm') = apply ts fullapp
-                            upd <- get Upd
-                            put Upd (upd || u)
+                            update Upd (|| u)
                             pure tm'
 trans env stk (Meta fc n i args)
     = do args' <- traverse (trans env []) args

--- a/src/Core/Unify.idr
+++ b/src/Core/Unify.idr
@@ -1160,15 +1160,14 @@ mutual
       = do gam <- get Ctxt
            if tagx == tagy
              then
-                  do ust <- get UST
-                     -- Constantly checking the log setting appears to have
+                  do -- Constantly checking the log setting appears to have
                      -- a bit of overhead, but I'm keeping this here because it
                      -- may prove useful again...
                      {-
+                     ust <- get UST
                      when (logging ust) $
                         do log "unify" 20 $ "Constructor " ++ show !(toFullNames x) ++ " " ++ show loc
                            log "unify" 20 "ARGUMENTS:"
-                           defs <- get Ctxt
                            traverse_ (dumpArg env) xs
                            log "unify" 20 "WITH:"
                            traverse_ (dumpArg env) ys
@@ -1623,8 +1622,7 @@ checkDots
          hs <- getCurrentHoles
          traverse_ checkConstraint (reverse (dotConstraints ust))
          hs <- getCurrentHoles
-         ust <- get UST
-         put UST ({ dotConstraints := [] } ust)
+         update UST { dotConstraints := [] }
   where
     getHoleName : Term [] -> Core (Maybe Name)
     getHoleName tm

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -317,9 +317,7 @@ mutual
   desugarB side ps (PRunElab fc tm)
       = pure $ IRunElab fc !(desugarB side ps tm)
   desugarB side ps (PHole fc br holename)
-      = do when br $
-              do syn <- get Syn
-                 put Syn ({ bracketholes $= ((UN (Basic holename)) ::) } syn)
+      = do when br $ update Syn { bracketholes $= ((UN (Basic holename)) ::) }
            pure $ IHole fc holename
   desugarB side ps (PType fc) = pure $ IType fc
   desugarB side ps (PAs fc nameFC vname pattern)
@@ -589,7 +587,6 @@ mutual
   expandDo side ps topfc ns (DoExp fc tm :: rest)
       = do tm' <- desugarDo side ps ns tm
            rest' <- expandDo side ps topfc ns rest
-           gam <- get Ctxt
            pure $ seqFun fc ns tm' rest'
   expandDo side ps topfc ns (DoBind fc nameFC n tm :: rest)
       = do tm' <- desugarDo side ps ns tm
@@ -878,8 +875,7 @@ mutual
                                             pure (fst ntm, btm)) uimpls
            put Syn ({ usingImpl := uimpls' ++ oldu } syn)
            uds' <- traverse (desugarDecl ps) uds
-           syn <- get Syn
-           put Syn ({ usingImpl := oldu } syn)
+           update Syn { usingImpl := oldu }
            pure (concat uds')
   desugarDecl ps (PReflect fc tm)
       = throw (GenericMsg fc "Reflection not implemented yet")
@@ -1012,12 +1008,10 @@ mutual
       mapDesugarPiInfo ps = traverse (desugar AnyExpr ps)
 
   desugarDecl ps (PFixity fc Prefix prec (UN (Basic n)))
-      = do syn <- get Syn
-           put Syn ({ prefixes $= insert n (fc, prec) } syn)
+      = do update Syn { prefixes $= insert n (fc, prec) }
            pure []
   desugarDecl ps (PFixity fc fix prec (UN (Basic n)))
-      = do syn <- get Syn
-           put Syn ({ infixes $= insert n (fc, fix, prec) } syn)
+      = do update Syn { infixes $= insert n (fc, fix, prec) }
            pure []
   desugarDecl ps (PFixity fc _ _ _)
       = throw (GenericMsg fc "Fixity declarations must be for unqualified names")

--- a/src/Idris/Driver.idr
+++ b/src/Idris/Driver.idr
@@ -85,9 +85,8 @@ updateEnv
 updateREPLOpts : {auto o : Ref ROpts REPLOpts} ->
                  Core ()
 updateREPLOpts
-    = do opts <- get ROpts
-         ed <- coreLift $ idrisGetEnv "EDITOR"
-         whenJust ed $ \ e => put ROpts ({ editor := e } opts)
+    = do ed <- coreLift $ idrisGetEnv "EDITOR"
+         whenJust ed $ \ e => update ROpts { editor := e }
 
 showInfo : {auto c : Ref Ctxt Defs}
         -> {auto o : Ref ROpts REPLOpts}

--- a/src/Idris/Elab/Interface.idr
+++ b/src/Idris/Elab/Interface.idr
@@ -296,11 +296,10 @@ updateIfaceSyn : {auto c : Ref Ctxt Defs} ->
                  List Declaration -> List (Name, List ImpClause) ->
                  Core ()
 updateIfaceSyn iname cn impps ps cs ms ds
-    = do syn <- get Syn
-         ms' <- traverse totMeth ms
+    = do ms' <- traverse totMeth ms
          let info = MkIFaceInfo cn impps ps cs ms' ds
-         put Syn ({ ifaces $= addName iname info,
-                    saveIFaces $= (iname :: ) } syn)
+         update Syn { ifaces     $= addName iname info,
+                      saveIFaces $= (iname :: ) }
  where
     findSetTotal : List FnOpt -> Maybe TotalReq
     findSetTotal [] = Nothing

--- a/src/Idris/ModTree.idr
+++ b/src/Idris/ModTree.idr
@@ -84,8 +84,7 @@ mkModTree loc done modFP mod
                                 else do
                                   ms <- traverse (mkModTree loc (mod :: done) Nothing) imps
                                   let mt = MkModTree mod (Just file) ms
-                                  all <- get AllMods
-                                  put AllMods ((mod, mt) :: all)
+                                  update AllMods ((mod, mt) ::)
                                   pure mt
                          Just m => pure m)
                 -- Couldn't find source, assume it's in a package directory
@@ -114,12 +113,10 @@ mkBuildMods mod
                        do -- build dependencies
                           traverse_ mkBuildMods (deps mod)
                           -- build it now
-                          bo <- get BuildOrder
-                          put BuildOrder
-                                (MkBuildMod sf (nspace mod)
-                                            (map nspace (deps mod)) :: bo)
-                          done <- get DoneMod
-                          put DoneMod (insert sf () done)
+                          update BuildOrder
+                                   (MkBuildMod sf mod.nspace
+                                               (map nspace mod.deps) ::)
+                          update DoneMod $ insert sf ()
 
 -- Given a main file name, return the list of modules that need to be
 -- built for that main file, in the order they need to be built
@@ -266,7 +263,6 @@ buildMod loc num len mod
               log "import.file" 10 $ "Processing " ++ sourceFile
               process {u} {m} msgPrefix buildMsg sourceFile modNamespace
 
-        defs <- get Ctxt
         ws <- emitWarningsAndErrors (if null errs then ferrs else errs)
         pure (ws ++ if null errs then ferrs else ferrs ++ errs)
 

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -270,11 +270,8 @@ runScript (Just (fc, s))
          when (res /= 0) $
             throw (GenericMsg fc "Script failed")
 
-addDeps : {auto c : Ref Ctxt Defs} ->
-          PkgDesc -> Core ()
-addDeps pkg
-    = do defs <- get Ctxt
-         traverse_ (\p => addPkgDir p.pkgname p.pkgbounds) (depends pkg)
+addDeps : {auto c : Ref Ctxt Defs} -> PkgDesc -> Core ()
+addDeps pkg = traverse_ (\p => addPkgDir p.pkgname p.pkgbounds) (depends pkg)
 
 processOptions : {auto c : Ref Ctxt Defs} ->
                  {auto o : Ref ROpts REPLOpts} ->
@@ -304,8 +301,6 @@ prepareCompilation : {auto c : Ref Ctxt Defs} ->
                      Core (List Error)
 prepareCompilation pkg opts =
   do
-    defs <- get Ctxt
-
     processOptions (options pkg)
     addDeps pkg
 
@@ -848,8 +843,7 @@ findIpkg fname
              Just srcpath  =>
                 do let src' = up </> srcpath
                    setSource src'
-                   opts <- get ROpts
-                   put ROpts ({ mainfile := Just src' } opts)
+                   update ROpts { mainfile := Just src' }
                    pure (Just src')
   where
     dropHead : String -> List String -> List String

--- a/src/Idris/ProcessIdr.idr
+++ b/src/Idris/ProcessIdr.idr
@@ -184,8 +184,7 @@ readAsMain fname
          -- from that for the fresh metavariable name generation
          -- TODO: Maybe we should record this per namespace, since this is
          -- a little bit of a hack? Or maybe that will have too much overhead.
-         ust <- get UST
-         put UST ({ nextName := nextName ustm } ust)
+         update UST { nextName := nextName ustm }
 
          setNS replNS
          setNestedNS replNestedNS
@@ -346,8 +345,7 @@ processMod sourceFileName ttcFileName msg sourcecode origin
                 addModDocString (moduleNS mod) (documentation mod)
 
                 addSemanticDecorations decor
-                syn <- get Syn
-                put Syn ({ holeNames := hnames } syn)
+                update Syn { holeNames := hnames }
 
                 initHash
                 traverse_ addPublicHash (sort importMetas)
@@ -381,8 +379,7 @@ processMod sourceFileName ttcFileName msg sourcecode origin
                 -- Save the import hashes for the imports we just read.
                 -- If they haven't changed next time, and the source
                 -- file hasn't changed, no need to rebuild.
-                defs <- get Ctxt
-                put Ctxt ({ importHashes := importInterfaceHashes } defs)
+                update Ctxt { importHashes := importInterfaceHashes }
                 pure (Just errs))
           (\err => pure (Just [err]))
 
@@ -411,8 +408,7 @@ process msgPrefix buildMsg sourceFileName ident
                                      pure [] -- skipped it
                    if isNil errs
                       then
-                        do defs <- get Ctxt
-                           ns <- ctxtPathToNS sourceFileName
+                        do ns <- ctxtPathToNS sourceFileName
                            makeBuildDirectory ns
                            traverse_
                               (\cg =>

--- a/src/Idris/REPL/Common.idr
+++ b/src/Idris/REPL/Common.idr
@@ -174,14 +174,9 @@ getFCLine : FC -> Maybe Int
 getFCLine = map startLine . isNonEmptyFC
 
 export
-updateErrorLine : {auto o : Ref ROpts REPLOpts} ->
-                  List Error -> Core ()
-updateErrorLine []
-    = do opts <- get ROpts
-         put ROpts ({ errorLine := Nothing } opts)
-updateErrorLine (e :: _)
-    = do opts <- get ROpts
-         put ROpts ({ errorLine := (getErrorLoc e) >>= getFCLine } opts)
+updateErrorLine : {auto o : Ref ROpts REPLOpts} -> List Error -> Core ()
+updateErrorLine []       = update ROpts { errorLine := Nothing }
+updateErrorLine (e :: _) = update ROpts { errorLine := getErrorLoc e >>= getFCLine }
 
 export
 resetContext : {auto c : Ref Ctxt Defs} ->

--- a/src/Idris/REPL/Opts.idr
+++ b/src/Idris/REPL/Opts.idr
@@ -96,44 +96,32 @@ withROpts = wrapRef ROpts (\_ => pure ())
 export
 setOutput : {auto o : Ref ROpts REPLOpts} ->
             OutputMode -> Core ()
-setOutput m
-    = do opts <- get ROpts
-         put ROpts ({ idemode := m } opts)
+setOutput m = update ROpts { idemode := m }
 
 export
 getOutput : {auto o : Ref ROpts REPLOpts} -> Core OutputMode
-getOutput = do opts <- get ROpts
-               pure (idemode opts)
+getOutput = idemode <$> get ROpts
 
 export
 setMainFile : {auto o : Ref ROpts REPLOpts} ->
               Maybe String -> Core ()
-setMainFile src
-    = do opts <- get ROpts
-         put ROpts ({ mainfile := src,
-                      literateStyle := litStyle src } opts)
+setMainFile src = update ROpts { mainfile      := src,
+                                 literateStyle := litStyle src }
 
 export
-resetProofState : {auto o : Ref ROpts REPLOpts} ->
-                  Core ()
-resetProofState
-    = do opts <- get ROpts
-         put ROpts ({ psResult := Nothing,
-                      gdResult := Nothing } opts)
+resetProofState : {auto o : Ref ROpts REPLOpts} -> Core ()
+resetProofState = update ROpts { psResult := Nothing,
+                                 gdResult := Nothing }
 
 export
 setSource : {auto o : Ref ROpts REPLOpts} ->
             String -> Core ()
-setSource src
-    = do opts <- get ROpts
-         put ROpts ({ source := src } opts)
+setSource src = update ROpts { source := src }
 
 export
 getSource : {auto o : Ref ROpts REPLOpts} ->
             Core String
-getSource
-    = do opts <- get ROpts
-         pure (source opts)
+getSource = source <$> get ROpts
 
 export
 getSourceLine : {auto o : Ref ROpts REPLOpts} ->
@@ -145,73 +133,55 @@ getSourceLine l
 export
 getLitStyle : {auto o : Ref ROpts REPLOpts} ->
               Core (Maybe LiterateStyle)
-getLitStyle
-    = do opts <- get ROpts
-         pure (literateStyle opts)
+getLitStyle = literateStyle <$> get ROpts
 
 export
 setCurrentElabSource : {auto o : Ref ROpts REPLOpts} ->
                        String -> Core ()
-setCurrentElabSource src
-    = do opts <- get ROpts
-         put ROpts ({ currentElabSource := src } opts)
+setCurrentElabSource src = update ROpts { currentElabSource := src }
 
 export
 getCurrentElabSource : {auto o : Ref ROpts REPLOpts} ->
                        Core String
-getCurrentElabSource
-     = do opts <- get ROpts
-          pure (currentElabSource opts)
+getCurrentElabSource = currentElabSource <$> get ROpts
 
 addCodegen : {auto o : Ref ROpts REPLOpts} ->
              String -> Codegen -> Core ()
-addCodegen s cg = do opts <- get ROpts
-                     put ROpts ({ extraCodegens $= ((s,cg)::) } opts)
+addCodegen s cg = update ROpts { extraCodegens $= ((s,cg)::) }
 
 export
 getCodegen : {auto o : Ref ROpts REPLOpts} ->
              String -> Core (Maybe Codegen)
-getCodegen s = do opts <- get ROpts
-                  pure $ lookup s (extraCodegens opts)
+getCodegen s = lookup s . extraCodegens <$> get ROpts
 
 export
 getConsoleWidth : {auto o : Ref ROpts REPLOpts} -> Core (Maybe Nat)
-getConsoleWidth = do opts <- get ROpts
-                     pure $ opts.consoleWidth
+getConsoleWidth = consoleWidth <$> get ROpts
 
 export
 setConsoleWidth : {auto o : Ref ROpts REPLOpts} -> Maybe Nat -> Core ()
-setConsoleWidth n = do opts <- get ROpts
-                       put ROpts ({ consoleWidth := n } opts)
+setConsoleWidth n = update ROpts { consoleWidth := n }
 
 export
 getColor : {auto o : Ref ROpts REPLOpts} -> Core Bool
-getColor = do opts <- get ROpts
-              pure $ opts.color
+getColor = color <$> get ROpts
 
 export
 setColor : {auto o : Ref ROpts REPLOpts} -> Bool -> Core ()
-setColor b = do opts <- get ROpts
-                put ROpts ({ color := b } opts)
+setColor b = update ROpts { color := b }
 
 export
 getSynHighlightOn : {auto o : Ref ROpts REPLOpts} -> Core Bool
-getSynHighlightOn = do opts <- get ROpts
-                       pure $ opts.synHighlightOn
+getSynHighlightOn = synHighlightOn <$> get ROpts
 
 export
 setSynHighlightOn : {auto o : Ref ROpts REPLOpts} -> Bool -> Core ()
-setSynHighlightOn b = do opts <- get ROpts
-                         put ROpts ({ synHighlightOn := b } opts)
+setSynHighlightOn b = update ROpts { synHighlightOn := b }
 
 export
 getEvalTiming : {auto o : Ref ROpts REPLOpts} -> Core Bool
-getEvalTiming
-    = do opts <- get ROpts
-         pure (evalTiming opts)
+getEvalTiming = evalTiming <$> get ROpts
 
 export
 setEvalTiming : {auto o : Ref ROpts REPLOpts} -> Bool -> Core ()
-setEvalTiming b
-    = do opts <- get ROpts
-         put ROpts ({ evalTiming := b } opts)
+setEvalTiming b = update ROpts { evalTiming := b }

--- a/src/TTImp/Elab.idr
+++ b/src/TTImp/Elab.idr
@@ -135,11 +135,9 @@ elabTermSub {vars} defining mode opts nest env env' sub tm ty
                              (sortBy (\x, y => compare (fst x) (fst y))
                                        (delayedElab ust)))
                  (\err =>
-                    do ust <- get UST
-                       put UST ({ delayedElab := olddelayed } ust)
+                    do update UST { delayedElab := olddelayed }
                        throw err)
-         ust <- get UST
-         put UST ({ delayedElab := olddelayed } ust)
+         update UST { delayedElab := olddelayed }
          solveConstraintsAfter constart solvemode MatchArgs
 
          -- As long as we're not in the RHS of a case block,

--- a/src/TTImp/Elab/Ambiguity.idr
+++ b/src/TTImp/Elab/Ambiguity.idr
@@ -355,7 +355,6 @@ checkAlternative rig elabinfo nest env fc (UniqueDefault def) alts mexpected
          delayOnFailure fc rig env (Just expected) ambiguous Ambiguity $
              \delayed =>
                do solveConstraints solvemode Normal
-                  defs <- get Ctxt
                   exp <- getTerm expected
 
                   -- We can't just use the old NF on the second attempt,
@@ -408,8 +407,7 @@ checkAlternative rig elabinfo nest env fc uniq alts mexpected
                                       _ => inTerm
                 delayOnFailure fc rig env (Just expected) ambiguous Ambiguity $
                      \delayed =>
-                       do defs <- get Ctxt
-                          exp <- getTerm expected
+                       do exp <- getTerm expected
 
                           -- We can't just use the old NF on the second attempt,
                           -- because we might know more now, so recalculate it

--- a/src/TTImp/Elab/App.idr
+++ b/src/TTImp/Elab/App.idr
@@ -56,10 +56,7 @@ getNameType elabMode rigc env fc x
                  log "metadata.names" 7 $ "getNameType is adding ↓"
                  addNameType fc x env bty
 
-                 when (isLinear rigb) $
-                      do est <- get EST
-                         put EST
-                            ({ linearUsed $= ((MkVar lv) :: ) } est)
+                 when (isLinear rigb) $ update EST { linearUsed $= ((MkVar lv) :: ) }
                  log "ide-mode.highlight" 8
                      $ "getNameType is trying to add Bound: "
                       ++ show x ++ " (" ++ show fc ++ ")"
@@ -186,9 +183,7 @@ mutual
            metaval <- metaVar fc argRig env nm metaty
            let fntm = App fc tm metaval
            fnty <- sc defs (toClosure defaultOpts env metaval)
-           when (bindingVars elabinfo) $
-                do est <- get EST
-                   put EST (addBindIfUnsolved nm argRig Implicit env metaval metaty est)
+           when (bindingVars elabinfo) $ update EST $ addBindIfUnsolved nm argRig Implicit env metaval metaty
            checkAppWith rig elabinfo nest env fc
                         fntm fnty (n, 1 + argpos) expargs autoargs namedargs kr expty
 
@@ -220,8 +215,7 @@ mutual
                    metaval <- metaVar fc argRig env nm metaty
                    let fntm = App fc tm metaval
                    fnty <- sc defs (toClosure defaultOpts env metaval)
-                   est <- get EST
-                   put EST (addBindIfUnsolved nm argRig AutoImplicit env metaval metaty est)
+                   update EST $ addBindIfUnsolved nm argRig AutoImplicit env metaval metaty
                    checkAppWith rig elabinfo nest env fc
                                 fntm fnty (n, 1 + argpos) expargs autoargs namedargs kr expty
            else do defs <- get Ctxt
@@ -277,8 +271,7 @@ mutual
                    metaval <- metaVar fc argRig env nm metaty
                    let fntm = App fc tm metaval
                    fnty <- sc defs (toClosure defaultOpts env metaval)
-                   est <- get EST
-                   put EST (addBindIfUnsolved nm argRig AutoImplicit env metaval metaty est)
+                   update EST $ addBindIfUnsolved nm argRig AutoImplicit env metaval metaty
                    checkAppWith rig elabinfo nest env fc
                                 fntm fnty (n, 1 + argpos) expargs autoargs namedargs kr expty
            else do defs <- get Ctxt

--- a/src/TTImp/Elab/As.idr
+++ b/src/TTImp/Elab/As.idr
@@ -47,11 +47,8 @@ checkAs rig elabinfo nest env fc nameFC side n_in pat topexp
                                             topexp
                     log "elab.as" 5 $ "Added as pattern name " ++ show (n, (rigAs, tm, exp, bty))
                     defs <- get Ctxt
-                    est <- get EST
-                    put EST
-                        ({ boundNames $= ((n, AsBinding rigAs Explicit tm exp pattm) :: ),
-                           toBind $= ((n, AsBinding rigAs Explicit tm bty pattm) ::) }
-                         est)
+                    update EST { boundNames $= ((n, AsBinding rigAs Explicit tm exp pattm) :: ),
+                                 toBind $= ((n, AsBinding rigAs Explicit tm bty pattm) ::) }
                     (ntm, nty) <- checkExp rig elabinfo env nameFC tm (gnf env exp)
                                            (Just patty)
 

--- a/src/TTImp/Elab/Local.idr
+++ b/src/TTImp/Elab/Local.idr
@@ -72,12 +72,9 @@ localHelper {vars} nest env nestdecls_in func
          log "elab.def.local" 20 $ show nestdecls
 
          traverse_ (processDecl [] nest' env') nestdecls
-         ust <- get UST
-         put UST ({ delayedElab := olddelayed } ust)
-         defs <- get Ctxt
+         update UST { delayedElab := olddelayed }
          res <- func nest'
-         defs <- get Ctxt
-         put Ctxt ({ localHints := oldhints } defs)
+         update Ctxt { localHints := oldhints }
          pure res
   where
     -- For the local definitions, don't allow access to linear things

--- a/src/TTImp/Elab/Quote.idr
+++ b/src/TTImp/Elab/Quote.idr
@@ -71,8 +71,7 @@ mutual
       = pure $ IQuote fc !(getUnquote t)
   getUnquote (IUnquote fc tm)
       = do qv <- genVarName "q"
-           unqs <- get Unq
-           put Unq ((qv, fc, tm) :: unqs)
+           update Unq ((qv, fc, tm) ::)
            pure (IUnquote fc (IVar fc qv)) -- turned into just qv when reflecting
   getUnquote tm = pure tm
 

--- a/src/TTImp/Elab/Term.idr
+++ b/src/TTImp/Elab/Term.idr
@@ -217,14 +217,12 @@ checkTerm rig elabinfo nest env (IUnifyLog fc lvl tm) exp
 checkTerm rig elabinfo nest env (Implicit fc b) (Just gexpty)
     = do nm <- genName "_"
          expty <- getTerm gexpty
-         defs <- get Ctxt
          metaval <- metaVar fc rig env nm expty
          -- Add to 'bindIfUnsolved' if 'b' set
          when (b && bindingVars elabinfo) $
-            do est <- get EST
-               expty <- getTerm gexpty
+            do expty <- getTerm gexpty
                -- Explicit because it's an explicitly given thing!
-               put EST (addBindIfUnsolved nm rig Explicit env metaval expty est)
+               update EST $ addBindIfUnsolved nm rig Explicit env metaval expty
          pure (metaval, gexpty)
 checkTerm rig elabinfo nest env (Implicit fc b) Nothing
     = do nmty <- genName "implicit_type"
@@ -234,8 +232,7 @@ checkTerm rig elabinfo nest env (Implicit fc b) Nothing
          metaval <- metaVar fc rig env nm ty
          -- Add to 'bindIfUnsolved' if 'b' set
          when (b && bindingVars elabinfo) $
-            do est <- get EST
-               put EST (addBindIfUnsolved nm rig Explicit env metaval ty est)
+            update EST $ addBindIfUnsolved nm rig Explicit env metaval ty
          pure (metaval, gnf env ty)
 checkTerm rig elabinfo nest env (IWithUnambigNames fc ns rhs) exp
     = do -- enter the scope -> add unambiguous names
@@ -288,9 +285,7 @@ TTImp.Elab.Check.check rigc elabinfo nest env tm@(ILocal _ _ _) exp
 TTImp.Elab.Check.check rigc elabinfo nest env tm@(IUpdate _ _ _) exp
     = checkImp rigc elabinfo nest env tm exp
 TTImp.Elab.Check.check rigc elabinfo nest env tm_in exp
-    = do defs <- get Ctxt
-         est <- get EST
-         tm <- expandAmbigName (elabMode elabinfo) nest env tm_in [] tm_in exp
+    = do tm <- expandAmbigName (elabMode elabinfo) nest env tm_in [] tm_in exp
          case elabMode elabinfo of
               InLHS _ => -- Don't expand implicit lambda on lhs
                  checkImp rigc elabinfo nest env tm exp

--- a/src/TTImp/Elab/Utils.idr
+++ b/src/TTImp/Elab/Utils.idr
@@ -156,9 +156,7 @@ data Used : Type where
 setUsed : {idx : _} ->
           {auto u : Ref Used (Usage vars)} ->
           (0 _ : IsVar n idx vars) -> Core ()
-setUsed p
-    = do used <- get Used
-         put Used (setUsedVar p used)
+setUsed p = update Used $ setUsedVar p
 
 extendUsed : ArgUsed -> (new : List Name) -> Usage vars -> Usage (new ++ vars)
 extendUsed a [] x = x

--- a/src/TTImp/Interactive/CaseSplit.idr
+++ b/src/TTImp/Interactive/CaseSplit.idr
@@ -272,7 +272,7 @@ recordUpdate : {auto u : Ref UPD Updates} ->
                FC -> Name -> RawImp -> Core ()
 recordUpdate fc n tm
     = do u <- get UPD
-         let nupdates = map (\x => (fst x, IVar fc (snd x))) (namemap u)
+         let nupdates = mapSnd (IVar fc) <$> namemap u
          put UPD ({ updates $= ((n, substNames [] nupdates tm) ::) } u)
 
 findUpdates : {auto u : Ref UPD Updates} ->

--- a/src/TTImp/Interactive/ExprSearch.idr
+++ b/src/TTImp/Interactive/ExprSearch.idr
@@ -415,7 +415,6 @@ tryRecursive fc rig opts hints env ty topty rdata
                 do res <- searchName fc rig ({ recData := Nothing } opts) hints
                                      env !(nf defs env ty)
                                      topty (recname rdata, def)
-                   defs <- get Ctxt
                    res' <- traverse (\ (t, ds) => pure (!(toFullNames t), ds)) res
                    filterS (structDiffTm (lhsapp rdata)) res'
   where
@@ -580,7 +579,6 @@ makeHelper fc rig opts env letty targetty (Result (locapp, ds) next)
          logTerm "interaction.search" 10 "Local app" locapp
          let Just gendef = genExpr opts
              | Nothing => noResult
-         defs <- get Ctxt
          intn <- genVarName "cval"
          helpern_in <- genCaseName "search"
          helpern <- inCurrentNS helpern_in

--- a/src/TTImp/PartialEval.idr
+++ b/src/TTImp/PartialEval.idr
@@ -289,8 +289,7 @@ mkSpecDef {vars} fc gdef pename sargs fn stk
         (\err =>
            do log "specialise" 1 $ "Partial evaluation of " ++ show !(toFullNames fn) ++ " failed" ++
                       "\n" ++ show err
-              defs <- get Ctxt
-              put Ctxt ({ peFailures $= insert pename () } defs)
+              update Ctxt { peFailures $= insert pename () }
               pure (applyWithFC (Ref fc Func fn) stk))
   where
     getAllRefs : NameMap Bool -> List ArgMode -> NameMap Bool

--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -882,8 +882,7 @@ compileRunTime fc atotal
          traverse_ (mkRunTime fc) (toCompileCase defs)
          traverse_ (calcRefs True atotal) (toCompileCase defs)
 
-         defs <- get Ctxt
-         put Ctxt ({ toCompileCase := [] } defs)
+         update Ctxt { toCompileCase := [] }
 
 toPats : Clause -> (vs ** (Env Term vs, Term vs, Term vs))
 toPats (MkClause {vars} env lhs rhs)
@@ -1022,8 +1021,7 @@ processDef opts nest env fc n_in cs_in
          addToSave n
 
          -- Flag this name as one which needs compiling
-         defs <- get Ctxt
-         put Ctxt ({ toCompileCase $= (n ::) } defs)
+         update Ctxt { toCompileCase $= (n ::) }
 
          atotal <- toResolvedNames (NS builtinNS (UN $ Basic "assert_total"))
          logTime ("+++ Building size change graphs " ++ show n) $

--- a/src/TTImp/ProcessRecord.idr
+++ b/src/TTImp/ProcessRecord.idr
@@ -64,11 +64,10 @@ elabRecord {vars} eopts fc env nest newns vis mbtot tn_in params conName_in fiel
                       extendNS (mkNamespace ns)
                       newns <- getNS
                       elabGetters tn conName 0 [] [] conty
-                      defs <- get Ctxt
                       -- Record that the current namespace is allowed to look
                       -- at private names in the nested namespace
-                      put Ctxt ({ currentNS := cns,
-                                  nestedNS := newns :: nns } defs)
+                      update Ctxt { currentNS := cns,
+                                    nestedNS := newns :: nns }
 
   where
     paramTelescope : List (FC, Maybe Name, RigCount, PiInfo RawImp, RawImp)

--- a/src/Yaffle/Main.idr
+++ b/src/Yaffle/Main.idr
@@ -56,8 +56,6 @@ yaffleMain sourceFileName args
                             ttcFileName <- getTTCFileName sourceFileName "ttc"
                             writeToTTC () sourceFileName ttcFileName
                             coreLift_ $ putStrLn "Written TTC"
-         ust <- get UST
-
          repl {c} {u} {s}
 
 ymain : IO ()


### PR DESCRIPTION
When inspecting the `Core` code I found that there are a few places where `Ref` is read using `get` for no visible reason and can be eliminated. While finding such places, I found a lot of repeating consequent `get`+`put` calls which could be replaced with existing `update` one.