### PR TITLE
[ re #2370 ] Add forgotten export clause

### DIFF
--- a/libs/base/Control/Function/FunExt.idr
+++ b/libs/base/Control/Function/FunExt.idr
@@ -7,5 +7,6 @@ module Control.Function.FunExt
 ||| It can be used to mark properties as requiring function extensionality to hold,
 ||| i.e. its main objective is to provide a universal way to formulate a conditional property
 ||| that holds only in the presence of function extensionality.
+public export
 interface FunExt where
   0 funExt : {0 f, g : a -> b} -> ((x : a) -> f x = g x) -> f = g


### PR DESCRIPTION
OMG, only after merging I realised that I forgot to export the definition. Sorry