### PR TITLE
add `dflip`, a dependent version of `flip`

### DIFF
--- a/libs/base/Control/Function.idr
+++ b/libs/base/Control/Function.idr
@@ -2,6 +2,12 @@ module Control.Function
 
 %default total
 
+||| Takes in the first two arguments in reverse order. This is a dependent version of `flip`, where
+||| the return type can depend on the function inputs.
+public export
+dflip : {0 c : a -> b -> Type} -> ((x : a) -> (y : b) -> c x y) -> (y : b) -> (x : a) -> c x y
+dflip f x y = f y x
+
 ||| An injective function maps distinct elements to distinct elements.
 public export
 interface Injective (f : a -> b) | f where


### PR DESCRIPTION
This came out of https://github.com/idris-lang/Idris2/issues/2589. I thought, since @buzden gave it a 👍🏻 I'd see if there was wider support for it

I'm very aware this is in one of the most core modules in the stdlib, so we'll want to be sure it's worth adding.