### PR TITLE
[ fix ] HTML doc contents

### DIFF
--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -29,7 +29,7 @@ import public Libraries.Utils.Binary
 ||| version number if you're changing the version more than once in the same day.
 export
 ttcVersion : Int
-ttcVersion = 20220310 * 100 + 0
+ttcVersion = 20220413 * 100 + 0
 
 export
 checkTTCVersion : String -> Int -> Int -> Core ()

--- a/src/Core/Options/Log.idr
+++ b/src/Core/Options/Log.idr
@@ -86,6 +86,7 @@ knownTopics = [
     ("doc.implementation", Nothing),
     ("doc.record", Nothing),
     ("doc.module", Nothing),
+    ("doc.module.definitions", Nothing),
     ("elab", Nothing),
     ("elab.ambiguous", Nothing),
     ("elab.app.var", Nothing),

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -84,6 +84,7 @@ extendSyn newsyn
                     prefixes $= mergeLeft (prefixes newsyn),
                     ifaces $= merge (ifaces newsyn),
                     modDocstrings $= mergeLeft (modDocstrings newsyn),
+                    modDocexports $= mergeLeft (modDocexports newsyn),
                     defDocstrings $= merge (defDocstrings newsyn),
                     bracketholes $= ((bracketholes newsyn) ++) }
                   syn)

--- a/src/Idris/Doc/HTML.idr
+++ b/src/Idris/Doc/HTML.idr
@@ -91,6 +91,12 @@ renderHtml (STAnn (Syntax (TCon mn)) rest) = do
 renderHtml (STAnn (Syntax (Fun n)) rest) = do
   fun <- renderHtml rest
   addLink (Just n) $ "<span class=\"name function\">" <+> fun <+> "</span>"
+renderHtml (STAnn (Syntax Keyword) rest) = do
+  key <- renderHtml rest
+  pure $ "<span class=\"keyword\">" <+> key <+> "</span>"
+renderHtml (STAnn (Syntax Bound) rest) = do
+  bnd <- renderHtml rest
+  pure $ "<span class=\"boundvar\">" <+> bnd <+> "</span>"
 renderHtml (STAnn Header rest) = do
   resthtml <- renderHtml rest
   pure $ "<b>" <+> resthtml <+> "</b>"
