### PR TITLE
[ cleanup ] add proper depends field to network.ipkg

### DIFF
--- a/libs/network/network.ipkg
+++ b/libs/network/network.ipkg
@@ -1,7 +1,7 @@
 package network
 version = 0.5.1
 
-opts = "--ignore-missing-ipkg -p contrib"
+opts = "--ignore-missing-ipkg"
 
 modules = Control.Linear.Network,
 
@@ -9,3 +9,5 @@ modules = Control.Linear.Network,
           Network.Socket.Data,
           Network.Socket.Raw,
           Network.FFI
+
+depends = contrib


### PR DESCRIPTION
I have no idea why `network.ipkg` lists its dependency on contrib in the `opts` field. I consider this to be really bad style, so I suggest we change this, which also will remove some manual dependency listing for *network* in pack's source code. In addition, this shows that actually the Idris compiler still transitively depends on contrib, although it doesn't make use of the `LIO` stuff. Therefore, an alternative to this would be to get rid of the `LIO` part altogether, and drop *network*'s dependency on contrib.