### PR TITLE
[ test ] Fix timing issue in interactive044 test

### DIFF
--- a/tests/idris2/interactive044/run
+++ b/tests/idris2/interactive044/run
@@ -2,6 +2,7 @@ rm -rf build
 rm -f SplitShadowGen.idr
 
 cp SplitShadow.idr SplitShadowGen.idr
+sleep 1
 
 $1 --no-color --console-width 0 --no-banner SplitShadowGen.idr < input
 


### PR DESCRIPTION
The test interactive044 randomly fails due to a timing issue.  I've seen this in CI and locally.

It copies a file and then runs an interactive session on it which generates a `.ttc` file and reloads.  Sometimes the `.ttc` file has the same timestamp as the source, causing it to be rebuilt on reload.  (Idris looks at the timestamps with a one second resolution and will rebuild if equal.) The rebuild emits an additional line of text causing the test to fail. 

I fixed the issue by adding a `sleep 1` after the file copy.

Below is a sample of two different outputs from running the test twice in a row locally:

```
dunham@peri interactive044 % ./run idris2
1/1: Building SplitShadowGen (SplitShadowGen.idr)
Main> colour (Emerald colour) = ?colour_rhs_6
Main> Loaded file SplitShadowGen.idr
Main> Bye for now!
dunham@peri interactive044 % ./run idris2
1/1: Building SplitShadowGen (SplitShadowGen.idr)
Main> colour (Emerald colour) = ?colour_rhs_6
Main> 1/1: Building SplitShadowGen (SplitShadowGen.idr)
Loaded file SplitShadowGen.idr
Main> Bye for now!
```