### PR TITLE
[ base ] Add mapProperty to Data.Vect.Quantifiers.All

### DIFF
--- a/libs/base/Data/Vect/Quantifiers.idr
+++ b/libs/base/Data/Vect/Quantifiers.idr
@@ -63,6 +63,12 @@ namespace All
     Nil  : All p Nil
     (::) : {0 xs : Vect n a} -> p x -> All p xs -> All p (x :: xs)
 
+  ||| Modify the property given a pointwise function
+  export
+  mapProperty : (f : {0 x : a} -> p x -> q x) -> All p xs -> All q xs
+  mapProperty f [] = []
+  mapProperty f (p::ps) = f p :: mapProperty f ps
+
   ||| If there does not exist an element that satifies the property, then it is
   ||| the case that all elements do not satisfy.
   export


### PR DESCRIPTION
such function is present in Data.List.Quantifiers.All but not in
Data.Vect.Quantifiers.All