### PR TITLE
Add Data.Rational

### DIFF
--- a/libs/contrib/Data/Rational.idr
+++ b/libs/contrib/Data/Rational.idr
@@ -1,0 +1,91 @@
+module Data.Rational
+
+import Data.Nat.Factor
+
+%default total
+
+public export
+data Nat1 : Type where
+   S : Nat -> Nat1
+
+export
+Cast Nat1 Integer where
+   cast (S n) = (natToInteger n) + 1
+
+mult : Nat1 -> Nat1 -> Nat1
+mult (S m) (S n) = S (m + n + m * n)
+
+toNat_notbothzero : Nat1 -> Nat
+toNat_notbothzero (S n) = S n
+
+fromNat_coerce : Nat -> Nat1
+fromNat_coerce Z = S Z
+fromNat_coerce (S n) = S n
+
+public export
+record Rational where
+   constructor RatioOf
+   numerator : Integer
+   denominator : Nat1
+
+
+-- TODO: inline all this as prim__
+toUnsigned : Integer -> (Nat, Bool)
+toUnsigned n = if n < 0 then (cast n, False) else (cast (negate n), True)
+
+fromUnsigned : (Nat, Bool) -> Integer
+fromUnsigned (n, False) = cast n
+fromUnsigned (n, True) = negate (cast n)
+
+lcd : Nat -> Nat -> Nat
+lcd 0 _ = 1
+lcd _ 0 = 1
+lcd m 1 = 1
+lcd 1 n = 1
+lcd m n = if m > n then lcd n (assert_smaller m (m `minus` n)) else lcd n m
+
+divide : Nat -> Nat -> Nat
+divide m n = fromInteger $ (natToInteger m) `div` (natToInteger n)
+
+gcd_div : (Nat, Nat) -> (Nat, Nat)
+gcd_div (m, n) = do
+   let l = lcd m n
+   (m `divide` l, n `divide` l)
+
+simplify : Rational -> Rational
+simplify (RatioOf m n) = do
+   let n' = toNat_notbothzero n
+   let (m', is_negative) = toUnsigned m
+   let (n'', m'') = gcd_div (n', m')
+   RatioOf (fromUnsigned (m'', is_negative)) (fromNat_coerce n'')
+-- inline this (end)
+
+
+export
+Num Rational where
+   (+) (RatioOf m n) (RatioOf m' n') =
+      let 
+         numer = (m * (cast n')) + (m' * (cast n))
+         denom = n `mult` n'
+      in
+         -- TODO: produce better algorithm to simplify inplace
+         simplify (RatioOf numer denom)
+
+   (*) (RatioOf m n) (RatioOf m' n') =
+      let
+         numer = m * m'
+         denom = n `mult` n'
+      in
+         -- TODO: produce better algorithm to simplify inplace
+         simplify (RatioOf numer denom)
+      
+   fromInteger n = RatioOf n (S 0)
+
+export
+Neg Rational where
+   negate (RatioOf m n) = RatioOf (negate m) n
+   (-) m n = (+) m (negate n)
+
+export
+Abs Rational where
+   abs (RatioOf m n) = RatioOf (abs m) n

--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -80,6 +80,8 @@ modules = Control.ANSI,
 
           Data.Path,
 
+          Data.Rational,
+
           Data.Rel.Complement,
 
           Data.Seq.Internal,

--- a/libs/prelude/Prelude/Types.idr
+++ b/libs/prelude/Prelude/Types.idr
@@ -27,7 +27,7 @@ data Nat =
 prim__integerToNat : Integer -> Nat
 prim__integerToNat i
   = if intToBool (prim__lte_Integer 0 i)
-      then believe_me i
+      then believe_me i -- Integer and Nat must have same internal representation
       else Z
 
 public export


### PR DESCRIPTION
Current implementation is naive. I think that's why Haskell GHC has Rational as primitive.

Fix https://github.com/idris-lang/Idris2/issues/2545