### PR TITLE
Ide random socket

### DIFF
--- a/src/Idris/CommandLine.idr
+++ b/src/Idris/CommandLine.idr
@@ -164,10 +164,10 @@ data CLOpt
 ||| Extract the host and port to bind the IDE socket to
 export
 ideSocketModeAddress : List CLOpt -> (String, Int)
-ideSocketModeAddress []  = ("localhost", 38398)
+ideSocketModeAddress []  = ("localhost", 0)
 ideSocketModeAddress (IdeModeSocket hp :: _) =
   let (h, p) = String.break (== ':') hp
-      port = fromMaybe 38398 (portPart p >>= parsePositive)
+      port = fromMaybe 0 (portPart p >>= parsePositive)
       host = if h == "" then "localhost" else h
   in (host, port)
   where
@@ -300,8 +300,7 @@ options = [MkOpt ["--check", "-c"] [] [CheckOnly]
               (Just "Run the REPL with machine-readable syntax"),
            MkOpt ["--ide-mode-socket"] [Optional "host:port"]
                  (\hp => [IdeModeSocket $ fromMaybe (formatSocketAddress (ideSocketModeAddress [])) hp])
-              (Just $ "Run the ide socket mode on given host and port " ++
-                      showDefault (formatSocketAddress (ideSocketModeAddress []))),
+              (Just $ "Run the ide socket mode on given host and port (random open socket by default)"),
 
            optSeparator,
            MkOpt ["--client"] [Required "REPL command"] (\f => [RunREPL f])

--- a/src/Idris/IDEMode/REPL.idr
+++ b/src/Idris/IDEMode/REPL.idr
@@ -31,6 +31,7 @@ import System.File
 
 import Network.Socket
 import Network.Socket.Data
+import Network.Socket.Raw
 
 import TTImp.Interactive.Completion
 
@@ -69,7 +70,8 @@ initIDESocketFile h p = do
                 then
                   pure (Left ("Failed to listen on socket with error: " ++ show res))
                else
-                 do putStrLn (show p)
+                 do p <- getSockPort sock
+                    putStrLn (show p)
                     fflush stdout
                     res <- accept sock
                     case res of


### PR DESCRIPTION
The primary issue this addresses is that there can be only one ide server running at the same time, because they all use the same socket number.  (idris-community/idris2-mode#26). 

Since the plugins read the socket number from stdout, this could be worked around by opening socket "0" which means "choose an open socket", but idris2 currently prints the configured value rather than the actual socket number that was chosen by the OS.

This PR changes `--ide-mode-socket` to print the number of the socket that was opened, rather than the configured value.  This change enables `--ide-mode-socket :0` to work correctly.

It also changes the default socket to 0.  This change allows existing clients to benefit from having more than one server running at a time, without change.  But it assumes they respect the socket number printed on stdout. I don't see any evidence via google of anyone hardcoding the number 38398, so I think this is safe.

If clients do want a specific socket, they can still specify it on the command line.

Do any plugins besides the emacs ones use ide-mode-socket?
