### PR TITLE
[ new ] logging topics autocompletion in the emacs REPL

### DIFF
--- a/src/TTImp/Interactive/Completion.idr
+++ b/src/TTImp/Interactive/Completion.idr
@@ -115,6 +115,9 @@ completion line = do
   case task of
     NameCompletion pref => (Just . (ctxt,)) <$> nameCompletion pref
     PragmaCompletion mprag pref => map (mapFst (ctxt ++)) <$> pragmaCompletion mprag pref
-    CommandCompletion pref =>
-      let commands = concatMap fst parserCommandsForHelp in
-      pure $ map ((ctxt,) . map (":" ++)) $ oneOfCompletion pref commands
+    CommandCompletion pref => case words pref of
+      ["logging"] => pure $ Just (ctxt ++ ":logging", map ((" " ++) . show . fst) knownTopics)
+      [pref] => let commands = concatMap fst parserCommandsForHelp in
+                pure $ map ((ctxt,) . map (":" ++)) $ oneOfCompletion pref commands
+      ["logging", w] => pure $ map (ctxt ++ ":logging ",) (oneOfCompletion w (map (show . fst) knownTopics))
+      _ => pure Nothing


### PR DESCRIPTION
Auto-complete logging topics in the emacs REPL via the IDE-mode.