### PR TITLE
[ papers ] Implement a postulate hole by requiring a special interface

### DIFF
--- a/libs/papers/Data/W.idr
+++ b/libs/papers/Data/W.idr
@@ -405,64 +405,64 @@ namespace PartitionedSets
 
   namespace Examples
 
-    ORD : Type
-    ORD = PartitionedSets.W (Shape ("zero" || "succ" || "lim")) $ cases
-        ( "zero" .= mkPSet AVoid ()
-        , "succ" .= mkPSet "x" ("x" .= ())
-        , "lim"  .= mkPSet "f" ("f" .= NAT)
-        )
+    -- proceed with the following assumption
+    parameters { auto etaUnit : forall a. (o : () -> a) -> o === (\ _ => o ()) }
 
-    zero : ORD
-    zero = mkW "zero" ()
+      ORD : Type
+      ORD = PartitionedSets.W (Shape ("zero" || "succ" || "lim")) $ cases
+          ( "zero" .= mkPSet AVoid ()
+          , "succ" .= mkPSet "x" ("x" .= ())
+          , "lim"  .= mkPSet "f" ("f" .= NAT)
+          )
 
-    succ : ORD -> ORD
-    succ o = mkW "succ" ("x" .= \ _ => o)
+      zero : ORD
+      zero = mkW "zero" ()
 
-    lim : (NAT -> ORD) -> ORD
-    lim f = mkW "lim" ("f" .= f)
+      succ : ORD -> ORD
+      succ o = mkW "succ" ("x" .= \ _ => o)
 
-    ORDind : (0 pred : ORD -> Type) ->
-             pred Examples.zero ->
-             ((n : ORD) -> pred n -> pred (succ n)) ->
-             ((f : NAT -> ORD) -> ((n : NAT) -> pred (f n)) -> pred (lim f)) ->
-             (n : ORD) -> pred n
-    ORDind pred pZ pS pL
-      = elim pred
-      $ cases ("zero" .= pZero, "succ" .= pSucc, "lim" .= pLim)
+      lim : (NAT -> ORD) -> ORD
+      lim f = mkW "lim" ("f" .= f)
 
-      where
+      ORDind : (0 pred : ORD -> Type) ->
+               pred Examples.zero ->
+               ((n : ORD) -> pred n -> pred (succ n)) ->
+               ((f : NAT -> ORD) -> ((n : NAT) -> pred (f n)) -> pred (lim f)) ->
+               (n : ORD) -> pred n
+      ORDind pred pZ pS pL
+        = elim pred
+        $ cases ("zero" .= pZero, "succ" .= pSucc, "lim" .= pLim)
 
-        -- we're forced to do quite a bit of additional pattern matching
-        -- because of a lack of eta
+        where
 
-        pZero : (o : mkPSet AVoid () ~> ORD) -> ? -> pred (MkW "zero" o)
-        pZero (MkArr ()) ih = pZ
+          -- we're forced to do quite a bit of additional pattern matching
+          -- because of a lack of eta
 
-        -- oops we need to postulate this!
-        etaUnit : (o : () -> a) -> o === (\ _ => o ())
+          pZero : (o : mkPSet AVoid () ~> ORD) -> ? -> pred (MkW "zero" o)
+          pZero (MkArr ()) ih = pZ
 
-        pSucc : (o : mkPSet (AUnit "x") ("x" .= ()) ~> ORD) ->
-                Pi (mkPSet (AUnit "x") ("x" .= ())) (lam (\p => pred (o $$ p))) ->
-                pred (MkW "succ" o)
-        pSucc (MkArr (MkOne o)) (MkPi (MkOne po)) =
-          rewrite etaUnit o in pS (o ()) (po ())
+          pSucc : (o : mkPSet (AUnit "x") ("x" .= ()) ~> ORD) ->
+                  Pi (mkPSet (AUnit "x") ("x" .= ())) (lam (\p => pred (o $$ p))) ->
+                  pred (MkW "succ" o)
+          pSucc (MkArr (MkOne o)) (MkPi (MkOne po)) =
+            rewrite etaUnit o in pS (o ()) (po ())
 
-        pLim : (o : mkPSet (AUnit "f") ("f" .= ?A) ~> ORD) ->
-               Pi (mkPSet (AUnit "f") ("f" .= ?B)) (lam (\p => pred (o $$ p))) ->
-               pred (MkW "lim" o)
-        pLim (MkArr (MkOne o)) (MkPi (MkOne po)) = pL o po
+          pLim : (o : mkPSet (AUnit "f") ("f" .= ?A) ~> ORD) ->
+                 Pi (mkPSet (AUnit "f") ("f" .= ?B)) (lam (\p => pred (o $$ p))) ->
+                 pred (MkW "lim" o)
+          pLim (MkArr (MkOne o)) (MkPi (MkOne po)) = pL o po
 
 
-    ORDindZ : {0 pred : ORD -> Type} -> {0 pZ, pS, pL : ?} ->
-              ORDind pred pZ pS pL Examples.zero === pZ
-    ORDindZ = Refl
+      ORDindZ : {0 pred : ORD -> Type} -> {0 pZ, pS, pL : ?} ->
+                ORDind pred pZ pS pL Examples.zero === pZ
+      ORDindZ = Refl
 
-    ORDindS : {0 pred : ORD -> Type} -> {0 pZ, pL : ?} ->
-              {pS : (n : ORD) -> pred n -> pred (succ n)} ->
-              {0 n : ORD} -> ORDind pred pZ pS pL (succ n) === pS n (ORDind pred pZ pS pL n)
-    ORDindS = Refl
+      ORDindS : {0 pred : ORD -> Type} -> {0 pZ, pL : ?} ->
+                {pS : (n : ORD) -> pred n -> pred (succ n)} ->
+                {0 n : ORD} -> ORDind pred pZ pS pL (succ n) === pS n (ORDind pred pZ pS pL n)
+      ORDindS = Refl
 
-    ORDindL : {0 pred : ORD -> Type} -> {0 pZ, pS : ?} ->
-              {pL : (f : NAT -> ORD) -> ((n : NAT) -> pred (f n)) -> pred (lim f)} ->
-              {0 f : NAT -> ORD} -> ORDind pred pZ pS pL (lim f) === pL f (\ n => ORDind pred pZ pS pL (f n))
-    ORDindL = Refl
+      ORDindL : {0 pred : ORD -> Type} -> {0 pZ, pS : ?} ->
+                {pL : (f : NAT -> ORD) -> ((n : NAT) -> pred (f n)) -> pred (lim f)} ->
+                {0 f : NAT -> ORD} -> ORDind pred pZ pS pL (lim f) === pL f (\ n => ORDind pred pZ pS pL (f n))
+      ORDindL = Refl


### PR DESCRIPTION
Recently several modules were added to the `paper` lib, and one of them contains a postulate which leads to a warning each time one builds a compiler. The main reason for this PR is to remove this warning.

Since this is a postulate, one could just make it explicit, say with `believe_me`, and warning would be gone while postulate would stay a postulate. But I decided to suggest an implementation for this hole, since the standard library contains an interface which can be used as an external postulate. As far as I can see, this anyway does not break any idea inside this module, does it?

Unfortunately, for this trick a bunch of lines are indented, thus two-line change looks big in diff.