### PR TITLE
[ parser ] improvements to parser error messages

### DIFF
--- a/libs/contrib/Text/Parser/Core.idr
+++ b/libs/contrib/Text/Parser/Core.idr
@@ -329,7 +329,7 @@ doParse s com (Alt {c1} {c2} x y) xs
                                                                      -- Only add the errors together if the second branch
                                                                      -- is also non-committed and non-fatal.
                                                              then Failure com'' fatal' errs'
-                                                             else Failure False False (errs ++ errs')
+                                                             else Failure com False (errs ++ errs')
                              (Res s _ val xs) => Res s com val xs
            -- Successfully parsed the first option, so use the outer commit flag
            Res s _ val xs => Res s com val xs

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -793,6 +793,7 @@ mutual
   if_ : OriginDesc -> IndentInfo -> Rule PTerm
   if_ fname indents
       = do b <- bounds (do decoratedKeyword fname "if"
+                           commit
                            x <- expr pdef fname indents
                            commitKeyword fname indents "then"
                            t <- typeExpr pdef fname indents

--- a/src/Libraries/Text/Parser/Core.idr
+++ b/src/Libraries/Text/Parser/Core.idr
@@ -355,7 +355,7 @@ doParse s ws com (Alt {c1} {c2} x y) xs
                                                                      -- Only add the errors together if the second branch
                                                                      -- is also non-committed and non-fatal.
                                                              then Failure com'' fatal' errs'
-                                                             else Failure False False (errs ++ errs')
+                                                             else Failure com False (errs ++ errs')
                              (Res s ws _ val xs) => Res s ws com val xs
            -- Successfully parsed the first option, so use the outer commit flag
            Res s ws _ val xs => Res s ws com val xs

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -91,7 +91,8 @@ idrisTestsError = MkTestPool "Error messages" [] Nothing
        -- Parse errors
        "perror001", "perror002", "perror003", "perror004", "perror005",
        "perror006", "perror007", "perror008", "perror009", "perror010",
-       "perror011", "perror012", "perror013", "perror014", "perror015"]
+       "perror011", "perror012", "perror013", "perror014", "perror015",
+       "perror016"]
 
 idrisTestsInteractive : TestPool
 idrisTestsInteractive = MkTestPool "Interactive editing" [] Nothing

--- a/tests/idris2/perror016/ParseIf.idr
+++ b/tests/idris2/perror016/ParseIf.idr
@@ -1,0 +1,3 @@
+
+test : Int -> Int
+test a = if a < 10 the 0 else a

--- a/tests/idris2/perror016/ParseIf2.idr
+++ b/tests/idris2/perror016/ParseIf2.idr
@@ -1,0 +1,5 @@
+
+test : Int -> Int
+test a = if a < 10
+            then if a < 0 the 0 else 5
+            else a

--- a/tests/idris2/perror016/expected
+++ b/tests/idris2/perror016/expected
@@ -1,0 +1,10 @@
+1/1: Building ParseIf (ParseIf.idr)
+Error: Couldn't parse any alternatives:
+1: Expected 'then'.
+
+ParseIf:3:26--3:30
+ 1 | 
+ 2 | test : Int -> Int
+ 3 | test a = if a < 10 the 0 else a
+                              ^^^^
+... (14 others)

--- a/tests/idris2/perror016/expected
+++ b/tests/idris2/perror016/expected
@@ -8,3 +8,14 @@ ParseIf:3:26--3:30
  3 | test a = if a < 10 the 0 else a
                               ^^^^
 ... (14 others)
+1/1: Building ParseIf2 (ParseIf2.idr)
+Error: Couldn't parse any alternatives:
+1: Expected 'then'.
+
+ParseIf2:4:33--4:37
+ 1 | 
+ 2 | test : Int -> Int
+ 3 | test a = if a < 10
+ 4 |             then if a < 0 the 0 else 5
+                                     ^^^^
+... (28 others)

--- a/tests/idris2/perror016/run
+++ b/tests/idris2/perror016/run
@@ -1,3 +1,4 @@
 rm -rf build
 
 $1 --no-color --console-width 0 --check ParseIf.idr || true
+$1 --no-color --console-width 0 --check ParseIf2.idr || true

--- a/tests/idris2/perror016/run
+++ b/tests/idris2/perror016/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --check ParseIf.idr || true

--- a/tests/idris2/with003/expected
+++ b/tests/idris2/with003/expected
@@ -35,10 +35,10 @@ Mismatch between: Vect 0 ?elem and List ?a.
 
 Main> the (Maybe Integer) (pure 4) : Maybe Integer
 Main> Couldn't parse any alternatives:
-1: Expected 'case', 'if', 'do', application or operator expression.
+1: Expected namespaced name.
 
-(Interactive):1:4--1:8
+(Interactive):1:10--1:11
  1 | :t with [] 4
-        ^^^^
-... (45 others)
+              ^
+... (16 others)
 Main> Bye for now!


### PR DESCRIPTION
I made an `if the else` typo the other day, and the error message pointed to the `if` saying that it expected an `if`.  This PR adds a `commit` after the `if` is accepted to improve error messages inside `if` statements.

Before:

```
1/1: Building perror016.ParseIf (perror016/ParseIf.idr)
Error: Couldn't parse any alternatives:
1: Expected 'case', 'if', 'do', application or operator expression.

perror016.ParseIf:3:10--3:12
 1 |
 2 | test : Int -> Int
 3 | test a = if a < 10 the 0 else a
              ^^
```

After:

```
1/1: Building ParseIf (ParseIf.idr)
Error: Couldn't parse any alternatives:
1: Expected 'then'.

ParseIf:3:26--3:30
 1 |
 2 | test : Int -> Int
 3 | test a = if a < 10 the 0 else a
                              ^^^^
```

The second part is a bit more subtle. The PR also fixes an issue where an `Alt` will sometimes revert a previous commit. 

After the above fix the following was giving an `Expected 'case', ...` error pointing to the first `if` because the `commit` that I added was being canceled by the nested parser. After fixing the parser, the error points to the first `else` and says the `then` was expected.

```idris
test : Int -> Int
test a = if a < 10 then if a < 0 the 0 else 5 else a
```

I applied the fix to both copies of `Parser/Core.idr` to keep them in sync. 

This change had the side effect of fixing an inaccurate error message in the `with003` test.  (See the diff.) I suspect there are other cases where `Expected 'case', ...` has been replaced by a more accurate error message. 

There is one case that I have not fixed. Parens around an expression can kill a previous commit. The code:
```idris
test : Int -> Int
test a = if a < 10 then (if a < 0 the 0 else 5) else a
```
will still error with the `Expected 'case',...` message pointing at the first `if`.
