### PR TITLE
Signature of NoMangle from Language.Reflection.FnOpts

### DIFF
--- a/libs/base/Language/Reflection/TTImp.idr
+++ b/libs/base/Language/Reflection/TTImp.idr
@@ -115,7 +115,7 @@ mutual
        Macro : FnOpt
        SpecArgs : List Name -> FnOpt
        ||| Keep the user provided name during codegen
-       NoMangle : NoMangleDirective -> FnOpt
+       NoMangle : Maybe NoMangleDirective -> FnOpt
 
   public export
   data ITy : Type where


### PR DESCRIPTION
This PR aligns the signature of `NoMangle` from `Language.Reflection.FnOpts` with the counterpart in `TTImp.TTImp.FnOpts'`.

It solves the following issue:
When entering the following in the repl:
```haskell
decl : List Decl
decl= `[export %nomangle myId : Int -> Int ; myId = id]
```
It outputs (I replaced the FCs for better readability):
```haskell
IClaim EmptyFC MW Export [NoMangle Nothing] (MkTy EmptyFC EmptyFC (UN (Basic "myId")) (IPi EmptyFC MW ExplicitArg Nothing (IPrimVal EmptyFC (PrT IntType)) (IPrimVal EmptyFC (PrT IntType)))),
IDef EmptyFC (UN (Basic "myId")) [PatClause EmptyFC (IVar EmptyFC (UN (Basic "myId"))) (IVar EmptyFC (UN (Basic "id")))]
```

When using the above to declare the function in `Elab` like this:
```haskell
declareMyId : Elab ()
declareMyId = declare [
    IClaim EmptyFC MW Export [NoMangle Nothing] (MkTy EmptyFC EmptyFC (UN (Basic "myId")) (IPi EmptyFC MW ExplicitArg Nothing (IPrimVal EmptyFC (PrT IntType)) (IPrimVal EmptyFC (PrT IntType)))),
    IDef EmptyFC (UN (Basic "myId")) [PatClause EmptyFC (IVar EmptyFC (UN (Basic "myId"))) (IVar EmptyFC (UN (Basic "id")))]]

%runElab declareMyId
```

The compiler generates an error:
```
Error: While processing right hand side of declareMyId. When unifying:
    Maybe ?ty
and:
    NoMangleDirective
Mismatch between: Maybe ?ty and NoMangleDirective.
```

This PR fixes this.


