### PR TITLE
[ cleanup ] Clean up `DecEq` implementations

### DIFF
--- a/libs/base/Control/Function.idr
+++ b/libs/base/Control/Function.idr
@@ -1,5 +1,7 @@
 module Control.Function
 
+%default total
+
 ||| An injective function maps distinct elements to distinct elements.
 public export
 interface Injective (f : a -> b) | f where
@@ -16,7 +18,7 @@ inj _ eq = irrelevantEq (injective eq)
 public export
 [ComposeInjective] {f : a -> b} -> {g : b -> c} ->
   (Injective f, Injective g) => Injective (g . f) where
-    injective prf = injective $ injective prf
+    injective = injective . injective
 
 ||| If (g . f) is injective, so is f.
 public export
@@ -27,3 +29,47 @@ public export
 public export
 [IdInjective] Injective Prelude.id where
   injective = id
+
+----------------------------------------
+
+||| An bi-injective function maps distinct elements to distinct elements in both arguments.
+||| This is more strict than injectivity on each of arguments.
+||| For instance, list appending is injective on both arguments but is not biinjective.
+public export
+interface Biinjective (f : a -> b -> c) | f where
+  constructor MkBiinjective
+  biinjective : {x, y : a} -> {v, w : b} -> f x v = f y w -> (x = y, v = w)
+
+public export
+biinj : (0 f : _) -> (0 _ : Biinjective f) => (0 _ : f x v = f y w) -> (x = y, v = w)
+biinj _ eq = let 0 bii = biinjective eq in (irrelevantEq $ fst bii, irrelevantEq $ snd bii)
+
+public export
+[ComposeBiinjective] {f : a -> b -> c} -> {g : c -> d} ->
+  Biinjective f => Injective g => Biinjective (g .: f) where
+    biinjective = biinjective . injective
+
+||| If (g .: f) is biinjective, so is f.
+public export
+[BiinjFromComp] {f : a -> b -> c} -> {g : c -> d} ->
+  Biinjective (g .: f) => Biinjective f where
+    biinjective = biinjective {f = (g .: f)} . cong g
+
+public export
+[FlipBiinjective] {f : a -> b -> c} ->
+  Biinjective f => Biinjective (flip f) where
+    biinjective = swap . biinjective
+
+public export
+[FromBiinjectiveL] {f : a -> b -> c} -> {x : a} ->
+  Biinjective f => Injective (f x) where
+    injective = snd . biinjective
+
+public export
+[FromBiinjectiveR] {f : a -> b -> c} -> {y : b} ->
+  Biinjective f => Injective (`f` y) where
+    injective = fst . biinjective
+
+export
+Biinjective MkPair where
+  biinjective Refl = (Refl, Refl)

--- a/libs/base/Data/Fin.idr
+++ b/libs/base/Data/Fin.idr
@@ -283,12 +283,9 @@ public export
 public export
 DecEq (Fin n) where
   decEq FZ FZ = Yes Refl
