### PR TITLE
[ re #2533 ] Fix printing of lazy types and values in `Show TTImp`

### DIFF
--- a/libs/base/Language/Reflection/TTImp.idr
+++ b/libs/base/Language/Reflection/TTImp.idr
@@ -611,9 +611,11 @@ mutual
     showPrec d (IAs fc nameFC side nm s)
       = "\{show nm}@\{showPrec App s}"
     showPrec d (IMustUnify fc dr s) = ".(\{show s})"
-    showPrec d (IDelayed fc lr s) = showPrec d s
-    showPrec d (IDelay fc s) = showCon d "Delay" $ assert_total (showArg s)
-    showPrec d (IForce fc s) = showPrec d s
+    showPrec d (IDelayed fc LInf s) = showCon d "Inf" $ assert_total $ showArg s
+    showPrec d (IDelayed fc LLazy s) = showCon d "Lazy" $ assert_total $ showArg s
+    showPrec d (IDelayed fc LUnknown s) = "({- unknown lazy -} \{showPrec Open s})"
+    showPrec d (IDelay fc s) = showCon d "Delay" $ assert_total $ showArg s
+    showPrec d (IForce fc s) = showCon d "Force" $ assert_total $ showArg s
     showPrec d (IQuote fc s) = "`(\{show s})"
     showPrec d (IQuoteName fc nm) = "`{\{show nm}}"
     showPrec d (IQuoteDecl fc xs) = "`[\{joinBy "; " (assert_total $ map show xs)}]"

--- a/libs/base/Language/Reflection/TTImp.idr
+++ b/libs/base/Language/Reflection/TTImp.idr
@@ -539,7 +539,7 @@ mutual
 
   export
   Show Clause where
-    show (PatClause fc lhs rhs) = "\{show lhs} = \{show rhs}"
+    show (PatClause fc lhs rhs) = "\{show lhs} => \{show rhs}"
     show (WithClause fc lhs rig wval prf flags cls) -- TODO print flags
       = unwords
       [ show lhs, "with"
@@ -581,10 +581,14 @@ mutual
           "let \{showCount rig (show nm)} : \{show nTy} = \{show nVal} in \{show scope}"
     showPrec d (ICase fc s ty xs)
       = showParens (d > Open) $
-          unwords [ "case", show s, ":", show ty, "of", "{"
-                  , joinBy "; " (assert_total $ map show xs)
-                  , "}"
-                  ]
+          unwords $ [ "case", show s ] ++ typeFor ty ++ [ "of", "{"
+                    , joinBy "; " (assert_total $ map show xs)
+                    , "}"
+                    ]
+          where
+            typeFor : TTImp -> List String
+            typeFor $ Implicit _ False = []
+            typeFor ty = [ "{-", ":", show ty, "-}" ]
     showPrec d (ILocal fc decls s)
       = showParens (d > Open) $
           unwords [ "let", joinBy "; " (assert_total $ map show decls)


### PR DESCRIPTION
The only controversial thing I see in this change is the way I decided to print `LUknown` delayed type. But this type of expression rarely appears and I think it's important to show that this type is actually a some kind of lazy type when printing. I think, we don't have any adequate Idris syntax for this, so it's printed in the comment.