### PR TITLE
Include "showmachinenames" in the output of :opts

### DIFF
--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -198,7 +198,8 @@ getOptions : {auto c : Ref Ctxt Defs} ->
 getOptions = do
   pp <- getPPrint
   opts <- get ROpts
-  pure $ [ ShowImplicits (showImplicits pp), ShowNamespace (fullNamespace pp)
+  pure $ [ ShowImplicits (showImplicits pp), ShowMachineNames (showMachineNames pp)
+         , ShowNamespace (fullNamespace pp)
          , ShowTypes (showTypes opts), EvalMode (evalMode opts)
          , Editor (editor opts)
          ]


### PR DESCRIPTION
This PR adds showmachinenames  to the list of flags enumerated by the `:opts` command:

```
Welcome to Idris 2.  Enjoy yourself!
Main> :opts
showimplicits = False
showmachinenames = False
shownamespace = False
showtypes = False
eval = normalise
editor = vim
Main>
```


