### PR TITLE
[ parser ] fix issue where indentation is not checked in record params

### DIFF
--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1701,7 +1701,7 @@ recordDecl fname indents
                          col         <- column
                          decoratedKeyword fname "record"
                          n       <- mustWork (decoratedDataTypeName fname)
-                         paramss <- many (recordParam fname indents)
+                         paramss <- many (continue indents >> recordParam fname indents)
                          let params = concat paramss
                          recordBody fname indents doc vis mbtot col n params)
          pure (b.val (boundToFC fname b))

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -94,7 +94,7 @@ idrisTestsError = MkTestPool "Error messages" [] Nothing
        "perror006", "perror007", "perror008", "perror009", "perror010",
        "perror011", "perror012", "perror013", "perror014", "perror015",
        "perror016", "perror017", "perror018", "perror019", "perror020",
-       "perror021"]
+       "perror021", "perror022"]
 
 idrisTestsInteractive : TestPool
 idrisTestsInteractive = MkTestPool "Interactive editing" [] Nothing

--- a/tests/idris2/perror022/Indent.idr
+++ b/tests/idris2/perror022/Indent.idr
@@ -1,0 +1,2 @@
+record Rec (a : Type)
+b : Int

--- a/tests/idris2/perror022/expected
+++ b/tests/idris2/perror022/expected
@@ -1,0 +1,1 @@
+1/1: Building Indent (Indent.idr)

--- a/tests/idris2/perror022/run
+++ b/tests/idris2/perror022/run
@@ -1,0 +1,4 @@
+rm -rf build
+
+$1 --no-banner --no-color --console-width 0 --check Indent.idr
+


### PR DESCRIPTION
This issue was reported by "Oxy" on discord.  

When parsing record params on forward record declarations, the Idris parser is not checking indentation and may interpret a subsequent top level line as part of the record declaration.  

So this valid code:
```idris
record Rec (a : Type)
b : Int
```
yields the following error:
```
1/1: Building Indent (Indent.idr)
Error: Expected 'where'.

Indent:2:3--2:4
 1 | record Rec (a : Type)
 2 | b : Int
       ^
```

This patch fixes the issue by adding an indentation check in front of each parameter.