### PR TITLE
Replace ``\d`` to ``\a`` as Vim shortcut to create definition

### DIFF
--- a/docs/source/proofs/patterns.rst
+++ b/docs/source/proofs/patterns.rst
@@ -109,7 +109,7 @@ concrete value for its *second argument* (in fact, the left hand side of
 the equality has been reduced from ``plus Z m``.) Again, we can prove
 this by induction, this time on ``m``.
 
-First, create a template definition with ``\d``:
+First, create a template definition with ``\a``:
 
 .. code-block:: idris
 


### PR DESCRIPTION
Note that I did not check that one (I'm not a Vim user), but it makes sense according to the table at the top of the page.