### PR TITLE
[ perf ] compile Core.CompileExpr.Pretty faster

### DIFF
--- a/src/Core/CompileExpr/Pretty.idr
+++ b/src/Core/CompileExpr/Pretty.idr
@@ -60,19 +60,22 @@ prettyCon x ci mtag
       , prettyFlag ci
       ]
 
+prettyName : Name -> Doc IdrisSyntax
+prettyName = pretty0
+
 mutual
 
   prettyNamedCExp : NamedCExp -> Doc IdrisSyntax
   prettyNamedCExp = prettyPrecNamedCExp Open
 
   prettyPrecNamedCExp : Prec -> NamedCExp -> Doc IdrisSyntax
-  prettyPrecNamedCExp d (NmLocal _ x) = annotate Bound $ pretty0 x
-  prettyPrecNamedCExp d (NmRef _ x) = annotate (Fun x) $ pretty0 x
+  prettyPrecNamedCExp d (NmLocal _ x) = annotate Bound $ prettyName x
+  prettyPrecNamedCExp d (NmRef _ x) = annotate (Fun x) $ prettyName x
   prettyPrecNamedCExp d (NmLam _ x y)
-    = parenthesise (d > Open) $ keyword "\\" <+> pretty0 x <+> fatArrow <++> prettyNamedCExp y
+    = parenthesise (d > Open) $ keyword "\\" <+> prettyName x <+> fatArrow <++> prettyNamedCExp y
   prettyPrecNamedCExp d (NmLet _ x y z)
       = parenthesise (d > Open) $
-          vcat [ let_ <++> pretty0 x <++> equals <++> prettyNamedCExp y <++> in_, prettyNamedCExp z ]
+          vcat [ let_ <++> prettyName x <++> equals <++> prettyNamedCExp y <++> in_, prettyNamedCExp z ]
   prettyPrecNamedCExp d (NmApp _ x xs)
       = parenthesise (d > Open) $
           sep (prettyNamedCExp x :: map (prettyPrecNamedCExp App) xs)
@@ -106,7 +109,7 @@ mutual
 
   prettyNamedConAlt : NamedConAlt -> Doc IdrisSyntax
   prettyNamedConAlt (MkNConAlt x ci tag args exp)
-        = sep (prettyCon x ci tag :: map pretty0 args ++ [fatArrow <+> softline <+> align (prettyNamedCExp exp) ])
+        = sep (prettyCon x ci tag :: map prettyName args ++ [fatArrow <+> softline <+> align (prettyNamedCExp exp) ])
 
   prettyNamedConstAlt : NamedConstAlt -> Doc IdrisSyntax
   prettyNamedConstAlt (MkNConstAlt x exp)
@@ -126,7 +129,7 @@ prettyCExp = prettyNamedCExp . forget
 prettyCDef : CDef -> Doc IdrisDocAnn
 prettyCDef (MkFun [] exp) = reAnnotate Syntax $ prettyCExp exp
 prettyCDef (MkFun args exp) = reAnnotate Syntax $
-  keyword "\\" <++> concatWith (\ x, y => x <+> keyword "," <++> y) (map pretty0 args)
+  keyword "\\" <++> concatWith (\ x, y => x <+> keyword "," <++> y) (map prettyName args)
        <++> fatArrow <++> prettyCExp exp
 prettyCDef (MkCon mtag arity nt)
   = vcat $ header (maybe "Data" (const "Type") mtag <++> "Constructor") :: map (indent 2)

--- a/src/Core/CompileExpr/Pretty.idr
+++ b/src/Core/CompileExpr/Pretty.idr
@@ -14,6 +14,18 @@ import Libraries.Data.String.Extra
 
 %hide Vect.(::)
 %hide Vect.Nil
+%hide Vect.catMaybes
+%hide Vect.(++)
+
+%hide HasLength.cast
+
+%hide SizeOf.map
+
+%hide Core.Name.prettyOp
+
+%hide Core.TT.Bound
+%hide Core.TT.App
+
 %hide CompileExpr.(::)
 %hide CompileExpr.Nil
 %hide String.(::)
@@ -31,8 +43,7 @@ import Libraries.Data.String.Extra
 %hide String.indent
 %hide Extra.indent
 %hide List1.(++)
-%hide Vect.(++)
--- %hide SnocList.(++)
+%hide SnocList.(++)
 %hide String.(++)
 %hide Pretty.Syntax
 %hide List1.forget
