### PR TITLE
Support System.Signal for node backend

### DIFF
--- a/libs/base/System/Signal.idr
+++ b/libs/base/System/Signal.idr
@@ -16,47 +16,50 @@ import System.Errno
 signalFFI : String -> String
 signalFFI fn = "C:" ++ fn ++ ", libidris2_support, idris_signal.h"
 
+signalFFINode : String -> String
+signalFFINode fn = "node:support:" ++ fn ++ ",support_system_signal"
+
 --
 -- Signals
 --
 %foreign signalFFI "sighup"
-         "node:support:sighup,support_system_signal"
+         signalFFINode "sighup"
 prim__sighup : Int
 
 %foreign signalFFI "sigint"
-         "node:support:sigint,support_system_signal"
+         signalFFINode "sigint"
 prim__sigint : Int
 
 %foreign signalFFI "sigabrt"
-         "node:support:sigabrt,support_system_signal"
+         signalFFINode "sigabrt"
 prim__sigabrt : Int
 
 %foreign signalFFI "sigquit"
-         "node:support:sigquit,support_system_signal"
+         signalFFINode "sigquit"
 prim__sigquit : Int
 
 %foreign signalFFI "sigill"
-         "node:support:sigill,support_system_signal"
+         signalFFINode "sigill"
 prim__sigill : Int
 
 %foreign signalFFI "sigsegv"
-         "node:support:sigsegv,support_system_signal"
+         signalFFINode "sigsegv"
 prim__sigsegv : Int
 
 %foreign signalFFI "sigtrap"
-         "node:support:sigtrap,support_system_signal"
+         signalFFINode "sigtrap"
 prim__sigtrap : Int
 
 %foreign signalFFI "sigfpe"
-         "node:support:sigfpe,support_system_signal"
+         signalFFINode "sigfpe"
 prim__sigfpe : Int
 
 %foreign signalFFI "sigusr1"
-         "node:support:sigusr1,support_system_signal"
+         signalFFINode "sigusr1"
 prim__sigusr1 : Int
 
 %foreign signalFFI "sigusr2"
-         "node:support:sigusr2,support_system_signal"
+         signalFFINode "sigusr2"
 prim__sigusr2 : Int
 
 public export
@@ -136,27 +139,27 @@ toSignal x    = lookup x codes
 -- Signal Handling
 --
 %foreign signalFFI "ignore_signal"
-         "node:support:ignoreSignal,support_system_signal"
+         signalFFINode "ignoreSignal"
 prim__ignoreSignal : Int -> PrimIO Int
 
 %foreign signalFFI "default_signal"
-         "node:support:defaultSignal,support_system_signal"
+         signalFFINode "defaultSignal"
 prim__defaultSignal : Int -> PrimIO Int
 
 %foreign signalFFI "collect_signal"
-         "node:support:collectSignal,support_system_signal"
+         signalFFINode "collectSignal"
 prim__collectSignal : Int -> PrimIO Int
 
 %foreign signalFFI "handle_next_collected_signal"
-         "node:support:handleNextCollectedSignal,support_system_signal"
+         signalFFINode "handleNextCollectedSignal"
 prim__handleNextCollectedSignal : PrimIO Int
 
 %foreign signalFFI "send_signal"
-         "node:support:sendSignal,support_system_signal"
+         signalFFINode "sendSignal"
 prim__sendSignal : Int -> Int -> PrimIO Int
 
 %foreign signalFFI "raise_signal"
-         "node:support:raiseSignal,support_system_signal"
+         signalFFINode "raiseSignal"
 prim__raiseSignal : Int -> PrimIO Int
 
 ||| An Error represented by a code. See

--- a/libs/base/System/Signal.idr
+++ b/libs/base/System/Signal.idr
@@ -20,33 +20,43 @@ signalFFI fn = "C:" ++ fn ++ ", libidris2_support, idris_signal.h"
 -- Signals
 --
 %foreign signalFFI "sighup"
+         "node:support:sighup,support_system_signal"
 prim__sighup : Int
 
 %foreign signalFFI "sigint"