+  decEq (FS f) (FS f') = decEqCong $ decEq f f'
   decEq FZ (FS f) = No absurd
   decEq (FS f) FZ = No absurd
-  decEq (FS f) (FS f')
-      = case decEq f f' of
-             Yes p => Yes $ cong FS p
-             No p => No $ p . injective
 
 namespace Equality
 

--- a/libs/base/Data/List.idr
+++ b/libs/base/Data/List.idr
@@ -1,5 +1,7 @@
 module Data.List
 
+import public Control.Function
+
 import Data.Nat
 import Data.List1
 import Data.Fin
@@ -913,6 +915,11 @@ export
   uninhabited @{Right z} Refl = uninhabited @{z} Refl
 
 ||| (::) is injective
+export
+Biinjective Prelude.(::) where
+  biinjective Refl = (Refl, Refl)
+
+||| Heterogeneous injectivity for (::)
 export
 consInjective : forall x, xs, y, ys .
                 the (List a) (x :: xs) = the (List b) (y :: ys) -> (x = y, xs = ys)

--- a/libs/base/Data/List/Elem.idr
+++ b/libs/base/Data/List/Elem.idr
@@ -32,11 +32,9 @@ Injective (There {x} {y} {xs}) where
 export
 DecEq (Elem x xs) where
   decEq Here Here = Yes Refl
+  decEq (There this) (There that) = decEqCong $ decEq this that
   decEq Here (There later) = No absurd
   decEq (There later) Here = No absurd
-  decEq (There this) (There that) with (decEq this that)
-    decEq (There this) (There this) | Yes Refl  = Yes Refl
-    decEq (There this) (There that) | No contra = No (contra . injective)
 
 export
 Uninhabited (Elem {a} x []) where

--- a/libs/base/Data/List1.idr
+++ b/libs/base/Data/List1.idr
@@ -1,7 +1,7 @@
 module Data.List1
 
 import public Data.Zippable
-import Control.Function
+import public Control.Function
 
 %default total
 

--- a/libs/base/Data/List1/Properties.idr
+++ b/libs/base/Data/List1/Properties.idr
@@ -12,8 +12,13 @@ import Data.List1
 %default total
 
 export
+-- %deprecate -- deprecated in favor of Biinjective interface
 consInjective : (x ::: xs) === (y ::: ys) -> (x === y, xs === ys)
 consInjective Refl = (Refl, Refl)
+
+export
+Biinjective (:::) where
+  biinjective Refl = (Refl, Refl)
 
 export
 {x : a} -> Injective (x :::) where
@@ -64,6 +69,5 @@ fromListAppend [] ys with (fromList ys)
   _ | (Just _) = Refl
 fromListAppend (x::xs) ys with (fromList ys) proof prf
   fromListAppend (x::xs) []      | Nothing         = rewrite appendNilRightNeutral xs in Refl
-  fromListAppend (x::xs) (y::ys) | (Just $ l:::ls) = do
-    let (prfL, prfLs) = consInjective $ injective prf
-    rewrite prfL; rewrite prfLs; Refl
+  fromListAppend (x::xs) (y::ys) | (Just $ l:::ls) =
+    let (Refl, Refl) = biinjective $ injective prf in Refl

--- a/libs/base/Data/SnocList/Elem.idr
+++ b/libs/base/Data/SnocList/Elem.idr
@@ -32,11 +32,9 @@ Injective (There {x} {y} {sx}) where
 export
 DecEq (x `Elem` sx) where
   decEq Here Here = Yes Refl
+  decEq (There y) (There z) = decEqCong $ decEq y z
   decEq Here (There _) = No absurd
   decEq (There _) Here = No absurd
-  decEq (There y) (There z) with (decEq y z)
-    decEq (There y) (There y) | Yes Refl = Yes Refl
-    decEq (There y) (There z) | No neq = No $ neq . injective
 
 ||| Remove the element at the given position.
 public export

--- a/libs/base/Data/These.idr
+++ b/libs/base/Data/These.idr
@@ -51,6 +51,10 @@ export
 {y : _} -> Injective (`Both` y) where
   injective Refl = Refl
 
+export
+Biinjective Both where
+  biinjective Refl = (Refl, Refl)
+
 public export
 (Show a, Show b) => Show (These a b) where
   showPrec d (This x)   = showCon d "This" $ showArg x

--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -331,10 +331,7 @@ Eq a => Eq (Vect n a) where
 public export
 DecEq a => DecEq (Vect n a) where
   decEq []      []      = Yes Refl
-  decEq (x::xs) (y::ys) with (decEq x y, decEq xs ys)
-    decEq (x::xs) (x::xs) | (Yes Refl, Yes Refl) = Yes Refl
-    decEq (x::xs) (y::ys) | (No nhd, _) = No $ nhd . fst . biinjective
-    decEq (x::xs) (y::ys) | (_, No ntl) = No $ ntl . snd . biinjective
+  decEq (x::xs) (y::ys) = decEqCong2 (decEq x y) (decEq xs ys)
 
 --------------------------------------------------------------------------------
 -- Order

--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -33,10 +33,6 @@ lengthCorrect : (xs : Vect len elem) -> length xs = len
 lengthCorrect []        = Refl
 lengthCorrect (_ :: xs) = rewrite lengthCorrect xs in Refl
 
-||| If two vectors are equal, their heads and tails are equal
-vectInjective : {0 xs : Vect n a} -> {0 ys : Vect m b} -> x::xs = y::ys -> (x = y, xs = ys)
-vectInjective Refl = (Refl, Refl)
-
 export
 {x : a} -> Injective (Vect.(::) x) where
   injective Refl = Refl
@@ -44,6 +40,10 @@ export
 export
 {xs : Vect n a} -> Injective (\x => Vect.(::) x xs) where
   injective Refl = Refl
+
+export
+Biinjective Vect.(::) where
+  biinjective Refl = (Refl, Refl)
 
 --------------------------------------------------------------------------------
 -- Indexing into vectors
@@ -333,8 +333,8 @@ DecEq a => DecEq (Vect n a) where
   decEq []      []      = Yes Refl
   decEq (x::xs) (y::ys) with (decEq x y, decEq xs ys)
     decEq (x::xs) (x::xs) | (Yes Refl, Yes Refl) = Yes Refl
-    decEq (x::xs) (y::ys) | (No nhd, _) = No $ nhd . fst . vectInjective
-    decEq (x::xs) (y::ys) | (_, No ntl) = No $ ntl . snd . vectInjective
+    decEq (x::xs) (y::ys) | (No nhd, _) = No $ nhd . fst . biinjective
+    decEq (x::xs) (y::ys) | (_, No ntl) = No $ ntl . snd . biinjective
 
 --------------------------------------------------------------------------------
 -- Order

--- a/libs/base/Decidable/Equality.idr
+++ b/libs/base/Decidable/Equality.idr
@@ -39,11 +39,9 @@ DecEq Bool where
 public export
 DecEq Nat where
   decEq Z     Z     = Yes Refl
+  decEq (S n) (S m) = decEqCong $ decEq n m
   decEq Z     (S _) = No absurd
   decEq (S _) Z     = No absurd
-  decEq (S n) (S m) with (decEq n m)
-   decEq (S n) (S m) | Yes p = Yes $ cong S p
-   decEq (S n) (S m) | No p = No $ \h : (S n = S m) => p $ injective h
 
 --------------------------------------------------------------------------------
 -- Maybe
@@ -52,12 +50,9 @@ DecEq Nat where
 public export
 DecEq t => DecEq (Maybe t) where
   decEq Nothing Nothing = Yes Refl
+  decEq (Just x) (Just y) = decEqCong $ decEq x y
   decEq Nothing (Just _) = No absurd
   decEq (Just _) Nothing = No absurd
-  decEq (Just x') (Just y') with (decEq x' y')
-    decEq (Just x') (Just y') | Yes p = Yes $ cong Just p
-    decEq (Just x') (Just y') | No p
-       = No $ \h : Just x' = Just y' => p $ injective h
 
 --------------------------------------------------------------------------------
 -- Either
@@ -65,14 +60,10 @@ DecEq t => DecEq (Maybe t) where
 
 public export
 (DecEq t, DecEq s) => DecEq (Either t s) where
-  decEq (Left x) (Left y) with (decEq x y)
-   decEq (Left x) (Left x) | Yes Refl = Yes Refl
-   decEq (Left x) (Left y) | No contra = No (contra . injective)
+  decEq (Left x)  (Left y)  = decEqCong $ decEq x y
+  decEq (Right x) (Right y) = decEqCong $ decEq x y
   decEq (Left x) (Right y) = No absurd
   decEq (Right x) (Left y) = No absurd
-  decEq (Right x) (Right y) with (decEq x y)
-   decEq (Right x) (Right x) | Yes Refl = Yes Refl
-   decEq (Right x) (Right y) | No contra = No (contra . injective)
 
 --------------------------------------------------------------------------------
 -- These (inclusive or)

--- a/libs/base/Decidable/Equality.idr
+++ b/libs/base/Decidable/Equality.idr
@@ -73,9 +73,7 @@ public export
 DecEq t => DecEq s => DecEq (These t s) where
   decEq (This x) (This y) = decEqCong $ decEq x y
   decEq (That x) (That y) = decEqCong $ decEq x y
-  decEq (Both x z) (Both y w) with (decEq x y)
-    decEq (Both x z) (Both x w) | Yes Refl = decEqCong $ decEq z w
-    _                           | No ctr   = No $ \case Refl => ctr Refl
+  decEq (Both x z) (Both y w) = decEqCong2 (decEq x y) (decEq z w)
   decEq (This x)   (That y)    = No $ \case Refl impossible
   decEq (This x)   (Both y z)  = No $ \case Refl impossible
   decEq (That x)   (This y)    = No $ \case Refl impossible
@@ -92,13 +90,7 @@ pairInjective Refl = (Refl, Refl)
 
 public export
 (DecEq a, DecEq b) => DecEq (a, b) where
-  decEq (a, b) (a', b') with (decEq a a')
-    decEq (a, b) (a', b') | (No contra) =
-      No $ contra . fst . pairInjective
-    decEq (a, b) (a, b') | (Yes Refl) with (decEq b b')
-      decEq (a, b) (a, b) | (Yes Refl) | (Yes Refl) = Yes Refl
-      decEq (a, b) (a, b') | (Yes Refl) | (No contra) =
-        No $ contra . snd . pairInjective
+  decEq (a, b) (a', b') = decEqCong2 (decEq a a') (decEq b b')
 
 --------------------------------------------------------------------------------
 -- List
@@ -109,14 +101,7 @@ DecEq a => DecEq (List a) where
   decEq [] [] = Yes Refl
   decEq (x :: xs) [] = No absurd
   decEq [] (x :: xs) = No absurd
-  decEq (x :: xs) (y :: ys) with (decEq x y)
-    decEq (x :: xs) (y :: ys) | No contra =
-      No $ contra . fst . consInjective
-    decEq (x :: xs) (x :: ys) | Yes Refl with (decEq xs ys)
-      decEq (x :: xs) (x :: xs) | (Yes Refl) | (Yes Refl) = Yes Refl
-      decEq (x :: xs) (x :: ys) | (Yes Refl) | (No contra) =
-        No $ contra . snd . consInjective
-
+  decEq (x :: xs) (y :: ys) = decEqCong2 (decEq x y) (decEq xs ys)
 
 --------------------------------------------------------------------------------
 -- List1
@@ -124,12 +109,7 @@ DecEq a => DecEq (List a) where
 
 public export
 DecEq a => DecEq (List1 a) where
-
-  decEq (x ::: xs) (y ::: ys) with (decEq x y)
-    decEq (x ::: xs) (y ::: ys) | No contra = No (contra . fst . consInjective)
-    decEq (x ::: xs) (y ::: ys) | Yes eqxy with (decEq xs ys)
-      decEq (x ::: xs) (y ::: ys) | Yes eqxy | No contra = No (contra . (rewrite sym eqxy in injective))
-      decEq (x ::: xs) (y ::: ys) | Yes eqxy | Yes eqxsys = Yes (cong2 (:::) eqxy eqxsys)
+  decEq (x ::: xs) (y ::: ys) = decEqCong2 (decEq x y) (decEq xs ys)
 
 -- TODO: Other prelude data types
 

--- a/libs/base/Decidable/Equality/Core.idr
+++ b/libs/base/Decidable/Equality/Core.idr
@@ -37,12 +37,17 @@ decEqContraIsNo uxy with (decEq x y)
   decEqContraIsNo uxy | Yes xy = absurd $ uxy xy
   decEqContraIsNo _   | No uxy = (uxy ** Refl)
 
-export
+public export
 decEqCong : (0 _ : Injective f) => Dec (x = y) -> Dec (f x = f y)
 decEqCong $ Yes prf   = Yes $ cong f prf
 decEqCong $ No contra = No $ \c => contra $ inj f c
 
-export
+public export
 decEqInj : (0 _ : Injective f) => Dec (f x = f y) -> Dec (x = y)
 decEqInj $ Yes prf   = Yes $ inj f prf
 decEqInj $ No contra = No $ contra . cong f
+
+public export
+decEqCong2 : (0 _ : Biinjective f) => Dec (x = y) -> Lazy (Dec (v = w)) -> Dec (f x v = f y w)
+decEqCong2 (Yes Refl)  s = decEqCong s @{FromBiinjectiveL}
+decEqCong2 (No contra) _ = No $ \c => let (Refl, Refl) = biinj f c in contra Refl

--- a/libs/contrib/Data/List/Palindrome.idr
+++ b/libs/contrib/Data/List/Palindrome.idr
@@ -39,7 +39,7 @@ reversePalindromeEqualsLemma x x' xs prf = equateInnerAndOuter flipHeadX
     flipLastX' : reverse (xs ++ [x']) = x :: xs -> (x' :: reverse xs) = (x :: xs)
     flipLastX' prf = rewrite (revAppend xs [x']) in prf
     cancelOuter : (reverse (xs ++ [x'])) = x :: xs -> reverse xs = xs
-    cancelOuter prf = snd (consInjective (flipLastX' prf))
+    cancelOuter prf = snd (biinjective (flipLastX' prf))
     equateInnerAndOuter
       : reverse (xs ++ [x']) ++ [x] = (x :: xs) ++ [x']
       -> (reverse xs = xs, x = x')

--- a/libs/contrib/Data/Validated.idr
+++ b/libs/contrib/Data/Validated.idr
@@ -1,5 +1,7 @@
 module Data.Validated
 
+import Control.Function
+
 import Data.List1
 
 import Decidable.Equality
@@ -22,6 +24,14 @@ export
 (Show e, Show a) => Show (Validated e a) where
   showPrec d $ Valid   x = showCon d "Valid" $ showArg x
   showPrec d $ Invalid e = showCon d "Invalid" $ showArg e
+
+export
+Injective Valid where
+  injective Refl = Refl
+
+export
+Injective Invalid where
+  injective Refl = Refl
 
 public export
 Functor (Validated e) where
@@ -129,14 +139,10 @@ Uninhabited (Invalid e = Valid x) where
 
 public export
 (DecEq e, DecEq a) => DecEq (Validated e a) where
+  decEq (Valid x) (Valid y) = decEqCong $ decEq x y
+  decEq (Invalid x) (Invalid y) = decEqCong $ decEq x y
   decEq (Valid x) (Invalid y) = No uninhabited
   decEq (Invalid x) (Valid y) = No uninhabited
-  decEq (Valid x) (Valid y) with (decEq x y)
-    decEq (Valid _) (Valid _) | Yes p = rewrite p in Yes Refl
-    decEq (Valid _) (Valid _) | No up = No $ \case Refl => up Refl
-  decEq (Invalid x) (Invalid y) with (decEq x y)
-    decEq (Invalid _) (Invalid _) | Yes p = rewrite p in Yes Refl
-    decEq (Invalid _) (Invalid _) | No up = No $ \case Refl => up Refl
 
 --- Convenience representations ---
 


### PR DESCRIPTION
I couldn't stop myself from doing this after recent additions ;-)

All commits contain different changes. The first commit is independent of the other two and I hope is not controversal, while invention of the new interface in the later commit may be. WDYT?