### PR TITLE
[ base ] Change the `FunExt` interface to support dependent functions

### DIFF
--- a/libs/base/Control/Function/FunExt.idr
+++ b/libs/base/Control/Function/FunExt.idr
@@ -9,4 +9,4 @@ module Control.Function.FunExt
 ||| that holds only in the presence of function extensionality.
 public export
 interface FunExt where
-  0 funExt : {0 f, g : a -> b} -> ((x : a) -> f x = g x) -> f = g
+  funExt : {0 b : a -> Type} -> {0 f, g : (x : a) -> b x} -> ((x : a) -> f x = g x) -> f = g


### PR DESCRIPTION
It is needed for more complex cases and better fits the type system ;-)

The type of existing function was changed (rather than a separate function added) because I didn't find any case where type inference didn't manage to work for old code with newer definition.

I also removed `0` for the function because it is inconvenient sometimes and anyway it does not matter for a fiction that is not meant to be implemented.