+         "node:support:sigint,support_system_signal"
 prim__sigint : Int
 
 %foreign signalFFI "sigabrt"
+         "node:support:sigabrt,support_system_signal"
 prim__sigabrt : Int
 
 %foreign signalFFI "sigquit"
+         "node:support:sigquit,support_system_signal"
 prim__sigquit : Int
 
 %foreign signalFFI "sigill"
+         "node:support:sigill,support_system_signal"
 prim__sigill : Int
 
 %foreign signalFFI "sigsegv"
+         "node:support:sigsegv,support_system_signal"
 prim__sigsegv : Int
 
 %foreign signalFFI "sigtrap"
+         "node:support:sigtrap,support_system_signal"
 prim__sigtrap : Int
 
 %foreign signalFFI "sigfpe"
+         "node:support:sigfpe,support_system_signal"
 prim__sigfpe : Int
 
 %foreign signalFFI "sigusr1"
+         "node:support:sigusr1,support_system_signal"
 prim__sigusr1 : Int
 
 %foreign signalFFI "sigusr2"
+         "node:support:sigusr2,support_system_signal"
 prim__sigusr2 : Int
 
 public export
@@ -126,21 +136,27 @@ toSignal x    = lookup x codes
 -- Signal Handling
 --
 %foreign signalFFI "ignore_signal"
+         "node:support:ignoreSignal,support_system_signal"
 prim__ignoreSignal : Int -> PrimIO Int
 
 %foreign signalFFI "default_signal"
+         "node:support:defaultSignal,support_system_signal"
 prim__defaultSignal : Int -> PrimIO Int
 
 %foreign signalFFI "collect_signal"
+         "node:support:collectSignal,support_system_signal"
 prim__collectSignal : Int -> PrimIO Int
 
 %foreign signalFFI "handle_next_collected_signal"
+         "node:support:handleNextCollectedSignal,support_system_signal"
 prim__handleNextCollectedSignal : PrimIO Int
 
 %foreign signalFFI "send_signal"
+         "node:support:sendSignal,support_system_signal"
 prim__sendSignal : Int -> Int -> PrimIO Int
 
 %foreign signalFFI "raise_signal"
+         "node:support:raiseSignal,support_system_signal"
 prim__raiseSignal : Int -> PrimIO Int
 
 ||| An Error represented by a code. See

