### PR TITLE
fix tanh value at infinity

### DIFF
--- a/libs/prelude/Prelude/Types.idr
+++ b/libs/prelude/Prelude/Types.idr
@@ -815,7 +815,10 @@ cosh x = (exp x + exp (-x)) / 2
 
 public export
 tanh : Double -> Double
-tanh x = sinh x / cosh x
+tanh x = let inf = 1.0 / 0.0 in
+  if x == inf then 1.0 else
+  if x == -inf then 1.0
+  else sinh x / cosh x
 
 public export
 sqrt : Double -> Double

--- a/libs/prelude/Prelude/Types.idr
+++ b/libs/prelude/Prelude/Types.idr
@@ -817,7 +817,7 @@ public export
 tanh : Double -> Double
 tanh x = let inf = 1.0 / 0.0 in
   if x == inf then 1.0 else
-  if x == -inf then 1.0
+  if x == -inf then -1.0
   else sinh x / cosh x
 
 public export

--- a/libs/prelude/Prelude/Types.idr
+++ b/libs/prelude/Prelude/Types.idr
@@ -817,8 +817,8 @@ public export
 tanh : Double -> Double
 tanh x = let inf = 1.0 / 0.0 in
   if x == inf then 1.0 else
-  if x == -inf then -1.0
-  else sinh x / cosh x
+  if x == -inf then -1.0 else
+  sinh x / cosh x
 
 public export
 sqrt : Double -> Double


### PR DESCRIPTION
tanh should be plus or minus 1 at plus or minus infinity, but because it's calculated by dividing `sinh` and `cosh`, we get `nan`. This fixes that. I could perhaps make it cleaner if there's a `sign` function somewhere

I've not had a thorough think if there are other special cases that need accounting for here