### PR TITLE
[ fix ] Flush standard when prompting for package information

### DIFF
--- a/src/Idris/Package/Init.idr
+++ b/src/Idris/Package/Init.idr
@@ -9,6 +9,7 @@ import Data.String
 
 import Idris.Package.Types
 import System.Directory
+import Control.App.FileIO
 
 import Libraries.Utils.Path
 import Libraries.System.Directory.Tree
@@ -59,14 +60,17 @@ findModules start = do
                    (fileName dir :: path, (_ ** iot))
       go (mods ++ acc) (dirs ++ iots)
 
+prompt : String -> IO String
+prompt p = putStr p >> fflush stdout >> getLine
+
 export
 covering
 interactive : IO PkgDesc
 interactive = do
-  pname    <- putStr "Package name: " *> getLine
-  pauthors <- putStr "Package authors: " *> getLine
-  poptions <- putStr "Package options: " *> getLine
-  psource  <- putStr "Source directory: " *> getLine
+  pname    <- prompt "Package name: "
+  pauthors <- prompt "Package authors: "
+  poptions <- prompt "Package options: "
+  psource  <- prompt "Source directory: "
   let sourcedir = mstring psource
   modules  <- findModules sourcedir
   let pkg : PkgDesc =


### PR DESCRIPTION
On Unix-like operating systems stdio.h is usually line-buffered. As
putStr uses fputs(3) from stdio.h internally, output will be written to
standard out after a newline character is written to the buffer. Since
the various prompts written by `idris2 --init` don't contain a newline
character they are buffered indefinitely. As such, the prompt strings
themselves are never presented to the user.

To fix this issue, this commit introduces a prompt utility procedure
which prints a prompt string and afterwards flushes standard output
before receiving input using getLine. This ensures that the prompt
string is always written before input is retrieved via getLine.

This is similar to c725b11c891b9f9f1e25ead66d9fc75a91b69836.