### PR TITLE
[ error ] Make failing `IAlternative` w/ `FirstSuccess` print all errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 * Adds documentation for unquotes `~( )`.
 
+### Compiler changes
+
+* If `IAlternative` expression with `FirstSuccess` rule fails to typecheck,
+  compiler prints all tried alternatives, not only the last one.
+
 ### Library changes
 
 #### System

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -88,7 +88,7 @@ idrisTestsError = MkTestPool "Error messages" [] Nothing
        "error006", "error007", "error008", "error009", "error010",
        "error011", "error012", "error013", "error014", "error015",
        "error016", "error017", "error018", "error019", "error020",
-       "error021", "error022", "error023", "error024",
+       "error021", "error022", "error023", "error024", "error025",
        -- Parse errors
        "perror001", "perror002", "perror003", "perror004", "perror005",
        "perror006", "perror007", "perror008", "perror009", "perror010",

--- a/tests/idris2/error025/IAlternativePrints.idr
+++ b/tests/idris2/error025/IAlternativePrints.idr
@@ -1,0 +1,34 @@
+import Language.Reflection
+
+%language ElabReflection
+%default total
+
+magicScript : Elab a
+magicScript = check $ IAlternative EmptyFC FirstSuccess
+  [ `(the Nat 5)
+  , `(the String "foo")
+  ]
+
+x : Nat
+x = %runElab magicScript
+
+y : String
+y = %runElab magicScript
+
+-- Check necessary parts of the expected error message
+
+failing "Sorry, I can't find any elaboration which works. All errors:"
+  z : Bool
+  z = %runElab magicScript
+
+failing "Mismatch between: Nat and Bool"
+  z : Bool
+  z = %runElab magicScript
+
+failing "Mismatch between: String and Bool"
+  z : Bool
+  z = %runElab magicScript
+
+-- For the whole error message
+z : Bool
+z = %runElab magicScript

--- a/tests/idris2/error025/expected
+++ b/tests/idris2/error025/expected
@@ -1,0 +1,30 @@
+1/1: Building IAlternativePrints (IAlternativePrints.idr)
+Error: While processing right hand side of z. Error during reflection: Sorry, I can't find any elaboration which works. All errors:
+If the: When unifying:
+    Nat
+and:
+    Bool
+Mismatch between: Nat and Bool.
+
+IAlternativePrints:8:7--8:16
+ 4 | %default total
+ 5 | 
+ 6 | magicScript : Elab a
+ 7 | magicScript = check $ IAlternative EmptyFC FirstSuccess
+ 8 |   [ `(the Nat 5)
+           ^^^^^^^^^
+
+If the: When unifying:
+    String
+and:
+    Bool
+Mismatch between: String and Bool.
+
+IAlternativePrints:9:7--9:23
+ 5 | 
+ 6 | magicScript : Elab a
+ 7 | magicScript = check $ IAlternative EmptyFC FirstSuccess
+ 8 |   [ `(the Nat 5)
+ 9 |   , `(the String "foo")
+           ^^^^^^^^^^^^^^^^
+

--- a/tests/idris2/error025/run
+++ b/tests/idris2/error025/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --check IAlternativePrints.idr


### PR DESCRIPTION
At the moment if all alternatives of `IAlternative` with `FirstSuccess` rule are failing, only the last error is printed, which can be misleading.