### PR TITLE
[ elab ] Improve elab script errors + extend docs + cleanup

### DIFF
--- a/libs/base/Language/Reflection.idr
+++ b/libs/base/Language/Reflection.idr
@@ -126,6 +126,10 @@ interface Monad m => Elaboration m where
            ((val : x) -> Elab (ty val)) -> m ((val : x) -> (ty val))
 
   ||| Get the goal type of the current elaboration
+  |||
+  ||| `Nothing` means the script is run in the top-level `%runElab` clause.
+  ||| If elaboration script is run in expression mode, this function will always return `Just`.
+  ||| In the case of unknown result type in the expression mode, returned `TTImp` would be an `IHole`.
   goal : m (Maybe TTImp)
 
   ||| Get the names of the local variables in scope

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -778,6 +778,7 @@ HasNames Error where
     = BadDotPattern fc <$> full gam rho <*> pure x <*> full gam s <*> full gam t
   full gam (BadImplicit fc x) = pure (BadImplicit fc x)
   full gam (BadRunElab fc rho s desc) = BadRunElab fc <$> full gam rho <*> full gam s <*> pure desc
+  full gam (RunElabFail e) = RunElabFail <$> full gam e
   full gam (GenericMsg fc x) = pure (GenericMsg fc x)
   full gam (TTCError x) = pure (TTCError x)
   full gam (FileErr x y) = pure (FileErr x y)
@@ -866,6 +867,7 @@ HasNames Error where
     = BadDotPattern fc <$> resolved gam rho <*> pure x <*> resolved gam s <*> resolved gam t
   resolved gam (BadImplicit fc x) = pure (BadImplicit fc x)
   resolved gam (BadRunElab fc rho s desc) = BadRunElab fc <$> resolved gam rho <*> resolved gam s <*> pure desc
+  resolved gam (RunElabFail e) = RunElabFail <$> resolved gam e
   resolved gam (GenericMsg fc x) = pure (GenericMsg fc x)
   resolved gam (TTCError x) = pure (TTCError x)
   resolved gam (FileErr x y) = pure (FileErr x y)

--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -151,6 +151,7 @@ data Error : Type where
      BadImplicit : FC -> String -> Error
      BadRunElab : {vars : _} ->
                   FC -> Env Term vars -> Term vars -> (description : String) -> Error
+     RunElabFail : Error -> Error
      GenericMsg : FC -> String -> Error
      TTCError : TTCErrorMsg -> Error
      FileErr : String -> FileError -> Error
@@ -334,6 +335,7 @@ Show Error where
            " - it elaborates to " ++ show y
   show (BadImplicit fc str) = show fc ++ ":" ++ str ++ " can't be bound here"
   show (BadRunElab fc env script desc) = show fc ++ ":Bad elaborator script " ++ show script ++ " (" ++ desc ++ ")"
+  show (RunElabFail e) = "Error during reflection: " ++ show e
   show (GenericMsg fc str) = show fc ++ ":" ++ str
   show (TTCError msg) = "Error in TTC file: " ++ show msg
   show (FileErr fname err) = "File error (" ++ fname ++ "): " ++ show err
@@ -438,6 +440,7 @@ getErrorLoc (MatchTooSpecific loc _ _) = Just loc
 getErrorLoc (BadDotPattern loc _ _ _ _) = Just loc
 getErrorLoc (BadImplicit loc _) = Just loc
 getErrorLoc (BadRunElab loc _ _ _) = Just loc
+getErrorLoc (RunElabFail e) = getErrorLoc e
 getErrorLoc (GenericMsg loc _) = Just loc
 getErrorLoc (TTCError _) = Nothing
 getErrorLoc (FileErr _ _) = Nothing
@@ -520,6 +523,7 @@ killErrorLoc (MatchTooSpecific fc x y) = MatchTooSpecific emptyFC x y
 killErrorLoc (BadDotPattern fc x y z w) = BadDotPattern emptyFC x y z w
 killErrorLoc (BadImplicit fc x) = BadImplicit emptyFC x
 killErrorLoc (BadRunElab fc x y description) = BadRunElab emptyFC x y description
+killErrorLoc (RunElabFail e) = RunElabFail $ killErrorLoc e
 killErrorLoc (GenericMsg fc x) = GenericMsg emptyFC x
 killErrorLoc (TTCError x) = TTCError x
 killErrorLoc (FileErr x y) = FileErr x y

