### PR TITLE
[ contrib ] Add `keySet` function for dependent sorted maps too

### DIFF
--- a/libs/contrib/Data/SortedMap.idr
+++ b/libs/contrib/Data/SortedMap.idr
@@ -136,3 +136,11 @@ Semigroup v => Semigroup (SortedMap k v) where
 export
 (Ord k, Semigroup v) => Monoid (SortedMap k v) where
   neutral = empty
+
+export %inline
+Cast (SortedDMap k (const v)) (SortedMap k v) where
+  cast = M
+
+export %inline
+Cast (SortedMap k v) (SortedDMap k (const v)) where
+  cast = unM

--- a/libs/contrib/Data/SortedSet.idr
+++ b/libs/contrib/Data/SortedSet.idr
@@ -2,6 +2,7 @@ module Data.SortedSet
 
 import Data.Maybe
 import Data.SortedMap
+import Data.SortedMap.Dependent
 
 %hide Prelude.toList
 
@@ -80,6 +81,12 @@ Show k => Show (SortedSet k) where
 export
 keySet : SortedMap k v -> SortedSet k
 keySet = SetWrapper . map (const ())
+
+namespace Dependent
+
+  export
+  keySet : SortedDMap k v -> SortedSet k
+  keySet = SetWrapper . cast . map (const ())
 
 export
 singleton : Ord k => k -> SortedSet k


### PR DESCRIPTION
Usual sorted maps have this, but existing code that uses `keySet` breaks when switching from a sorted map to a dependent one.