### PR TITLE
[ base ] Add a `trace` variant easily embeddable to point-free expression

### DIFF
--- a/libs/base/Debug/Trace.idr
+++ b/libs/base/Debug/Trace.idr
@@ -8,3 +8,11 @@ import PrimIO
 export
 trace : (msg : String) -> (result : a) -> a
 trace x val = unsafePerformIO (do putStrLn x; pure val)
+
+export %inline
+traceValBy : (msgF : a -> String) -> (result : a) -> a
+traceValBy f v = trace (f v) v
+
+export %inline
+traceVal : Show a => a -> a
+traceVal = traceValBy show


### PR DESCRIPTION
I suggest to add such a function for simpler code when value should be traced and is not present with a name.