@@ -50,75 +61,86 @@ prettyCon x ci mtag
       ]
 
 mutual
-  Pretty IdrisSyntax NamedCExp where
-    prettyPrec d (NmLocal _ x) = annotate Bound $ pretty0 x
-    prettyPrec d (NmRef _ x) = annotate (Fun x) $ pretty0 x
-    prettyPrec d (NmLam _ x y)
-      = parenthesise (d > Open) $ keyword "\\" <+> pretty0 x <+> fatArrow <++> pretty y
-    prettyPrec d (NmLet _ x y z)
-        = parenthesise (d > Open) $
-            vcat [ let_ <++> pretty0 x <++> equals <++> pretty y <++> in_, pretty z ]
-    prettyPrec d (NmApp _ x xs)
-        = parenthesise (d > Open) $
-            sep (pretty x :: map (prettyPrec App) xs)
-    prettyPrec d (NmCon _ x ci tag xs)
-        = parenthesise (d > Open) $
-            sep (prettyCon x ci tag :: map (prettyPrec App) xs)
-    prettyPrec d (NmOp _ op xs)
-        = parenthesise (d > Open) $ prettyOp op $ map (prettyPrec App) xs
-    prettyPrec d (NmExtPrim _ p xs)
-        = parenthesise (d > Open) $
-            sep (annotate (Fun p) (pretty0 p) :: map (prettyPrec App) xs)
-    prettyPrec d (NmForce _  lr x)
-        = parenthesise (d > Open) $
-            sep [keyword "Force", byShow lr, prettyPrec App x]
-    prettyPrec d (NmDelay _ lr x)
-        = parenthesise (d > Open) $
-            sep [keyword "Delay", byShow lr, prettyPrec App x]
-    prettyPrec d (NmConCase _ sc xs def)
-        = parenthesise (d > Open) $ vcat [case_ <++> pretty sc <++> of_, indent 2 (prettyAlts xs def)]
-    prettyPrec d (NmConstCase _ sc xs def)
-        = parenthesise (d > Open) $ vcat [case_ <++> pretty sc <++> of_, indent 2 (prettyAlts xs def)]
-    prettyPrec d (NmPrimVal _ x) = pretty x
-    prettyPrec d (NmErased _) = "___"
-    prettyPrec d (NmCrash _ x)
-        = parenthesise (d > Open) $
-            sep [annotate Keyword "crash", byShow x]
 
-  Pretty IdrisSyntax NamedConAlt where
-    pretty (MkNConAlt x ci tag args exp)
-        = sep (prettyCon x ci tag :: map pretty0 args ++ [fatArrow <+> softline <+> align (pretty exp) ])
+  prettyNamedCExp : NamedCExp -> Doc IdrisSyntax
+  prettyNamedCExp = prettyPrecNamedCExp Open
 
