### PR TITLE
[ new ] Allow forward declarations of records

### DIFF
--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -985,7 +985,13 @@ mutual
       isNamed Nothing = False
       isNamed (Just _) = True
 
-  desugarDecl ps (PRecord fc doc vis mbtot tn params opts conname_in fields)
+  desugarDecl ps (PRecord fc doc vis mbtot (MkPRecordLater tn params))
+      = desugarDecl ps (PData fc doc vis mbtot (MkPLater fc tn (mkRecType params)))
+    where
+      mkRecType : List (Name, RigCount, PiInfo PTerm, PTerm) -> PTerm
+      mkRecType [] = PType fc
+      mkRecType ((n, c, p, t) :: ts) = PPi fc c p (Just n) t (mkRecType ts)
+  desugarDecl ps (PRecord fc doc vis mbtot (MkPRecord tn params opts conname_in fields))
       = do addDocString tn doc
            params' <- traverse (\ (n,c,p,tm) =>
                           do tm' <- desugar AnyExpr ps tm

--- a/src/Idris/Desugar/Mutual.idr
+++ b/src/Idris/Desugar/Mutual.idr
@@ -23,7 +23,7 @@ getDecl AsType d@(PClaim _ _ _ _ _) = Just d
 getDecl AsType (PData fc doc vis mbtot (MkPData dfc tyn tyc _ _))
     = Just (PData fc doc vis mbtot (MkPLater dfc tyn tyc))
 getDecl AsType d@(PInterface _ _ _ _ _ _ _ _ _) = Just d
-getDecl AsType d@(PRecord fc doc vis mbtot n ps _ _ _)
+getDecl AsType (PRecord fc doc vis mbtot (MkPRecord n ps _ _ _))
     = Just (PData fc doc vis mbtot (MkPLater fc n (mkRecType ps)))
   where
     mkRecType : List (Name, RigCount, PiInfo PTerm, PTerm) -> PTerm
@@ -36,7 +36,7 @@ getDecl AsType d = Nothing
 getDecl AsDef (PClaim _ _ _ _ _) = Nothing
 getDecl AsDef d@(PData _ _ _ _ (MkPLater _ _ _)) = Just d
 getDecl AsDef (PInterface _ _ _ _ _ _ _ _ _) = Nothing
-getDecl AsDef d@(PRecord _ _ _ _ _ _ _ _ _) = Just d
+getDecl AsDef d@(PRecord _ _ _ _ (MkPRecordLater _ _)) = Just d
 getDecl AsDef (PFixity _ _ _ _) = Nothing
 getDecl AsDef (PDirective _ _) = Nothing
 getDecl AsDef d = Just d

--- a/src/Idris/Resugar.idr
+++ b/src/Idris/Resugar.idr
@@ -531,7 +531,7 @@ mutual
                 (catMaybes ds')))
   toPDecl (IRecord fc _ vis mbtot r)
       = do (n, ps, opts, con, fs) <- toPRecord r
-           pure (Just (PRecord fc "" vis mbtot n ps opts con fs))
+           pure (Just (PRecord fc "" vis mbtot (MkPRecord n ps opts con fs)))
   toPDecl (IFail fc msg ds)
       = do ds' <- traverse toPDecl ds
            pure (Just (PFail fc msg (catMaybes ds')))

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -271,6 +271,18 @@ mutual
                  (datacons : List (PTypeDecl' nm)) -> PDataDecl' nm
        MkPLater : FC -> (tyname : Name) -> (tycon : PTerm' nm) -> PDataDecl' nm
 
+  public export
+  data PRecordDecl' : Type -> Type where
+       MkPRecord : (tyname : Name) ->
+                   (params : List (Name, RigCount, PiInfo (PTerm' nm), PTerm' nm)) ->
+                   (opts : List DataOpt) ->
+                   (conName : Maybe Name) ->
+                   List (PField' nm) ->
+                   PRecordDecl' nm
+       MkPRecordLater : (tyname : Name) ->
+                        (params : List (Name, RigCount, PiInfo (PTerm' nm), PTerm' nm)) ->
+                        PRecordDecl' nm
+
   export
   getPDataDeclLoc : PDataDecl' nm -> FC
   getPDataDeclLoc (MkPData fc _ _ _ _) = fc
@@ -408,11 +420,7 @@ mutual
        PRecord : FC ->
                  (doc : String) ->
                  Visibility -> Maybe TotalReq ->
-                 Name ->
-                 (params : List (Name, RigCount, PiInfo (PTerm' nm), PTerm' nm)) ->
-                 (opts : List DataOpt) ->
-                 (conName : Maybe Name) ->
-                 List (PField' nm) ->
+                 PRecordDecl' nm ->
                  PDecl' nm
 
        -- TODO: PPostulate
@@ -439,7 +447,7 @@ mutual
   getPDeclLoc (PReflect fc _) = fc
   getPDeclLoc (PInterface fc _ _ _ _ _ _ _ _) = fc
   getPDeclLoc (PImplementation fc _ _ _ _ _ _ _ _ _ _) = fc
-  getPDeclLoc (PRecord fc _ _ _ _ _ _ _ _) = fc
+  getPDeclLoc (PRecord fc _ _ _ _) = fc
   getPDeclLoc (PMutual fc _) = fc
   getPDeclLoc (PFail fc _ _) = fc
   getPDeclLoc (PFixity fc _ _ _) = fc

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -167,7 +167,7 @@ idrisTestsData = MkTestPool "Data and record types" [] Nothing
        "record001", "record002", "record003", "record004", "record005",
        "record006", "record007", "record008", "record009", "record010",
        "record011", "record012", "record013", "record014", "record015",
-       "record016", "record017" ]
+       "record016", "record017", "record018" ]
 
 idrisTestsBuiltin : TestPool
 idrisTestsBuiltin = MkTestPool "Builtin types and functions" [] Nothing

--- a/tests/idris2/record018/expected
+++ b/tests/idris2/record018/expected
@@ -1,0 +1,1 @@
+1/1: Building mut (mut.idr)

--- a/tests/idris2/record018/mut.idr
+++ b/tests/idris2/record018/mut.idr
@@ -1,0 +1,6 @@
+record B
+
+record A where
+  b : B
+record B where
+  a : A

--- a/tests/idris2/record018/run
+++ b/tests/idris2/record018/run
@@ -1,0 +1,4 @@
+rm -rf build
+
+$1 --no-color --console-width 0 mut.idr --check
+


### PR DESCRIPTION
This change allows users to forward declare `record`, like they can for `data`, by omitting the `where` clause. The implementation follows the pattern of same functionality for `data`.  After the change you can do:

```idris
record B
record A where
  b : B
record B where
  a : A
```
instead of
```idris
mutual
  record A where
    b : B
  record B where
    a : A
```
