### PR TITLE
[ fix #2402 ] Check totality before exiting `failing` block

### DIFF
--- a/idris2api.ipkg
+++ b/idris2api.ipkg
@@ -240,6 +240,7 @@ modules =
     TTImp.ProcessBuiltin,
     TTImp.ProcessData,
     TTImp.ProcessDecls,
+    TTImp.ProcessDecls.Totality,
     TTImp.ProcessDef,
     TTImp.ProcessParams,
     TTImp.ProcessRecord,

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -791,7 +791,7 @@ HasNames Error where
   full gam (BadMultiline fc x) = pure (BadMultiline fc x)
   full gam (Timeout x) = pure (Timeout x)
   full gam (FailingDidNotFail fc) = pure (FailingDidNotFail fc)
-  full gam (FailingWrongError fc x err) = FailingWrongError fc x <$> full gam err
+  full gam (FailingWrongError fc x err) = FailingWrongError fc x <$> traverseList1 (full gam) err
   full gam (InType fc n err) = InType fc <$> full gam n <*> full gam err
   full gam (InCon fc n err) = InCon fc <$> full gam n <*> full gam err
   full gam (InLHS fc n err) = InLHS fc <$> full gam n <*> full gam err
@@ -879,7 +879,7 @@ HasNames Error where
   resolved gam (BadMultiline fc x) = pure (BadMultiline fc x)
   resolved gam (Timeout x) = pure (Timeout x)
   resolved gam (FailingDidNotFail fc) = pure (FailingDidNotFail fc)
-  resolved gam (FailingWrongError fc x err) = FailingWrongError fc x <$> resolved gam err
+  resolved gam (FailingWrongError fc x err) = FailingWrongError fc x <$> traverseList1 (resolved gam) err
   resolved gam (InType fc n err) = InType fc <$> resolved gam n <*> resolved gam err
   resolved gam (InCon fc n err) = InCon fc <$> resolved gam n <*> resolved gam err
   resolved gam (InLHS fc n err) = InLHS fc <$> resolved gam n <*> resolved gam err

--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -167,7 +167,7 @@ data Error : Type where
      BadMultiline : FC -> String -> Error
      Timeout : String -> Error
      FailingDidNotFail : FC -> Error
-     FailingWrongError : FC -> String -> Error -> Error
+     FailingWrongError : FC -> String -> List1 Error -> Error
 
      InType : FC -> Name -> Error -> Error
      InCon : FC -> Name -> Error -> Error
@@ -535,7 +535,7 @@ killErrorLoc (NoForeignCC fc xs) = NoForeignCC emptyFC xs
 killErrorLoc (BadMultiline fc x) = BadMultiline emptyFC x
 killErrorLoc (Timeout x) = Timeout x
 killErrorLoc (FailingDidNotFail fc) = FailingDidNotFail emptyFC
-killErrorLoc (FailingWrongError fc x err) = FailingWrongError emptyFC x (killErrorLoc err)
+killErrorLoc (FailingWrongError fc x errs) = FailingWrongError emptyFC x (map killErrorLoc errs)
 killErrorLoc (InType fc x err) = InType emptyFC x (killErrorLoc err)
 killErrorLoc (InCon fc x err) = InCon emptyFC x (killErrorLoc err)
 killErrorLoc (InLHS fc x err) = InLHS emptyFC x (killErrorLoc err)

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -1069,7 +1069,7 @@ mutual
                               -- Unless the error is the expected one
                               guard (not test)
                               -- We should complain we had the wrong one
-                              pure (FailingWrongError fc msg err))
+                              pure (FailingWrongError fc msg (err ::: [])))
            -- Reset the state
            put UST ust
            md' <- get MD

--- a/src/Idris/Error.idr
+++ b/src/Idris/Error.idr
@@ -26,6 +26,112 @@ import System.File
 
 %default covering
 
