### PR TITLE
Allow for proofs involving parsing numbers from strings.

### DIFF
--- a/libs/base/Data/String.idr
+++ b/libs/base/Data/String.idr
@@ -250,6 +250,7 @@ public export
 isInfixOf : String -> String -> Bool
 isInfixOf a b = isInfixOf (unpack a) (unpack b)
 
+public export
 parseNumWithoutSign : List Char -> Integer -> Maybe Integer
 parseNumWithoutSign []        acc = Just acc
 parseNumWithoutSign (c :: cs) acc =

--- a/tests/base/data_string_parse_proof/StringParse.idr
+++ b/tests/base/data_string_parse_proof/StringParse.idr
@@ -1,0 +1,17 @@
+import Data.String
+import Data.Nat
+
+%default total
+
+posNat : Maybe Nat
+posNat = parsePositive "2"
+
+posNatProof : Main.posNat === Just 2
+posNatProof = Refl
+
+int : Maybe Integer
+int = parseInteger "-123"
+
+integerProof : Main.int === Just (-123)
+integerProof = Refl
+

--- a/tests/base/data_string_parse_proof/expected
+++ b/tests/base/data_string_parse_proof/expected
@@ -1,0 +1,1 @@
+1/1: Building StringParse (StringParse.idr)

--- a/tests/base/data_string_parse_proof/run
+++ b/tests/base/data_string_parse_proof/run
@@ -1,0 +1,3 @@
+$1 --no-banner --no-color --console-width 0 -c StringParse.idr
+
+rm -rf build


### PR DESCRIPTION
I recently wanted to jot down a little proof that a function was working but got caught on the last remaining private function in the way of the compiler evaluating natural number and integer string parsing.