--- a/src/Idris/Error.idr
+++ b/src/Idris/Error.idr
@@ -106,6 +106,7 @@ Eq Error where
   BadDotPattern fc1 rho1 x1 s1 t1 == BadDotPattern fc2 rho2 x2 s2 t2 = fc1 == fc2
   BadImplicit fc1 x1 == BadImplicit fc2 x2 = fc1 == fc2 && x1 == x2
   BadRunElab fc1 rho1 s1 d1 == BadRunElab fc2 rho2 s2 d2 = fc1 == fc2 && d1 == d2
+  RunElabFail e1 == RunElabFail e2 = e1 == e2
   GenericMsg fc1 x1 == GenericMsg fc2 x2 = fc1 == fc2 && x1 == x2
   TTCError x1 == TTCError x2 = x1 == x2
   FileErr x1 y1 == FileErr x2 y2 = x1 == x2 && y1 == y2
@@ -595,6 +596,8 @@ perrorRaw (BadRunElab fc env script desc)
     = pure $ errorDesc (reflow "Bad elaborator script" <++> code !(pshow env script)
        <++> parens (pretty0 desc) <+> dot)
         <+> line <+> !(ploc fc)
+perrorRaw (RunElabFail e)
+    = pure $ reflow "Error during reflection" <+> colon <++> !(perrorRaw e)
 perrorRaw (GenericMsg fc str) = pure $ pretty0 str <+> line <+> !(ploc fc)
 perrorRaw (TTCError msg)
     = pure $ errorDesc (reflow "Error in TTC file" <+> colon <++> byShow msg)

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -142,7 +142,7 @@ elabScript fc nest env script@(NDCon nfc nm t ar args) exp
     elabCon defs "Lambda" [x, _, scope]
         = do empty <- clearDefs defs
              NBind bfc x (Lam fc' c p ty) sc <- evalClosure defs scope
-                   | _ => throw (GenericMsg fc "Not a lambda")
+                   | _ => failWith defs "Not a lambda"
              n <- genVarName "x"
              sc' <- sc defs (toClosure withAll env (Ref bfc Bound n))
              qsc <- quote empty env sc'
@@ -159,7 +159,7 @@ elabScript fc nest env script@(NDCon nfc nm t ar args) exp
          quotePi Explicit = pure Explicit
          quotePi Implicit = pure Implicit
          quotePi AutoImplicit = pure AutoImplicit
-         quotePi (DefImplicit t) = throw (GenericMsg fc "Can't add default lambda")
+         quotePi (DefImplicit t) = failWith defs "Can't add default lambda"
     elabCon defs "Goal" []
         = do let Just gty = exp
                  | Nothing => nfOpts withAll defs env
@@ -196,13 +196,13 @@ elabScript fc nest env script@(NDCon nfc nm t ar args) exp
                        do let binder = getBinder lv env
                           let bty = binderType binder
                           scriptRet $ map rawName !(unelabUniqueBinders env bty)
-                  _ => throw (GenericMsg fc (show n ++ " is not a local variable"))
+                  _ => failWith defs $ show n ++ " is not a local variable"
     elabCon defs "GetCons" [n]
         = do n' <- evalClosure defs n
              cn <- reify defs n'
              Just (TCon _ _ _ _ _ _ cons _) <-
                      lookupDefExact cn (gamma defs)
-                 | _ => throw (GenericMsg fc (show cn ++ " is not a type"))
+                 | _ => failWith defs $ show cn ++ " is not a type"
              scriptRet cons
     elabCon defs "Declare" [d]
         = do d' <- evalClosure defs d

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -234,7 +234,6 @@ checkRunElab rig elabinfo nest env fc script exp
          unless (isExtension ElabReflection defs) $
              throw (GenericMsg fc "%language ElabReflection not enabled")
          let n = NS reflectionNS (UN $ Basic "Elab")
-         let ttn = reflectiontt "TT"
          elabtt <- appCon fc defs n [expected]
          (stm, sty) <- runDelays (const True) $
                            check rig elabinfo nest env script (Just (gnf env elabtt))


### PR DESCRIPTION
While I'm finding a less hacky way to deal with problems mentioned in #2517, I found that some changes from the original PR are not needed for the fix anymore, but they still can be valuable.

Despite some cleanup and more precise and verbose errors in case of badly built elaboration scripts, I suggest to mark any error from checks inside elaboration scripts with a "error during reflection", as it is done with user fails (with `fail` and `failAt` functions). I found it extremely nice: now I'm sure that a type error is in a generated code just by looking at the message.

Also, I realised one my mistake and I'm suggesting to document a thought that would prevent anyone to make such a mistake.