### PR TITLE
[ tests ] Don't run channels006 due to a race condition

### DIFF
--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -189,7 +189,9 @@ idrisTestsAllSchemes cg = MkTestPool
       ("Test across all scheme backends: " ++ show cg ++ " instance")
       [] (Just cg)
       [ "scheme001"
-      , "channels001", "channels002", "channels003", "channels004", "channels005", "channels006"
+      , "channels001", "channels002", "channels003", "channels004", "channels005"
+      -- FIXME: sometimes works, depending on a race condition
+      -- , "channels006"
       ]
 
 idrisTestsAllBackends : Requirement -> TestPool


### PR DESCRIPTION
#2698 fixed the inconsistent behaviour of Channels in Chez vs Racket. However, it also introduced a test which seems to pass based on a race-condition:
- pass: https://github.com/idris-lang/Idris2/actions/runs/3177998302/jobs/5183686575
- fail: https://github.com/idris-lang/Idris2/actions/runs/3182193785/jobs/5187953144

<details><summary>fail logs</summary>

```
allschemes/channels006: FAILURE                                  01.648s
Expected:
> 1
> 2
< 1
> 3
< 2
> 4
< 3
< 4
done

Given:
> 1
> 2
> 3
< 1
< 2
> 4
< 3
< 4
done
```

</details>
I've commented out the test for now, until we have a better solution. (Should we just remove `channels006`?)