### PR TITLE
[ breaking ] Make arguments of `runRWST` be ordered like in other transformers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,8 @@
   Use the type `IsYes` (with constructor `ItIsYes`) from the same module instead.
 * Adds `Data.List1.Elem`, ported from `Data.List.Elem`.
 * Adds `Data.List1.Quantifiers`, ported from `Data.List.Quantifiers`.
+* Changes the order of arguments in `RWST` transformer's runners functions (`runRWST`. `evalRWST`, `execRWST`),
+  now transformer argument is the last, as in the other standard transformers, like `ReaderT` and `StateT`.
 
 #### Test
 

--- a/libs/base/Control/Monad/RWS/CPS.idr
+++ b/libs/base/Control/Monad/RWS/CPS.idr
@@ -24,8 +24,8 @@ record RWST (r : Type) (w : Type) (s : Type) (m : Type -> Type) (a : Type) where
 |||
 ||| This is the inverse of `rwsT`.
 public export %inline
-runRWST : Monoid w => RWST r w s m a -> r -> s -> m (a, s, w)
-runRWST m r s = unRWST m r s neutral
+runRWST : Monoid w => r -> s -> RWST r w s m a -> m (a, s, w)
+runRWST r s m = unRWST m r s neutral
 
 ||| Construct an RWST computation from a function.
 |||
@@ -37,21 +37,21 @@ rwsT f = MkRWST $ \r,s,w => (\(a,s',w') => (a,s',w <+> w')) <$> f r s
 ||| Evaluate a computation with the given initial state and environment,
 ||| returning the final value and output, discarding the final state.
 public export %inline
-evalRWST : Monoid w => Functor m => RWST r w s m a -> r -> s -> m (a,w)
-evalRWST m r s = (\(a,_,w) => (a,w)) <$> runRWST m r s
+evalRWST : Monoid w => Functor m => r -> s -> RWST r w s m a -> m (a,w)
+evalRWST r s m = (\(a,_,w) => (a,w)) <$> runRWST r s m
 
 ||| Evaluate a computation with the given initial state and environment,
 ||| returning the final state and output, discarding the final value.
 public export %inline
-execRWST : Monoid w => Functor m => RWST r w s m a -> r -> s -> m (s,w)
-execRWST m r s = (\(_,s',w) => (s',w)) <$> runRWST m r s
+execRWST : Monoid w => Functor m => r -> s -> RWST r w s m a -> m (s,w)
+execRWST r s m = (\(_,s',w) => (s',w)) <$> runRWST r s m
 
 ||| Map over the inner computation.
 public export %inline
 mapRWST : (Functor n, Monoid w, Semigroup w')
         => (m (a, s, w) -> n (b, s, w')) -> RWST r w s m a -> RWST r w' s n b
 mapRWST f m = MkRWST $ \r,s,w =>
-                (\(a,s',w') => (a,s',w <+> w')) <$> f (runRWST m r s)
+                (\(a,s',w') => (a,s',w <+> w')) <$> f (runRWST r s m)
 
 ||| `withRWST f m` executes action `m` with an initial environment
 ||| and state modified by applying `f`.
@@ -75,8 +75,8 @@ RWS r w s = RWST r w s Identity
 |||
 ||| This is the inverse of `rws`.
 public export %inline
-runRWS : Monoid w => RWS r w s a -> r -> s -> (a, s, w)
-runRWS m r s = runIdentity (runRWST m r s)
+runRWS : Monoid w => r -> s -> RWS r w s a -> (a, s, w)
+runRWS r s = runIdentity . runRWST r s
 
 ||| Construct an RWS computation from a function.
 |||
@@ -89,15 +89,15 @@ rws f = MkRWST $ \r,s,w => let (a, s', w') = f r s
 ||| Evaluate a computation with the given initial state and environment,
 ||| returning the final value and output, discarding the final state.
 public export %inline
-evalRWS : Monoid w => RWS r w s a -> r -> s -> (a,w)
-evalRWS m r s = let (a,_,w) = runRWS m r s
+evalRWS : Monoid w => r -> s -> RWS r w s a -> (a,w)
+evalRWS r s m = let (a,_,w) = runRWS r s m
                  in (a,w)
 
 ||| Evaluate a computation with the given initial state and environment,
 ||| returning the final state and output, discarding the final value.
 public export %inline
-execRWS : Monoid w => RWS r w s a -> r -> s -> (s,w)
-execRWS m r s = let (_,s1,w) = runRWS m r s
+execRWS : Monoid w => r -> s -> RWS r w s a -> (s,w)
+execRWS r s m = let (_,s1,w) = runRWS r s m
                  in (s1,w)
 
 ||| Map the return value, final state and output of a computation using

--- a/libs/base/Control/Monad/Writer/Interface.idr
+++ b/libs/base/Control/Monad/Writer/Interface.idr
@@ -75,10 +75,10 @@ public export %inline
   tell w' = writer ((), w')
 
   listen m = MkRWST $ \r,s,w =>
-               (\(a,s',w') => ((a,w'),s',w <+> w')) <$> runRWST m r s
+               (\(a,s',w') => ((a,w'),s',w <+> w')) <$> runRWST r s m
 
   pass m = MkRWST $ \r,s,w =>
-             (\((a,f),s',w') => (a,s',w <+> f w')) <$> runRWST m r s
+             (\((a,f),s',w') => (a,s',w <+> f w')) <$> runRWST r s m
 
 public export %inline
 MonadWriter w m => MonadWriter w (EitherT e m) where


### PR DESCRIPTION
Put the `RWST` argument to be the last one. This makes such functions to be easier used in point-free compositions and to be easily interchangeable with existing `runStateT`-like functions.

I ran into this when I wanted to replace `evalStateT s` by `evalRWST () s` to switch from `m a` to `m (a, w)`, but couldn't do it naturally because of different order conventions in `RWST` and the rest of transformers.

Pinging @stefan-hoeck as the person who added `RWST` into the `base` of Idris 2. Was the order intentional? I understand that this order is the original order of the Haskell implementation, but historically Idris had another (and subjectively, much better) order for `StateT` and `ReaderT` which allows partial point-free connections. I think, `RWST` should follow this convention.