### PR TITLE
[ error ] Improve error messages on record and interface constructors (#2769)

### DIFF
--- a/src/Idris/Elab/Interface.idr
+++ b/src/Idris/Elab/Interface.idr
@@ -115,7 +115,7 @@ mkIfaceData {vars} ifc vis env constraints n conName ps dets meths
           retty = apply (IVar vfc n) (map (IVar EmptyFC) pNames)
           conty = mkTy Implicit (map jname ps) $
                   mkTy AutoImplicit (map bhere constraints) (mkTy Explicit (map bname meths) retty)
-          con = MkImpTy EmptyFC EmptyFC conName !(bindTypeNames ifc [] (pNames ++ map fst meths ++ vars) conty) in
+          con = MkImpTy vfc EmptyFC conName !(bindTypeNames ifc [] (pNames ++ map fst meths ++ vars) conty) in
           pure $ IData vfc vis Nothing {- ?? -} (MkImpData vfc n
                                   !(bindTypeNames ifc [] (pNames ++ map fst meths ++ vars)
                                                   (mkDataTy vfc ps))

--- a/src/TTImp/ProcessRecord.idr
+++ b/src/TTImp/ProcessRecord.idr
@@ -129,7 +129,7 @@ elabRecord {vars} eopts fc env nest newns vis mbtot tn_in params opts conName_in
              let conty = mkTy paramTelescope $
                          mkTy (map farg fields) (recTy tn)
              let boundNames = paramNames ++ map fname fields ++ vars
-             let con = MkImpTy EmptyFC EmptyFC cname
+             let con = MkImpTy (virtualiseFC fc) EmptyFC cname
                        !(bindTypeNames fc [] boundNames conty)
              let dt = MkImpData fc tn !(bindTypeNames fc [] boundNames (mkDataTy fc params)) opts [con]
              log "declare.record" 5 $ "Record data type " ++ show dt

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -93,7 +93,7 @@ idrisTestsError = MkTestPool "Error messages" [] Nothing
        "perror001", "perror002", "perror003", "perror004", "perror005",
        "perror006", "perror007", "perror008", "perror009", "perror010",
        "perror011", "perror012", "perror013", "perror014", "perror015",
-       "perror016", "perror017", "perror018", "perror019"]
+       "perror016", "perror017", "perror018", "perror019", "perror020"]
 
 idrisTestsInteractive : TestPool
 idrisTestsInteractive = MkTestPool "Interactive editing" [] Nothing

--- a/tests/idris2/perror020/Issue2769.idr
+++ b/tests/idris2/perror020/Issue2769.idr
@@ -1,0 +1,5 @@
+module Issue2769
+
+record SomeRecord where
+  constructor SomeRecord
+  field : Int

--- a/tests/idris2/perror020/Issue2769b.idr
+++ b/tests/idris2/perror020/Issue2769b.idr
@@ -1,0 +1,6 @@
+
+
+data Foo = Bar
+
+interface Blah where
+  constructor Bar

--- a/tests/idris2/perror020/expected
+++ b/tests/idris2/perror020/expected
@@ -6,3 +6,10 @@ Issue2769:3:1--5:14
  4 |   constructor SomeRecord
  5 |   field : Int
 
+1/1: Building Issue2769b (Issue2769b.idr)
+Error: Main.Bar is already defined.
+
+Issue2769b:5:1--6:18
+ 5 | interface Blah where
+ 6 |   constructor Bar
+

--- a/tests/idris2/perror020/expected
+++ b/tests/idris2/perror020/expected
@@ -1,0 +1,8 @@
+1/1: Building Issue2769 (Issue2769.idr)
+Error: Issue2769.SomeRecord is already defined.
+
+Issue2769:3:1--5:14
+ 3 | record SomeRecord where
+ 4 |   constructor SomeRecord
+ 5 |   field : Int
+

--- a/tests/idris2/perror020/run
+++ b/tests/idris2/perror020/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-banner --no-color --console-width 0 --check Issue2769.idr

--- a/tests/idris2/perror020/run
+++ b/tests/idris2/perror020/run
@@ -1,3 +1,4 @@
 rm -rf build
 
 $1 --no-banner --no-color --console-width 0 --check Issue2769.idr
+$1 --no-banner --no-color --console-width 0 --check Issue2769b.idr


### PR DESCRIPTION
If a record constructor or interface constructor is given a name that is already defined, the error message ends up at EmptyFC. This was reported as #2769.

This PR places the error message on the entire record/interface expression to avoid having to change TTimp to add an FC for the constructor name.

For the code:
```idris
module Issue2769

record SomeRecord where
  constructor SomeRecord
  field : Int
```

The message before the patch is:
```
1/1: Building Issue2769 (Issue2769.idr)
Warning: No incremental compile data for Prelude
Error: Issue2769.SomeRecord is already defined.
```
and after the patch it is
```
1/1: Building Issue2769 (Issue2769.idr)
Error: Issue2769.SomeRecord is already defined.

Issue2769:3:1--5:14
 3 | record SomeRecord where
 4 |   constructor SomeRecord
 5 |   field : Int
```
