### PR TITLE
Better parse error for missing paren after with

### DIFF
--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1050,7 +1050,7 @@ withFlags fname
 withProblem : OriginDesc -> Int -> IndentInfo -> Rule PWithProblem
 withProblem fname col indents
   = do rig <- multiplicity fname
-       start <- bounds (decoratedSymbol fname "(")
+       start <- mustWork $ bounds (decoratedSymbol fname "(")
        wval <- bracketedExpr fname start indents
        prf <- optional (decoratedKeyword fname "proof"
               *> UN . Basic <$> decoratedSimpleBinderName fname)

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -81,7 +81,7 @@ idrisTestsError = MkTestPool "Error messages" [] Nothing
        -- Parse errors
        "perror001", "perror002", "perror003", "perror004", "perror005",
        "perror006", "perror007", "perror008", "perror009", "perror010",
-       "perror011", "perror012", "perror013", "perror014"]
+       "perror011", "perror012", "perror013", "perror014", "perror015"]
 
 idrisTestsInteractive : TestPool
 idrisTestsInteractive = MkTestPool "Interactive editing" [] Nothing

--- a/tests/idris2/perror015/ParseWith.idr
+++ b/tests/idris2/perror015/ParseWith.idr
@@ -1,0 +1,4 @@
+foo : Nat -> Nat
+foo a with a
+  _ | 0 = a
+  _ | S k = a

--- a/tests/idris2/perror015/expected
+++ b/tests/idris2/perror015/expected
@@ -1,0 +1,8 @@
+1/1: Building ParseWith (ParseWith.idr)
+Error: Expected '('.
+
+ParseWith:2:12--2:13
+ 1 | foo : Nat -> Nat
+ 2 | foo a with a
+                ^
+

--- a/tests/idris2/perror015/run
+++ b/tests/idris2/perror015/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --check ParseWith.idr || true


### PR DESCRIPTION
A user on discourse was missing parens after `with` and couldn't figure out the issue from the compiler error message.

This PR changes the error message to:

```
1/1: Building ParseWith (ParseWith.idr)
Error: Expected '('.

ParseWith:2:12--2:13
 1 | foo : Nat -> Nat
 2 | foo a with a
                ^
```