### PR TITLE
Fix for lexer colums

### DIFF
--- a/libs/contrib/Text/Lexer/Core.idr
+++ b/libs/contrib/Text/Lexer/Core.idr
@@ -147,7 +147,7 @@ tokenise pred line col acc tmap str
 
     getCols : List Char -> Int -> Int
     getCols x c
-         = case span (/= '\n') (reverse x) of
+         = case span (/= '\n') x of
                 (incol, []) => c + cast (length incol)
                 (incol, _) => cast (length incol)
 


### PR DESCRIPTION
The lexer under contrib Text.Lexer.Core assigns wrong colum numbers to tokens after line breaks. This patch fixes this bug.