### PR TITLE
[doc] Fix wiki links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ general philosophy of the Idris project, which can be summarised as follows:
   properties of programs, but will not *require* them to do so
 
 Many contributions will require acccompanying tests and documentation updates.
-Bug fixes in particular should be accompanied by tests, to avoid future
+Bugfixes in particular should be accompanied by tests, to avoid future
 regressions.
 
 Library functions should be `total` as far as possible, and at least `covering`
@@ -116,7 +116,7 @@ Things we probably won't accept
     We encourage following the camp site rule: leave the code tidier than you
     found it!
 * Primitive updates without a strong justification
-  - Primitives increase the burden on back end authors, for example. They may
+  - Primitives increase the burden on backend authors, for example. They may
     be necessary to support a new library, if a foreign function call is not
     appropriate, but we won't accept a primitive on the basis that it could be
     useful in future.
@@ -128,9 +128,9 @@ Things we probably won't accept
   Idris 2 API, to minimise the maintenance burden on the compiler.
 * Similarly, anything which adds an external dependency. We aim to keep
   dependencies minimal for ease of initial installation.
-* New back ends. You can implement new back ends via the Idris 2 API - and indeed
-  several people have. The back ends in this repository are limited to those
-  we are able to commit to maintaining.
+* New backends. You can implement new backends via the Idris 2 API - and indeed
+  several people have. The backends in this repository are limited to those we
+  are able to commit to maintaining.
 
 Other possible contributions
 ----------------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,8 +42,8 @@ we haven't been too prescriptive about this. If you're editing a source file,
 try to be consistent with the existing style choices made by previous authors.
 We may need to be more formal about this in future!
 
-Please remember to update CHANGELOG.md, and if it's your first contribution you
-can add yourself to CONTRIBUTORS.
+Please remember to update `CHANGELOG.md`, and if it's your first contribution
+you can add yourself to `CONTRIBUTORS`.
 
 In all cases, a pull request must have a short description (one sentence is
 usually enough) that explains its purpose. However obvious you think it might
@@ -142,8 +142,8 @@ just remember that whatever you contribute, we have to maintain!
 
 Good places to discuss possible contributions are:
 
