### PR TITLE
make the Int type explicit

### DIFF
--- a/docs/source/tutorial/multiplicities.rst
+++ b/docs/source/tutorial/multiplicities.rst
@@ -551,7 +551,7 @@ is certainly not the identity function
 
 .. code-block:: idris
 
-    notId {a = Int} x = x + 1
+    notId {a = Integer} x = x + 1
     notId x = x
 
 ::


### PR DESCRIPTION
Idris will treat a number as an `Integer` by default, it's required to make the `Int` explicit to ouput 94.