-  Pretty IdrisSyntax NamedConstAlt where
-    pretty (MkNConstAlt x exp)
-        = pretty x <++> fatArrow <+> softline <+> align (pretty exp)
+  prettyPrecNamedCExp : Prec -> NamedCExp -> Doc IdrisSyntax
+  prettyPrecNamedCExp d (NmLocal _ x) = annotate Bound $ pretty0 x
+  prettyPrecNamedCExp d (NmRef _ x) = annotate (Fun x) $ pretty0 x
+  prettyPrecNamedCExp d (NmLam _ x y)
+    = parenthesise (d > Open) $ keyword "\\" <+> pretty0 x <+> fatArrow <++> prettyNamedCExp y
+  prettyPrecNamedCExp d (NmLet _ x y z)
+      = parenthesise (d > Open) $
+          vcat [ let_ <++> pretty0 x <++> equals <++> prettyNamedCExp y <++> in_, prettyNamedCExp z ]
+  prettyPrecNamedCExp d (NmApp _ x xs)
+      = parenthesise (d > Open) $
+          sep (prettyNamedCExp x :: map (prettyPrecNamedCExp App) xs)
+  prettyPrecNamedCExp d (NmCon _ x ci tag xs)
+      = parenthesise (d > Open) $
+          sep (prettyCon x ci tag :: map (prettyPrecNamedCExp App) xs)
+  prettyPrecNamedCExp d (NmOp _ op xs)
+      = parenthesise (d > Open) $ prettyOp op $ map (prettyPrecNamedCExp App) xs
+  prettyPrecNamedCExp d (NmExtPrim _ p xs)
+      = parenthesise (d > Open) $
+          sep (annotate (Fun p) (pretty0 p) :: map (prettyPrecNamedCExp App) xs)
+  prettyPrecNamedCExp d (NmForce _  lr x)
+      = parenthesise (d > Open) $
+          sep [keyword "Force", byShow lr, prettyPrecNamedCExp App x]
+  prettyPrecNamedCExp d (NmDelay _ lr x)
+      = parenthesise (d > Open) $
+          sep [keyword "Delay", byShow lr, prettyPrecNamedCExp App x]
+  prettyPrecNamedCExp d (NmConCase _ sc xs def)
+      = parenthesise (d > Open) $
+          vcat [ case_ <++> prettyNamedCExp sc <++> of_
+               , indent 2 (prettyAlts prettyNamedConAlt xs def)]
+  prettyPrecNamedCExp d (NmConstCase _ sc xs def)
+      = parenthesise (d > Open) $
+          vcat [ case_ <++> prettyNamedCExp sc <++> of_
+               , indent 2 (prettyAlts prettyNamedConstAlt xs def)]
+  prettyPrecNamedCExp d (NmPrimVal _ x) = pretty x
+  prettyPrecNamedCExp d (NmErased _) = "___"
+  prettyPrecNamedCExp d (NmCrash _ x)
+      = parenthesise (d > Open) $
+          sep [annotate Keyword "crash", byShow x]
 
-  prettyAlts : Pretty IdrisSyntax alt => List alt -> Maybe NamedCExp -> Doc IdrisSyntax
-  prettyAlts xs def = vcat
-    $ zipWith (\ s, p => s <++> pretty p)
+  prettyNamedConAlt : NamedConAlt -> Doc IdrisSyntax
+  prettyNamedConAlt (MkNConAlt x ci tag args exp)
+        = sep (prettyCon x ci tag :: map pretty0 args ++ [fatArrow <+> softline <+> align (prettyNamedCExp exp) ])
+
+  prettyNamedConstAlt : NamedConstAlt -> Doc IdrisSyntax
+  prettyNamedConstAlt (MkNConstAlt x exp)
+        = pretty x <++> fatArrow <+> softline <+> align (prettyNamedCExp exp)
+
+  prettyAlts : (alt -> Doc IdrisSyntax) -> List alt -> Maybe NamedCExp -> Doc IdrisSyntax
+  prettyAlts pre xs def = vcat
+    $ zipWith (\ s, p => s <++> pre p)
               (keyword "{" :: (keyword ";" <$ xs))
               xs
-   ++ maybe [] (\ deflt => [keyword "; _" <++> fatArrow <+> softline <+> align (pretty deflt)]) def
+   ++ maybe [] (\ deflt => [keyword "; _" <++> fatArrow <+> softline <+> align (prettyNamedCExp deflt)]) def
    ++ [keyword "}"]
 
-{args : _} -> Pretty IdrisSyntax (CExp args) where
-  pretty = pretty . forget
+prettyCExp : {args : _} -> CExp args -> Doc IdrisSyntax
+prettyCExp = prettyNamedCExp . forget
+
+prettyCDef : CDef -> Doc IdrisDocAnn
+prettyCDef (MkFun [] exp) = reAnnotate Syntax $ prettyCExp exp
+prettyCDef (MkFun args exp) = reAnnotate Syntax $
+  keyword "\\" <++> concatWith (\ x, y => x <+> keyword "," <++> y) (map pretty0 args)
+       <++> fatArrow <++> prettyCExp exp
+prettyCDef (MkCon mtag arity nt)
+  = vcat $ header (maybe "Data" (const "Type") mtag <++> "Constructor") :: map (indent 2)
+         ( maybe [] (\ tag => ["tag:" <++> byShow tag]) mtag ++
+         [ "arity:" <++> byShow arity ] ++
+           maybe [] (\ n => ["newtype by:" <++> byShow n]) nt)
+prettyCDef (MkForeign ccs args ret)
+  = vcat $ header "Foreign function" :: map (indent 2)
+         [ "bindings:" <++> cast (prettyList ccs)
+         , "argument types:" <++> byShow args
+         , "return type:" <++> byShow ret
+         ]
+prettyCDef (MkError exp) = "Error:" <++> reAnnotate Syntax (prettyCExp exp)
 
 export
 Pretty IdrisDocAnn CDef where
