### PR TITLE
[ fix ] Fixes memory leaks in currentDir, fGetLine, and fGetChars

### DIFF
--- a/libs/base/System/Directory.idr
+++ b/libs/base/System/Directory.idr
@@ -3,6 +3,7 @@ module System.Directory
 
 import System.Errno
 import public System.File
+import System.FFI
 
 %default total
 
@@ -83,7 +84,9 @@ currentDir
     = do res <- primIO prim__currentDir
          if prim__nullPtr res /= 0
             then pure Nothing
-            else pure (Just (prim__getString res))
+            else do let s = prim__getString res
+                    free $ prim__forgetPtr res
+                    pure (Just s)
 
 ||| Try to open the directory at the specified path.
 export

--- a/libs/base/System/FFI.idr
+++ b/libs/base/System/FFI.idr
@@ -52,6 +52,7 @@ setField s n val = primIO (prim__setField s n fieldok val)
 prim__malloc : (size : Int) -> PrimIO AnyPtr
 
 %foreign "C:idris2_free, libidris2_support, idris_memory.h"
+         "javascript:lambda:()=>undefined"
 prim__free : AnyPtr -> PrimIO ()
 
 ||| Allocate memory with libc `malloc`.


### PR DESCRIPTION
This PR fixes the memory leak described in #2552 in addition to two other leaks.

The `fGetLine` function leaks 1kb for every line of text read by the compiler.  This happens because scheme is not freeing pointers returned from the C FFI.  (And, in the case of the getenv FFI, we don't want it to.)  This can be a problem with long running sessions like the REPL or idris2-lsp that reload lots of files.

The leaks and the fix were verified with the MacOS `leaks` utility and Linux `valgrind` utility (see #2552 for details).
