### PR TITLE
[fix] look for lib folders in package directories.

### DIFF
--- a/src/Core/Directory.idr
+++ b/src/Core/Directory.idr
@@ -149,20 +149,24 @@ readDataFile fname
             | Left err => throw (FileErr f err)
          pure d
 
--- Look for a library file required by a code generator. Look in the
--- library directories, and in the lib/ subdirectory of all the 'extra import'
--- directories
+||| Look for a library file required by a code generator. Look in the
+||| library directories, and in the lib/ subdirectory of all the 'extra import'
+||| directories and the package directory roots.
 export
 findLibraryFile : {auto c : Ref Ctxt Defs} ->
                   String -> Core String
 findLibraryFile fname
     = do d <- getDirs
+         let packageLibs = libDirs (package_dirs d)
+         let extraLibs = libDirs (extra_dirs d)
          let fs = map (\p => cleanPath $ p </> fname)
-                      (lib_dirs d ++ map (\x => x </> "lib")
-                                         (extra_dirs d))
+                      (lib_dirs d ++ packageLibs ++ extraLibs)
          Just f <- firstAvailable fs
             | Nothing => throw (InternalError ("Can't find library " ++ fname))
          pure f
+    where
+      libDirs : List String -> List String
+      libDirs = map (\x => x </> "lib")
 
 -- Given a namespace, return the full path to the checked module,
 -- looking first in the build directory then in the extra_dirs


### PR DESCRIPTION
Prior to https://github.com/idris-lang/Idris2/pull/2684, any `lib` folder found in the `$(idris2 --libdir)/package-dir/` directory would be searched for `so` or `dylib` files that might need to be copied into the `_app` directory of an executable produced by the Chez Scheme backend.

After the TTC PR (2684), this stopped working because such directories were removed from the list of "extra" directories and added to the list of "package" directories. This move in isolation makes sense -- we are talking about a package directory, after all. So, this PR fixes the `lib` folder searching by adding these package directories to the list of searched paths in the `findLibraryFile` function that is ultimately responsible for locating the `so`/`dylib` files in question.