### PR TITLE
Fix typing of `connect` in network's Linear module, and add bytes-specific functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,12 @@
   `Prelude.Interfaces` instead.
 * Implements `Show tok => Show (ParsingError tok)` for `Text.Parser.Core`.
 
+#### Network
+
+* `Control.Linear.Network` now supports `connect` in the linear environment, and
+  can also access the `sendBytes`, `recvBytes` and `recvAllBytes` functions of
+  the underlying `Socket` module.
+
 ### Other changes
 
 * Adds docstrings for the lambda-lifted IR.

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -14,6 +14,7 @@ Arnaud Bailly
 Brian Wignall
 Bryn Keller
 Christian Rasmussen
+Cyrill Brunner
 Danylo Lapirov
 David Smith
 Denis Buzdalov


### PR DESCRIPTION
The `connect` function as defined by `Control.Linear.Network` currently only works if you obtained the raw socket object from `Network.Socket.socket` itself, leading to a possibly polluted namespace with both imported.
This changes the function to require a Socket in the `Ready` state.

As far as I understand sockets, this might *technically* be too constrained -- a client socket that `connect`s can also first `bind` itself (though it's not advised to do so?), but more importantly, according to the [connect(2)](https://man7.org/linux/man-pages/man2/connect.2.html) man page, certain protocol sockets may (disconnect and) reconnect multiple times. Tracking this however would probably need a more major change to the `Socket` data type to track its protocol, which I believe is probably out of scope.

This also adds missing bindings to the Bytes-specific functions from `Network.Socket`. I did not look at `sendTo` and `recvFrom` as their role in the state transition diagram wouldn't be quite clear to me.

I have previously mentioned this [on the Discord](https://discord.com/channels/827106007712661524/900662634217627649/1012647679303618580) and didn't receive any input against this change.