+-- Not fully correct, see e.g. `UnreachableClause` where we don't check the
+-- Envs & Terms because we don't yet have equality instances for these
+export
+Eq Warning where
+  ParserWarning fc1 x1 == ParserWarning fc2 x2 = fc1 == fc2 && x1 == x2
+  UnreachableClause fc1 rho1 s1 == UnreachableClause fc2 rho2 s2 = fc1 == fc2
+  ShadowingGlobalDefs fc1 xs1 == ShadowingGlobalDefs fc2 xs2 = fc1 == fc2 && xs1 == xs2
+  Deprecated x1 y1 == Deprecated x2 y2 = x1 == x2 && y1 == y2
+  GenericWarn x1 == GenericWarn x2 = x1 == x2
+  _ == _ = False
+
+export
+Eq TTCErrorMsg where
+  Format x1 y1 z1 == Format x2 y2 z2 = x1 == x2 && y1 == y2 && z1 == z2
+  EndOfBuffer x1 == EndOfBuffer x2 = x1 == x2
+  Corrupt x1 == Corrupt x2 = x1 == x2
+  _ == _ = False
+
+export
+Eq FileError where
+  GenericFileError x1 == GenericFileError x2 = x1 == x2
+  FileReadError == FileReadError = True
+  FileWriteError == FileWriteError = True
+  FileNotFound == FileNotFound = True
+  PermissionDenied == PermissionDenied = True
+  FileExists == FileExists = True
+  _ == _ = False
+
+-- Not fully correct, see e.g. `CantConvert` where we don't check the Env
+export
+Eq Error where
+  Fatal err1 == Fatal err2 = err1 == err2
+  CantConvert fc1 gam1 rho1 s1 t1 == CantConvert fc2 gam2 rho2 s2 t2 = fc1 == fc2
+  CantSolveEq fc1 gam1 rho s1 t1 == CantSolveEq fc2 gam2 rho2 s2 t2 = fc1 == fc2
+  PatternVariableUnifies fc1 rho1 n1 s1 == PatternVariableUnifies fc2 rho2 n2 s2 = fc1 == fc2 && n1 == n2
+  CyclicMeta fc1 rho1 n1 s1 == CyclicMeta fc2 rho2 n2 s2 = fc1 == fc2 && n1 == n2
+  WhenUnifying fc1 gam1 rho1 s1 t1 err1 == WhenUnifying fc2 gam2 rho2 s2 t2 err2 = fc1 == fc2 && err1 == err2
+  ValidCase fc1 rho1 x1 == ValidCase fc2 rho2 x2 = fc1 == fc2
+  UndefinedName fc1 n1 == UndefinedName fc2 n2 = fc1 == fc2 && n1 == n2
+  InvisibleName fc1 n1 x1 == InvisibleName fc2 n2 x2 = fc1 == fc2 && n1 == n2 && x1 == x2
+  BadTypeConType fc1 n1 == BadTypeConType fc2 n2 = fc1 == fc2 && n1 == n2
+  BadDataConType fc1 n1 m1 == BadDataConType fc2 n2 m2 = fc1 == fc2 && n1 == n2 && m1 == m2
+  NotCovering fc1 n1 x1 == NotCovering fc2 n2 x2 = fc1 == fc2 && n1 == n2
+  NotTotal fc1 n1 x1 == NotTotal fc2 n2 x2 = fc1 == fc2 && n1 == n2
+  LinearUsed fc1 k1 n1 == LinearUsed fc2 k2 n2 = fc1 == fc2 && k1 == k2 && n1 == n2
+  LinearMisuse fc1 n1 x1 y1 == LinearMisuse fc2 n2 x2 y2 = fc1 == fc2 && n1 == n2 && x1 == x2 && y1 == y2
+  BorrowPartial fc1 rho1 s1 t1 == BorrowPartial fc2 rho2 s2 t2 = fc1 == fc2
+  BorrowPartialType fc1 rho1 s1 == BorrowPartialType fc2 rho2 s2 = fc1 == fc2
+  AmbiguousName fc1 xs1 == AmbiguousName fc2 xs2 = fc1 == fc2 && xs1 == xs2
+  AmbiguousElab fc1 rho1 xs1 == AmbiguousElab fc2 rho2 xs2 = fc1 == fc2
+  AmbiguousSearch fc1 rho1 s1 xs1 == AmbiguousSearch fc2 rho2 s2 xs2 = fc1 == fc2
+  AmbiguityTooDeep fc1 n1 xs1 == AmbiguityTooDeep fc2 n2 xs2 = fc1 == fc2 && n1 == n2 && xs1 == xs2
+  AllFailed xs1 == AllFailed xs2 = assert_total (xs1 == xs2)
+  RecordTypeNeeded fc1 rho1 == RecordTypeNeeded fc2 rho2 = fc1 == fc2
+  DuplicatedRecordUpdatePath fc1 xs1 == DuplicatedRecordUpdatePath fc2 xs2 = fc1 == fc2 && xs1 == xs2
+  NotRecordField fc1 x1 y1 == NotRecordField fc2 x2 y2 = fc1 == fc2 && x1 == x2 && y1 == y2
+  NotRecordType fc1 n1 == NotRecordType fc2 n2 = fc1 == fc2 && n1 == n2
+  IncompatibleFieldUpdate fc1 xs1 == IncompatibleFieldUpdate fc2 xs2 = fc1 == fc2 && xs1 == xs2
+  InvalidArgs fc1 rho1 xs1 s1 == InvalidArgs fc2 rho2 xs2 s2 = fc1 == fc2
+  TryWithImplicits fc1 rho1 xs1 == TryWithImplicits fc2 rho2 xs2 = fc1 == fc2
+  BadUnboundImplicit fc1 rho1 n1 s1 == BadUnboundImplicit fc2 rho2 n2 s2 = fc1 == fc2 && n1 == n2
+  CantSolveGoal fc1 gam1 rho1 s1 x1 == CantSolveGoal fc2 gam2 rho2 s2 x2 = fc1 == fc2
+  DeterminingArg fc1 n1 x1 rho1 s1 == DeterminingArg fc2 n2 x2 rho2 s2 = fc1 == fc2 && n1 == n2 && x1 == x2
+  UnsolvedHoles xs1 == UnsolvedHoles xs2 = xs1 == xs2
+  CantInferArgType fc1 rho1 n1 m1 s1 == CantInferArgType fc2 rho2 n2 m2 s2 = fc1 == fc2 && n1 == n2 && m1 == m2
+  SolvedNamedHole fc1 rho1 n1 s1 == SolvedNamedHole fc2 rho2 n2 s2 = fc1 == fc2 && n1 == n2
+  VisibilityError fc1 x1 n1 y1 m1 == VisibilityError fc2 x2 n2 y2 m2
+    = fc1 == fc2 && x1 == x2 && n1 == n2 && y1 == y2 && m1 == m2
+  NonLinearPattern fc1 n1 == NonLinearPattern fc2 n2 = fc1 == fc2 && n1 == n2
+  BadPattern fc1 n1 == BadPattern fc2 n2 =  fc1 == fc2 && n1 == n2
+  NoDeclaration fc1 n1 == NoDeclaration fc2 n2 = fc1 == fc2 && n1 == n2
+  AlreadyDefined fc1 n1 == AlreadyDefined fc2 n2 = fc1 == fc2 && n1 == n2
+  NotFunctionType fc1 rho1 s1 == NotFunctionType fc2 rho2 s2 = fc1 == fc2
+  RewriteNoChange fc1 rho1 s1 t1 == RewriteNoChange fc2 rho2 s2 t2 = fc1 == fc2
+  NotRewriteRule fc1 rho1 s1 == NotRewriteRule fc2 rho2 s2 = fc1 == fc2
+  CaseCompile fc1 n1 x1 == CaseCompile fc2 n2 x2 = fc1 == fc2 && n1 == n2
+  MatchTooSpecific fc1 rho1 s1 == MatchTooSpecific fc2 rho2 s2 = fc1 == fc2
+  BadDotPattern fc1 rho1 x1 s1 t1 == BadDotPattern fc2 rho2 x2 s2 t2 = fc1 == fc2
+  BadImplicit fc1 x1 == BadImplicit fc2 x2 = fc1 == fc2 && x1 == x2
+  BadRunElab fc1 rho1 s1 d1 == BadRunElab fc2 rho2 s2 d2 = fc1 == fc2 && d1 == d2
+  GenericMsg fc1 x1 == GenericMsg fc2 x2 = fc1 == fc2 && x1 == x2
+  TTCError x1 == TTCError x2 = x1 == x2
+  FileErr x1 y1 == FileErr x2 y2 = x1 == x2 && y1 == y2
+  CantFindPackage x1 == CantFindPackage x2 = x1 == x2
+  LitFail fc1 == LitFail fc2 = fc1 == fc2
+  LexFail fc1 x1 == LexFail fc2 x2 = fc1 == fc2 && x1 == x2
+  ParseFail xs1 == ParseFail xs2 = xs1 == xs2
+  ModuleNotFound fc1 x1 == ModuleNotFound fc2 x2 = fc1 == fc2 && x1 == x2
+  CyclicImports xs1 == CyclicImports xs2 = xs1 == xs2
+  ForceNeeded == ForceNeeded = True
+  InternalError x1 == InternalError x2 = x1 == x2
+  UserError x1 == UserError x2 = x1 == x2
+  NoForeignCC fc1 xs1 == NoForeignCC fc2 xs2 = fc1 == fc2 && xs1 == xs2
+  BadMultiline fc1 x1 == BadMultiline fc2 x2 = fc1 == fc2 && x1 == x2
+  Timeout x1 == Timeout x2 = x1 == x2
+  FailingDidNotFail fc1 == FailingDidNotFail fc2 = fc1 == fc2
+  FailingWrongError fc1 x1 err1 == FailingWrongError fc2 x2 err2
+    = fc1 == fc2 && x1 == x2 && assert_total (err1 == err2)
+  InType fc1 n1 err1 == InType fc2 n2 err2 = fc1 == fc2 && n1 == n2 && err1 == err2
+  InCon fc1 n1 err1 == InCon fc2 n2 err2 = fc1 == fc2 && n1 == n2 && err1 == err2
+  InLHS fc1 n1 err1 == InLHS fc2 n2 err2 = fc1 == fc2 && n1 == n2 && err1 == err2
+  InRHS fc1 n1 err1 == InRHS fc2 n2 err2 = fc1 == fc2 && n1 == n2 && err1 == err2
+  MaybeMisspelling err1 xs1 == MaybeMisspelling err2 xs2 = err1 == err2 && xs1 == xs2
+  WarningAsError wrn1 == WarningAsError wrn2 = wrn1 == wrn2
+  _ == _ = False
+
 keyword : Doc IdrisAnn -> Doc IdrisAnn
 keyword = annotate (Syntax Keyword)
 
