### PR TITLE
Let qualified do-notation apply to `pure` and to idiom brackets

### DIFF
--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -266,7 +266,7 @@ idrisTests = MkTestPool "Misc" [] Nothing
        -- Implicit laziness, lazy evaluation
        "lazy001", "lazy002",
        -- Namespace blocks
-       "namespace001", "namespace002",
+       "namespace001", "namespace002", "namespace003",
        -- Parameters blocks
        "params001", "params002", "params003",
        -- Larger programs arising from real usage. Typically things with

--- a/tests/idris2/namespace003/Test.idr
+++ b/tests/idris2/namespace003/Test.idr
@@ -1,0 +1,33 @@
+namespace A
+  public export
+  pure : a -> IO a
+  pure x = io_pure x
+
+  public export
+  (<*>) : IO (a -> b) -> IO a -> IO b
+  (<*>) = (<*>) @{%search}
+
+namespace B
+  public export
+  pure : a -> IO a
+  pure x = io_pure x
+
+  public export
+  (<*>) : IO (a -> b) -> IO a -> IO b
+  (<*>) = (<*>) @{%search}
+
+testFailing1 : IO ()
+testFailing1 = pure ()
+
+testSucceeding1 : IO ()
+testSucceeding1 = A.do
+  pure ()
+
+testFailing2 : (a -> b) -> IO a -> IO b
+testFailing2 f a =
+  [| f a |]
+
+testSucceeding2 : (a -> b) -> IO a -> IO b
+testSucceeding2 f a = B.do
+  [| f a |]
+

--- a/tests/idris2/namespace003/expected
+++ b/tests/idris2/namespace003/expected
@@ -1,0 +1,25 @@
+1/1: Building Test (Test.idr)
+Error: While processing right hand side of testFailing1. Ambiguous elaboration. Possible results:
+    Main.B.pure Builtin.MkUnit
+    Main.A.pure Builtin.MkUnit
+
+Test:20:16--20:20
+ 16 |   (<*>) : IO (a -> b) -> IO a -> IO b
+ 17 |   (<*>) = (<*>) @{%search}
+ 18 | 
+ 19 | testFailing1 : IO ()
+ 20 | testFailing1 = pure ()
+                     ^^^^
+
+Error: While processing right hand side of testFailing2. Ambiguous elaboration. Possible results:
+    ?delayed Main.B.(<*>) a
+    ?delayed Main.A.(<*>) a
+
+Test:28:3--28:12
+ 24 |   pure ()
+ 25 | 
+ 26 | testFailing2 : (a -> b) -> IO a -> IO b
+ 27 | testFailing2 f a =
+ 28 |   [| f a |]
+        ^^^^^^^^^
+

--- a/tests/idris2/namespace003/run
+++ b/tests/idris2/namespace003/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --check Test.idr || true


### PR DESCRIPTION
This can come in handy when one deploys their own namespace with a subset of `pure`, `>>=`, `>>`, `<*>` overloaded in it and where one uses the qualified do-notation to disambiguate monad-style code.