### PR TITLE
Clean path in more `Core.Directory` functions

### DIFF
--- a/src/Core/Directory.idr
+++ b/src/Core/Directory.idr
@@ -50,6 +50,10 @@ public export
 listOfExtensionsStr : List String
 listOfExtensionsStr = listOfExtensionsLiterate ++ [".yaff", ".idr"]
 
+||| Given a path, removes trailing separators and current directory identifiers, '.'.
+cleanPath : String -> String
+cleanPath = show . the (Path -> Path) { hasTrailSep := False, body $= filter (/= CurDir) } . parse
+
 ||| Return the basename and extension used *if* given filename is a valid idris filename.
 |||
 ||| Extensions are returned with a leading "." separator.
@@ -85,7 +89,7 @@ findDataFile : {auto c : Ref Ctxt Defs} ->
                String -> Core String
 findDataFile fname
     = do d <- getDirs
-         let fs = map (\p => p </> fname) (data_dirs d)
+         let fs = map (\p => cleanPath $ p </> fname) (data_dirs d)
          Just f <- firstAvailable fs
             | Nothing => throw (InternalError ("Can't find data file " ++ fname ++
                                                " in any of " ++ show fs))
@@ -102,14 +106,14 @@ readDataFile fname
          pure d
 
 -- Look for a library file required by a code generator. Look in the
--- library directories, and in the lib/ subdirectoriy of all the 'extra import'
+-- library directories, and in the lib/ subdirectory of all the 'extra import'
 -- directories
 export
 findLibraryFile : {auto c : Ref Ctxt Defs} ->
                   String -> Core String
 findLibraryFile fname
     = do d <- getDirs
-         let fs = map (\p => p </> fname)
+         let fs = map (\p => cleanPath $ p </> fname)
                       (lib_dirs d ++ map (\x => x </> "lib")
                                          (extra_dirs d))
          Just f <- firstAvailable fs
@@ -124,7 +128,7 @@ nsToPath : {auto c : Ref Ctxt Defs} ->
 nsToPath loc ns
     = do d <- getDirs
          let fnameBase = ModuleIdent.toPath ns
-         let fs = map (\p => p </> fnameBase <.> "ttc")
+         let fs = map (\p => cleanPath $ p </> fnameBase <.> "ttc")
                       ((build_dir d </> "ttc") :: extra_dirs d)
          Just f <- firstAvailable fs
             | Nothing => pure (Left (ModuleNotFound loc ns))
@@ -138,11 +142,12 @@ nsToSource : {auto c : Ref Ctxt Defs} ->
 nsToSource loc ns
     = do d <- getDirs
          let fnameOrig = ModuleIdent.toPath ns
-         let fnameBase = maybe fnameOrig (\srcdir => srcdir </> fnameOrig) (source_dir d)
+         let fnameBase = cleanPath $ maybe fnameOrig (\srcdir => srcdir </> fnameOrig) (source_dir d)
          let fs = map ((fnameBase ++)) listOfExtensionsStr
          Just f <- firstAvailable fs
             | Nothing => throw (ModuleNotFound loc ns)
          pure f
+
 
 -- Given a filename in the working directory + source directory, return the correct
 -- namespace for it
@@ -150,10 +155,6 @@ export
 mbPathToNS : String -> Maybe String -> String -> Maybe ModuleIdent
 mbPathToNS wdir sdir fname =
   let
-    cleanPath : String -> String
-      := show
-       . the (Path -> Path) { hasTrailSep := False, body $= filter (/= CurDir) }
-       . parse
     sdir = fromMaybe "" sdir
     base = if isAbsolute fname then wdir </> sdir else sdir
   in

--- a/tests/idris2/pkg011/expected
+++ b/tests/idris2/pkg011/expected
@@ -1,14 +1,14 @@
 dot
-1/1: Building Main (./Main.idr)
+1/1: Building Main (Main.idr)
 1/1: Building Main (Main.idr)
 dot-slash
-1/1: Building Main (./Main.idr)
+1/1: Building Main (Main.idr)
 1/1: Building Main (Main.idr)
 dot-slash-dot
-1/1: Building Main (./Main.idr)
+1/1: Building Main (Main.idr)
 1/1: Building Main (Main.idr)
 dot-slash-name-slash
-1/1: Building Main (./src/Main.idr)
+1/1: Building Main (src/Main.idr)
 1/1: Building Main (src/Main.idr)
 sibling/pkg
 1/1: Building Main (../src/Main.idr)


### PR DESCRIPTION
Following https://github.com/idris-lang/Idris2/pull/2134, I've lifted the `cleanPath` function and applied it to other functions in the `Core.Directory` module that output paths. Essentially this means that those functions do not output paths with interleaved `.` identifiers. This is visible from the updated test that is now consistent in the output both with and without the ipkg. Also some tools may have issues with those non-normalized paths, i.e. LSP uses the API and produced paths that were not recognized by some clients like neovim.