@@ -526,7 +632,7 @@ perrorRaw (FailingDidNotFail fc)
 perrorRaw (FailingWrongError fc msg err)
   = pure $ vcat [ errorDesc (reflow "Failing block failed with the wrong error" <+> dot)
                 , "Expected" <++> dquote <+> pretty msg <+> dquote <++> "but got:"
-                , !(perrorRaw err)
+                , vsep !(traverse perrorRaw (forget err))
                 ]
 
 perrorRaw (InType fc n err)

--- a/src/Idris/ProcessIdr.idr
+++ b/src/Idris/ProcessIdr.idr
@@ -26,6 +26,7 @@ import Parser.Unlit
 
 import TTImp.Elab.Check
 import TTImp.ProcessDecls
+import TTImp.ProcessDecls.Totality
 import TTImp.TTImp
 
 import Idris.Desugar

--- a/src/TTImp/ProcessDecls/Totality.idr
+++ b/src/TTImp/ProcessDecls/Totality.idr
@@ -1,0 +1,64 @@
+module TTImp.ProcessDecls.Totality
+
+import Core.Context
+import Core.Context.Log
+import Core.Termination
+
+import Libraries.Data.NameMap
+
+%default covering
+
+export
+checkTotalityOK : {auto c : Ref Ctxt Defs} ->
+                  Name -> Core (Maybe Error)
+checkTotalityOK (NS _ (MN _ _)) = pure Nothing -- not interested in generated names
+checkTotalityOK (NS _ (CaseBlock _ _)) = pure Nothing -- case blocks checked elsewhere
+checkTotalityOK n
+    = do defs <- get Ctxt
+         Just gdef <- lookupCtxtExact n (gamma defs)
+              | Nothing => pure Nothing
+         let fc = location gdef
+
+         -- #524: need to check positivity even if we're not in a total context
+         -- because a definition coming later may need to know it is positive
+         case definition gdef of
+           (TCon _ _ _ _ _ _ _ _) => ignore $ checkPositive fc n
+           _ => pure ()
+
+         -- Once that is done, we build up errors if necessary
+         let treq = fromMaybe !getDefaultTotalityOption (findSetTotal (flags gdef))
+         let tot = totality gdef
+         log "totality" 3 $ show n ++ " must be: " ++ show treq
+         case treq of
+            PartialOK => pure Nothing
+            CoveringOnly => checkCovering fc (isCovering tot)
+            Total => checkTotality fc
+  where
+    checkCovering : FC -> Covering -> Core (Maybe Error)
+    checkCovering fc IsCovering = pure Nothing
+    checkCovering fc cov
+        = pure (Just (NotCovering fc n cov))
+
+    checkTotality : FC -> Core (Maybe Error)
+    checkTotality fc
+        = do ignore $ logTime ("+++ Checking Termination " ++ show n) (checkTotal fc n)
+             -- ^ checked lazily, so better calculate here
+             t <- getTotality fc n
+             err <- checkCovering fc (isCovering t)
+             maybe (case isTerminating t of
+                         NotTerminating p => pure (Just (NotTotal fc n p))
+                         _ => pure Nothing)
+                   (pure . Just) err
+
+-- Check totality of all the names added in the file, and return a list of
+-- totality errors.
+-- Do this at the end of processing a file (or a batch of definitions) since
+-- they might be mutually dependent so we need all the definitions to be able
+-- to check accurately.
+export
+getTotalityErrors : {auto c : Ref Ctxt Defs} ->
+                    Core (List Error)
+getTotalityErrors
+    = do defs <- get Ctxt
+         errs <- traverse checkTotalityOK (keys (toSave defs))
+         pure (mapMaybe id errs)

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -67,7 +67,7 @@ idrisTestsWarning = MkTestPool "Warnings" [] Nothing
 
 idrisTestsFailing : TestPool
 idrisTestsFailing = MkTestPool "Failing blocks" [] Nothing
-      ["failing001", "failing002"
+      ["failing001", "failing002", "failing003"
       ]
 
 idrisTestsError : TestPool

--- a/tests/idris2/failing003/FailingTotality.idr
+++ b/tests/idris2/failing003/FailingTotality.idr
@@ -1,0 +1,21 @@
+module FailingTotality
+
+%default total
+
+failing "x is not covering."
+
+  x : Bool -> Nat
+  x True = 0
+
+
+failing "x is not total, possibly not terminating due to recursive
+         path FailingTotality.x -> FailingTotality.x"
+
+  x : Bool
+  x = x
+
+failing "D is not total, not strictly positive"
+
+  data D : Type where
+    Lam : (D -> D) -> D
+

--- a/tests/idris2/failing003/expected
+++ b/tests/idris2/failing003/expected
@@ -1,0 +1,1 @@
+1/1: Building FailingTotality (FailingTotality.idr)

--- a/tests/idris2/failing003/run
+++ b/tests/idris2/failing003/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --check FailingTotality.idr


### PR DESCRIPTION
I had to program defensively against the fact that we usually check totality at the end of a file
but here do so in the middle and so may be finding out about partial definitions that have nothing
to do with the `failing` block.