### PR TITLE
[ fix ] remove --only option in Makefile when "only" is not specified

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,11 +3,15 @@ threads ?= $(shell (nproc || sysctl -n hw.ncpu) 2>/dev/null || echo 1)
 
 .PHONY: testbin test
 
+ifneq ($(only),)
+ONLYOPT := --only $(only)
+endif
+
 test:
-	./build/exec/runtests $(IDRIS2) $(INTERACTIVE) --timing --failure-file failures --threads $(threads) --only $(only)
+	./build/exec/runtests $(IDRIS2) $(INTERACTIVE) --timing --failure-file failures --threads $(threads) $(ONLYOPT)
 
 retest:
-	./build/exec/runtests $(IDRIS2) $(INTERACTIVE) --timing --failure-file failures --threads $(threads) --only-file failures --only $(only)
+	./build/exec/runtests $(IDRIS2) $(INTERACTIVE) --timing --failure-file failures --threads $(threads) --only-file failures $(ONLYOPT)
 
 testbin:
 	${IDRIS2} --build tests.ipkg


### PR DESCRIPTION
Run `make test` will not actually run any test after #2705.

It seems that when the option `--only` is followed by an empty string, the behavior changes from running all tests to filtering out all tests.