### PR TITLE
[ fix ] bump version of linear and papers packages

### DIFF
--- a/Release/CHECKLIST
+++ b/Release/CHECKLIST
@@ -1,6 +1,6 @@
 [ ] Change version number (MAJOR, MINOR, PATCH) in Makefile
 [ ] Change version numbers in doc listings
-[ ] Change version numbers in prelude, base, contrib, network, and test ipkgs
+[ ] Change version numbers in prelude, base, contrib, linear, network, papers, and test ipkgs
 [ ] Change version number in idris2api.ipkg
 [ ] Change version number in flake.nix
 [ ] Change version number in test pkg010 (TODO: make this step unnecessary!)

--- a/libs/linear/linear.ipkg
+++ b/libs/linear/linear.ipkg
@@ -1,5 +1,5 @@
 package linear
-version = 0.5.1
+version = 0.6.0
 
 options = "--ignore-missing-ipkg"
 

--- a/libs/papers/papers.ipkg
+++ b/libs/papers/papers.ipkg
@@ -1,5 +1,5 @@
 package papers
-version = 0.5.1
+version = 0.6.0
 
 depends = contrib, linear
 


### PR DESCRIPTION
This might be an oversight. It leads to issues with pack, which uses the same version for all libraries from the Idris2 project. If this was left at 0.5.1 on purpose, feel free to close this and I'll fix pack instead.