### PR TITLE
[ fix #2493 ] Put `%runElab` smartly in a call of `%macro`

### DIFF
--- a/src/TTImp/Elab/Ambiguity.idr
+++ b/src/TTImp/Elab/Ambiguity.idr
@@ -124,24 +124,21 @@ expandAmbigName mode nest env orig args (IVar fc x) exp
             else IMustUnify fc NotConstructor tm
     wrapDot _ _ _ _ _ _ tm = tm
 
+    notLHS : ElabMode -> Bool
+    notLHS (InLHS _) = False
+    notLHS _ = True
 
     mkTerm : Bool -> EState vars -> Name -> GlobalDef -> RawImp
     mkTerm prim est n def
         = let tm = wrapDot prim est mode n (map (snd . snd) args)
                        (definition def) (buildAlt (IVar fc n) args) in
-              if Context.Macro `elem` flags def
-                 then case mode of
-                           InLHS _ => tm
-                           _ => IRunElab fc (ICoerced fc tm)
+              if (Context.Macro `elem` flags def) && notLHS mode
+                 then IRunElab fc (ICoerced fc tm)
                  else tm
 
     mkAlt : Bool -> EState vars -> (Name, Int, GlobalDef) -> RawImp
     mkAlt prim est (fullname, i, gdef)
         = mkTerm prim est (Resolved i) gdef
-
-    notLHS : ElabMode -> Bool
-    notLHS (InLHS _) = False
-    notLHS _ = True
 
 expandAmbigName mode nest env orig args (IApp fc f a) exp
     = expandAmbigName mode nest env orig

--- a/src/TTImp/Elab/Ambiguity.idr
+++ b/src/TTImp/Elab/Ambiguity.idr
@@ -20,6 +20,7 @@ import TTImp.TTImp
 
 import Data.List
 import Data.String
+import Data.Vect
 
 import Libraries.Data.UserNameMap
 
@@ -130,11 +131,21 @@ expandAmbigName mode nest env orig args (IVar fc x) exp
 
     mkTerm : Bool -> EState vars -> Name -> GlobalDef -> RawImp
     mkTerm prim est n def
-        = let tm = wrapDot prim est mode n (map (snd . snd) args)
-                       (definition def) (buildAlt (IVar fc n) args) in
-              if (Context.Macro `elem` flags def) && notLHS mode
-                 then IRunElab fc (ICoerced fc tm)
-                 else tm
+        = if (Context.Macro `elem` flags def) && notLHS mode
+             then alternativeFirstSuccess $ reverse $
+                    allSplits args <&> \(macroArgs, extArgs) =>
+                      (IRunElab fc $ ICoerced fc $ IVar fc n `buildAlt` macroArgs) `buildAlt` extArgs
+             else wrapDot prim est mode n (map (snd . snd) args)
+                    (definition def) (buildAlt (IVar fc n) args)
+      where
+        -- All splits of the original list starting from the (empty, full) finishing with (full, empty)
+        allSplits : (l : List a) -> Vect (S $ length l) (List a, List a)
+        allSplits []           = [([], [])]
+        allSplits full@(x::xs) = ([], full) :: (mapFst (x::) <$> allSplits xs)
+
+        alternativeFirstSuccess : forall n. Vect (S n) RawImp -> RawImp
+        alternativeFirstSuccess [x] = x
+        alternativeFirstSuccess xs  = IAlternative fc FirstSuccess $ toList xs
 
     mkAlt : Bool -> EState vars -> (Name, Int, GlobalDef) -> RawImp
     mkAlt prim est (fullname, i, gdef)

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -219,7 +219,7 @@ idrisTestsReflection = MkTestPool "Quotation and Reflection" [] Nothing
       ["reflection001", "reflection002", "reflection003", "reflection004",
        "reflection005", "reflection006", "reflection007", "reflection008",
        "reflection009", "reflection010", "reflection011", "reflection012",
-       "reflection013", "reflection014"
+       "reflection013", "reflection014", "reflection015"
       ]
 
 idrisTestsWith : TestPool

--- a/tests/idris2/reflection015/MacroRetFunc.idr
+++ b/tests/idris2/reflection015/MacroRetFunc.idr
@@ -1,0 +1,97 @@
+import Language.Reflection
+
+import Data.Vect
+
+%language ElabReflection
+
+%macro
+coolMacro : Nat -> Elab (Nat -> Nat)
+coolMacro n = lambda Nat $ \m => pure $ n + m + 1
+
+Cool_indirect : Nat
+Cool_indirect = let z = coolMacro 4 in z 5
+
+Cool_direct : Nat
+Cool_direct = coolMacro 4 5
+
+cool_eq : Cool_indirect = Cool_direct
+cool_eq = Refl
+
+cool_eq' : Cool_indirect ~=~ coolMacro 4 5
+cool_eq' = Refl
+
+Cool_direct' : ?
+Cool_direct' = coolMacro 4 5
+
+cool_eq'' : Cool_indirect ~=~ Cool_direct'
+cool_eq'' = Refl
+
+%macro
+depMacro : (b : Bool) -> if b then Elab (Nat -> Nat) else Nat -> Elab Nat
+depMacro False = \m => pure $ m + 100
+depMacro True  = lambda Nat $ \m => pure $ m + 200
+
+Dep_indirect_t : Nat
+Dep_indirect_t = let z = depMacro True in z 5
+
+Dep_direct_t : Nat
+Dep_direct_t = depMacro True 5
+
+dep_t : Dep_indirect_t = Dep_direct_t
+dep_t = Refl
+
+dep_t' : Dep_indirect_t ~=~ depMacro True 5
+dep_t' = Refl
+
+dep_t'' : S Dep_indirect_t ~=~ S (depMacro True 5)
+dep_t'' = Refl
+
+Dep_indirect_f : Nat
+Dep_indirect_f = let z = depMacro False 5 in z
+
+Dep_direct_f : Nat
+Dep_direct_f = depMacro False 5
+
+dep_f : Dep_indirect_f = Dep_direct_f
+dep_f = Refl
+
+dep_f' : Dep_indirect_f ~=~ depMacro False 5
+dep_f' = Refl
+
+dep_f'' : S Dep_indirect_f ~=~ S (depMacro False 5)
+dep_f'' = Refl
+
+%macro
+depDepMacro : (b : Bool) -> if b then Elab ((n : Nat) -> Vect n Nat) else (n : Nat) -> Elab $ Vect n Nat
+depDepMacro False = \m => pure $ replicate m 0
+depDepMacro True  = lambda Nat $ \m => pure $ replicate m 1
+
+DepDep_indirect_t : Vect ? Nat
+DepDep_indirect_t = let z = depDepMacro True in z 5
+
+DepDep_direct_t : Vect ? Nat
+DepDep_direct_t = depDepMacro True 5
+
+depDep_t : DepDep_indirect_t = DepDep_direct_t
+depDep_t = Refl
+
+depDep_t' : DepDep_indirect_t = depDepMacro True 5
+depDep_t' = Refl
+
+depDep_t'' : 9 :: DepDep_indirect_t = 9 :: depDepMacro True 5
+depDep_t'' = Refl
+
+DepDep_indirect_f : Vect ? Nat
+DepDep_indirect_f = let z = depDepMacro False 5 in z
+
+DepDep_direct_f : Vect ? Nat
+DepDep_direct_f = depDepMacro False 5
+
+depDep_f : DepDep_indirect_f = DepDep_direct_f
+depDep_f = Refl
+
+depDep_f' : DepDep_indirect_f = depDepMacro False 5
+depDep_f' = Refl
+
+depDep_f'' : 9 :: DepDep_indirect_f = 9 :: depDepMacro False 5
+depDep_f'' = Refl

--- a/tests/idris2/reflection015/expected
+++ b/tests/idris2/reflection015/expected
@@ -1,0 +1,1 @@
+1/1: Building MacroRetFunc (MacroRetFunc.idr)

--- a/tests/idris2/reflection015/run
+++ b/tests/idris2/reflection015/run
@@ -1,0 +1,4 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --no-banner --check MacroRetFunc.idr
+


### PR DESCRIPTION
This should be a fully backward-compatible change. In all previously working cases elaboration should produce expressions with the same meaning. But when it fails with `%runElab macroF arg1 arg2 arg3`, it successively tries `(%runElab macroF arg1 arg2) arg3`, `(%runElab macroF arg1) arg2 arg3`, etc. The longest argument lists inside `%runElab` are taken because of backward-compatibility **and** possible dependent types in a type of macro function (see tests).

Fixes #2493