### PR TITLE
[ new ] add --ttc-version command

### DIFF
--- a/src/Idris/CommandLine.idr
+++ b/src/Idris/CommandLine.idr
@@ -333,7 +333,7 @@ options = [MkOpt ["--check", "-c"] [] [CheckOnly]
            optSeparator,
            MkOpt ["--version", "-v"] [] [Version]
               (Just "Display version string"),
-           MkOpt ["--ttc-version", "-v"] [] [TTCVersion]
+           MkOpt ["--ttc-version"] [] [TTCVersion]
               (Just "Display TTC version string"),
            MkOpt ["--help", "-h", "-?"] [Optional "topic"] (\ tp => [Help (tp >>= recogniseHelpTopic)])
               (Just "Display help text"),

--- a/src/Idris/CommandLine.idr
+++ b/src/Idris/CommandLine.idr
@@ -88,6 +88,8 @@ data CLOpt
   Profile |
    ||| Display Idris version
   Version |
+   ||| Display the TTC version currently used
+  TTCVersion |
    ||| Display help text
   Help (Maybe HelpTopic) |
    ||| Suppress the banner
@@ -331,6 +333,8 @@ options = [MkOpt ["--check", "-c"] [] [CheckOnly]
            optSeparator,
            MkOpt ["--version", "-v"] [] [Version]
               (Just "Display version string"),
+           MkOpt ["--ttc-version", "-v"] [] [TTCVersion]
+              (Just "Display TTC version string"),
            MkOpt ["--help", "-h", "-?"] [Optional "topic"] (\ tp => [Help (tp >>= recogniseHelpTopic)])
               (Just "Display help text"),
 

--- a/src/Idris/Driver.idr
+++ b/src/Idris/Driver.idr
@@ -2,6 +2,7 @@ module Idris.Driver
 
 import Compiler.Common
 
+import Core.Binary
 import Core.Context.Log
 import Core.Core
 import Core.Directory
@@ -239,6 +240,9 @@ quitOpts : List CLOpt -> IO Bool
 quitOpts [] = pure True
 quitOpts (Version :: _)
     = do putStrLn versionMsg
+         pure False
+quitOpts (TTCVersion :: _)
+    = do printLn ttcVersion
          pure False
 quitOpts (Help Nothing :: _)
     = do putStrLn usage


### PR DESCRIPTION
This adds a new command for printing the current value of `Core.Binary.ttcVersion`. Tools like pack require this, because they need access to the `.ttc` files built by Idris, which are now hidden behind a directory consisting of this version number. For instance, pack is no longer able to use katla to generate semantically highlighted html docs, because it can no longer find the corresponding `.ttc` files.

It looks like this has been an issue for several days now, but it has only shown up because katla was adjusted to more often fail with a non-zero exit code.