### PR TITLE
Update nix build scripts to build Idris with the current version of Idris #2087

### DIFF
--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -231,10 +231,9 @@ jobs:
     needs: quick-check
     runs-on: ubuntu-latest
     if: |
-      false
-      && (!contains(needs.initialise.outputs.commit_message, '[ci:')
+      !contains(needs.initialise.outputs.commit_message, '[ci:')
       || contains(needs.initialise.outputs.commit_message, '[ci: nix]')
-      || contains(needs.initialise.outputs.commit_message, '[ci: chez]'))
+      || contains(needs.initialise.outputs.commit_message, '[ci: chez]')
     steps:
     - uses: actions/checkout@v2
       with:

--- a/flake.nix
+++ b/flake.nix
@@ -30,8 +30,12 @@
           chez = if system == "x86_64-linux"
             then pkgs.chez
             else pkgs.chez-racket; # TODO: Should this always be the default?
-          idris2Pkg = pkgs.callPackage ./nix/package.nix {
+          idris2Bootstrap = pkgs.callPackage ./nix/bootstrap.nix {
             inherit idris2-version chez;
+            srcRev = self.shortRev or "dirty";
+          };
+          idris2Pkg = pkgs.callPackage ./nix/package.nix {
+            inherit idris2-version chez idris2Bootstrap;
             srcRev = self.shortRev or "dirty";
           };
           buildIdris = pkgs.callPackage ./nix/buildIdris.nix { inherit idris2-version; idris2 = idris2Pkg; };

--- a/nix/bootstrap.nix
+++ b/nix/bootstrap.nix
@@ -10,7 +10,6 @@
 , gambit
 , nodejs
 , zsh
-, idris2Bootstrap
 }:
 
 # Uses scheme to bootstrap the build of idris2
@@ -21,7 +20,7 @@ stdenv.mkDerivation rec {
   src = ../.;
 
   strictDeps = true;
-  nativeBuildInputs = [ makeWrapper clang chez idris2Bootstrap ]
+  nativeBuildInputs = [ makeWrapper clang chez ]
     ++ lib.optional stdenv.isDarwin [ zsh ];
   buildInputs = [ chez gmp ];
 
@@ -34,7 +33,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional stdenv.isDarwin "OS=";
 
   # The name of the main executable of pkgs.chez is `scheme`
-  buildFlags = [ ];
+  buildFlags = [ "bootstrap" "SCHEME=scheme" ];
 
   checkInputs = [ gambit nodejs ]; # racket ];
   checkFlags = [ "INTERACTIVE=" ];


### PR DESCRIPTION
This PR changes the nix build scripts to bootstrap idris and then use the bootstrapped compiler to build the final version. It also reenables CI for nix. This addresses #2087 for nix.

Previously, the nix scripts would test and install the copy of Idris built by the bootstrap compiler. The bootstrap compiler doesn't handle multiline strings properly, so the resulting compiler failed test `idris2/repl005`. 

To accomplish this, I duplicated `package.nix` as `bootstrap.nix` and changed `package.nix` to use the idris compiler in the result of `bootstrap.nix`.

I'm somewhat new to nix, so it would be good to have this reviewed by someone who knows idiomatic nix.

