### PR TITLE
[ fix ] dont prefix lib dirs with ttc version

### DIFF
--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -219,8 +219,7 @@ loadSO appdir "" = pure ""
 loadSO appdir mod
     = do d <- getDirs
          bdir <- ttcBuildDirectory
-         let allDirs = extra_dirs d ++ package_dirs d
-             fs = map (\p => p </> mod) (bdir :: allDirs)
+         let fs = map (\p => p </> mod) (bdir :: extra_dirs d)
          Just fname <- firstAvailable fs
             | Nothing => throw (InternalError ("Missing .so:" ++ mod))
          -- Easier to put them all in the same directory, so we don't need

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -219,7 +219,7 @@ loadSO appdir "" = pure ""
 loadSO appdir mod
     = do d <- getDirs
          bdir <- ttcBuildDirectory
-         let fs = map (\p => p </> mod) (bdir :: extra_dirs d)
+         let fs = map (\p => p </> mod) (bdir :: extra_dirs d ++ package_dirs d)
          Just fname <- firstAvailable fs
             | Nothing => throw (InternalError ("Missing .so:" ++ mod))
          -- Easier to put them all in the same directory, so we don't need

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -219,8 +219,8 @@ loadSO appdir "" = pure ""
 loadSO appdir mod
     = do d <- getDirs
          bdir <- ttcBuildDirectory
-         allDirs <- extraSearchDirectories
-         let fs = map (\p => p </> mod) (bdir :: allDirs)
+         let allDirs = extra_dirs d ++ package_dirs d
+             fs = map (\p => p </> mod) (bdir :: allDirs)
          Just fname <- firstAvailable fs
             | Nothing => throw (InternalError ("Missing .so:" ++ mod))
          -- Easier to put them all in the same directory, so we don't need


### PR DESCRIPTION
As discussed on discord, this fixes another regression introduced by #2684: `.so` files installed into custom lib dirs are no longer found by Idris. This reverts the relevant section of `Compiler.Scheme.Chez.loadSO` to its version before #2684. I'm not sure about the `bdir <- ttcBuildDirectory` on line 221: Do we want the `ttc` prefix here or not?

@mattpolzin Could you please test this against pg-idris?