### PR TITLE
Inline SnocList foldl utility function

### DIFF
--- a/libs/base/Data/SnocList.idr
+++ b/libs/base/Data/SnocList.idr
@@ -84,10 +84,8 @@ public export
 Foldable SnocList where
   foldr f z = foldr f z . (<>> [])
 
-  foldl f z xs = h xs where
-    h : SnocList elem -> acc
-    h Lin = z
-    h (xs :< x) = f (h xs) x
+  foldl f z Lin = z
+  foldl f z (xs :< x) = f (foldl f z xs) x
 
   null Lin      = True
   null (_ :< _) = False


### PR DESCRIPTION
The scoping of the utility function meant that Idris treats `foldl f z (xs :< x)` and `f (foldl f z xs) x` as two different terms, making proving things about it difficult.