### PR TITLE
[ fix ] search should solve auto implicits before implicits

### DIFF
--- a/src/Core/AutoSearch.idr
+++ b/src/Core/AutoSearch.idr
@@ -60,13 +60,10 @@ mkArgs fc rigc env ty = pure ([], ty)
 
 export
 impLast : List (ArgInfo vars) -> List (ArgInfo vars)
-impLast xs = filter (not . impl) xs ++ filter impl xs
-  where
-      impl : ArgInfo vs -> Bool
-      impl inf
-          = case plicit inf of
-                 Explicit => False
-                 _ => True
+impLast xs =
+  let (exp, imp) = partition (isExplicit . plicit) xs in
+  let (aut, imp) = partition (isAutoImplicit . plicit) imp in
+  exp ++ aut ++ imp
 
 searchIfHole : {vars : _} ->
                {auto c : Ref Ctxt Defs} ->
@@ -536,7 +533,7 @@ searchType {vars} fc rigc defaults trying depth def checkdets top env target
                                                  then throw e
                                                  else tryGroups Nothing nty (hintGroups sd))
                      else throw (CantSolveGoal fc (gamma defs) [] top Nothing)
-              _ => do logNF "auto" 10 "Next target: " env nty
+              _ => do logNF "auto" 10 "Next target" env nty
                       searchLocalVars fc rigc defaults trying' depth def top env nty
   where
     ambig : Error -> Bool

--- a/src/Core/TT.idr
+++ b/src/Core/TT.idr
@@ -441,6 +441,16 @@ data PiInfo t = Implicit | Explicit | AutoImplicit | DefImplicit t
 namespace PiInfo
 
   export
+  isExplicit : PiInfo t -> Bool
+  isExplicit Explicit = True
+  isExplicit _ = False
+
+  export
+  isAutoImplicit : PiInfo t -> Bool
+  isAutoImplicit AutoImplicit = True
+  isAutoImplicit _ = False
+
+  export
   isImplicit : PiInfo t -> Bool
   isImplicit Explicit = False
   isImplicit _ = True

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -107,7 +107,8 @@ idrisTestsInterface = MkTestPool "Interface" [] Nothing
        "interface013", "interface014", "interface015", "interface016",
        "interface017", "interface018", "interface019", "interface020",
        "interface021", "interface022", "interface023", "interface024",
-       "interface025", "interface026", "interface027", "interface028"]
+       "interface025", "interface026", "interface027", "interface028",
+       "interface029"]
 
 idrisTestsLinear : TestPool
 idrisTestsLinear = MkTestPool "Quantities" [] Nothing

--- a/tests/idris2/interface029/FailedSearch.idr
+++ b/tests/idris2/interface029/FailedSearch.idr
@@ -1,0 +1,21 @@
+data A = AA
+data B = BB
+
+interface TJSON a where
+    constructor MkTJSON
+    tJSON : a -> ()
+
+interface TFFI a b | a where
+    tFFI : a -> b
+
+TJSON B where
+  tJSON BB = ()
+
+TFFI A B where
+  tFFI AA = BB
+
+(TFFI a b, TJSON b) => TJSON a where
+  tJSON = tJSON . tFFI
+
+test : ()
+test = tJSON AA

--- a/tests/idris2/interface029/expected
+++ b/tests/idris2/interface029/expected
@@ -1,0 +1,1 @@
+1/1: Building FailedSearch (FailedSearch.idr)

--- a/tests/idris2/interface029/run
+++ b/tests/idris2/interface029/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-banner --no-color --console-width 0 --check FailedSearch.idr


### PR DESCRIPTION
We currently try to solve the explicit arguments first (because they may force implicit ones)
and we don't distinguish between implicit & auto-implicit ones even though, because of
determining arguments, auto-implicit ones may also force implicit ones