### PR TITLE
[ new ] Add a `Monoid` instance of the `f a` where `f` is `Applicative`

### DIFF
--- a/libs/prelude/Prelude/Interfaces.idr
+++ b/libs/prelude/Prelude/Interfaces.idr
@@ -433,6 +433,14 @@ public export
 for_ : Applicative f => Foldable t => t a -> (a -> f b) -> f ()
 for_ = flip traverse_
 
+public export
+[SemigroupApplicative] Applicative f => Semigroup a => Semigroup (f a) where
+  x <+> y = [| x <+> y |]
+
+public export
+[MonoidApplicative] Applicative f => Monoid a => Monoid (f a) using SemigroupApplicative where
+  neutral = pure neutral
+
 namespace Lazy
   public export
   [SemigroupAlternative] Alternative f => Semigroup (Lazy (f a)) where


### PR DESCRIPTION
The place is chosen to be near to the `Semigroup` and `Monoid` instances of `Alternative`.