### PR TITLE
[ ci ] Replace deprecated feature with its functional equivalent

### DIFF
--- a/.github/workflows/ci-bootstrap.yml
+++ b/.github/workflows/ci-bootstrap.yml
@@ -34,9 +34,9 @@ jobs:
         id: get_commit_message
         run: |
           if   [[ '${{ github.event_name }}' == 'push' ]]; then
-            echo ::set-output name=commit_message::$(git log --format=%B -n 1 HEAD)
+            echo "commit_message=$(git log --format=%B -n 1 HEAD)" >> "$GITHUB_OUTPUT"
           elif [[ '${{ github.event_name }}' == 'pull_request' ]]; then
-            echo ::set-output name=commit_message::$(git log --format=%B -n 1 HEAD^2)
+            echo "commit_message=$(git log --format=%B -n 1 HEAD^2)" >> "$GITHUB_OUTPUT"
           fi
 
     outputs:
@@ -58,6 +58,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y chezscheme
-          echo "$HOME/.idris2/bin" >> $GITHUB_PATH
+          echo "$HOME/.idris2/bin" >> "$GITHUB_PATH"
       - name: Build bootstrap
         run: make bootstrap

--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -50,9 +50,9 @@ jobs:
         id: get_commit_message
         run: |
           if   [[ '${{ github.event_name }}' == 'push' ]]; then
-            echo "::set-output name=commit_message::$(git log --format=%B -n 1 HEAD)"
+            echo "commit_message=$(git log --format=%B -n 1 HEAD)" >> "$GITHUB_OUTPUT"
           elif [[ '${{ github.event_name }}' == 'pull_request' ]]; then
-            echo "::set-output name=commit_message::$(git log --format=%B -n 1 HEAD^2)"
+            echo "commit_message=$(git log --format=%B -n 1 HEAD^2)" >> "$GITHUB_OUTPUT"
           fi
 
     outputs:


### PR DESCRIPTION
According to [this](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/), `set-output` feature will be deprecated. Now CI already prints warning during run. There is suggested change that does the same, but is not deprecated, thus let's use it.
