### PR TITLE
Fix issue with case inside a Pi type.

### DIFF
--- a/src/TTImp/Elab/Binders.idr
+++ b/src/TTImp/Elab/Binders.idr
@@ -84,6 +84,7 @@ checkPi rig elabinfo nest env fc rigf info n argTy retTy expTy
     -- it's always erased
     getRig : ElabMode -> RigCount
     getRig (InLHS _) = rig
+    getRig InExpr = rig
     getRig _ = erased
 
 findLamRig : {auto c : Ref Ctxt Defs} ->

--- a/tests/idris2/reg051/expected
+++ b/tests/idris2/reg051/expected
@@ -1,0 +1,1 @@
+1/1: Building test (test.idr)

--- a/tests/idris2/reg051/run
+++ b/tests/idris2/reg051/run
@@ -1,0 +1,2 @@
+rm -rf build
+$1 --no-banner --no-color --console-width 0 test.idr --check

--- a/tests/idris2/reg051/test.idr
+++ b/tests/idris2/reg051/test.idr
@@ -1,0 +1,2 @@
+Test : Type
+Test = (case () of () => String) -> ()


### PR DESCRIPTION
On discord, @michaelmesser reported that this code:

```idris
Test : Type
Test = (case () of () => String) -> ()
```
 gives this error message:
```
While processing right hand side of Test. Main.case block in Test is not accessible in this context.
```

The case is being turned into an erased top level function. which is then used in a non-erased context. To address the issue I changed `checkPi` in `Binders.idr` to keep the contextual quantity when processing the `argTy` of an `IPi` while in the `InExpr` elab mode (instead of forcing erased).

This passes tests and I believe it is correct, but I'd like someone more knowledgable to verify.
