### PR TITLE
Remove implicit argument in documentation for parseDouble

### DIFF
--- a/libs/base/Data/String.idr
+++ b/libs/base/Data/String.idr
@@ -310,10 +310,10 @@ parseInteger s = parseIntTrimmed (trim s)
 ||| parseDouble "+123.123e-2"
 ||| ```
 ||| ```idris example
-||| parseDouble {a=Int} " -123.123E+2"
+||| parseDouble " -123.123E+2"
 ||| ```
 ||| ```idris example
-||| parseDouble {a=Int} " +123.123"
+||| parseDouble " +123.123"
 ||| ```
 export -- it's a bit too slow at compile time
 covering


### PR DESCRIPTION
Small PR that removes the implicit argument from the documentation of `parseDouble`. I am guessing these examples were once copied `parseInteger`, which is polymorphic. 