### PR TITLE
[ doc ] Add :doc for unquotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Next version]
+
+### REPL changes
+
+* Adds documentation for unquotes `~( )`.
+
 ## v0.6.0
 
 ### REPL changes

--- a/src/Idris/Doc/String.idr
+++ b/src/Idris/Doc/String.idr
@@ -573,6 +573,23 @@ getDocsForPTerm (PUnit _) = pure $ vcat
   [ "Unit Literal"
   , indent 2 "Desugars to MkUnit or Unit"
   ]
+getDocsForPTerm (PUnquote _ _) = pure $ vcat $
+  header "Unquotes" :: ""
+  :: map (indent 2) [
+  """
+  Unquotes allows us to use TTImp expressions inside a quoted expression.
+  This is useful when we want to add some computed TTImp while building up
+  complex expressions.
+
+  ```idris
+  module Quote
+
+  import Language.Reflection
+
+  foo : TTImp -> TTImp
+  foo expr = `(either ~(expr) x y)
+  ```
+  """]
 getDocsForPTerm pterm = pure $ "Docs not implemented for" <++> pretty0 (show pterm) <++> "yet"
 
 export


### PR DESCRIPTION
Adds the ability to get help for unquotes through `:doc ~( )` at the REPL