### PR TITLE
[ base ] Change `Reader` to fix search for `MonadReader` instance

### DIFF
--- a/libs/base/Control/Monad/Reader/Reader.idr
+++ b/libs/base/Control/Monad/Reader/Reader.idr
@@ -34,7 +34,7 @@ runReaderT s action = runReaderT' action s
 ||| This is `ReaderT` applied to `Identity`.
 public export
 Reader : (stateType : Type) -> (a : Type) -> Type
-Reader s a = ReaderT s Identity a
+Reader s = ReaderT s Identity
 
 ||| Unwrap and apply a Reader monad computation
 public export %inline

--- a/tests/base/control_monad_instances/SearchReader.idr
+++ b/tests/base/control_monad_instances/SearchReader.idr
@@ -1,0 +1,7 @@
+module SearchReader
+
+import Control.Monad.Identity
+import Control.Monad.Reader
+
+monadReaderInstance : MonadReader a (Reader a)
+monadReaderInstance = %search

--- a/tests/base/control_monad_instances/SearchState.idr
+++ b/tests/base/control_monad_instances/SearchState.idr
@@ -1,0 +1,6 @@
+module SearchState
+
+import Control.Monad.State
+
+monadWriterInstance : MonadState a (State a)
+monadWriterInstance = %search

--- a/tests/base/control_monad_instances/SearchWriter.idr
+++ b/tests/base/control_monad_instances/SearchWriter.idr
@@ -1,0 +1,7 @@
+module SearchWriter
+
+import Control.Monad.Identity
+import Control.Monad.Writer
+
+monadWriterInstance : (Monoid a) => MonadWriter a (Writer a)
+monadWriterInstance = %search

--- a/tests/base/control_monad_instances/expected
+++ b/tests/base/control_monad_instances/expected
@@ -1,0 +1,3 @@
+1/1: Building SearchReader (SearchReader.idr)
+1/1: Building SearchWriter (SearchWriter.idr)
+1/1: Building SearchState (SearchState.idr)

--- a/tests/base/control_monad_instances/run
+++ b/tests/base/control_monad_instances/run
@@ -1,0 +1,6 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --no-banner -c SearchReader.idr
+$1 --no-color --console-width 0 --no-banner -c SearchWriter.idr
+$1 --no-color --console-width 0 --no-banner -c SearchState.idr
+


### PR DESCRIPTION
Instance of `MonadReader` cannot be automatically found for the current definition of `Reader`. This PR introduces a small change to `Reader` definition that fixes this along with the test checking that `MonadReader`, `MonadWriter` and `MonadState` could be found for `Reader`, `Writer` and `State` respectively.