### PR TITLE
[ fix #2721 ] Don't reflow doc lines

### DIFF
--- a/src/Idris/Doc/String.idr
+++ b/src/Idris/Doc/String.idr
@@ -262,7 +262,7 @@ getDocsForName fc n config
     showDoc : Config -> (Name, String) -> Core (Doc IdrisDocAnn)
 
     reflowDoc : String -> List (Doc IdrisDocAnn)
-    reflowDoc str = map (indent 2 . reflow) (lines str)
+    reflowDoc str = map (indent 2 . pretty0) (lines str)
 
     showTotal : Totality -> Maybe (Doc IdrisDocAnn)
     showTotal tot

--- a/tests/idris2/docs001/expected
+++ b/tests/idris2/docs001/expected
@@ -81,8 +81,8 @@ Main> interface Prelude.Show : Type -> Type
       
       A value should produce parentheses around itself if and only if the given
       precedence context is greater than or equal to the precedence of the
-      outermost operation represented in the produced `String`. *This is
-      different from Haskell*, which requires it to be strictly greater. `Open`
+      outermost operation represented in the produced `String`.  *This is
+      different from Haskell*, which requires it to be strictly greater.  `Open`
       should thus always produce *no* outermost parens, `App` should always
       produce outermost parens except on atomic values and those that provide
       their own bracketing, like `Pair` and `List`.

--- a/tests/idris2/interactive019/expected
+++ b/tests/idris2/interactive019/expected
@@ -8,7 +8,7 @@ Data.String.singleton : Char -> String
 Prelude.Show.show : Char -> String
 Prelude.Cast.cast : Char -> String
 Main> Prelude.const : a -> b -> a
-  Constant function. Ignores its second argument.
+  Constant function.  Ignores its second argument.
   Totality: total
   Visibility: public export
 Main> Builtin.fromChar : Char -> Char


### PR DESCRIPTION
I don't think there's a good solution at least until we start parsing these comments so let's just keep them as they were written by the library writer.