### PR TITLE
[ fix ] Fix usage of `void` instead of `NULL` for Unit value in RefC

### DIFF
--- a/src/Compiler/RefC/RefC.idr
+++ b/src/Compiler/RefC/RefC.idr
@@ -812,7 +812,7 @@ emitFDef funcName ((varType, varName, varCFType) :: xs) = do
 data CLang = CLangC | CLangRefC
 
 extractValue : (cLang : CLang) -> (cfType:CFType) -> (varName:String) -> String
-extractValue _ CFUnit           varName = "void"
+extractValue _ CFUnit           varName = "NULL"
 extractValue _ CFInt            varName = "((Value_Int64*)" ++ varName ++ ")->i64"
 extractValue _ CFInt8           varName = "((Value_Int8*)" ++ varName ++ ")->i8"
 extractValue _ CFInt16          varName = "((Value_Int16*)" ++ varName ++ ")->i16"


### PR DESCRIPTION
This causes issues whenever you have a FFI function taking `()` as an
argument. (Not that such a function is really useful, and I assume this
is the reason the issue hasn't been noticed so far.)
