### PR TITLE
[ performance ] constant fold prim__integerToNat

### DIFF
--- a/tests/chez/constfold/Check.idr
+++ b/tests/chez/constfold/Check.idr
@@ -7,7 +7,9 @@ path = "build/exec/fold_app/fold.ss"
 
 mainLine : String -> Bool
 mainLine str =
-  ("(define Main-main(" `isPrefixOf` str) && (" 99))))" `isSuffixOf` str)
+  ("(define Main-main(" `isPrefixOf` str) &&
+  (" 99)" `isInfixOf` str) &&
+  not ("prim__integerToNat" `isInfixOf` str)
 
 main : IO ()
 main = do

--- a/tests/chez/constfold/Fold.idr
+++ b/tests/chez/constfold/Fold.idr
@@ -1,2 +1,5 @@
 main : IO ()
-main = printLn (the Bits8 0xff + 100)
+main = do
+  printLn (the Bits8 0xff + 100)
+  printLn (the Nat 12345)
+  printLn (the Nat (-12345))

--- a/tests/chez/constfold/Fold.idr
+++ b/tests/chez/constfold/Fold.idr
@@ -1,5 +1,8 @@
+import Data.Nat
+
 main : IO ()
 main = do
   printLn (the Bits8 0xff + 100)
   printLn (the Nat 12345)
   printLn (the Nat (-12345))
+  printLn (271 `minus` 12)


### PR DESCRIPTION
Literals for natural numbers are now constant folded by giving function `prim__integerToNat` some special treatment. In addition, the existing test case for constant folding was extended with this use case.

This enables constant folding for other arithmetic expressions involving natural numbers.