### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt install -y gcc git make racket libgmp3-dev build-essential clang
+RUN git clone https://github.com/idris-lang/Idris2 /opt/idris2
+
+WORKDIR /opt/idris2
+
+ENV IDRIS2_CG=racket
+RUN make bootstrap-racket
+RUN make install
+
+RUN export PATH="${PATH}:/root/.idris2/bin"
+
+ENTRYPOINT [ "idris2" ]
+CMD [ "-h" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:22.04
 
+RUN apt update
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt update && apt install -y gcc git make racket libgmp3-dev build-essential clang
+RUN apt install -y racket
+RUN apt install -y git libgmp3-dev make gcc
 RUN git clone https://github.com/idris-lang/Idris2 /opt/idris2
 
 WORKDIR /opt/idris2
@@ -10,7 +12,5 @@ ENV IDRIS2_CG=racket
 RUN make bootstrap-racket
 RUN make install
 
-RUN export PATH="${PATH}:/root/.idris2/bin"
-
-ENTRYPOINT [ "idris2" ]
+ENTRYPOINT [ "/root/.idris2/bin/idris2" ]
 CMD [ "-h" ]


### PR DESCRIPTION
What: A Dockerfile to build a container which creates an endpoint to Idris. With this approach, it is possible to e.g. type-check an Idris file by running: `podman run -v "$PWD:$PWD":z -w "$PWD" idris -c Vect.idr`. What happens here is the current folder is mounted to the container and the workspace is changed to the mounted folder inside the container. Then, the container runs Idris, and you can pass arguments as if you would have local version of Idris. If no parameters is given, help is printed.

Why: I wanted to have an ARM build on the Apple M1 and needed an easy way to run the latest changes. Coincidentally, I occasionally use Fedora Silverblue which requires everything to be a container.

Most of this code is from #2237 but uses a more recent version of Linux. I also noticed that containers were discussed in #1507.

I used racket because chez-scheme did not exist on ubuntu:22.04. I also looked into something more lightweight than ubuntu, in particular alpine linux, but neither chez-scheme nor racket is currently in the package manager.

Do you think providing a Dockerfile within the repository to run Idris is a good idea?
