### PR TITLE
[ parse ] Add fc to IPragma for better error messages

### DIFF
--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -929,11 +929,11 @@ mutual
            let consb = map (\ (nm, tm) => (nm, doBind bnames tm)) cons'
 
            body' <- traverse (desugarDecl (ps ++ mnames ++ paramNames)) body
-           pure [IPragma (maybe [tn] (\n => [tn, n]) conname)
-                         (\nest, env =>
-                             elabInterface fc vis env nest consb
-                                           tn paramsb det conname
-                                           (concat body'))]
+           pure [IPragma fc (maybe [tn] (\n => [tn, n]) conname)
+                            (\nest, env =>
+                              elabInterface fc vis env nest consb
+                                            tn paramsb det conname
+                                            (concat body'))]
     where
       -- Turns pairs in the constraints to individual constraints. This
       -- is a bit of a hack, but it's necessary to build parent constraint
@@ -974,12 +974,12 @@ mutual
            -- given.
            let impname = maybe (mkImplName fc tn paramsb) id impln
 
-           pure [IPragma [impname]
-                         (\nest, env =>
-                             elabImplementation fc vis opts pass env nest isb consb
-                                                tn paramsb (isNamed impln)
-                                                impname nusing
-                                                body')]
+           pure [IPragma fc [impname]
+                            (\nest, env =>
+                               elabImplementation fc vis opts pass env nest isb consb
+                                                  tn paramsb (isNamed impln)
+                                                  impname nusing
+                                                  body')]
     where
       isNamed : Maybe a -> Bool
       isNamed Nothing = False
@@ -1095,31 +1095,31 @@ mutual
            pure [IRunElabDecl fc tm']
   desugarDecl ps (PDirective fc d)
       = case d of
-             Hide n => pure [IPragma [] (\nest, env => hide fc n)]
-             Unhide n => pure [IPragma [] (\nest, env => unhide fc n)]
+             Hide n => pure [IPragma fc [] (\nest, env => hide fc n)]
+             Unhide n => pure [IPragma fc [] (\nest, env => unhide fc n)]
              Logging i => pure [ILog ((\ i => (topics i, verbosity i)) <$> i)]
-             LazyOn a => pure [IPragma [] (\nest, env => lazyActive a)]
+             LazyOn a => pure [IPragma fc [] (\nest, env => lazyActive a)]
              UnboundImplicits a => do
                setUnboundImplicits a
-               pure [IPragma [] (\nest, env => setUnboundImplicits a)]
+               pure [IPragma fc [] (\nest, env => setUnboundImplicits a)]
              PrefixRecordProjections b => do
-               pure [IPragma [] (\nest, env => setPrefixRecordProjections b)]
-             AmbigDepth n => pure [IPragma [] (\nest, env => setAmbigLimit n)]
-             AutoImplicitDepth n => pure [IPragma [] (\nest, env => setAutoImplicitLimit n)]
-             NFMetavarThreshold n => pure [IPragma [] (\nest, env => setNFThreshold n)]
-             SearchTimeout n => pure [IPragma [] (\nest, env => setSearchTimeout n)]
-             PairNames ty f s => pure [IPragma [] (\nest, env => setPair fc ty f s)]
-             RewriteName eq rw => pure [IPragma [] (\nest, env => setRewrite fc eq rw)]
-             PrimInteger n => pure [IPragma [] (\nest, env => setFromInteger n)]
-             PrimString n => pure [IPragma [] (\nest, env => setFromString n)]
-             PrimChar n => pure [IPragma [] (\nest, env => setFromChar n)]
-             PrimDouble n => pure [IPragma [] (\nest, env => setFromDouble n)]
-             CGAction cg dir => pure [IPragma [] (\nest, env => addDirective cg dir)]
-             Names n ns => pure [IPragma [] (\nest, env => addNameDirective fc n ns)]
-             StartExpr tm => pure [IPragma [] (\nest, env => throw (InternalError "%start not implemented"))] -- TODO!
-             Overloadable n => pure [IPragma [] (\nest, env => setNameFlag fc n Overloadable)]
-             Extension e => pure [IPragma [] (\nest, env => setExtension e)]
-             DefaultTotality tot => pure [IPragma [] (\_, _ => setDefaultTotalityOption tot)]
+               pure [IPragma fc [] (\nest, env => setPrefixRecordProjections b)]
+             AmbigDepth n => pure [IPragma fc [] (\nest, env => setAmbigLimit n)]
+             AutoImplicitDepth n => pure [IPragma fc [] (\nest, env => setAutoImplicitLimit n)]
+             NFMetavarThreshold n => pure [IPragma fc [] (\nest, env => setNFThreshold n)]
+             SearchTimeout n => pure [IPragma fc [] (\nest, env => setSearchTimeout n)]
+             PairNames ty f s => pure [IPragma fc [] (\nest, env => setPair fc ty f s)]
+             RewriteName eq rw => pure [IPragma fc [] (\nest, env => setRewrite fc eq rw)]
+             PrimInteger n => pure [IPragma fc [] (\nest, env => setFromInteger n)]
+             PrimString n => pure [IPragma fc [] (\nest, env => setFromString n)]
+             PrimChar n => pure [IPragma fc [] (\nest, env => setFromChar n)]
+             PrimDouble n => pure [IPragma fc [] (\nest, env => setFromDouble n)]
+             CGAction cg dir => pure [IPragma fc [] (\nest, env => addDirective cg dir)]
+             Names n ns => pure [IPragma fc [] (\nest, env => addNameDirective fc n ns)]
+             StartExpr tm => pure [IPragma fc [] (\nest, env => throw (InternalError "%start not implemented"))] -- TODO!
+             Overloadable n => pure [IPragma fc [] (\nest, env => setNameFlag fc n Overloadable)]
+             Extension e => pure [IPragma fc [] (\nest, env => setExtension e)]
+             DefaultTotality tot => pure [IPragma fc [] (\_, _ => setDefaultTotalityOption tot)]
   desugarDecl ps (PBuiltin fc type name) = pure [IBuiltin fc type name]
 
   export

--- a/src/Idris/Resugar.idr
+++ b/src/Idris/Resugar.idr
@@ -544,7 +544,7 @@ mutual
                                   !(toPTerm startPrec rhs)))
   toPDecl (IRunElabDecl fc tm)
       = pure (Just (PRunElabDecl fc !(toPTerm startPrec tm)))
-  toPDecl (IPragma _ _) = pure Nothing
+  toPDecl (IPragma _ _ _) = pure Nothing
   toPDecl (ILog _) = pure Nothing
   toPDecl (IBuiltin fc type name) = pure $ Just $ PBuiltin fc type name
 

--- a/src/TTImp/ProcessDecls.idr
+++ b/src/TTImp/ProcessDecls.idr
@@ -126,7 +126,7 @@ process eopts nest env (ITransform fc n lhs rhs)
     = processTransform eopts nest env fc n lhs rhs
 process eopts nest env (IRunElabDecl fc tm)
     = processRunElab eopts nest env fc tm
-process eopts nest env (IPragma _ act)
+process eopts nest env (IPragma _ _ act)
     = act nest env
 process eopts nest env (ILog lvl)
     = addLogLevel (uncurry unsafeMkLogLevel <$> lvl)

--- a/src/TTImp/Reflect.idr
+++ b/src/TTImp/Reflect.idr
@@ -809,7 +809,7 @@ mutual
              appCon fc defs (reflectionttimp "ITransform") [w', x', y', z']
     reflect fc defs lhs env (IRunElabDecl w x)
         = throw (GenericMsg fc "Can't reflect a %runElab")
-    reflect fc defs lhs env (IPragma _ x)
+    reflect fc defs lhs env (IPragma _ _ x)
         = throw (GenericMsg fc "Can't reflect a pragma")
     reflect fc defs lhs env (ILog x)
         = do x' <- reflect fc defs lhs env x

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -448,9 +448,9 @@ mutual
        INamespace : FC -> Namespace -> List (ImpDecl' nm) -> ImpDecl' nm
        ITransform : FC -> Name -> RawImp' nm -> RawImp' nm -> ImpDecl' nm
        IRunElabDecl : FC -> RawImp' nm -> ImpDecl' nm
-       IPragma : List Name -> -- pragmas might define names that wouldn't
-                       -- otherwise be spotted in 'definedInBlock' so they
-                       -- can be flagged here.
+       IPragma : FC -> List Name -> -- pragmas might define names that wouldn't
+                                    -- otherwise be spotted in 'definedInBlock' so they
+                                    -- can be flagged here.
                  ({vars : _} ->
                   NestedNames vars -> Env Term vars -> Core ()) ->
                  ImpDecl' nm
@@ -479,7 +479,7 @@ mutual
         = "%transform " ++ show n ++ " " ++ show lhs ++ " ==> " ++ show rhs
     show (IRunElabDecl _ tm)
         = "%runElab " ++ show tm
-    show (IPragma _ _) = "[externally defined pragma]"
+    show (IPragma _ _ _) = "[externally defined pragma]"
     show (ILog Nothing) = "%logging off"
     show (ILog (Just (topic, lvl))) = "%logging " ++ case topic of
       [] => show lvl
@@ -816,7 +816,7 @@ definedInBlock ns decls =
         all : List Name
         all = expandNS ns n :: map (expandNS fldns') (fnsRF ++ fnsUN)
 
-    defName ns (IPragma pns _) = map (expandNS ns) pns
+    defName ns (IPragma _ pns _) = map (expandNS ns) pns
     defName _ _ = []
 
 export
@@ -879,7 +879,7 @@ namespace ImpDecl
   getFC (INamespace fc _ _) = fc
   getFC (ITransform fc _ _ _) = fc
   getFC (IRunElabDecl fc _) = fc
-  getFC (IPragma _ _) = EmptyFC
+  getFC (IPragma fc _ _) = fc
   getFC (ILog _) = EmptyFC
   getFC (IBuiltin fc _ _) = fc
 

--- a/src/TTImp/TTImp/Functor.idr
+++ b/src/TTImp/TTImp/Functor.idr
@@ -106,7 +106,7 @@ mutual
       = ITransform fc n (map f lhs) (map f rhs)
     map f (IRunElabDecl fc t)
       = IRunElabDecl fc (map f t)
-    map f (IPragma xs k) = IPragma xs k
+    map f (IPragma fc xs k) = IPragma fc xs k
     map f (ILog x) = ILog x
     map f (IBuiltin fc ty n) = IBuiltin fc ty n
 

--- a/src/TTImp/TTImp/TTC.idr
+++ b/src/TTImp/TTImp/TTC.idr
@@ -380,7 +380,7 @@ mutual
         = do tag 6; toBuf b fc; toBuf b n; toBuf b lhs; toBuf b rhs
     toBuf b (IRunElabDecl fc tm)
         = do tag 7; toBuf b fc; toBuf b tm
-    toBuf b (IPragma _ f) = throw (InternalError "Can't write Pragma")
+    toBuf b (IPragma _ _ f) = throw (InternalError "Can't write Pragma")
     toBuf b (ILog n)
         = do tag 8; toBuf b n
     toBuf b (IBuiltin fc type name)

--- a/src/TTImp/TTImp/Traversals.idr
+++ b/src/TTImp/TTImp/Traversals.idr
@@ -71,7 +71,7 @@ parameters (f : RawImp' nm -> RawImp' nm)
   mapImpDecl (INamespace fc mi xs) = INamespace fc mi (assert_total $ map mapImpDecl xs)
   mapImpDecl (ITransform fc n t u) = ITransform fc n (mapTTImp t) (mapTTImp u)
   mapImpDecl (IRunElabDecl fc t) = IRunElabDecl fc (mapTTImp t)
-  mapImpDecl (IPragma ns g) = IPragma ns g
+  mapImpDecl (IPragma fc ns g) = IPragma fc ns g
   mapImpDecl (ILog x) = ILog x
   mapImpDecl (IBuiltin fc x n) = IBuiltin fc x n
 

--- a/src/TTImp/Utils.idr
+++ b/src/TTImp/Utils.idr
@@ -42,7 +42,7 @@ rawImpFromDecl decl = case decl of
     INamespace fc1 ys zs => rawImpFromDecl !zs
     ITransform fc1 y z w => [z, w]
     IRunElabDecl fc1 y => [] -- Not sure about this either
-    IPragma _ f => []
+    IPragma _ _ f => []
     ILog k => []
     IBuiltin _ _ _ => []
   where getParamTy : (a, b, c, RawImp) -> RawImp

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -92,7 +92,7 @@ idrisTestsError = MkTestPool "Error messages" [] Nothing
        "perror001", "perror002", "perror003", "perror004", "perror005",
        "perror006", "perror007", "perror008", "perror009", "perror010",
        "perror011", "perror012", "perror013", "perror014", "perror015",
-       "perror016", "perror017", "perror018"]
+       "perror016", "perror017", "perror018", "perror019"]
 
 idrisTestsInteractive : TestPool
 idrisTestsInteractive = MkTestPool "Interactive editing" [] Nothing

--- a/tests/idris2/perror019/ImplError.idr
+++ b/tests/idris2/perror019/ImplError.idr
@@ -1,0 +1,5 @@
+data Foo = Bar
+
+implementation Show Foo where
+  show Bar = "a Foo"
+  f

--- a/tests/idris2/perror019/expected
+++ b/tests/idris2/perror019/expected
@@ -1,0 +1,11 @@
+1/1: Building ImplError (ImplError.idr)
+Error: Implementation body can only contain definitions
+
+ImplError:5:3--5:4
+ 1 | data Foo = Bar
+ 2 | 
+ 3 | implementation Show Foo where
+ 4 |   show Bar = "a Foo"
+ 5 |   f
+       ^
+

--- a/tests/idris2/perror019/run
+++ b/tests/idris2/perror019/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-banner --no-color --console-width 0 --check ImplError.idr


### PR DESCRIPTION
In the example below, you get an `Error: Implementation body can only contain definitions` located at `EmptyFC` (beginning of the file). So the user has no clue where the error is located. This patch changes the error to be located at the offending term.

```idris
data Foo = Bar

implementation Show Foo where
  show Bar = "a Foo"
  f
```

The root cause of this is that the `f` in the text below is interpreted as an interface implementation. That ends up as an `IPragma` which doesn't have an FC. I fixed it by adding an `FC` to `IPragma`.

Before change:
```
1/1: Building ImplError (ImplError.idr)
Error: Implementation body can only contain definitions
```

After change:
```
1/1: Building ImplError (ImplError.idr)
Error: Implementation body can only contain definitions

ImplError:5:3--5:4
 1 | data Foo = Bar
 2 |
 3 | implementation Show Foo where
 4 |   show Bar = "a Foo"
 5 |   f
       ^
```

An alternative solution that I considered was to add a redundant check for `IDef` in `Idris/Elab/Implementation.idr`, where we still have the `FC` from the `PImplementation`. That would be a smaller change, but I was reluctant to duplicate that check and figured having the `FC` in place might help some other errors too.

