### PR TITLE
[ base ] Add finToNatEqualityAsPointwise, an inverse of finToNatQuotient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,8 @@
 * Adds `Data.List1.Quantifiers`, ported from `Data.List.Quantifiers`.
 * Changes the order of arguments in `RWST` transformer's runners functions (`runRWST`. `evalRWST`, `execRWST`),
   now transformer argument is the last, as in the other standard transformers, like `ReaderT` and `StateT`.
+* Adds `Data.Fin.finToNatEqualityAsPointwise`,
+  which takes a witness of `finToNat k = finToNat l` and proves `k ~~~ l`.
 
 #### Test
 

--- a/libs/base/Data/Fin.idr
+++ b/libs/base/Data/Fin.idr
@@ -374,6 +374,17 @@ namespace Equality
   finToNatQuotient FZ = Refl
   finToNatQuotient (FS prf) = cong S (finToNatQuotient prf)
 
+  ||| Propositional equality on `finToNat`s implies pointwise equality on the `Fin`s themselves
+  export
+  finToNatEqualityAsPointwise : (k : Fin m) ->
+                                (l : Fin n) ->
+                                finToNat k = finToNat l ->
+                                k ~~~ l
+  finToNatEqualityAsPointwise FZ FZ _ = FZ
+  finToNatEqualityAsPointwise FZ (FS _) prf = absurd prf
+  finToNatEqualityAsPointwise (FS _) FZ prf = absurd prf
+  finToNatEqualityAsPointwise (FS k) (FS l) prf = FS $ finToNatEqualityAsPointwise k l (injective prf)
+
   export
   weakenNeutral : (k : Fin n) -> weaken k ~~~ k
   weakenNeutral FZ = FZ


### PR DESCRIPTION
This adds a theorem that's conceptually an inverse of `finToNatQuotient`.

I was a bit torn whether this should go to `base` or `contrib` (or anywhere at all), but since `finToNatQuotient` is already here, it feels natural to add its friend to this same module.