### PR TITLE
[ test ] Fix timing issue in interactive045 test

### DIFF
--- a/tests/idris2/interactive045/run
+++ b/tests/idris2/interactive045/run
@@ -2,6 +2,7 @@ rm -rf build
 rm -f Issue1742Gen.idr
 
 cp Issue1742.idr Issue1742Gen.idr
+sleep 1
 
 $1 --no-color --console-width 0 --no-banner Issue1742Gen.idr < input
 


### PR DESCRIPTION
This is similar to #2644 - the test interactive045 randomly fails because the newly copied .idr file sometimes ends up with the same timestamp as its .ttc file. 