### PR TITLE
[ re #2742 ] Count no. processors online rather than configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Next version]
+
+### Library changes
+
+#### System
+
+* Changes `getNProcessors` to return the number of online processors rather than
+  the number of configured processors.
+
 ## v0.6.0
 
 ### REPL changes

--- a/support/c/idris_support.c
+++ b/support/c/idris_support.c
@@ -119,6 +119,6 @@ long idris2_getNProcessors() {
 #ifdef _WIN32
   return win32_getNProcessors();
 #else
-  return sysconf(_SC_NPROCESSORS_CONF);
+  return sysconf(_SC_NPROCESSORS_ONLN);
 #endif
 }


### PR DESCRIPTION
Seems there might be some oddities with what is reported when, e.g. reporting the maximum number of processors supported by the currently installed motherboard, regardless of which processor is socketed.

I hope this fixes things, but I'm waiting on confirmation.