### PR TITLE
[ re #2499 ] Fix possible bad error messages in result-polymorphic scripts

### DIFF
--- a/libs/base/Language/Reflection/TTImp.idr
+++ b/libs/base/Language/Reflection/TTImp.idr
@@ -89,6 +89,7 @@ mutual
        FirstSuccess : AltType
        Unique : AltType
        UniqueDefault : TTImp -> AltType
+       FirstReflection : AltType
 
   public export
   data NoMangleDirective : Type where
@@ -362,6 +363,7 @@ parameters {auto eqTTImp : Eq TTImp}
     FirstSuccess    == FirstSuccess     = True
     Unique          == Unique           = True
     UniqueDefault t == UniqueDefault t' = t == t'
+    FirstReflection == FirstReflection  = True
     _ == _ = False
 
   public export

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -29,7 +29,7 @@ import public Libraries.Utils.Binary
 ||| version number if you're changing the version more than once in the same day.
 export
 ttcVersion : Int
-ttcVersion = 20220425 * 100 + 0
+ttcVersion = 20220531 * 100 + 0
 
 export
 checkTTCVersion : String -> Int -> Int -> Core ()

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -778,6 +778,7 @@ HasNames Error where
     = BadDotPattern fc <$> full gam rho <*> pure x <*> full gam s <*> full gam t
   full gam (BadImplicit fc x) = pure (BadImplicit fc x)
   full gam (BadRunElab fc rho s desc) = BadRunElab fc <$> full gam rho <*> full gam s <*> pure desc
+  full gam (RunElabFail e) = RunElabFail <$> full gam e
   full gam (GenericMsg fc x) = pure (GenericMsg fc x)
   full gam (TTCError x) = pure (TTCError x)
   full gam (FileErr x y) = pure (FileErr x y)
@@ -866,6 +867,7 @@ HasNames Error where
     = BadDotPattern fc <$> resolved gam rho <*> pure x <*> resolved gam s <*> resolved gam t
   resolved gam (BadImplicit fc x) = pure (BadImplicit fc x)
   resolved gam (BadRunElab fc rho s desc) = BadRunElab fc <$> resolved gam rho <*> resolved gam s <*> pure desc
+  resolved gam (RunElabFail e) = RunElabFail <$> resolved gam e
   resolved gam (GenericMsg fc x) = pure (GenericMsg fc x)
   resolved gam (TTCError x) = pure (TTCError x)
   resolved gam (FileErr x y) = pure (FileErr x y)

--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -151,6 +151,7 @@ data Error : Type where
      BadImplicit : FC -> String -> Error
      BadRunElab : {vars : _} ->
                   FC -> Env Term vars -> Term vars -> (description : String) -> Error
+     RunElabFail : Error -> Error
      GenericMsg : FC -> String -> Error
      TTCError : TTCErrorMsg -> Error
      FileErr : String -> FileError -> Error
@@ -334,6 +335,7 @@ Show Error where
            " - it elaborates to " ++ show y
   show (BadImplicit fc str) = show fc ++ ":" ++ str ++ " can't be bound here"
   show (BadRunElab fc env script desc) = show fc ++ ":Bad elaborator script " ++ show script ++ " (" ++ desc ++ ")"
+  show (RunElabFail e) = "Error during reflection: " ++ show e
   show (GenericMsg fc str) = show fc ++ ":" ++ str
   show (TTCError msg) = "Error in TTC file: " ++ show msg
   show (FileErr fname err) = "File error (" ++ fname ++ "): " ++ show err
@@ -438,6 +440,7 @@ getErrorLoc (MatchTooSpecific loc _ _) = Just loc
 getErrorLoc (BadDotPattern loc _ _ _ _) = Just loc
 getErrorLoc (BadImplicit loc _) = Just loc
 getErrorLoc (BadRunElab loc _ _ _) = Just loc
+getErrorLoc (RunElabFail e) = getErrorLoc e
 getErrorLoc (GenericMsg loc _) = Just loc
 getErrorLoc (TTCError _) = Nothing
 getErrorLoc (FileErr _ _) = Nothing
@@ -520,6 +523,7 @@ killErrorLoc (MatchTooSpecific fc x y) = MatchTooSpecific emptyFC x y
 killErrorLoc (BadDotPattern fc x y z w) = BadDotPattern emptyFC x y z w
 killErrorLoc (BadImplicit fc x) = BadImplicit emptyFC x
 killErrorLoc (BadRunElab fc x y description) = BadRunElab emptyFC x y description
+killErrorLoc (RunElabFail e) = RunElabFail $ killErrorLoc e
 killErrorLoc (GenericMsg fc x) = GenericMsg emptyFC x
 killErrorLoc (TTCError x) = TTCError x
 killErrorLoc (FileErr x y) = FileErr x y

--- a/src/Idris/Error.idr
+++ b/src/Idris/Error.idr
@@ -106,6 +106,7 @@ Eq Error where
   BadDotPattern fc1 rho1 x1 s1 t1 == BadDotPattern fc2 rho2 x2 s2 t2 = fc1 == fc2
   BadImplicit fc1 x1 == BadImplicit fc2 x2 = fc1 == fc2 && x1 == x2
   BadRunElab fc1 rho1 s1 d1 == BadRunElab fc2 rho2 s2 d2 = fc1 == fc2 && d1 == d2
+  RunElabFail e1 == RunElabFail e2 = e1 == e2
   GenericMsg fc1 x1 == GenericMsg fc2 x2 = fc1 == fc2 && x1 == x2
   TTCError x1 == TTCError x2 = x1 == x2
   FileErr x1 y1 == FileErr x2 y2 = x1 == x2 && y1 == y2
@@ -595,6 +596,8 @@ perrorRaw (BadRunElab fc env script desc)
     = pure $ errorDesc (reflow "Bad elaborator script" <++> code !(pshow env script)
        <++> parens (pretty0 desc) <+> dot)
         <+> line <+> !(ploc fc)
+perrorRaw (RunElabFail e)
+    = pure $ reflow "Error during reflection" <+> colon <++> !(perrorRaw e)
 perrorRaw (GenericMsg fc str) = pure $ pretty0 str <+> line <+> !(ploc fc)
 perrorRaw (TTCError msg)
     = pure $ errorDesc (reflow "Error in TTC file" <+> colon <++> byShow msg)

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -142,7 +142,7 @@ elabScript fc nest env script@(NDCon nfc nm t ar args) exp
     elabCon defs "Lambda" [x, _, scope]
         = do empty <- clearDefs defs
              NBind bfc x (Lam fc' c p ty) sc <- evalClosure defs scope
-                   | _ => throw (GenericMsg fc "Not a lambda")
+                   | _ => failWith defs "Not a lambda"
              n <- genVarName "x"
              sc' <- sc defs (toClosure withAll env (Ref bfc Bound n))
              qsc <- quote empty env sc'
@@ -159,7 +159,7 @@ elabScript fc nest env script@(NDCon nfc nm t ar args) exp
          quotePi Explicit = pure Explicit
          quotePi Implicit = pure Implicit
          quotePi AutoImplicit = pure AutoImplicit
-         quotePi (DefImplicit t) = throw (GenericMsg fc "Can't add default lambda")
+         quotePi (DefImplicit t) = failWith defs "Can't add default lambda"
     elabCon defs "Goal" []
         = do let Just gty = exp
                  | Nothing => nfOpts withAll defs env
@@ -196,13 +196,13 @@ elabScript fc nest env script@(NDCon nfc nm t ar args) exp
                        do let binder = getBinder lv env
                           let bty = binderType binder
                           scriptRet $ map rawName !(unelabUniqueBinders env bty)
-                  _ => throw (GenericMsg fc (show n ++ " is not a local variable"))
+                  _ => failWith defs $ show n ++ " is not a local variable"
     elabCon defs "GetCons" [n]
         = do n' <- evalClosure defs n
              cn <- reify defs n'
              Just (TCon _ _ _ _ _ _ cons _) <-
                      lookupDefExact cn (gamma defs)
-                 | _ => throw (GenericMsg fc (show cn ++ " is not a type"))
+                 | _ => failWith defs $ show cn ++ " is not a type"
              scriptRet cons
     elabCon defs "Declare" [d]
         = do d' <- evalClosure defs d

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -236,12 +236,11 @@ checkRunElab rig elabinfo nest env fc script exp
          unless (isExtension ElabReflection defs) $
              throw (GenericMsg fc "%language ElabReflection not enabled")
          let n = NS reflectionNS (UN $ Basic "Elab")
-         let ttn = reflectiontt "TT"
          elabtt <- appCon fc defs n [expected]
          (stm, sty) <- runDelays (const True) $
                            check rig elabinfo nest env script (Just (gnf env elabtt))
          defs <- get Ctxt -- checking might have resolved some holes
-         ntm <- elabScript fc nest env !(nfOpts withAll defs env stm) (Just (gnf env expected))
+         ntm <- elabScript fc nest env !(nfOpts withAll defs env stm) exp
          defs <- get Ctxt -- might have updated as part of the script
          empty <- clearDefs defs
          pure (!(quote empty env ntm), gnf env expected)

--- a/src/TTImp/Reflect.idr
+++ b/src/TTImp/Reflect.idr
@@ -268,6 +268,8 @@ mutual
                (UN (Basic "UniqueDefault"), [(_, x)])
                     => do x' <- reify defs !(evalClosure defs x)
                           pure (UniqueDefault x')
+               (UN (Basic "FirstReflection"), _)
+                    => pure FirstReflection
                _ => cantReify val "AltType"
     reify defs val = cantReify val "AltType"
 
@@ -664,6 +666,7 @@ mutual
     reflect fc defs lhs env (UniqueDefault x)
         = do x' <- reflect fc defs lhs env x
              appCon fc defs (reflectionttimp "UniqueDefault") [x']
+    reflect fc defs lhs env FirstReflection = getCon fc defs (reflectionttimp "FirstReflection")
 
   export
   Reflect NoMangleDirective where

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -143,6 +143,7 @@ mutual
        FirstSuccess : AltType' nm
        Unique : AltType' nm
        UniqueDefault : RawImp' nm -> AltType' nm
+       FirstReflection : AltType' nm
 
   export
   covering
@@ -1178,6 +1179,7 @@ mutual
     toBuf b FirstSuccess = tag 0
     toBuf b Unique = tag 1
     toBuf b (UniqueDefault x) = do tag 2; toBuf b x
+    toBuf b FirstReflection = tag 3
 
     fromBuf b
         = case !getTag of
@@ -1185,6 +1187,7 @@ mutual
                1 => pure Unique
                2 => do x <- fromBuf b
                        pure (UniqueDefault x)
+               3 => pure FirstReflection
                _ => corrupt "AltType"
 
   export

--- a/src/TTImp/TTImp/Functor.idr
+++ b/src/TTImp/TTImp/Functor.idr
@@ -164,3 +164,4 @@ mutual
     map f FirstSuccess = FirstSuccess
     map f Unique = Unique
     map f (UniqueDefault t) = UniqueDefault (map f t)
+    map f FirstReflection = FirstReflection

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -219,7 +219,7 @@ idrisTestsReflection = MkTestPool "Quotation and Reflection" [] Nothing
       ["reflection001", "reflection002", "reflection003", "reflection004",
        "reflection005", "reflection006", "reflection007", "reflection008",
        "reflection009", "reflection010", "reflection011", "reflection012",
-       "reflection013", "reflection014", "reflection015"
+       "reflection013", "reflection014", "reflection015", "reflection016"
       ]
 
 idrisTestsWith : TestPool

--- a/tests/idris2/reflection016/Goaly.idr
+++ b/tests/idris2/reflection016/Goaly.idr
@@ -1,0 +1,95 @@
+import Language.Reflection
+
+%default total
+
+%macro
+failyGoaly : Nat -> Elab a
+failyGoaly _ = do
+  Just goal <- goal
+     | Nothing => fail "no goal at all"
+  logSugaredTerm "bug.lostgoal" 0 "the goal" goal
+  case goal of
+    `(Prelude.Types.Nat) => fail "good goal; intensional (expected) failure"
+    _                    => fail "unexpected goal"
+
+%language ElabReflection
+
+x : Nat
+x = failyGoaly 5
+
+%macro
+choosing : Elab a
+choosing = do
+  Just goal <- goal
+    | Nothing => fail "no goal at all"
+  logSugaredTerm "bug.lostgoal.uns" 0 "the goal" goal
+  case goal of
+    `(Prelude.Types.Nat)                                  => check `(5)
+    IPi _ _ _ _ `(Prelude.Types.Nat) `(Prelude.Types.Nat) => check `((+6))
+    _                                                     => fail "unexpected goal"
+
+chV : Nat -> Nat
+chV x = x + choosing
+
+chF : Nat -> Nat
+chF = choosing
+
+chF' : Nat -> Nat
+chF' x = choosing x
+
+%macro
+goaly : Nat => Elab $ Nat -> a
+goaly = do
+  Just g <- goal
+    | Nothing => fail "no goal"
+  case g of
+    IPi _ _ _ _ _ res => case res of
+                           `(Prelude.Types.Nat) => check `(S)
+                           IHole _ _            => fail "unknown resulting type of a function"
+                           _                    => fail "unsupported resulting type of a function"
+    IHole _ n         => fail "goal is hole \{show n}"
+    _                 => do logSugaredTerm "nogoal" 0 "goal" g
+                            fail "can't manage the given result type"
+
+%language ElabReflection
+
+knownCorrectGoal : Nat -> Nat
+knownCorrectGoal = goaly @{Z}
+
+knownCorrectGoal' : Nat -> Nat
+knownCorrectGoal' = S . the (Nat -> Nat) (goaly @{Z})
+
+knownIncorrectGoal : Nat -> String
+knownIncorrectGoal = goaly @{Z}
+
+holeInGoal : Nat -> ?
+holeInGoal = goaly @{Z}
+
+uknownOrNoHole : ?
+uknownOrNoHole = goaly @{Z}
+
+knownResultInGoal : Nat -> Nat
+knownResultInGoal = S . goaly @{Z}
+
+nowYetKnownResultInGoal : Nat -> Nat
+nowYetKnownResultInGoal = goaly @{Z} . S
+
+goalInMap : List Nat -> List Nat
+goalInMap = map $ goaly @{Z}
+
+%macro
+goaly' : Nat -> Elab $ Nat -> a
+goaly' _ = do
+  Just g <- goal
+    | Nothing => fail "no goal"
+  case g of
+    IPi _ _ _ _ _ res => case res of
+                           `(Prelude.Types.Nat) => check `(S)
+                           IHole _ _            => fail "unknown resulting type of a function"
+                           _                    => fail "unsupported resulting type of a function"
+    IHole _ n         => fail "goal is hole \{show n}"
+    _                 => do logSugaredTerm "nogoal" 0 "goal" g
+                            fail "can't manage the given result type"
+
+noStart : String -> String
+noStart = goaly' 4

--- a/tests/idris2/reflection016/expected
+++ b/tests/idris2/reflection016/expected
@@ -1,0 +1,105 @@
+1/1: Building Goaly (Goaly.idr)
+LOG bug.lostgoal:0: the goal: Nat
+LOG bug.lostgoal.uns:0: the goal: Nat
+LOG bug.lostgoal.uns:0: the goal: (arg : Nat) -> Nat
+Error: While processing right hand side of x. Error during reflection: good goal; intensional (expected) failure
+
+Goaly:18:5--18:15
+ 14 | 
+ 15 | %language ElabReflection
+ 16 | 
+ 17 | x : Nat
+ 18 | x = failyGoaly 5
+          ^^^^^^^^^^
+
+Error: While processing right hand side of chF'. Error during reflection: no goal at all
+
+Goaly:38:10--38:18
+ 34 | chF : Nat -> Nat
+ 35 | chF = choosing
+ 36 | 
+ 37 | chF' : Nat -> Nat
+ 38 | chF' x = choosing x
+               ^^^^^^^^
+
+Error: While processing right hand side of knownIncorrectGoal. Error during reflection: unsupported resulting type of a function
+
+Goaly:63:22--63:27
+ 59 | knownCorrectGoal' : Nat -> Nat
+ 60 | knownCorrectGoal' = S . the (Nat -> Nat) (goaly @{Z})
+ 61 | 
+ 62 | knownIncorrectGoal : Nat -> String
+ 63 | knownIncorrectGoal = goaly @{Z}
+                           ^^^^^
+
+Error: While processing right hand side of holeInGoal. Error during reflection: unknown resulting type of a function
+
+Goaly:66:14--66:19
+ 62 | knownIncorrectGoal : Nat -> String
+ 63 | knownIncorrectGoal = goaly @{Z}
+ 64 | 
+ 65 | holeInGoal : Nat -> ?
+ 66 | holeInGoal = goaly @{Z}
+                   ^^^^^
+
+Error: While processing right hand side of uknownOrNoHole. Error during reflection: goal is hole "_"
+
+Goaly:69:18--69:23
+ 65 | holeInGoal : Nat -> ?
+ 66 | holeInGoal = goaly @{Z}
+ 67 | 
+ 68 | uknownOrNoHole : ?
+ 69 | uknownOrNoHole = goaly @{Z}
+                       ^^^^^
+
+Error: While processing right hand side of nowYetKnownResultInGoal. Error during reflection: unknown resulting type of a function
+
+Goaly:75:27--75:32
+ 71 | knownResultInGoal : Nat -> Nat
+ 72 | knownResultInGoal = S . goaly @{Z}
+ 73 | 
+ 74 | nowYetKnownResultInGoal : Nat -> Nat
+ 75 | nowYetKnownResultInGoal = goaly @{Z} . S
+                                ^^^^^
+
+Error: While processing right hand side of goalInMap. Error during reflection: unknown resulting type of a function
+
+Goaly:78:19--78:24
+ 74 | nowYetKnownResultInGoal : Nat -> Nat
+ 75 | nowYetKnownResultInGoal = goaly @{Z} . S
+ 76 | 
+ 77 | goalInMap : List Nat -> List Nat
+ 78 | goalInMap = map $ goaly @{Z}
+                        ^^^^^
+
+Error: While processing right hand side of noStart. Sorry, I can't find any elaboration which works. All errors:
+Possible error:
+    When unifying:
+        Elab (Nat -> ?a)
+    and:
+        Elab (String -> String)
+    Mismatch between: Nat and String.
+
+    Goaly:95:11--95:19
+     91 |     _                 => do logSugaredTerm "nogoal" 0 "goal" g
+     92 |                             fail "can't manage the given result type"
+     93 | 
+     94 | noStart : String -> String
+     95 | noStart = goaly' 4
+                    ^^^^^^^^
+
+Possible error:
+    When unifying:
+        Nat -> Elab (Nat -> ?a)
+    and:
+        Elab ?scriptTy
+    Mismatch between: Nat -> Elab (Nat -> ?a) and Elab ?scriptTy.
+
+    Goaly:95:11--95:17
+     91 |     _                 => do logSugaredTerm "nogoal" 0 "goal" g
+     92 |                             fail "can't manage the given result type"
+     93 | 
+     94 | noStart : String -> String
+     95 | noStart = goaly' 4
+                    ^^^^^^
+

--- a/tests/idris2/reflection016/run
+++ b/tests/idris2/reflection016/run
@@ -1,0 +1,4 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --no-banner --check Goaly.idr
+


### PR DESCRIPTION
While #2499 fixed one bug, it (together with behaviour described in #2516) introduced an unpleasant behaviour in a quite non-trivial case.

TLDR: *the logic of alternatives run from #2499 was tuned to work well when elaboration script fails; i.e. as previous, if at least one alternative succeeds, the first one is used; but if all alternatives fail _but elaboration script has started_, the first error of elaboration script run is printed; if elaboration script was not started at all, errors from all the alternatives are printed (usually, unification errors).*

Consider an macro elaboration script which is polymorphic on the result and which analyses its current goal type (this was the only way to get a type with 0-args as input before #1847) having also its own `auto` params, i.e.
```idris
%macro
m : Externals => Elab a
m = do
  Just g <- goal
    | Nothing => fail "no goal"
  -- analyse the goal, fail if it can't manage it, produce the result if can
  -- ...
```

Consider now that we are calling this macro with a particular `auto` parameter:
```idris
x : Nat
x = m @{ext}
```

If the `Nat` goal is not appropriate for the `m` macro (and it should fail), then alternative mechanism tries to apply `@{ext}` to the result of the elaboration script, in which case it cannot have any particular goal type yet. This but due to problem in #2516, it prints only the last error, i.e. no goal (a side note that before a fix in this PR, a no-goal situation was done as if goal is a `?scriptTy` hole, not nevertheless).

We could just print all the errors, as it is done in #2516, but there is a problem: the value of errors from inside the elaboration script is more than of unification errors saying "I couldn't run the elaboration script". So, if the elaboration script has started, we shouldn't print errors that were trying to start it, but didn't succeed (anyway, those alternatives are blind guesses with the only pupose: to start the elaboration script).

So, I suggest to distinguish all the errors from inside elaboration scripts and print only them if elaboration script started.

Then, probably, the most controversal part, I suggest to print only the first such because 1) if script is not polymorphic on its goal type, it probably would start only in one alternative anyway 2) if script analyses its goal type, there is anyway probably won't be any good goals for more than one alternatives.

---

Thia PR depends on #2516.

Also, it contains a little fix: `goal` function in the `Elaboration` interface returns `Maybe` because there may be no decided goal yet. However, the running code (I guess, for technical reasons and finally by mistake) replaces it with a hole with a `scriptTy` name. This goal is essential for unification with `Elab ?scriptTy` but shouldn't be passed inside the script (since, we have `Nothing` case for this already).

Oh, and wrapping all errors from inside the elaboration script changes error messages from elaboration scripts, but I think it is an improvement: previously errors outside the elaboration script with of its run attempt and from inside could look similarly. Now, even ordinary typechecking errors from inside the elaboration scripts are prepended with the "error during reflection" string.

Also, this PR requires a patch to `elab-utils`, since it adds an alternative to a pretty-printable data type, it will follow.

This PR contains all logically separate changes in separate commits, I hope this will ease the review.