### PR TITLE
Reduce ambiguity in dependent types `filter` example

### DIFF
--- a/docs/source/tutorial/typesfuns.rst
+++ b/docs/source/tutorial/typesfuns.rst
@@ -1008,7 +1008,7 @@ intermediate values:
 
 .. code-block:: idris
 
-    filter : (a -> Bool) -> Vect n a -> (p ** Vect p a)
+    filter : (a -> Bool) -> Vect n a -> (n' ** Vect n' a)
     filter p Nil = (_ ** [])
     filter p (x :: xs)
         = case filter p xs of


### PR DESCRIPTION
`p` was used for both the filter predicate and the length of the filtered vector. This renames the latter to `n'`.

Thanks to ruchira for reporting this on the Discord.