### PR TITLE
[ base ] Implement `MonadError ()` for `MaybeT`

### DIFF
--- a/libs/base/Control/Monad/Error/Interface.idr
+++ b/libs/base/Control/Monad/Error/Interface.idr
@@ -75,6 +75,11 @@ MonadError () Maybe where
   catchError x       _ = x
 
 public export
+Monad m => MonadError () (MaybeT m) where
+  throwError () = MkMaybeT $ pure Nothing
+  catchError (MkMaybeT m) f = MkMaybeT $ m >>= maybe (runMaybeT $ f ()) (pure @{Compose})
+
+public export
 MonadError e (Either e) where
   throwError             = Left
   Left  l `catchError` h = h l


### PR DESCRIPTION
`Either e` and `EitherT e` have similar implementations for `MonadError e` and that's great. `Maybe` implements `MonadError ()` and this is great too. However, we don't have similar implementation for `MaybeT`.

I think, this should not clash with existing dropping-into implementation. Moreover, I think, one of the important reasons why one may use `MaybeT` in his stack is implementation for `MonadError ()`, that's why I think this implementation should be unnamed.