### PR TITLE
[ new ] failing blocks

### DIFF
--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -69,6 +69,8 @@ data Warning : Type where
      Deprecated : String -> Maybe (FC, Name) -> Warning
      GenericWarn : String -> Warning
 
+%name Warning wrn
+
 -- All possible errors, carrying a location
 public export
 data Error : Type where
@@ -163,6 +165,8 @@ data Error : Type where
      NoForeignCC : FC -> List String -> Error
      BadMultiline : FC -> String -> Error
      Timeout : String -> Error
+     FailingDidNotFail : FC -> Error
+     FailingWrongError : FC -> Error -> Error
 
      InType : FC -> Name -> Error -> Error
      InCon : FC -> Name -> Error -> Error
@@ -171,6 +175,8 @@ data Error : Type where
 
      MaybeMisspelling : Error -> List1 String -> Error
      WarningAsError : Warning -> Error
+
+%name Error err
 
 export
 Show TTCErrorMsg where
@@ -345,6 +351,11 @@ Show Error where
   show (BadMultiline fc str) = "Invalid multiline string: " ++ str
   show (Timeout str) = "Timeout in " ++ str
 
+  show (FailingDidNotFail _) = "Failing block did not fail"
+  show (FailingWrongError fc err)
+       = show fc ++ ":Failing block failed with the wrong error:\n" ++
+         show err
+
   show (InType fc n err)
        = show fc ++ ":When elaborating type of " ++ show n ++ ":\n" ++
          show err
@@ -441,6 +452,8 @@ getErrorLoc (BadMultiline loc _) = Just loc
 getErrorLoc (Timeout _) = Nothing
 getErrorLoc (InType _ _ err) = getErrorLoc err
 getErrorLoc (InCon _ _ err) = getErrorLoc err
+getErrorLoc (FailingDidNotFail fc) = pure fc
+getErrorLoc (FailingWrongError fc _) = pure fc
 getErrorLoc (InLHS _ _ err) = getErrorLoc err
 getErrorLoc (InRHS _ _ err) = getErrorLoc err
 getErrorLoc (MaybeMisspelling err _) = getErrorLoc err

--- a/src/Core/FC.idr
+++ b/src/Core/FC.idr
@@ -73,6 +73,8 @@ data FC = MkFC        OriginDesc FilePos FilePos
           MkVirtualFC OriginDesc FilePos FilePos
         | EmptyFC
 
+%name FC fc
+
 ||| A version of a file context that cannot be empty
 public export
 NonEmptyFC : Type

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -1015,6 +1015,8 @@ mutual
            pure []
   desugarDecl ps (PFixity fc _ _ _)
       = throw (GenericMsg fc "Fixity declarations must be for unqualified names")
+  desugarDecl ps (PFail fc msg ds)
+      = (pure . IFail fc msg . concat) <$> traverse (desugarDecl ps) ds
   desugarDecl ps (PMutual fc ds)
       = do let (tys, defs) = splitMutual ds
            mds' <- traverse (desugarDecl ps) (tys ++ defs)

--- a/src/Idris/Doc/Keywords.idr
+++ b/src/Idris/Doc/Keywords.idr
@@ -278,17 +278,17 @@ interfacemechanism = vcat $
     """
     ```idris
     interface Failing (0 a : Type) where
-      fail : a
+      failing : a
 
     whenJust : Failing ret => Maybe a -> (a -> ret) -> ret
     whenJust (Just v) k = k v
-    whenJust Nothing  _ = fail
+    whenJust Nothing  _ = failing
 
     implementation Failing Bool where
-      fail = False
+      failing = False
 
     Failing (Maybe a) where
-      fail = Nothing
+      failing = Nothing
     ```
     """, "",
     """
@@ -369,6 +369,29 @@ parametersblock = vcat $
     and their respective types outside of the parameters block are
     `head : a -> List a -> a` and `last : a -> List a -> a`.
     """]
