### PR TITLE
[ parser ] better error messages for Haskellers

### DIFF
--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -76,7 +76,7 @@ idrisTestsError = MkTestPool "Error messages" [] Nothing
        -- Parse errors
        "perror001", "perror002", "perror003", "perror004", "perror005",
        "perror006", "perror007", "perror008", "perror009", "perror010",
-       "perror011"]
+       "perror011", "perror012"]
 
 idrisTestsInteractive : TestPool
 idrisTestsInteractive = MkTestPool "Interactive editing" [] Nothing

--- a/tests/idris2/perror012/CaseParseError.idr
+++ b/tests/idris2/perror012/CaseParseError.idr
@@ -1,0 +1,4 @@
+plus : Nat -> Nat -> Nat
+plus m n = case m of
+  Z => n
+  S m -> S (plus m n)

--- a/tests/idris2/perror012/LamParseError.idr
+++ b/tests/idris2/perror012/LamParseError.idr
@@ -1,0 +1,2 @@
+fun : a -> b -> c -> d -> a
+fun = \ a, b => \ c, d -> a

--- a/tests/idris2/perror012/expected
+++ b/tests/idris2/perror012/expected
@@ -1,0 +1,18 @@
+1/1: Building LamParseError (LamParseError.idr)
+Error: Expected '=>'.
+
+LamParseError:2:24--2:26
+ 1 | fun : a -> b -> c -> d -> a
+ 2 | fun = \ a, b => \ c, d -> a
+                            ^^
+
+1/1: Building CaseParseError (CaseParseError.idr)
+Error: Expected '=>' or 'impossible'.
+
+CaseParseError:4:7--4:9
+ 1 | plus : Nat -> Nat -> Nat
+ 2 | plus m n = case m of
+ 3 |   Z => n
+ 4 |   S m -> S (plus m n)
+           ^^
+

--- a/tests/idris2/perror012/run
+++ b/tests/idris2/perror012/run
@@ -1,0 +1,4 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --check LamParseError.idr
+$1 --no-color --console-width 0 --check CaseParseError.idr


### PR DESCRIPTION
People often get confused by `->` vs. `=>`. This should hopefully make things nicer.