### PR TITLE
Update tests using base64 utility to also work on macos

### DIFF
--- a/tests/base/system_file_copyFile/run
+++ b/tests/base/system_file_copyFile/run
@@ -1,6 +1,6 @@
 rm -rf build
 
 $1 --no-color --console-width 0 --no-banner CopyFile.idr < input
-base64 dest.bin
+base64 -i dest.bin
 
 rm dest.bin

--- a/tests/contrib/system_directory_tree_copyDir/run
+++ b/tests/contrib/system_directory_tree_copyDir/run
@@ -2,7 +2,7 @@ rm -rf build
 
 $1 --no-banner --no-color --console-width 0 -p contrib CopyDir.idr < input
 ls -R resultDir | sed '/^resultDir:$/d'
-base64 resultDir/source.bin
+base64 -i resultDir/source.bin
 cat resultDir/nestedDir/anotherFile.txt
 
 rm -rf resultDir

--- a/tests/refc/buffer/run
+++ b/tests/refc/buffer/run
@@ -2,6 +2,6 @@ rm -rf build
 
 $1 --no-banner --no-color --console-width 0 --cg refc -o refc_buffer TestBuffer.idr > /dev/null
 ./build/exec/refc_buffer
-base64 testWrite.buf
+base64 -i testWrite.buf
 
 rm testWrite.buf


### PR DESCRIPTION
Some of the tests fail on macos because the "base64" utility expects a `-i` switch in front of the input file.  The Linux version works both with and without the `-i`.  This PR updates the tests to add the `-i`.