+
+failblock : Doc IdrisDocAnn
+failblock = vcat $
+    header "Fail block" :: ""
+    :: map (indent 2) [
+    """
+    Fail blocks let users check that some code parses but is rejected during elaboration.
+    In the following example, we make sure that Idris rejects a proof that the character
+    'a' is equal to 'b' by throwing an error when unifying them.
+    """, "",
+    """
+    ```idris
+    failing "When unifying"
+      noteq : 'a' === 'b'
+      noteq = Refl
+    ```
+    """, "",
+    """
+    If the string attached to a failing block does not appear in the error raised, or if
+    no error is raised then the failing block is itself failing and thus leads to an error.
+    This lets users document the kind of error the block is meant to document.
+    """
+    ]
 
 mutualblock : Doc IdrisDocAnn
 mutualblock = vcat $
@@ -522,6 +545,7 @@ keywordsDoc =
   :: "auto" ::= implicitarg
   :: "default" ::= implicitarg
   :: "implicit" ::= unusedKeyword
+  :: "failing" ::= failblock
   :: "mutual" ::= mutualblock
   :: "namespace" ::= namespaceblock
   :: "parameters" ::= parametersblock

--- a/src/Idris/Error.idr
+++ b/src/Idris/Error.idr
@@ -514,6 +514,14 @@ perror (NoForeignCC fc specs) = do
 perror (BadMultiline fc str) = pure $ errorDesc (reflow "While processing multi-line string" <+> dot <++> pretty str <+> dot) <+> line <+> !(ploc fc)
 perror (Timeout str) = pure $ errorDesc (reflow "Timeout in" <++> pretty str)
 
