### PR TITLE
[ ide-mode ] Do not include whole error message in building file display result message.

### DIFF
--- a/src/Idris/IDEMode/REPL.idr
+++ b/src/Idris/IDEMode/REPL.idr
@@ -359,8 +359,7 @@ displayIDEResult outf i  (REPL $ FileLoaded x)
 displayIDEResult outf i  (REPL $ ErrorLoadingFile x err)
   = printIDEError outf i $ reflow "Error loading file" <++> pretty0 x <+> colon <++> pretty0 (show err)
 displayIDEResult outf i  (REPL $ ErrorsBuildingFile x errs)
-  = do errs' <- traverse perror errs
-       printIDEError outf i $ reflow "Error(s) building file" <++> pretty0 x <+> colon <++> vsep errs'
+  = printIDEError outf i $ reflow "Error(s) building file" <++> pretty0 x -- messages already displayed while building
 displayIDEResult outf i  (REPL $ NoFileLoaded)
   = printIDEError outf i $ reflow "No file can be reloaded"
 displayIDEResult outf i  (REPL $ CurrentDirectory dir)


### PR DESCRIPTION
**Why:**
Makes the error message being displayed twice in Emacs. 
This change aligns IDEMode/REPL.idr with Idris/REPL.idr which works as expected.
See https://github.com/idris-lang/Idris2/blob/main/src/Idris/REPL.idr#L1241-L1242

Before change:
![async-minibuffer-before-change-idris2](https://user-images.githubusercontent.com/578608/201442070-1b26b5a3-aa03-4ecd-a2b6-6c084d74dc77.jpg)

After change:
![async-minibuffer-after-change-idris2-idemode-repl](https://user-images.githubusercontent.com/578608/201442189-0d8172c5-4ac9-4228-a01b-4263ef090c5e.jpg)


Relates to:
https://github.com/idris-hackers/idris-mode/pull/563