--- a/support/js/support_system_signal.js
+++ b/support/js/support_system_signal.js
@@ -42,23 +42,43 @@ function signal_int_to_string(signal) {
 }
 
 function support_system_signal_ignoreSignal(signal) {
-    support_system_signal_process.on(signal_int_to_string(signal), sig => {})
-    return 0
+    let signal_string = signal_int_to_string(signal)
+    try {
+        support_system_signal_process.on(signal_string, sig => {})
+        return 0
+    } catch (e) {
+        return -1
+    }
 }
 
 function support_system_signal_sendSignal(pid, signal) {
-    support_system_signal_process.kill(pid, signal_int_to_string(signal))
-    return 0
+    let signal_string = signal_int_to_string(signal)
+    try {
+        support_system_signal_process.kill(pid)
+        return 0
+    } catch (e) {
+        return -1
+    }
 }
 
 function support_system_signal_raiseSignal(signal) {
-    support_system_signal_process.kill(support_system_signal_process.pid, signal_int_to_string(signal))
-    return 0
+    let signal_string = signal_int_to_string(signal)
+    try {
+        support_system_signal_process.kill(support_system_signal_process.pid)
+        return 0
+    } catch (e) {
+        return -1
+    }
 }
 
 function support_system_signal_defaultSignal(signal) {
-    support_system_signal_process.removeAllListeners(signal_int_to_string(signal))
-    return 0
+    let signal_string = signal_int_to_string(signal)
+    try {
+        support_system_signal_process.removeAllListeners()
+        return 0
+    } catch (e) {
+        return -1
+    }
 }
 
 function support_system_signal_collectSignal(signal) {

--- a/support/js/support_system_signal.js
+++ b/support/js/support_system_signal.js
@@ -1,28 +1,58 @@
 const support_system_signal_process = require('process')
 
-const support_system_signal_sighup = 'SIGHUP'
-const support_system_signal_sigint = 'SIGINT'
-const support_system_signal_sigabrt = 'SIGABRT'
-const support_system_signal_sigquit = 'SIGQUIT'
-const support_system_signal_sigill = 'SIGILL'
-const support_system_signal_sigsegv = 'SIGSEGV'
-const support_system_signal_sigtrap = 'SIGTRAP'
-const support_system_signal_sigfpe = 'SIGFPE'
-const support_system_signal_sigusr1 = 'SIGUSR1'
-const support_system_signal_sigusr2 = 'SIGUSR2'
+// https://en.wikipedia.org/wiki/Signal_(IPC)#Default_action
+const support_system_signal_sighup = 1
+const support_system_signal_sigint = 2
+const support_system_signal_sigquit = 3
+const support_system_signal_sigill = 4
+const support_system_signal_sigtrap = 5
+const support_system_signal_sigabrt = 6
+const support_system_signal_sigfpe = 8
+const support_system_signal_sigusr1 = 10
+const support_system_signal_sigsegv = 11
+const support_system_signal_sigusr2 = 12
+
+function signal_int_to_string(signal) {
+    switch (signal) {
+        case 1:
+            return 'SIGHUP'
+        case 2:
+            return 'SIGINT'
+        case 3:
+            return 'SIGQUIT'
+        case 4:
+            return 'SIGILL'
+        case 5:
+            return 'SIGTRAP'
+        case 6:
+            return 'SIGABRT'
+        case 8:
+            return 'SIGFPE'
+        case 10:
+            return 'SIGUSR1'
+        case 11:
+            return 'SIGSEGV'
+        case 12:
+            return 'SIGUSR2'
+        default:
+            // https://nodejs.org/api/process.html#signal-events
+            // 0 can be sent to test for the existence of a process, it has no effect if the process exists, but will throw an error if the process does not exist.
+            return 0
+    }
+}
 
 function support_system_signal_ignoreSignal(signal) {
-    support_system_signal_process.on(signal, sig => {})
+    support_system_signal_process.on(signal_int_to_string(signal), sig => {})
     return 0
 }
 
 function support_system_signal_sendSignal(pid, signal) {
-    support_system_signal_process.kill(pid, signal)
+    support_system_signal_process.kill(pid, signal_int_to_string(signal))
     return 0
 }
 
 function support_system_signal_raiseSignal(signal) {
-    support_system_signal_process.kill(support_system_signal_process.pid, signal)
+    support_system_signal_process.kill(support_system_signal_process.pid, signal_int_to_string(signal))
     return 0
 }
 

--- a/support/js/support_system_signal.js
+++ b/support/js/support_system_signal.js
@@ -54,7 +54,7 @@ function support_system_signal_ignoreSignal(signal) {
 function support_system_signal_sendSignal(pid, signal) {
     let signal_string = signal_int_to_string(signal)
     try {
-        support_system_signal_process.kill(pid)
+        support_system_signal_process.kill(pid, signal_string)
         return 0
     } catch (e) {
         return -1
@@ -64,7 +64,7 @@ function support_system_signal_sendSignal(pid, signal) {
 function support_system_signal_raiseSignal(signal) {
     let signal_string = signal_int_to_string(signal)
     try {
-        support_system_signal_process.kill(support_system_signal_process.pid)
+        support_system_signal_process.kill(support_system_signal_process.pid, signal_string)
         return 0
     } catch (e) {
         return -1
@@ -74,7 +74,7 @@ function support_system_signal_raiseSignal(signal) {
 function support_system_signal_defaultSignal(signal) {
     let signal_string = signal_int_to_string(signal)
     try {
-        support_system_signal_process.removeAllListeners()
+        support_system_signal_process.removeAllListeners(signal_string)
         return 0
     } catch (e) {
         return -1

--- a/support/js/support_system_signal.js
+++ b/support/js/support_system_signal.js
@@ -57,7 +57,8 @@ function support_system_signal_raiseSignal(signal) {
 }
 
 function support_system_signal_defaultSignal(signal) {
-    // TODO
+    support_system_signal_process.removeAllListeners(signal_int_to_string(signal))
+    return 0
 }
 
 function support_system_signal_collectSignal(signal) {

--- a/support/js/support_system_signal.js
+++ b/support/js/support_system_signal.js
@@ -1,0 +1,39 @@
+const support_system_signal_process = require('process')
+
+const support_system_signal_sighup = 'SIGHUP'
+const support_system_signal_sigint = 'SIGINT'
+const support_system_signal_sigabrt = 'SIGABRT'
+const support_system_signal_sigquit = 'SIGQUIT'
+const support_system_signal_sigill = 'SIGILL'
+const support_system_signal_sigsegv = 'SIGSEGV'
+const support_system_signal_sigtrap = 'SIGTRAP'
+const support_system_signal_sigfpe = 'SIGFPE'
+const support_system_signal_sigusr1 = 'SIGUSR1'
+const support_system_signal_sigusr2 = 'SIGUSR2'
+
+function support_system_signal_ignoreSignal(signal) {
+    support_system_signal_process.on(signal, sig => {})
+    return 0
+}
+
+function support_system_signal_sendSignal(pid, signal) {
+    support_system_signal_process.kill(pid, signal)
+    return 0
+}
+
+function support_system_signal_raiseSignal(signal) {
+    support_system_signal_process.kill(support_system_signal_process.pid, signal)
+    return 0
+}
+
+function support_system_signal_defaultSignal(signal) {
+    // TODO
+}
+
+function support_system_signal_collectSignal(signal) {
+    // TODO
+}
+
+function support_system_signal_handleNextCollectedSignal() {
+    // TODO
+}

--- a/support/js/support_system_signal.js
+++ b/support/js/support_system_signal.js
@@ -81,10 +81,26 @@ function support_system_signal_defaultSignal(signal) {
     }
 }
 
+// this implementation deduplicates signals and leaves handle ordering up to details of the Map impl
+var pending_signals = new Map();
+
 function support_system_signal_collectSignal(signal) {
-    // TODO
+    let signal_string = system_signal_int_to_string(signal)
+    try {
+        support_system_signal_process.on(signal_string, x => { pending_signals.set(signal) })
+        return 0
+    } catch (e) {
+        return -1
+    }
 }
 
 function support_system_signal_handleNextCollectedSignal() {
-    // TODO
+    let next = pending_signals.keys().next()
+    if (next.done) {
+        return -1
+    } else {
+        let val = next.value
+        pending_signals.delete(val)
+        return val
+    }
 }


### PR DESCRIPTION
In support of #2207 

This attempts to add signal support to the node backend. This is my first attempt at any contributions to the Idris2 codebase, as such I'm going about this rather naively. You'll see that there are currently 3 stubbed out TODOs.

1. `defaultSignal`: This is tricky because it doesn't appear that node *has* default Signal handlers so we would have to decide on what the normal ones would be. and as best I can tell there isn't a way to "reset" the signal handler as best I can tell
2. `collectSignal`: Since this is stateful I wanted to check in here and see if creating a global variable in the `support_system_signal.js` file that maintains a data structure of currently pending signals is OK here or if there's a better approach
3. `handleNextCollectedSignal`: similar to number 2 I wanted to get the approach OK'ed first

Lastly, node accepts signals as string arguments, while the primops call them ints. I *think* I can just cheat here and have the primops be strings under the hood since they will also be strings when supplied as arguments to the signal functions but I also don't know if that is safe given that the primops may try to properly use the signals as integers in which case we'd have to translate inside the individual handling functions.

Would really appreciate some feedback so I can finish this and move the needle on this.

Additional reference: https://nodejs.org/api/process.html#signal-events