### PR TITLE
Add documentation for Control.Monad.*

### DIFF
--- a/libs/base/Control/Monad/Identity.idr
+++ b/libs/base/Control/Monad/Identity.idr
@@ -4,6 +4,8 @@ import Data.Bits
 
 %default total
 
+||| The identity monad. This monad provides no abilities other than pure
+||| computation.
 public export
 record Identity (a : Type) where
   constructor Id

--- a/libs/base/Control/Monad/Reader/Reader.idr
+++ b/libs/base/Control/Monad/Reader/Reader.idr
@@ -5,7 +5,10 @@ import Control.Monad.Trans
 
 %default total
 
-||| The transformer on which the Reader monad is based
+||| A monad transformer extending an inner monad with access to an environment.
+|||
+||| The environment is the same for all actions in a sequence, but may be
+||| changed within scopes created by `Control.Monad.Reader.local`.
 public export
 record ReaderT (stateType : Type) (m : Type -> Type) (a : Type) where
   constructor MkReaderT
@@ -26,7 +29,9 @@ runReaderT s action = runReaderT' action s
 --          Reader
 --------------------------------------------------------------------------------
 
-||| The Reader monad. The ReaderT transformer applied to the Identity monad.
+||| A monad that can access an environment. 
+|||
+||| This is `ReaderT` applied to `Identity`.
 public export
 Reader : (stateType : Type) -> (a : Type) -> Type
 Reader s a = ReaderT s Identity a

--- a/libs/base/Control/Monad/Reader/Reader.idr
+++ b/libs/base/Control/Monad/Reader/Reader.idr
@@ -29,7 +29,7 @@ runReaderT s action = runReaderT' action s
 --          Reader
 --------------------------------------------------------------------------------
 
-||| A monad that can access an environment. 
+||| A monad that can access an environment.
 |||
 ||| This is `ReaderT` applied to `Identity`.
 public export

--- a/libs/base/Control/Monad/ST.idr
+++ b/libs/base/Control/Monad/ST.idr
@@ -56,7 +56,7 @@ newSTRef val
 ||| Read the value of a mutable reference.
 |||
 ||| This occurs within `ST s` to prevent `STRef`s from being usable if they are
-||| "leaked" via `runST`. 
+||| "leaked" via `runST`.
 %inline
 export
 readSTRef : STRef s a -> ST s a

--- a/libs/base/Control/Monad/ST.idr
+++ b/libs/base/Control/Monad/ST.idr
@@ -1,17 +1,29 @@
+||| Provides mutable references as described in Lazy Functional State Threads.
 module Control.Monad.ST
 
 import Data.IORef
 
 %default total
 
+||| A mutable reference, bound to a state thread.
+|||
+||| A value of type `STRef s a` contains a mutable `a`, bound to a "thread"
+||| `s`. Any access to the reference must occur in an `ST s` monad with the
+||| same "thread".
 export
 data STRef : Type -> Type -> Type where
      MkSTRef : IORef a -> STRef s a
 
+||| The `ST` monad allows for mutable access to references, but unlike `IO`, it
+||| is "escapable".
+|||
+||| The parameter `s` is a "thread" -- it ensures that access to mutable
+||| references created in each thread must occur in that same thread.
 export
 data ST : Type -> Type -> Type where
      MkST : IO a -> ST s a
 
+||| Run a `ST` computation.
 export
 runST : (forall s . ST s a) -> a
 runST p
@@ -34,22 +46,29 @@ Monad (ST s) where
                   let MkST kp = k p'
                   kp
 
+||| Create a new mutable reference with the given value.
 export
 newSTRef : a -> ST s (STRef s a)
 newSTRef val
     = MkST $ do r <- newIORef val
                 pure (MkSTRef r)
 
+||| Read the value of a mutable reference.
+|||
+||| This occurs within `ST s` to prevent `STRef`s from being usable if they are
+||| "leaked" via `runST`. 
 %inline
 export
 readSTRef : STRef s a -> ST s a
 readSTRef (MkSTRef r) = MkST $ readIORef r
 
+||| Write to a mutable reference.
 %inline
 export
 writeSTRef : STRef s a -> (val : a) -> ST s ()
 writeSTRef (MkSTRef r) val = MkST $ writeIORef r val
 
+||| Apply a function to the contents of a mutable reference.
 export
 modifySTRef : STRef s a -> (a -> a) -> ST s ()
 modifySTRef ref f

--- a/libs/base/Control/Monad/State/Interface.idr
+++ b/libs/base/Control/Monad/State/Interface.idr
@@ -10,7 +10,7 @@ import Control.Monad.Writer.CPS
 
 %default total
 
-||| A computation which runs in a context and produces an output
+||| A monadic computation that has access to state.
 public export
 interface Monad m => MonadState stateType m | m where
     ||| Get the context

--- a/libs/base/Control/Monad/State/State.idr
+++ b/libs/base/Control/Monad/State/State.idr
@@ -5,7 +5,9 @@ import Control.Monad.Trans
 
 %default total
 
-||| The transformer on which the State monad is based
+||| A monad transformer extending an inner monad `m` with state `stateType`.
+|||
+||| Updates to the state are applied in the order as the sequence of actions.
 public export
 record StateT (stateType : Type) (m : Type -> Type) (a : Type) where
   constructor ST

--- a/libs/base/Control/Monad/Trans.idr
+++ b/libs/base/Control/Monad/Trans.idr
@@ -2,6 +2,9 @@ module Control.Monad.Trans
 
 %default total
 
+||| A monad transformer is a type that can wrap an inner monad, extending it
+||| with additional abilities.
 public export
 interface MonadTrans t where
+    ||| Lift a computation from the inner monad to the transformed monad.
     lift : Monad m => m a -> t m a


### PR DESCRIPTION
Some modules in `Control.Monad` are missing documentation and there is some inconsistency between documentation styles and wording in existing documentation. This pull request addresses those issues.