-* The `mailing list <https://groups.google.com/forum/#!forum/idris-lang>`_.
-* The Idris community on Discord `(Invite link) <https://discord.gg/YXmWC5yKYM>`_
+* The [mailing list](https://groups.google.com/forum/#!forum/idris-lang).
+* The Idris community on Discord [(invite link)](https://discord.gg/YXmWC5yKYM).
 * The issue tracker (in this case, please make your proposal as concrete as
   possible).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,8 @@ Things we might accept
   - However, please consider whether it would be better as a separate library.
     If something is in the Idris2 repository, we need to commit to maintaining
     it to some extent, so we have to be sure that we can do so. You can find
-    (and contribute to) a list of `libraries on the wiki <https://github.com/idris-lang/Idris2/wiki/Libraries>`_.
+    (and contribute to) a list of [libraries on the wiki](
+    https://github.com/idris-lang/Idris2/wiki/1-%5BLanguage%5D-Libraries).
   - For any library additions, please try to include as many documentation
     strings as you can.
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ is often one of `scheme`, `chezscheme` or `chezscheme9.5` (depending on the
 version). On a modern desktop machine, this process (including tests)
 should take less than 5 minutes.
 
-Idris 2 is mostly backwards compatible with Idris 1, with some minor
-exceptions. The most notable user visible differences, which might cause Idris
-1 programs to fail to type check, are:
+Idris 2 is mostly backward compatible with Idris 1, with some minor exceptions.
+The most notable user visible differences, which might cause Idris 1 programs
+to fail to type check, are:
 
 + Unbound implicit arguments are always erased, so it is a type error to
   attempt to pattern match on one.
@@ -70,8 +70,8 @@ Summary of new features:
   declarations.
 + Better type checker implementation which minimises the need for compile
   time evaluation.
-+ New Chez Scheme based back end which both compiles and runs faster than the
-  default Idris 1 back end. (Also, optionally, Racket and Gambit can be used
++ New Chez Scheme based backend which both compiles and runs faster than the
+  default Idris 1 backend. (Also, optionally, Racket and Gambit can be used
   as targets).
 + Everything works faster :).
 
@@ -80,9 +80,9 @@ language `TTImp`, which is essentially a desugared Idris, and is cleanly
 separated from the high level language which means it is potentially usable
 as a core language for other high level syntaxes.
 
-Javascript
+JavaScript
 ----------
-The javascript codegen uses the new BigInt, hence nodejs 10.4 or higher is required.
+The JavaScript codegen uses the new BigInt, hence Node.js 10.4 or higher is required.
 
 Editor Plugins
 --------------

--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ The javascript codegen uses the new BigInt, hence nodejs 10.4 or higher is requi
 
 Editor Plugins
 --------------
-The [wiki](https://github.com/idris-lang/Idris2/wiki/The-Idris-editor-experience)
-lists the current plugins available for common text editors and their features.
+The [wiki lists the current plugins available for common text editors](
+https://github.com/idris-lang/Idris2/wiki/1-%5BLanguage%5D-Editor-support)
+and their features.
 
 Things still missing
 --------------------
@@ -101,7 +102,7 @@ Contributions wanted
 
 + [Contribution guidelines](CONTRIBUTING.md)
 + [Good first issues](https://github.com/idris-lang/Idris2/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
-+ [Contributors wanted](https://github.com/idris-lang/Idris2/wiki/Contributions-wanted)
++ [Contributors wanted](https://github.com/idris-lang/Idris2/wiki/2-%5BCommunity%5D-Contributions-wanted)
 
 If you want to learn about Idris more, contributing to the compiler could be one
 way to do so. Just select one good first issue and ask about it on the [Discord](https://discord.gg/UX68fDs2jc) channel.

--- a/docs/source/backends/index.rst
+++ b/docs/source/backends/index.rst
@@ -85,7 +85,7 @@ or via the `IDRIS2_CG` environment variable.
 There are also external code generators that aren't part of the main Idris 2
 repository and can be found on Idris 2 wiki:
 
-`External backends <https://github.com/idris-lang/Idris2/wiki/External-backends>`_
+`External backends <https://github.com/idris-lang/Idris2/wiki/1-%5BLanguage%5D-External-backends>`_
 
 There is work in progress support for generating
 libraries for other languages from idris2 code.

--- a/docs/source/faq/faq.rst
+++ b/docs/source/faq/faq.rst
@@ -24,7 +24,7 @@ Where can I find libraries? Is there a package manager?
 =======================================================
 
 We don't yet have a package manager, but you can still find a source of
-libraries on the wiki: https://github.com/idris-lang/Idris2/wiki/Libraries
+libraries on the wiki: https://github.com/idris-lang/Idris2/wiki/1-%5BLanguage%5D-Libraries
 
 Fortunately, the dependencies are currently not that complicated, but we'd
 still like a package manager to help! There isn't an official one yet, but

--- a/docs/source/libraries/index.rst
+++ b/docs/source/libraries/index.rst
@@ -2,7 +2,7 @@ Where To Find Libraries
 =======================
 
 You can find a canonical source of Idris libraries on the wiki on github:
-https://github.com/idris-lang/Idris2/wiki/Libraries
+https://github.com/idris-lang/Idris2/wiki/1-%5BLanguage%5D-Libraries
 
 Please feel free to contribute your own libraries there! Eventually, we aim to
 have a package manager for managing libraries and dependencies. We do not yet


### PR DESCRIPTION
Hi, I'm new here. In fact I haven't yet even *read* the `CONTRIBUTING.md` file which I've edited :wink:

@andrevidela I believe *either* this PR should be merged, *or* your recent changes to https://github.com/idris-lang/Idris2/wiki should be reverted.

IMO using the GitHub wiki is usually a bad idea - it changes out of lockstep with the main repo, and often ends up being yet another place people put information. I'd rather see the info from the wiki included in the `docs/`. I understand that might require rethinking how it fits together with the rest of the documentation. Perhaps just merge my PR for the time being to fix the links? :smile: 