### PR TITLE
[ re #950 ] Remove redunant legacy data definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,8 @@
   make the code consistent with the other quantifiers (`List` and `SnocList`).
 * Set the `all` and `any` functions for proof-quantifiers to `public export`
   instead of `export`, allowing them to be used with auto-implicit `IsYes`.
+* Legacy duplicating type `Given` (with constructor `Always`) is removed from the `Decidable.Decidable`.
+  Use the type `IsYes` (with constructor `ItIsYes`) from the same module instead.
 
 #### Test
 

--- a/libs/base/Decidable/Decidable.idr
+++ b/libs/base/Decidable/Decidable.idr
@@ -45,8 +45,3 @@ interface Decidable k ts p where
 ||| this relation.
 decision : (ts : Vect k Type) -> (p : Rel ts) -> Decidable k ts p => liftRel ts p Dec
 decision ts p = decide {ts} {p}
-
-using (a : Type, x : a)
-  public export
-  data Given : Dec a -> Type where
-    Always : Given (Yes x)


### PR DESCRIPTION
`Given` with `Always` from Idris 1 library are completely overridden by `IsYes` and `ItIsYes` respectively in #950, and new ones have a more common naming. This, however, may break some very old code (which can be fixed by a trivial rename).