@@ -223,7 +229,7 @@ renderModuleDoc mod modDoc modReexports allModuleDocs =
       mexp = maybe "" vcat modReexports
   in pure $ fastConcat
   [ htmlPreamble (show mod) "../" "namespace"
-  , "<div id=\"moduleHeader\">"
+  , "<div id=\"module-header\">"
   , "<h1>", show mod, "</h1>"
   , mdoc
   , "</div>"

--- a/src/Idris/Doc/HTML.idr
+++ b/src/Idris/Doc/HTML.idr
@@ -214,17 +214,22 @@ preserveLayout d = "<pre>" ++ d ++ "</pre>"
 export
 renderModuleDoc : {auto c : Ref Ctxt Defs} ->
                   ModuleIdent ->
-                  Maybe String ->
-                  Doc IdrisDocAnn ->
+                  Maybe String -> -- module description
+                  Maybe (List (Doc IdrisDocAnn)) -> -- module re-exports
+                  Maybe (Doc IdrisDocAnn) -> -- module definitions
                   Core String
-renderModuleDoc mod modDoc allModuleDocs =
+renderModuleDoc mod modDoc modReexports allModuleDocs =
   let mdoc = maybe "" (preserveLayout . htmlEscape) modDoc
+      mexp = maybe "" vcat modReexports
   in pure $ fastConcat
   [ htmlPreamble (show mod) "../" "namespace"
   , "<div id=\"moduleHeader\">"
   , "<h1>", show mod, "</h1>"
   , mdoc
   , "</div>"
-  , !(docDocToHtml allModuleDocs)
+  , maybe "" (const "<h2>Reexports</h2>") modReexports
+  , "<code>", !(docDocToHtml mexp), "</code>"
+  , maybe "" (const "<h2>Definitions</h2>") allModuleDocs
+  , !(docDocToHtml $ fromMaybe "" allModuleDocs)
   , htmlFooter
   ]

--- a/src/Idris/Doc/String.idr
+++ b/src/Idris/Doc/String.idr
@@ -41,15 +41,6 @@ import Idris.Doc.Brackets
 
 %default covering
 
--- Add a doc string for a module name
-export
-addModDocString : {auto s : Ref Syn SyntaxInfo} ->
-                  ModuleIdent -> String ->
-                  Core ()
-addModDocString mi doc
-    = update Syn { saveMod $= (mi ::)
-                 , modDocstrings $= insert mi doc }
-
 -- Add a doc string for a name in the current namespace
 export
 addDocString : {auto c : Ref Ctxt Defs} ->

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -502,13 +502,36 @@ makeDoc pkg opts =
 
            -- generate docs for all visible names
            defs <- get Ctxt
-           names <- allNames (gamma defs)
-           let allInNamespace = filter (inNS ns) names
-           visibleNames <- filterM (visible defs) allInNamespace
+           let ctxt = gamma defs
+
+           visibleDefs <- map catMaybes $ for [1..nextEntry ctxt - 1] $ \ i =>
+             do -- Select the entries that are from `mod` and visible
+                Just gdef <- lookupCtxtExact (Resolved i) ctxt
+                  | _ => pure Nothing
+                let Just nfc = isNonEmptyFC $ location gdef
+                  | _ => do log "doc.module.definitions" 70 $ unwords
+                              [ show mod ++ ":"
+                              , show (fullname gdef)
+                              , "has an empty FC"
+                              ]
+                            pure Nothing
+                let PhysicalIdrSrc mod' = origin nfc
+                  | _ => pure Nothing
+                let True = mod == mod'
+                  | _ => do log "doc.module.definitions" 60 $ unwords
+                              [ show mod ++ ":"
+                              , show (fullname gdef)
+                              , "was defined in"
+                              , show mod'
+                              ]
+                            pure Nothing
+                let True = visible gdef
+                  | _ => pure Nothing
+                pure (Just gdef)
 
            let outputFilePath = docDir </> (show mod ++ ".html")
-           allDocs <- for (sort visibleNames) $ \ nm =>
-                        getDocsForName emptyFC nm shortNamesConfig
+           allDocs <- for (sortBy (compare `on` startPos . toNonEmptyFC . location) visibleDefs) $ \ def =>
+                        getDocsForName emptyFC (fullname def) shortNamesConfig
            let allDecls = annotate Declarations $ vcat allDocs
 
            -- grab module header doc
@@ -546,19 +569,10 @@ makeDoc pkg opts =
        runScript (postbuild pkg)
        pure []
   where
-    visible : Defs -> Name -> Core Bool
-    visible defs n
-        = do Just def <- lookupCtxtExact n (gamma defs)
-                  | Nothing => pure False
-             -- TODO: if we can find out, whether a def has been declared as
-             -- part of an interface, hide it here
-             pure $ case definition def of
-                         (DCon _ _ _) => False
-                         _ => (visibility def /= Private)
-
-    inNS : Namespace -> Name -> Bool
-    inNS ns (NS xns (UN _)) = ns == xns
-    inNS _ _ = False
+    visible : GlobalDef -> Bool
+    visible def = case definition def of
+      (DCon _ _ _) => False
+      _ => (visibility def /= Private)
 
     fileError : String -> FileError -> Core (List Error)
     fileError filename err = pure [FileErr filename err]

--- a/src/Idris/Pretty.idr
+++ b/src/Idris/Pretty.idr
@@ -473,3 +473,11 @@ renderWithDecorations f doc =
   do (str, mspans) <- Render.renderWithSpans doc
      let spans = mapMaybe (traverse f) mspans
      pure (str, spans)
+
+export
+prettyImport : Import -> Doc IdrisSyntax
+prettyImport (MkImport loc reexport path nameAs)
+  = keyword "import"
+    <+> ifThenElse reexport (space <+> keyword "public") ""
+    <++> pretty path
+    <+> ifThenElse (miAsNamespace path /= nameAs) (space <+> keyword "as" <++> pretty nameAs) ""

--- a/src/Idris/Pretty.idr
+++ b/src/Idris/Pretty.idr
@@ -180,9 +180,8 @@ pragma = annotate Pragma
 
 export
 prettyRig : RigCount -> Doc IdrisSyntax
-prettyRig = keyword
-          . elimSemi (pretty '0' <+> space)
-                     (pretty '1' <+> space)
+prettyRig = elimSemi (keyword (pretty '0') <+> space)
+                     (keyword (pretty '1') <+> space)
                      (const emptyDoc)
 
 mutual

--- a/support/docs/alternative.css
+++ b/support/docs/alternative.css
@@ -65,7 +65,7 @@ h1 {
   font-family: "Trebuchet MS", Helvetica, sans-serif;
 }
 
-#moduleHeader {
+#module-header {
   border-bottom: 1px solid #bbb;
   padding-bottom: 2px;
 }
