### PR TITLE
Remove .d files from c backends on make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,8 +155,8 @@ support:
 	@${MAKE} -C support/chez
 
 support-clean:
-	@${MAKE} -C support/c cleandeps
-	@${MAKE} -C support/refc cleandeps
+	@${MAKE} -C support/c cleandep
+	@${MAKE} -C support/refc cleandep
 	@${MAKE} -C support/chez clean
 
 clean-libs:

--- a/Makefile
+++ b/Makefile
@@ -155,8 +155,8 @@ support:
 	@${MAKE} -C support/chez
 
 support-clean:
-	@${MAKE} -C support/c clean
-	@${MAKE} -C support/refc clean
+	@${MAKE} -C support/c cleandeps
+	@${MAKE} -C support/refc cleandeps
 	@${MAKE} -C support/chez clean
 
 clean-libs:


### PR DESCRIPTION
At the moment `make clean` on the main projects doesn't remove `.d` files from the `support` subdirectories.
It's problematic, as a classic `make clean install` would fail if we change dependencies in `c` backends.