### PR TITLE
List proofs

### DIFF
--- a/libs/prelude/Prelude/Types.idr
+++ b/libs/prelude/Prelude/Types.idr
@@ -490,7 +490,8 @@ Foldable List where
 
   foldMap f = foldl (\acc, elem => acc <+> f elem) neutral
 
-public export listBindOnto : (a -> List b) -> List b -> List a -> List b
+public export
+listBindOnto : (a -> List b) -> List b -> List a -> List b
 listBindOnto f xs []        = reverse xs
 listBindOnto f xs (y :: ys) = listBindOnto f (reverseOnto xs (f y)) ys
 

--- a/libs/prelude/Prelude/Types.idr
+++ b/libs/prelude/Prelude/Types.idr
@@ -490,13 +490,14 @@ Foldable List where
 
   foldMap f = foldl (\acc, elem => acc <+> f elem) neutral
 
+public export listBindOnto : (a -> List b) -> List b -> List a -> List b
+listBindOnto f xs []        = reverse xs
+listBindOnto f xs (y :: ys) = listBindOnto f (reverseOnto xs (f y)) ys
+
 -- tail recursive O(n) implementation of `(>>=)` for `List`
 public export
 listBind : List a -> (a -> List b) -> List b
-listBind as f = go Nil as
-  where go : List b -> List a -> List b
-        go xs []        = reverse xs
-        go xs (y :: ys) = go (reverseOnto xs (f y)) ys
+listBind as f = listBindOnto f Nil as
 
 public export
 Applicative List where


### PR DESCRIPTION
Added following proofs to `contrib`:
 - correspondence between bind and concatenation
 - if x is an element of (xs ++ ys) it is an element of xs or ys