### PR TITLE
[ fix ] drop first command-line arg on node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,7 @@
 * Adds `Data.Fin.finToNatEqualityAsPointwise`,
   which takes a witness of `finToNat k = finToNat l` and proves `k ~~~ l`.
 * Drop first argument (path to the `node` executable) from `System.getArgs` on
-  the node backend to make it consistent with other backends.
+  the Node.js backend to make it consistent with other backends.
 
 #### Test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,8 @@
   now transformer argument is the last, as in the other standard transformers, like `ReaderT` and `StateT`.
 * Adds `Data.Fin.finToNatEqualityAsPointwise`,
   which takes a witness of `finToNat k = finToNat l` and proves `k ~~~ l`.
+* Drop first argument (path to the `node` executable) from `System.getArgs` on
+  the node backend to make it consistent with other backends.
 
 #### Test
 

--- a/libs/base/System.idr
+++ b/libs/base/System.idr
@@ -58,15 +58,22 @@ usleep : HasIO io => (usec : Int) -> So (usec >= 0) => io ()
 usleep usec = primIO (prim__usleep usec)
 
 -- Get the number of arguments
+-- Note: node prefixes the list of command line arguments
+--       with the path to the `node` executable. This is
+--       inconsistent with other backends, which only list
+--       the path to the running program. For reasons of
+--       consistency across backends, this first argument ist
+--       dropped on the node backend.
 %foreign "scheme:blodwen-arg-count"
          supportC "idris2_getArgCount"
-         "node:lambda:() => process.argv.length"
+         "node:lambda:() => process.argv.length - 1"
 prim__getArgCount : PrimIO Int
 
--- Get argument number `n`
+-- Get argument number `n`. See also `prim__getArgCount`
+-- about the special treatment of the node backend.
 %foreign "scheme:blodwen-arg"
          supportC "idris2_getArg"
-         "node:lambda:n => process.argv[n]"
+         "node:lambda:n => process.argv[n + 1]"
 prim__getArg : Int -> PrimIO String
 
 ||| Retrieve the arguments to the program call, if there were any.

--- a/tests/node/args/TestArgs.idr
+++ b/tests/node/args/TestArgs.idr
@@ -4,4 +4,4 @@ import Data.List
 import System
 
 main : IO ()
-main = getArgs >>= (putStrLn . show . drop 2)
+main = getArgs >>= (putStrLn . show . drop 1)


### PR DESCRIPTION
As discussed on discord: The node backend comes with an additional command line argument listing the path to the `node` executable. This is inconsistent with other backends, which only list the path to the running program as their first command line argument. For consistency, this PR removes said first argument from the list of command line args on the node backend.