### PR TITLE
[ perf ] only normalise primitives on small strings on the RHS

### DIFF
--- a/src/TTImp/Elab/App.idr
+++ b/src/TTImp/Elab/App.idr
@@ -513,11 +513,10 @@ mutual
                               ignore $ updateSolution env metaval argv
                               pure tm
                       else pure tm
-             case elabMode elabinfo of
-                  InLHS _ => -- reset hole and redo it with the unexpanded definition
-                     do updateDef (Resolved idx) (const (Just (Hole 0 (holeInit False))))
-                        ignore $ solveIfUndefined env metaval argv
-                  _ => pure ()
+             when (onLHS $ elabMode elabinfo) $
+                 -- reset hole and redo it with the unexpanded definition
+                 do updateDef (Resolved idx) (const (Just (Hole 0 (holeInit False))))
+                    ignore $ solveIfUndefined env metaval argv
              removeHole idx
              pure (tm, gty)
 
@@ -829,9 +828,7 @@ checkApp rig elabinfo nest env fc (IVar fc' n) expargs autoargs namedargs exp
     normalisePrims prims env res
         = do tm <- Normalise.normalisePrims (`boundSafe` elabMode elabinfo)
                                             isIPrimVal
-                                            (case elabMode elabinfo of
-                                                  InLHS _ => True
-                                                  _ => False)
+                                            (onLHS (elabMode elabinfo))
                                             prims n expargs (fst res) env
              pure (fromMaybe (fst res) tm, snd res)
 

--- a/src/TTImp/Elab/App.idr
+++ b/src/TTImp/Elab/App.idr
@@ -836,11 +836,12 @@ checkApp rig elabinfo nest env fc (IVar fc' n) expargs autoargs namedargs exp
 
         boundSafe : Constant -> ElabMode -> Bool
         boundSafe _ (InLHS _) = True -- always need to expand on LHS
-        boundSafe (BI x) _ = abs x < 100 -- only do this for relatively small bounds.
-                           -- Once it gets too big, we might be making the term
-                           -- bigger than it would have been without evaluating!
+        -- only do this for relatively small bounds.
+        -- Once it gets too big, we might be making the term
+        -- bigger than it would have been without evaluating!
+        boundSafe (BI x) _ = abs x < 100
+        boundSafe (Str str) _ = length str < 10
         boundSafe _ _ = True
-
 
     updateElabInfo : List Name -> ElabMode -> Name ->
                      List RawImp -> ElabInfo -> Core ElabInfo


### PR DESCRIPTION
This takes `Idris.Doc.String` from (crudely measured) 1m to 25s compile time.

Update: during a more classic build rather than my flawed measurement, it looks like it's nearly instantaneous.