### PR TITLE
Fix the --dumpanf command line switch.

### DIFF
--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -785,6 +785,7 @@ partitionOpts opts = foldr pOptUpdate (MkPFR [] [] False) opts
     optType (Timing l)             = POpt
     optType (Logging l)            = POpt
     optType CaseTreeHeuristics     = POpt
+    optType (DumpANF f)            = POpt
     optType (DumpCases f)          = POpt
     optType (DumpLifted f)         = POpt
     optType (DumpVMCode f)         = POpt


### PR DESCRIPTION
You can dump the intermediate code with `--dumpcases`, `--dumplifted`, and `--dumpvmcode`. But if you try to use `--dumpanf` you get the error:

```
Not all command line options can be used to override package options.

Overridable options are:
    --quiet
    --verbose
    --timing
    --log <log level>
    --dumpcases <file>
    --dumplifted <file>
    --dumpvmcode <file>
    --debug-elab-check
    --codegen <cg>
    --directive <directive>
    --build-dir <dir>
    --output-dir <dir>
```

This patch enables `--dumpanf`.