-  pretty (MkFun [] exp) = prettyBy Syntax exp
-  pretty (MkFun args exp) = reAnnotate Syntax $
-    keyword "\\" <++> concatWith (\ x, y => x <+> keyword "," <++> y) (map pretty0 args)
-         <++> fatArrow <++> pretty exp
-  pretty (MkCon mtag arity nt)
-    = vcat $ header (maybe "Data" (const "Type") mtag <++> "Constructor") :: map (indent 2)
-           ( maybe [] (\ tag => ["tag:" <++> byShow tag]) mtag ++
-           [ "arity:" <++> byShow arity ] ++
-             maybe [] (\ n => ["newtype by:" <++> byShow n]) nt)
-  pretty (MkForeign ccs args ret)
-    = vcat $ header "Foreign function" :: map (indent 2)
-           [ "bindings:" <++> cast (prettyList ccs)
-           , "argument types:" <++> byShow args
-           , "return type:" <++> byShow ret
-           ]
-  pretty (MkError exp) = "Error:" <++> prettyBy Syntax exp
+  pretty = prettyCDef

--- a/src/TTImp/Elab/Ambiguity.idr
+++ b/src/TTImp/Elab/Ambiguity.idr
@@ -40,14 +40,14 @@ expandAmbigName (InLHS _) nest env orig args (IBindVar fc n) exp
             else pure $ orig
 expandAmbigName mode nest env orig args (IVar fc x) exp
    = case lookup x (names nest) of
-          Just _ => do log "elab.ambiguous" 10 $ "Nested " ++ show x
+          Just _ => do log "elab.ambiguous" 20 $ "Nested " ++ show x
                        pure orig
           Nothing => do
              defs <- get Ctxt
              case defined x env of
                   Just _ =>
                     if isNil args || notLHS mode
-                       then do log "elab.ambiguous" 10 $ "Defined in env " ++ show x
+                       then do log "elab.ambiguous" 20 $ "Defined in env " ++ show x
                                pure $ orig
                        else pure $ IMustUnify fc VarApplied orig
                   Nothing =>
@@ -57,18 +57,21 @@ expandAmbigName mode nest env orig args (IVar fc x) exp
                         let primApp = isPrimName prims x
                         case lookupUN (userNameRoot x) (unambiguousNames est) of
                           Just xr => do
-                            log "elab.ambiguous" 10 $ "unambiguous: " ++ show (fst xr)
+                            log "elab.ambiguous" 50 $ "unambiguous: " ++ show (fst xr)
                             pure $ mkAlt primApp est xr
                           Nothing => do
                             ns <- lookupCtxtName x (gamma defs)
                             ns' <- filterM visible ns
                             case ns' of
-                               [] => do log "elab.ambiguous" 10 $ "Failed to find " ++ show orig
+                               [] => do log "elab.ambiguous" 50 $ "Failed to find " ++ show orig
                                         pure orig
                                [nalt] =>
-                                     do log "elab.ambiguous" 10 $ "Only one " ++ show (fst nalt)
+                                     do log "elab.ambiguous" 40 $ "Only one " ++ show (fst nalt)
                                         pure $ mkAlt primApp est nalt
-                               nalts => pure $ IAlternative fc
+                               nalts =>
+                                     do log "elab.ambiguous" 10 $
+                                          "Ambiguous: " ++ joinBy ", " (map (show . fst) nalts)
+                                        pure $ IAlternative fc
                                                       (uniqType primNs x args)
                                                       (map (mkAlt primApp est) nalts)
   where
@@ -161,7 +164,7 @@ expandAmbigName mode nest env orig args (IAutoApp fc f a) exp
     = expandAmbigName mode nest env orig
                       ((fc, Just Nothing, a) :: args) f exp
 expandAmbigName elabmode nest env orig args tm exp
-    = do log "elab.ambiguous" 10 $ "No ambiguity " ++ show orig
+    = do log "elab.ambiguous" 50 $ "No ambiguity " ++ show orig
          pure orig
 
 stripDelay : NF vars -> NF vars


### PR DESCRIPTION
The auto search in the pretty instances is just too damn expensive.
It still takes 4s so we should be able to squeeze some more perf out of this.