### PR TITLE
Erase Fin fromInteger upper bound

### DIFF
--- a/libs/base/Data/Fin.idr
+++ b/libs/base/Data/Fin.idr
@@ -213,7 +213,7 @@ maybeLT : (x : Nat) -> (y : Nat) -> Maybe (x `LT` y)
 maybeLT x y = maybeLTE (S x) y
 
 public export
-finFromInteger : (x : Integer) -> {n : Nat} ->
+finFromInteger : (x : Integer) ->
                  {auto 0 prf : So (fromInteger x < n)} ->
                  Fin n
 finFromInteger x = natToFinLt (fromInteger x)
@@ -233,13 +233,13 @@ integerLessThanNat x n with (x < the Integer 0)
 ||| @ x the Integer that the user typed
 ||| @ prf an automatically-constructed proof that `x` is in bounds
 public export
-fromInteger : (x : Integer) -> {n : Nat} ->
+fromInteger : (x : Integer) ->
               {auto 0 prf : So (integerLessThanNat x n)} ->
               Fin n
 fromInteger x = finFromInteger x {prf = lemma prf} where
   -- to be minimally invasive, we just call the previous implementation.
   -- however, having a different proof obligation resolves #2032
-  0 lemma : {x : Integer} -> {n : Nat} -> So (integerLessThanNat x n) -> So (fromInteger {ty=Nat} x < n)
+  0 lemma : {x : Integer} -> So (integerLessThanNat x n) -> So (fromInteger {ty=Nat} x < n)
   lemma oh = believe_me oh
 
 -- %builtin IntegerToNatural Data.Fin.fromInteger


### PR DESCRIPTION
We don't need `n` at runtime to convert `x` from an `Integer` to a `Fin n`.