+perror (FailingDidNotFail fc)
+  = pure $ errorDesc (reflow "Failing block did not fail" <+> dot)
+    <+> line <+> !(ploc fc)
+perror (FailingWrongError fc err)
+  = pure $ hsep [ errorDesc (reflow "Failing block failed with the wrong error" <+> dot)
+                , !(perror err)
+                ]
+
 perror (InType fc n err)
     = pure $ hsep [ errorDesc (reflow "While processing type of" <++> code (pretty !(prettyName n))) <+> dot
                   , !(perror err)

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1378,6 +1378,18 @@ runElabDecl fname indents
                     expr pnowith fname indents
          pure (PRunElabDecl (boundToFC fname tm) tm.val)
 
+failDecls : OriginDesc -> IndentInfo -> Rule PDecl
+failDecls fname indents
+    = do msgds <- bounds $
+                 do decoratedKeyword fname "failing"
+                    commit
+                    msg <- simpleStr
+                    (msg,) <$> assert_total (nonEmptyBlock (topDecl fname))
+         pure $
+           let (msg, ds) = msgds.val
+               fc = boundToFC fname msgds
+           in PFail fc msg (collectDefs (concat ds))
+
 mutualDecls : OriginDesc -> IndentInfo -> Rule PDecl
 mutualDecls fname indents
     = do ds <- bounds $
@@ -1742,6 +1754,8 @@ topDecl fname indents
   <|> do d <- recordDecl fname indents
          pure [d]
   <|> do d <- namespaceDecl fname indents
+         pure [d]
+  <|> do d <- failDecls fname indents
          pure [d]
   <|> do d <- mutualDecls fname indents
          pure [d]

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -459,6 +459,10 @@ mutual
 
        -- TODO: PPostulate
        -- TODO: POpen (for opening named interfaces)
+       ||| PFail is a failing block. The string must appear as a
+       ||| substring of the error message raised when checking the block.
+       PFail : FC -> String -> List (PDecl' nm) -> PDecl' nm
+
        PMutual : FC -> List (PDecl' nm) -> PDecl' nm
        PFixity : FC -> Fixity -> Nat -> OpStr -> PDecl' nm
        PNamespace : FC -> Namespace -> List (PDecl' nm) -> PDecl' nm
@@ -479,6 +483,7 @@ mutual
   getPDeclLoc (PImplementation fc _ _ _ _ _ _ _ _ _ _) = fc
   getPDeclLoc (PRecord fc _ _ _ _ _ _ _) = fc
   getPDeclLoc (PMutual fc _) = fc
+  getPDeclLoc (PFail fc _ _) = fc
   getPDeclLoc (PFixity fc _ _ _) = fc
   getPDeclLoc (PNamespace fc _ _) = fc
   getPDeclLoc (PTransform fc _ _ _) = fc
@@ -1304,6 +1309,7 @@ mapPTermM f = goPTerm where
       PRecord fc doc v tot n <$> go4TupledPTerms nts
                              <*> pure mn
                              <*> goPFields fs
+    goPDecl (PFail fc msg ps) = PFail fc msg <$> goPDecls ps
     goPDecl (PMutual fc ps) = PMutual fc <$> goPDecls ps
     goPDecl p@(PFixity _ _ _ _) = pure p
     goPDecl (PNamespace fc strs ps) = PNamespace fc strs <$> goPDecls ps

--- a/src/Parser/Lexer/Source.idr
+++ b/src/Parser/Lexer/Source.idr
@@ -213,7 +213,7 @@ mkDirective str = CGDirective (trim (substr 3 (length str) str))
 public export
 keywords : List String
 keywords = ["data", "module", "where", "let", "in", "do", "record",
-            "auto", "default", "implicit", "mutual", "namespace",
+            "auto", "default", "implicit", "failing", "mutual", "namespace",
             "parameters", "with", "proof", "impossible", "case", "of",
             "if", "then", "else", "forall", "rewrite",
             "using", "interface", "implementation", "open", "import",

--- a/src/TTImp/Parser.idr
+++ b/src/TTImp/Parser.idr
@@ -751,6 +751,8 @@ collectDefs (IDef loc fn cs :: ds)
     isClause n _ = Nothing
 collectDefs (INamespace loc ns nds :: ds)
     = INamespace loc ns (collectDefs nds) :: collectDefs ds
+collectDefs (IFail loc msg nds :: ds)
+    = IFail loc msg (collectDefs nds) :: collectDefs ds
 collectDefs (d :: ds)
     = d :: collectDefs ds
 

--- a/src/TTImp/Reflect.idr
+++ b/src/TTImp/Reflect.idr
@@ -458,6 +458,11 @@ mutual
                           z' <- reify defs !(evalClosure defs z)
                           u' <- reify defs !(evalClosure defs u)
                           pure (IRecord w' x' y' z' u')
+               (UN (Basic "IFail"), [w,x,y])
+                    => do w' <- reify defs !(evalClosure defs w)
+                          x' <- reify defs !(evalClosure defs x)
+                          y' <- reify defs !(evalClosure defs y)
+                          pure (IFail w' x' y')
                (UN (Basic "INamespace"), [w,x,y])
                     => do w' <- reify defs !(evalClosure defs w)
                           x' <- reify defs !(evalClosure defs x)
@@ -806,6 +811,11 @@ mutual
              z' <- reflect fc defs lhs env z
              u' <- reflect fc defs lhs env u
              appCon fc defs (reflectionttimp "IRecord") [w', x', y', z', u']
+    reflect fc defs lhs env (IFail x y z)
+        = do x' <- reflect fc defs lhs env x
+             y' <- reflect fc defs lhs env y
+             z' <- reflect fc defs lhs env z
+             appCon fc defs (reflectionttimp "IFail") [x', y', z']
     reflect fc defs lhs env (INamespace x y z)
         = do x' <- reflect fc defs lhs env x
              y' <- reflect fc defs lhs env y

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -437,6 +437,7 @@ mutual
                  Maybe String -> -- nested namespace
                  Visibility -> Maybe TotalReq ->
                  ImpRecord' nm -> ImpDecl' nm
+       IFail : FC -> String -> List (ImpDecl' nm) -> ImpDecl' nm
        INamespace : FC -> Namespace -> List (ImpDecl' nm) -> ImpDecl' nm
        ITransform : FC -> Name -> RawImp' nm -> RawImp' nm -> ImpDecl' nm
        IRunElabDecl : FC -> RawImp' nm -> ImpDecl' nm
@@ -459,6 +460,9 @@ mutual
         = "parameters " ++ show ps ++ "\n\t" ++
           showSep "\n\t" (assert_total $ map show ds)
     show (IRecord _ _ _ _ d) = show d
+    show (IFail _ msg decls)
+        = "fail " ++ show msg ++ "\n" ++
+          showSep "\n" (assert_total $ map (("  " ++) . show) decls)
     show (INamespace _ ns decls)
         = "namespace " ++ show ns ++
           showSep "\n" (assert_total $ map show decls)
@@ -737,6 +741,8 @@ implicitsAs n defs ns tm
         impAs loc' (_ :: ns) tm = impAs loc' ns tm
     setAs is es tm = pure tm
 
+||| `definedInBlock` is used to figure out which definitions should
+||| receive the additional arguments introduced by a Parameters directive
 export
 definedInBlock : Namespace -> -- namespace to resolve names
                  List ImpDecl -> List Name
@@ -763,6 +769,7 @@ definedInBlock ns decls =
         = expandNS ns n :: map (expandNS ns) (map getName cons)
     defName ns (IData _ _ _ (MkImpLater _ n _)) = [expandNS ns n]
     defName ns (IParameters _ _ pds) = concatMap (defName ns) pds
+    defName ns (IFail _ _ nds) = concatMap (defName ns) nds
     defName ns (INamespace _ n nds) = concatMap (defName (ns <.> n)) nds
     defName ns (IRecord _ fldns _ _ (MkImpRecord _ n _ con flds))
         = expandNS ns con :: all
@@ -849,6 +856,7 @@ namespace ImpDecl
   getFC (IDef fc _ _) = fc
   getFC (IParameters fc _ _) = fc
   getFC (IRecord fc _ _ _ _) = fc
+  getFC (IFail fc _ _) = fc
   getFC (INamespace fc _ _) = fc
   getFC (ITransform fc _ _ _) = fc
   getFC (IRunElabDecl fc _) = fc
@@ -1332,6 +1340,8 @@ mutual
         = do tag 8; toBuf b n
     toBuf b (IBuiltin fc type name)
         = do tag 9; toBuf b fc; toBuf b type; toBuf b name
+    toBuf b (IFail _ _ _)
+        = pure ()
 
     fromBuf b
         = case !getTag of

--- a/src/TTImp/TTImp/Functor.idr
+++ b/src/TTImp/TTImp/Functor.idr
@@ -98,6 +98,8 @@ mutual
       = IParameters fc (map (map  {f = ImpParameter'} f) ps) (map (map f) ds)
     map f (IRecord fc cs vis mbtot rec)
       = IRecord fc cs vis mbtot (map f rec)
+    map f (IFail fc msg ds)
+      = IFail fc msg (map (map f) ds)
     map f (INamespace fc ns ds)
       = INamespace fc ns (map (map f) ds)
     map f (ITransform fc n lhs rhs)

--- a/src/TTImp/Utils.idr
+++ b/src/TTImp/Utils.idr
@@ -35,6 +35,7 @@ rawImpFromDecl decl = case decl of
     IRecord fc1 y z _ (MkImpRecord fc n params conName fields) => do
         (a, b) <- map (snd . snd) params
         getFromPiInfo a ++ [b] ++ getFromIField !fields
+    IFail fc1 msg zs => rawImpFromDecl !zs
     INamespace fc1 ys zs => rawImpFromDecl !zs
     ITransform fc1 y z w => [z, w]
     IRunElabDecl fc1 y => [] -- Not sure about this either
@@ -387,6 +388,8 @@ mutual
       = IDef fc n (map (substNamesClause' bvar bound ps) cs)
   substNamesDecl' bvar bound ps (IData fc vis mbtot d)
       = IData fc vis mbtot (substNamesData' bvar bound ps d)
+  substNamesDecl' bvar bound ps (IFail fc msg ds)
+      = IFail fc msg (map (substNamesDecl' bvar bound ps) ds)
   substNamesDecl' bvar bound ps (INamespace fc ns ds)
       = INamespace fc ns (map (substNamesDecl' bvar bound ps) ds)
   substNamesDecl' bvar bound ps d = d
@@ -485,6 +488,8 @@ mutual
       = IDef fc' n (map (substLocClause fc') cs)
   substLocDecl fc' (IData fc vis mbtot d)
       = IData fc' vis mbtot (substLocData fc' d)
+  substLocDecl fc' (IFail fc msg ds)
+      = IFail fc' msg (map (substLocDecl fc') ds)
   substLocDecl fc' (INamespace fc ns ds)
       = INamespace fc' ns (map (substLocDecl fc') ds)
   substLocDecl fc' d = d

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -72,7 +72,7 @@ idrisTestsError = MkTestPool "Error messages" [] Nothing
        "error006", "error007", "error008", "error009", "error010",
        "error011", "error012", "error013", "error014", "error015",
        "error016", "error017", "error018", "error019", "error020",
-       "error021", "error022", "error023",
+       "error021", "error022", "error023", "error024",
        -- Parse errors
        "perror001", "perror002", "perror003", "perror004", "perror005",
        "perror006", "perror007", "perror008", "perror009", "perror010",

--- a/tests/chez/newints/IntOps.idr
+++ b/tests/chez/newints/IntOps.idr
@@ -136,7 +136,7 @@ check :  (Num a, Cast a Integer) => Op a -> List String
 check (MkOp name op opInt allowZero $ MkIntType type signed bits mi ma) =
   let ps = if allowZero then pairs
            else filter ((0 /=) . checkBounds . snd) pairs
-   in mapMaybe failing ps
+   in mapMaybe fail ps
 
   where
     trueMod : Integer -> Integer -> Integer
@@ -149,8 +149,8 @@ check (MkOp name op opInt allowZero $ MkIntType type signed bits mi ma) =
                            then r1 - (ma + 1 - mi)
                            else r1
 
-    failing : (Integer,Integer) -> Maybe String
-    failing (x,y) =
+    fail : (Integer,Integer) -> Maybe String
+    fail (x,y) =
       let resInteger = opInt x y
           resMod     = checkBounds $ opInt (checkBounds x) (checkBounds y)
           resA       = cast {to = Integer} (op (fromInteger x) (fromInteger y))

--- a/tests/idris2/error024/Fail.idr
+++ b/tests/idris2/error024/Fail.idr
@@ -1,0 +1,25 @@
+%default total
+
+failing "mismatch: 1 and 2"
+
+  revAcc : List a -> List a -> List a
+  revAcc [] acc = acc
+  revAcc (x :: xs) acc = revAcc xs (x :: acc)
+
+  rev : List a -> List a
+  rev = revAcc []
+
+  oops : rev [1,2] === [2,1]
+  oops = Refl
+
+
+failing "Failing block did not fail"
+
+  failing ""
+    -- 1. The content of this `failing' block won't fail.
+    -- 2. And so the block will itself fail.
+    -- 3. Which means the enclosing one will succeed in
+    --    catching a "Failing block did not fail" error
+
+    success : 'a' === 'a'
+    success = Refl

--- a/tests/idris2/error024/expected
+++ b/tests/idris2/error024/expected
@@ -1,0 +1,1 @@
+1/1: Building Fail (Fail.idr)

--- a/tests/idris2/error024/run
+++ b/tests/idris2/error024/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --check Fail.idr

--- a/tests/node/newints/IntOps.idr
+++ b/tests/node/newints/IntOps.idr
@@ -134,7 +134,7 @@ check :  (Num a, Cast a Integer) => Op a -> List String
 check (MkOp name op opInt allowZero $ MkIntType type signed bits mi ma) =
   let ps = if allowZero then pairs
            else filter ((0 /=) . checkBounds . snd) pairs
-   in mapMaybe failing ps
+   in mapMaybe fail ps
 
   where
     trueMod : Integer -> Integer -> Integer
@@ -147,8 +147,8 @@ check (MkOp name op opInt allowZero $ MkIntType type signed bits mi ma) =
                            then r1 - (ma + 1 - mi)
                            else r1
 
-    failing : (Integer,Integer) -> Maybe String
-    failing (x,y) =
+    fail : (Integer,Integer) -> Maybe String
+    fail (x,y) =
       let resInteger = opInt x y
           resMod     = checkBounds $ opInt (checkBounds x) (checkBounds y)
           resA       = cast {to = Integer} (op (fromInteger x) (fromInteger y))


### PR DESCRIPTION
Blocks that let user document invalid code. Can be used in literate
mode to document things that do not typecheck.

Left to do:

* use the same error messages in pretty mode & when checking the
  substring is present.
* support syntax highlighting (I think we just need to purge the
  name information for the identifiers that won't make it to TTC)