### PR TITLE
Improve parser error messages when using reserved identifiers in decls

### DIFF
--- a/src/Parser/Rule/Source.idr
+++ b/src/Parser/Rule/Source.idr
@@ -337,6 +337,13 @@ reservedNames
       , "String", "Char", "Double", "Lazy", "Inf", "Force", "Delay"
       ]
 
+export
+anyReservedIdent : Rule (WithBounds String)
+anyReservedIdent = do
+    id <- bounds identPart
+    unless (id.val `elem` reservedNames) $ failLoc id.bounds "Expected reserved identifier"
+    pure id
+
 isNotReservedName : WithBounds String -> EmptyRule ()
 isNotReservedName x
     = when (x.val `elem` reservedNames) $

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -94,7 +94,7 @@ idrisTestsError = MkTestPool "Error messages" [] Nothing
        "perror006", "perror007", "perror008", "perror009", "perror010",
        "perror011", "perror012", "perror013", "perror014", "perror015",
        "perror016", "perror017", "perror018", "perror019", "perror020",
-       "perror021", "perror022"]
+       "perror021", "perror022", "perror023", "perror024"]
 
 idrisTestsInteractive : TestPool
 idrisTestsInteractive = MkTestPool "Interactive editing" [] Nothing

--- a/tests/idris2/perror023/ParseError.idr
+++ b/tests/idris2/perror023/ParseError.idr
@@ -1,0 +1,3 @@
+module ParseError
+
+String : Type

--- a/tests/idris2/perror023/expected
+++ b/tests/idris2/perror023/expected
@@ -1,0 +1,9 @@
+1/1: Building ParseError (ParseError.idr)
+Error: Cannot begin a declaration with a reserved identifier.
+
+ParseError:3:1--3:7
+ 1 | module ParseError
+ 2 | 
+ 3 | String : Type
+     ^^^^^^
+

--- a/tests/idris2/perror023/run
+++ b/tests/idris2/perror023/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --check ParseError.idr

--- a/tests/idris2/perror024/ParseError.idr
+++ b/tests/idris2/perror024/ParseError.idr
@@ -1,0 +1,3 @@
+module ParseError
+
+module : Type

--- a/tests/idris2/perror024/expected
+++ b/tests/idris2/perror024/expected
@@ -1,0 +1,9 @@
+1/1: Building ParseError (ParseError.idr)
+Error: Keyword 'module' is not a valid start to a declaration.
+
+ParseError:3:1--3:7
+ 1 | module ParseError
+ 2 | 
+ 3 | module : Type
+     ^^^^^^
+

--- a/tests/idris2/perror024/run
+++ b/tests/idris2/perror024/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --check ParseError.idr


### PR DESCRIPTION
## Problem

Currently, using a reserved identifier or keyword on the LHS of a type claim gives a generic error message.
```idris
-- Fails with "Couldn't parse declaration"
String : Type
```
This might be confusing for new users.

## Solution
I have updated the error messages:

```idris
Error: Cannot begin a declaration with a reserved identifier.

Test:4:1--4:7
 1 | module Test
 2 |
 3 |
 4 | String : Type
     ^^^^^^
```
```idris
Error: Keyword 'module' is not a valid start to a declaration.

Test:4:1--4:7
 1 | module Test
 2 |
 3 |
 4 | module : Type
     ^^^^^^
```

## Caveats

The error message is still poor when the reserved identifier is namespaced:
```idris
-- Fails with "Couldn't parse declaration"
X.String : Type
```

However I don't think this is a major problem as predeclaring names in other modules is an advanced use case, whereas this change is mainly benefiting new users.

