### PR TITLE
Add `mustWork` in GADT data declaration parser

### DIFF
--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1201,7 +1201,7 @@ dataBody : OriginDesc -> Int -> WithBounds t -> Name -> IndentInfo -> PTerm ->
 dataBody fname mincol start n indents ty
     = do atEndIndent indents
          pure (MkPLater (boundToFC fname start) n ty)
-  <|> do b <- bounds (do decoratedKeyword fname "where"
+  <|> do b <- bounds (do (mustWork $ decoratedKeyword fname "where")
                          opts <- dataOpts fname
                          cs <- blockAfter mincol (tyDecls (mustWork $ decoratedDataConstructorName fname) "" fname)
                          pure (opts, concatMap forget cs))

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -94,7 +94,7 @@ idrisTestsError = MkTestPool "Error messages" [] Nothing
        "perror006", "perror007", "perror008", "perror009", "perror010",
        "perror011", "perror012", "perror013", "perror014", "perror015",
        "perror016", "perror017", "perror018", "perror019", "perror020",
-       "perror021", "perror022", "perror023", "perror024"]
+       "perror021", "perror022", "perror023", "perror024", "perror025"]
 
 idrisTestsInteractive : TestPool
 idrisTestsInteractive = MkTestPool "Interactive editing" [] Nothing

--- a/tests/idris2/perror025/DataWhere.idr
+++ b/tests/idris2/perror025/DataWhere.idr
@@ -1,0 +1,2 @@
+data Foo : Type
+  Bar : Stnrig -> Foo

--- a/tests/idris2/perror025/expected
+++ b/tests/idris2/perror025/expected
@@ -1,0 +1,8 @@
+1/1: Building DataWhere (DataWhere.idr)
+Error: Expected 'where'.
+
+DataWhere:2:7--2:8
+ 1 | data Foo : Type
+ 2 |   Bar : Stnrig -> Foo
+           ^
+

--- a/tests/idris2/perror025/run
+++ b/tests/idris2/perror025/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --check DataWhere.idr


### PR DESCRIPTION
This makes the error message ever so slightly more helpful if you forget the `where` keyword in a data declaration.

before:

```
1/1: Building test (test.idr)
Error: Expected end of input.

test:3:1--3:5
 1 | module Main
 2 | 
 3 | data Foo : Type
     ^^^^
```
after
```
1/1: Building test (test.idr)
Error: Expected 'where'.

test:4:7--4:8
 1 | module Main
 2 | 
 3 | data Foo : Type
 4 |   Bar : String -> Foo
           ^
```

admittedly one might want to point in front of the `Bar` or underline it (I don't know yet how to do that, though)



# Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a user-facing change or a compiler change, I have updated
      `CHANGELOG.md` (and potentially also `CONTRIBUTORS.md`).

