### PR TITLE
[ parser ] Make commitKeyword fail fatally

### DIFF
--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -156,6 +156,7 @@ commitKeyword : OriginDesc -> IndentInfo -> String -> Rule ()
 commitKeyword fname indents req
     = do mustContinue indents (Just req)
          decoratedKeyword fname req
+          <|> the (Rule ()) (fatalError ("Expected '" ++ req ++ "'"))
          mustContinue indents Nothing
 
 commitSymbol : OriginDesc -> String -> Rule ()

--- a/tests/idris2/perror016/ParseIf3.idr
+++ b/tests/idris2/perror016/ParseIf3.idr
@@ -1,0 +1,3 @@
+
+test : Int -> Int
+test a = (if a < 0 the 0 else 5)

--- a/tests/idris2/perror016/expected
+++ b/tests/idris2/perror016/expected
@@ -1,16 +1,14 @@
 1/1: Building ParseIf (ParseIf.idr)
-Error: Couldn't parse any alternatives:
-1: Expected 'then'.
+Error: Expected 'then'.
 
 ParseIf:3:26--3:30
  1 | 
  2 | test : Int -> Int
  3 | test a = if a < 10 the 0 else a
                               ^^^^
-... (14 others)
+
 1/1: Building ParseIf2 (ParseIf2.idr)
-Error: Couldn't parse any alternatives:
-1: Expected 'then'.
+Error: Expected 'then'.
 
 ParseIf2:4:33--4:37
  1 | 
@@ -18,4 +16,13 @@ ParseIf2:4:33--4:37
  3 | test a = if a < 10
  4 |             then if a < 0 the 0 else 5
                                      ^^^^
-... (28 others)
+
+1/1: Building ParseIf3 (ParseIf3.idr)
+Error: Expected 'then'.
+
+ParseIf3:3:26--3:30
+ 1 | 
+ 2 | test : Int -> Int
+ 3 | test a = (if a < 0 the 0 else 5)
+                              ^^^^
+

--- a/tests/idris2/perror016/run
+++ b/tests/idris2/perror016/run
@@ -2,3 +2,4 @@ rm -rf build
 
 $1 --no-color --console-width 0 --check ParseIf.idr || true
 $1 --no-color --console-width 0 --check ParseIf2.idr || true
+$1 --no-color --console-width 0 --check ParseIf3.idr || true


### PR DESCRIPTION
This PR adds a fatal error to `commitKeyword` to improve locality and accuracy of errors in the parser.

In Parser.idr, the description of `commitKeyword` is
```idris
-- Expect a keyword, but if we get anything else it's a fatal error
```
But it currently does not emit a fatal error (`commitSymbol` does emit an error). Because of this, missing keyword errors (for "in", "of", "then", and "else") can get swallowed and we just get a generic error at top level. 

With this change, instead of
```
Couldn't parse any alternatives:
1: Expected 'case', 'if', 'do', application or operator expression.

(Interactive):1:1--1:2
 1 | (if True the 2 else 3)
     ^
... (90 others)
```
we get
```
Expected 'then'.

(Interactive):1:16--1:20
 1 | (if True the 2 else 3)
                    ^^^^
```