@@ -181,27 +181,27 @@ dd.fixity {
 */
 
 a.function {
-  color: rgb(53, 155, 115);
+  color: #359b73;
 }
 
 .function {
-  color: rgb(53, 155, 115);
+  color: #359b73;
 }
 
 a.constructor {
-  color: rgb(213, 94, 0);
+  color: #d55e;
 }
 
 .constructor {
-  color: rgb(213, 94, 0);
+  color: #d55e;
 }
 
 a.type {
-  color: rgb(61, 183, 233);
+  color: #3db7e9;
 }
 
 .type {
-  color: rgb(61, 183, 233);
+  color: #3db7e9;
 }
 
 .keyword {
@@ -209,8 +209,7 @@ a.type {
 }
 
 .boundvar {
-  color: rgb(247, 72, 165); /* Too much colour makes it hard to differ the rest of the colours */
-  color: inherit;
+  color: #f748a5;
 }
 
 .boundvar.implicit {

--- a/support/docs/blackandwhite.css
+++ b/support/docs/blackandwhite.css
@@ -65,7 +65,7 @@ h1 {
   font-family: "Trebuchet MS", Helvetica, sans-serif;
 }
 
-#moduleHeader {
+#module-header {
   border-bottom: 1px solid #bbb;
   padding-bottom: 2px;
 }

--- a/support/docs/default.css
+++ b/support/docs/default.css
@@ -65,7 +65,7 @@ h1 {
   font-family: "Trebuchet MS", Helvetica, sans-serif;
 }
 
-#moduleHeader {
+#module-header {
   border-bottom: 1px solid #bbb;
   padding-bottom: 2px;
 }
@@ -201,12 +201,11 @@ a.type {
 }
 
 .keyword {
-  color: inherit;
+  color: #999;
 }
 
 .boundvar {
-  color: #bf30bf; /* Too much colour makes it hard to differ the rest of the colours */
-  color: inherit;
+  color: #bf30bf;
 }
 
 .boundvar.implicit {

--- a/tests/ideMode/ideMode003/expected
+++ b/tests/ideMode/ideMode003/expected
@@ -64,5 +64,5 @@
 0000ca(:output (:ok (:highlight-source ((((:filename "LocType.idr") (:start 6 34) (:end 6 36)) ((:name "xs") (:namespace "") (:decor :bound) (:implicit :False) (:key "") (:doc-overview "") (:type "")))))) 1)
 0000ca(:output (:ok (:highlight-source ((((:filename "LocType.idr") (:start 6 37) (:end 6 39)) ((:name "ys") (:namespace "") (:decor :bound) (:implicit :False) (:key "") (:doc-overview "") (:type "")))))) 1)
 000015(:return (:ok ()) 1)
-0000af(:return (:ok "Main.Vect : Nat -> Type -> Type" ((0 0 ((:decor :keyword))) (0 9 ((:decor :type))) (12 3 ((:decor :type))) (19 4 ((:decor :type))) (27 4 ((:decor :type))))) 2)
+000095(:return (:ok "Main.Vect : Nat -> Type -> Type" ((0 9 ((:decor :type))) (12 3 ((:decor :type))) (19 4 ((:decor :type))) (27 4 ((:decor :type))))) 2)
 Alas the file is done, aborting


### PR DESCRIPTION
Previously we were using namespaces as a poor approximation of
source file. We're now actually looking at the source file the
definition arose from in order to decide whether to keep it.

See e.g. base's Data.DPair for a drastic change.

Additionally, we sort definitions by definition location rather
than alphabetical order to respect the user's decision to introduce
some things before other.