### PR TITLE
[ re #499 ] quantity-aware with-clauses

### DIFF
--- a/libs/base/Language/Reflection/TTImp.idr
+++ b/libs/base/Language/Reflection/TTImp.idr
@@ -155,8 +155,10 @@ mutual
   public export
   data Clause : Type where
        PatClause : FC -> (lhs : TTImp) -> (rhs : TTImp) -> Clause
-       WithClause : FC -> (lhs : TTImp) -> (wval : TTImp) ->
-                    (prf : Maybe Name) -> (flags : List WithFlag) ->
+       WithClause : FC -> (lhs : TTImp) ->
+                    (rig : Count) -> (wval : TTImp) -> -- with'd expression (& quantity)
+                    (prf : Maybe Name) -> -- optional name for the proof
+                    (flags : List WithFlag) ->
                     List Clause -> Clause
        ImpossibleClause : FC -> (lhs : TTImp) -> Clause
 

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -25,10 +25,11 @@ import public Libraries.Utils.Binary
 %default covering
 
 ||| TTC files can only be compatible if the version number is the same
-||| (Increment this when changing anything in the data format)
+||| Update with the current date in YYYYMMDD format, or bump the auxiliary
+||| version number if you're changing the version more than once in the same day.
 export
 ttcVersion : Int
-ttcVersion = 72
+ttcVersion = 20220208 * 100 + 0
 
 export
 checkTTCVersion : String -> Int -> Int -> Core ()

--- a/src/Core/Options/Log.idr
+++ b/src/Core/Options/Log.idr
@@ -87,6 +87,7 @@ knownTopics = [
     ("elab", Nothing),
     ("elab.ambiguous", Nothing),
     ("elab.app.var", Nothing),
+    ("elab.app.dot", Just "Dealing with forced expressions when elaborating applications"),
     ("elab.app.lhs", Nothing),
     ("elab.as", Nothing),
     ("elab.bindnames", Nothing),

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -763,11 +763,11 @@ mutual
 
            pure (nm, PatClause fc lhs' rhs')
 
-  desugarClause ps arg (MkWithClause fc lhs wval prf flags cs)
+  desugarClause ps arg (MkWithClause fc lhs rig wval prf flags cs)
       = do cs' <- traverse (map snd . desugarClause ps arg) cs
            (nm, bound, lhs') <- desugarLHS ps arg lhs
            wval' <- desugar AnyExpr (bound ++ ps) wval
-           pure (nm, WithClause fc lhs' wval' prf flags cs')
+           pure (nm, WithClause fc lhs' rig wval' prf flags cs')
 
   desugarClause ps arg (MkImpossible fc lhs)
       = do (nm, _, lhs') <- desugarLHS ps arg lhs
@@ -848,8 +848,8 @@ mutual
       toIDef : Name -> ImpClause -> Core ImpDecl
       toIDef nm (PatClause fc lhs rhs)
           = pure $ IDef fc nm [PatClause fc lhs rhs]
-      toIDef nm (WithClause fc lhs rhs prf flags cs)
-          = pure $ IDef fc nm [WithClause fc lhs rhs prf flags cs]
+      toIDef nm (WithClause fc lhs rig rhs prf flags cs)
+          = pure $ IDef fc nm [WithClause fc lhs rig rhs prf flags cs]
       toIDef nm (ImpossibleClause fc lhs)
           = pure $ IDef fc nm [ImpossibleClause fc lhs]
 

--- a/src/Idris/Elab/Implementation.idr
+++ b/src/Idris/Elab/Implementation.idr
@@ -479,10 +479,10 @@ elabImplementation {vars} ifc vis opts_in pass env nest is cons iname ps named i
     updateClause ns (PatClause fc lhs rhs)
         = do lhs' <- updateApp ns lhs
              pure (PatClause fc lhs' rhs)
-    updateClause ns (WithClause fc lhs wval prf flags cs)
+    updateClause ns (WithClause fc lhs rig wval prf flags cs)
         = do lhs' <- updateApp ns lhs
              cs' <- traverse (updateClause ns) cs
-             pure (WithClause fc lhs' wval prf flags cs')
+             pure (WithClause fc lhs' rig wval prf flags cs')
     updateClause ns (ImpossibleClause fc lhs)
         = do lhs' <- updateApp ns lhs
              pure (ImpossibleClause fc lhs')

--- a/src/Idris/Elab/Interface.idr
+++ b/src/Idris/Elab/Interface.idr
@@ -496,9 +496,10 @@ elabInterface {vars} ifc vis env nest constraints iname params dets mcon body
         changeName : Name -> ImpClause -> Core ImpClause
         changeName dn (PatClause fc lhs rhs)
             = PatClause fc <$> changeNameTerm dn lhs <*> pure rhs
-        changeName dn (WithClause fc lhs wval prf flags cs)
+        changeName dn (WithClause fc lhs rig wval prf flags cs)
             = WithClause fc
                  <$> changeNameTerm dn lhs
+                 <*> pure rig
                  <*> pure wval
                  <*> pure prf
                  <*> pure flags

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1059,16 +1059,17 @@ mutual
      <|> do b <- bounds (do decoratedKeyword fname "with"
                             commit
                             flags <- withFlags fname
+                            rig <- multiplicity fname
                             start <- bounds (decoratedSymbol fname "(")
                             wval <- bracketedExpr fname start indents
                             prf <- optional (decoratedKeyword fname "proof"
                                              *> UN . Basic <$> decoratedSimpleBinderName fname)
                             ws <- mustWork $ nonEmptyBlockAfter col
                                            $ clause (S withArgs) (Just lhs) fname
-                            pure (prf, flags, wval, forget ws))
-            (prf, flags, wval, ws) <- pure b.val
+                            pure (prf, flags, rig, wval, forget ws))
+            (prf, flags, rig, wval, ws) <- pure b.val
             let fc = boundToFC fname (mergeBounds start b)
-            pure (MkWithClause fc (uncurry applyArgs lhs) wval prf flags ws)
+            pure (MkWithClause fc (uncurry applyArgs lhs) rig wval prf flags ws)
      <|> do end <- bounds (decoratedKeyword fname "impossible")
             atEnd indents
             pure $ let fc = boundToFC fname (mergeBounds start end) in

--- a/src/Idris/Pretty.idr
+++ b/src/Idris/Pretty.idr
@@ -170,7 +170,7 @@ mutual
   prettyAlt : PClause' KindedName -> Doc IdrisSyntax
   prettyAlt (MkPatClause _ lhs rhs _) =
     space <+> pipe <++> prettyTerm lhs <++> pretty "=>" <++> prettyTerm rhs <+> semi
-  prettyAlt (MkWithClause _ lhs wval prf flags cs) =
+  prettyAlt (MkWithClause _ lhs rig wval prf flags cs) =
     space <+> pipe <++> angles (angles (reflow "with alts not possible")) <+> semi
   prettyAlt (MkImpossible _ lhs) =
     space <+> pipe <++> prettyTerm lhs <++> impossible_ <+> semi
@@ -178,7 +178,7 @@ mutual
   prettyCase : PClause' KindedName -> Doc IdrisSyntax
   prettyCase (MkPatClause _ lhs rhs _) =
     prettyTerm lhs <++> pretty "=>" <++> prettyTerm rhs
-  prettyCase (MkWithClause _ lhs rhs prf flags _) =
+  prettyCase (MkWithClause _ lhs rig rhs prf flags _) =
     space <+> pipe <++> angles (angles (reflow "with alts not possible"))
   prettyCase (MkImpossible _ lhs) =
     prettyTerm lhs <++> impossible_

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -206,13 +206,13 @@ printClause l i (PatClause _ lhsraw rhsraw)
     = do lhs <- pterm $ map defaultKindedName lhsraw -- hack
          rhs <- pterm $ map defaultKindedName rhsraw -- hack
          pure (relit l (pack (replicate i ' ') ++ show lhs ++ " = " ++ show rhs))
-printClause l i (WithClause _ lhsraw wvraw prf flags csraw)
+printClause l i (WithClause _ lhsraw rig wvraw prf flags csraw)
     = do lhs <- pterm $ map defaultKindedName lhsraw -- hack
          wval <- pterm $ map defaultKindedName wvraw -- hack
          cs <- traverse (printClause l (i + 2)) csraw
          pure (relit l ((pack (replicate i ' ')
                 ++ show lhs
-                ++ " with (" ++ show wval ++ ")"
+                ++ " with " ++ elimSemi "0 " "1 " (const "") rig ++ "(" ++ show wval ++ ")"
                 ++ maybe "" (\ nm => " proof " ++ show nm) prf
                 ++ "\n"))
                ++ showSep "\n" cs)

--- a/src/Idris/Resugar.idr
+++ b/src/Idris/Resugar.idr
@@ -416,9 +416,10 @@ mutual
       = pure (MkPatClause fc !(toPTerm startPrec lhs)
                              !(toPTerm startPrec rhs)
                              [])
-  toPClause (WithClause fc lhs rhs prf flags cs)
+  toPClause (WithClause fc lhs rig wval prf flags cs)
       = pure (MkWithClause fc !(toPTerm startPrec lhs)
-                              !(toPTerm startPrec rhs)
+                              rig
+                              !(toPTerm startPrec wval)
                               prf
                               flags
                               !(traverse toPClause cs))

--- a/src/TTImp/Elab/App.idr
+++ b/src/TTImp/Elab/App.idr
@@ -365,7 +365,12 @@ mutual
             -- if the argument type aty has a single constructor, there's no need
             -- to dot it
             defs <- get Ctxt
-            mconsCount <- countConstructors !(evalClosure defs argty)
+            nfargty <- evalClosure defs argty
+            mconsCount <- countConstructors nfargty
+            logNF "elab.app.dot" 50
+              "Found \{show mconsCount} constructors for type"
+              (mkEnv emptyFC vars)
+              nfargty
             if mconsCount == Just 1 || mconsCount == Just 0
               then pure tm
               else
@@ -378,6 +383,8 @@ mutual
                       else pure $ dotTerm tm
           else pure tm
     where
+      -- TODO: this seems too conservative. If we get back an expression stuck on a
+      -- meta, shouldn't we delay the check instead of declaring the tm dotted?
       ||| Count the constructors of a fully applied concrete datatype
       countConstructors : NF vars -> Core (Maybe Nat)
       countConstructors (NTCon _ tycName _ n args) =

--- a/src/TTImp/Elab/Case.idr
+++ b/src/TTImp/Elab/Case.idr
@@ -360,11 +360,11 @@ caseBlock {vars} rigc elabinfo fc nest env scr scrtm scrty caseRig alts expected
                         (bindCaseLocals loc' (map getNestData (names nest))
                                         ns rhs)
     -- With isn't allowed in a case block but include for completeness
-    updateClause casen splitOn nest env (WithClause loc' lhs wval prf flags cs)
+    updateClause casen splitOn nest env (WithClause loc' lhs rig wval prf flags cs)
         = let (_, args) = addEnv 0 env (usedIn lhs)
               args' = mkSplit splitOn lhs args
               lhs' = apply (IVar loc' casen) args' in
-              WithClause loc' (applyNested nest lhs') wval prf flags cs
+              WithClause loc' (applyNested nest lhs') rig wval prf flags cs
     updateClause casen splitOn nest env (ImpossibleClause loc' lhs)
         = let (_, args) = addEnv 0 env (usedIn lhs)
               args' = mkSplit splitOn lhs args

--- a/src/TTImp/Elab/Quote.idr
+++ b/src/TTImp/Elab/Quote.idr
@@ -83,10 +83,11 @@ mutual
                      Core ImpClause
   getUnquoteClause (PatClause fc l r)
       = pure $ PatClause fc !(getUnquote l) !(getUnquote r)
-  getUnquoteClause (WithClause fc l w prf flags cs)
+  getUnquoteClause (WithClause fc l rig w prf flags cs)
       = pure $ WithClause
                  fc
                  !(getUnquote l)
+                 rig
                  !(getUnquote w)
                  prf
                  flags

--- a/src/TTImp/Interactive/GenerateDef.idr
+++ b/src/TTImp/Interactive/GenerateDef.idr
@@ -80,8 +80,8 @@ expandClause loc opts n c
     updateRHS : ImpClause -> RawImp -> ImpClause
     updateRHS (PatClause fc lhs _) rhs = PatClause fc lhs rhs
     -- 'with' won't happen, include for completeness
-    updateRHS (WithClause fc lhs wval prf flags cs) rhs
-      = WithClause fc lhs wval prf flags cs
+    updateRHS (WithClause fc lhs rig wval prf flags cs) rhs
+      = WithClause fc lhs rig wval prf flags cs
     updateRHS (ImpossibleClause fc lhs) _ = ImpossibleClause fc lhs
 
     dropLams : Nat -> RawImp -> RawImp
@@ -146,7 +146,7 @@ generateSplits : {auto m : Ref MD Metadata} ->
                  FC -> SearchOpts -> Int -> ImpClause ->
                  Core (List (Name, List ImpClause))
 generateSplits loc opts fn (ImpossibleClause fc lhs) = pure []
-generateSplits loc opts fn (WithClause fc lhs wval prf flags cs) = pure []
+generateSplits loc opts fn (WithClause fc lhs rig wval prf flags cs) = pure []
 generateSplits loc opts fn (PatClause fc lhs rhs)
     = do (lhstm, _) <-
                 elabTerm fn (InLHS linear) [] (MkNested []) []

--- a/src/TTImp/Parser.idr
+++ b/src/TTImp/Parser.idr
@@ -514,6 +514,8 @@ mutual
            let fc = MkFC fname start end
            pure (!(getFn lhs), PatClause fc lhs rhs)
     <|> do keyword "with"
+           m <- multiplicity
+           rig <- getMult m
            wstart <- location
            symbol "("
            wval <- expr fname indents
@@ -522,7 +524,7 @@ mutual
            ws <- nonEmptyBlock (clause (S withArgs) fname)
            end <- location
            let fc = MkFC fname start end
-           pure (!(getFn lhs), WithClause fc lhs wval prf [] (forget $ map snd ws))
+           pure (!(getFn lhs), WithClause fc lhs rig wval prf [] (forget $ map snd ws))
 
     <|> do keyword "impossible"
            atEnd indents

--- a/src/TTImp/Reflect.idr
+++ b/src/TTImp/Reflect.idr
@@ -408,14 +408,15 @@ mutual
                           y' <- reify defs !(evalClosure defs y)
                           z' <- reify defs !(evalClosure defs z)
                           pure (PatClause x' y' z')
-               (UN (Basic "WithClause"), [u,v,w,x,y,z])
+               (UN (Basic "WithClause"), [u,v,w,x,y,z,a])
                     => do u' <- reify defs !(evalClosure defs u)
                           v' <- reify defs !(evalClosure defs v)
                           w' <- reify defs !(evalClosure defs w)
                           x' <- reify defs !(evalClosure defs x)
                           y' <- reify defs !(evalClosure defs y)
                           z' <- reify defs !(evalClosure defs z)
-                          pure (WithClause u' v' w' x' y' z')
+                          a' <- reify defs !(evalClosure defs a)
+                          pure (WithClause u' v' w' x' y' z' a')
                (UN (Basic "ImpossibleClause"), [x,y])
                     => do x' <- reify defs !(evalClosure defs x)
                           y' <- reify defs !(evalClosure defs y)
@@ -759,14 +760,15 @@ mutual
              y' <- reflect fc defs lhs env y
              z' <- reflect fc defs lhs env z
              appCon fc defs (reflectionttimp "PatClause") [x', y', z']
-    reflect fc defs lhs env (WithClause u v w x y z)
+    reflect fc defs lhs env (WithClause u v w x y z a)
         = do u' <- reflect fc defs lhs env u
              v' <- reflect fc defs lhs env v
              w' <- reflect fc defs lhs env w
              x' <- reflect fc defs lhs env x
              y' <- reflect fc defs lhs env y
              z' <- reflect fc defs lhs env z
-             appCon fc defs (reflectionttimp "WithClause") [u', v', w', x', y', z']
+             a' <- reflect fc defs lhs env a
+             appCon fc defs (reflectionttimp "WithClause") [u', v', w', x', y', z', a']
     reflect fc defs lhs env (ImpossibleClause x y)
         = do x' <- reflect fc defs lhs env x
              y' <- reflect fc defs lhs env y

--- a/src/TTImp/TTImp/Functor.idr
+++ b/src/TTImp/TTImp/Functor.idr
@@ -81,8 +81,8 @@ mutual
   Functor ImpClause' where
     map f (PatClause fc lhs rhs)
       = PatClause fc (map f lhs) (map f rhs)
-    map f (WithClause fc lhs wval prf flags xs)
-      = WithClause fc (map f lhs) (map f wval) prf flags (map (map f) xs)
+    map f (WithClause fc lhs rig wval prf flags xs)
+      = WithClause fc (map f lhs) rig (map f wval) prf flags (map (map f) xs)
     map f (ImpossibleClause fc lhs)
       = ImpossibleClause fc (map f lhs)
 

--- a/src/TTImp/Utils.idr
+++ b/src/TTImp/Utils.idr
@@ -47,7 +47,7 @@ rawImpFromDecl decl = case decl of
         getFromTy (MkImpTy _ _ _ ty) = ty
         getFromClause : ImpClause -> List RawImp
         getFromClause (PatClause fc1 lhs rhs) = [lhs, rhs]
-        getFromClause (WithClause fc1 lhs wval prf flags ys) = [wval, lhs] ++ getFromClause !ys
+        getFromClause (WithClause fc1 lhs rig wval prf flags ys) = [wval, lhs] ++ getFromClause !ys
         getFromClause (ImpossibleClause fc1 lhs) = [lhs]
         getFromPiInfo : PiInfo RawImp -> List RawImp
         getFromPiInfo (DefImplicit x) = [x]
@@ -131,7 +131,7 @@ findBindableNamesQuot env used (ICase fc x ty xs)
     = findBindableNamesQuot env used !([x, ty] ++ getRawImp !xs)
   where getRawImp : ImpClause -> List RawImp
         getRawImp (PatClause fc1 lhs rhs) = [lhs, rhs]
-        getRawImp (WithClause fc1 lhs wval prf flags ys) = [wval, lhs] ++ getRawImp !ys
+        getRawImp (WithClause fc1 lhs rig wval prf flags ys) = [wval, lhs] ++ getRawImp !ys
         getRawImp (ImpossibleClause fc1 lhs) = [lhs]
 findBindableNamesQuot env used (ILocal fc xs x)
     = findBindableNamesQuot env used !(x :: rawImpFromDecl !xs)
@@ -357,11 +357,11 @@ mutual
                      ++ bound in
             PatClause fc (substNames' bvar [] [] lhs)
                          (substNames' bvar bound' ps rhs)
-  substNamesClause' bvar bound ps (WithClause fc lhs wval prf flags cs)
+  substNamesClause' bvar bound ps (WithClause fc lhs rig wval prf flags cs)
       = let bound' = map (UN . Basic) (map snd (findBindableNames True bound [] lhs))
                      ++ findIBindVars lhs
                      ++ bound in
-            WithClause fc (substNames' bvar [] [] lhs)
+            WithClause fc (substNames' bvar [] [] lhs) rig
                           (substNames' bvar bound' ps wval) prf flags cs
   substNamesClause' bvar bound ps (ImpossibleClause fc lhs)
       = ImpossibleClause fc (substNames' bvar bound [] lhs)
@@ -458,8 +458,8 @@ mutual
   substLocClause fc' (PatClause fc lhs rhs)
       = PatClause fc' (substLoc fc' lhs)
                       (substLoc fc' rhs)
-  substLocClause fc' (WithClause fc lhs wval prf flags cs)
-      = WithClause fc' (substLoc fc' lhs)
+  substLocClause fc' (WithClause fc lhs rig wval prf flags cs)
+      = WithClause fc' (substLoc fc' lhs) rig
                        (substLoc fc' wval)
                        prf
                        flags

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -227,7 +227,7 @@ idrisTests = MkTestPool "Misc" [] Nothing
        -- Inlining
        "inlining001",
        -- The 'with' rule
-       "with001", "with002", "with004", "with005", "with006",
+       "with001", "with002", "with004", "with005", "with006", "with007",
        -- with-disambiguation
        "with003",
        -- pretty printing

--- a/tests/idris2/with007/With0.idr
+++ b/tests/idris2/with007/With0.idr
@@ -1,0 +1,5 @@
+%default total
+
+test : (0 n : Nat) -> Type -> Type
+test n a with 0 (n + n)
+  _ | twon = a

--- a/tests/idris2/with007/expected
+++ b/tests/idris2/with007/expected
@@ -1,0 +1,1 @@
+1/1: Building With0 (With0.idr)

--- a/tests/idris2/with007/run
+++ b/tests/idris2/with007/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --no-banner --check With0.idr


### PR DESCRIPTION
It's not solving the issue but it may be offering a workaround.

Example:

```idris
test : (0 n : Nat) -> Type -> Type
test n a with 0 (n + n)
  _ | twon = a
```