### PR TITLE
[ contrib ] Implement `Show ParsingError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@
   to 32 bits but now that is codified. JavaScript backends are now supported.
 * Removes `contrib`'s deprecated `Data.Num.Implementations` module. See
   `Prelude.Interfaces` instead.
+* Implements `Show tok => Show (ParsingError tok)` for `Text.Parser.Core`.
 
 ### Other changes
 

--- a/libs/contrib/Text/Parser/Core.idr
+++ b/libs/contrib/Text/Parser/Core.idr
@@ -271,6 +271,14 @@ position = Position
 public export
 data ParsingError tok = Error String (Maybe Bounds)
 
+public export
+Show tok => Show (ParsingError tok) where
+  show (Error s Nothing) = "PARSING ERROR: " ++ s
+  show (Error s (Just (MkBounds startLine startCol endLine endCol))) =
+    "PARSING ERROR: "
+    ++ s
+    ++ " @ L\{show startLine}:\{show startCol}-L\{show endLine}:\{show endCol}"
+
 data ParseResult : Type -> Type -> Type -> Type where
      Failure : (committed : Bool) -> (fatal : Bool) ->
                List1 (ParsingError tok) -> ParseResult state tok ty

--- a/libs/contrib/Text/Parser/Core.idr
+++ b/libs/contrib/Text/Parser/Core.idr
@@ -271,7 +271,7 @@ position = Position
 public export
 data ParsingError tok = Error String (Maybe Bounds)
 
-public export
+export
 Show tok => Show (ParsingError tok) where
   show (Error s Nothing) = "PARSING ERROR: " ++ s
   show (Error s (Just (MkBounds startLine startCol endLine endCol))) =


### PR DESCRIPTION
When writing parsers using the `contrib` library, it is often useful to be able to `show` the parse error (provided you can `show` your tokens).