### PR TITLE
Escape \ in the code example of lambdaAbstraction doc

### DIFF
--- a/src/Idris/Doc/Keywords.idr
+++ b/src/Idris/Doc/Keywords.idr
@@ -595,7 +595,7 @@ lambdaAbstraction = """
   For instance we can implement `transport` like so:
   ```
   transport : a === b -> a -> b
-  transport = \ Refl, v => v
+  transport = \\ Refl, v => v
   ```
   """
 


### PR DESCRIPTION
That way `:doc \` displays the code example correctly.