### PR TITLE
[ doc ] Proving Propositional Equality: example fixed

### DIFF
--- a/docs/source/proofs/propositional.rst
+++ b/docs/source/proofs/propositional.rst
@@ -8,7 +8,7 @@ We have seen that definitional equalities can be proved using ``Refl`` since the
 always normalise to values that can be compared directly.
 
 However with propositional equalities we are using symbolic variables, which do
-not always normalse.
+not always normalise.
 
 So to take the previous example:
 

--- a/docs/source/proofs/propositional.rst
+++ b/docs/source/proofs/propositional.rst
@@ -28,9 +28,9 @@ match all possible values of ``n``. In this case
    plusReducesR Z = Refl
    plusReducesR (S k)
        = let rec = plusReducesR k in
-             rewrite sym rec in Refl
+             rewrite rec in Refl
 
-we can't use ``Refl`` to prove ``n = plus n 0`` for all ``n``. Instead, we call
+we can't use ``Refl`` to prove ``plus n 0 = n`` for all ``n``. Instead, we call
 it for each case separately.  So, in the second line for example, the type checker
 substitutes ``Z`` for ``n`` in the type being matched, and reduces the type
 accordingly.


### PR DESCRIPTION
``plusReducesR`` is introduced in "Theorem Proving / Propositions and Judgments" section [1] with the following signature:

``plusReducesR : (n:Nat) -> plus n Z = n``

But it seems that in "Proving Propositional Equality" [2]  ``n = plus n 0`` (mentioned in text after example) is proved instead.

This PR fixes ``plusReducesR`` implementation and proposition mentioned in text: ``plus n 0 = 0``

1. https://idris2.readthedocs.io/en/latest/proofs/definitional.html#propositions-and-judgments

2. https://idris2.readthedocs.io/en/latest/proofs/propositional.html#proving-propositional-equality

