### PR TITLE
[ fix ] Add missing reserved words to JS backend

### DIFF
--- a/src/Compiler/ES/Codegen.idr
+++ b/src/Compiler/ES/Codegen.idr
@@ -81,10 +81,12 @@ jsIdent s = concatMap okchar (unpack s)
 
 jsReservedNames : List String
 jsReservedNames =
-  [ "var", "switch"
-  , "return", "const"
-  , "function", "break"
-  , "continue"
+  [ "await", "break", "case", "catch", "class", "const", "continue", "debugger"
+  , "default", "delete", "do", "else", "enum", "export", "extends", "false"
+  , "finally", "for", "function", "if", "implements", "import", "in"
+  , "instanceof", "interface", "let", "new", "null", "package", "private"
+  , "protected", "public", "return", "static", "super", "switch", "this"
+  , "throw", "true", "try", "typeof", "var", "void", "while", "with", "yield"
   ]
 
 keywordSafe : String -> String


### PR DESCRIPTION
Adds missing reserved keywords to JS backend so they are escaped properly in the output JavaScript.

Adds:

- all keywords that are always reserved (e.g. `this`...)
- all keywords that are reserved only in strict mode (e.g. `let`...)
- all keywords that are reserved only in modules or async functions (`await`)
- all future reserved keywords (`enum`)
- all future reserved keywords that are reserved only in strict mode (e.g. `public`...)

Reference list: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#keywords