### PR TITLE
[ performance ] replace `blodwen-lazy` with `delay` and `force` on Chez

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   Versions of the flags with the `IDRIS2_` prefix can also be used and take
   precedence.
 
+#### Chez
+
+* Use `delay` and `force` to lazily compute top-level constants.
+
 ### Compiler changes
 
 * If `IAlternative` expression with `FirstSuccess` rule fails to typecheck,

--- a/src/Compiler/Scheme/Common.idr
+++ b/src/Compiler/Scheme/Common.idr
@@ -652,6 +652,7 @@ parameters (schExtPrim : Int -> ExtPrim -> List NamedCExp -> Core String,
 --   schDef n (MkNmFun [] exp)
 --      = pure $ "(define " ++ schName !(getFullName n) ++ "(blodwen-lazy (lambda () "
 --                       ++ !(schExp 0 exp) ++ ")))\n"
+
   schDef n (MkNmFun args exp)
      = pure $ "(define " ++ schName !(getFullName n) ++ " (lambda (" ++ schArglist args ++ ") "
                       ++ !(schExp 0 exp) ++ "))\n"

--- a/src/Compiler/Scheme/Common.idr
+++ b/src/Compiler/Scheme/Common.idr
@@ -649,9 +649,9 @@ parameters (schExtPrim : Int -> ExtPrim -> List NamedCExp -> Core String,
 
   schDef : {auto c : Ref Ctxt Defs} ->
            Name -> NamedDef -> Core String
-  schDef n (MkNmFun [] exp)
-     = pure $ "(define " ++ schName !(getFullName n) ++ "(blodwen-lazy (lambda () "
-                      ++ !(schExp 0 exp) ++ ")))\n"
+--   schDef n (MkNmFun [] exp)
+--      = pure $ "(define " ++ schName !(getFullName n) ++ "(blodwen-lazy (lambda () "
+--                       ++ !(schExp 0 exp) ++ ")))\n"
   schDef n (MkNmFun args exp)
      = pure $ "(define " ++ schName !(getFullName n) ++ " (lambda (" ++ schArglist args ++ ") "
                       ++ !(schExp 0 exp) ++ "))\n"

--- a/src/Compiler/Scheme/Common.idr
+++ b/src/Compiler/Scheme/Common.idr
@@ -531,6 +531,8 @@ parameters (schExtPrim : Int -> ExtPrim -> List NamedCExp -> Core String,
        = do val' <- schExp i val
             sc' <- schExp i sc
             pure $ "(let ((" ++ schName x ++ " " ++ val' ++ ")) " ++ sc' ++ ")"
+    schExp i (NmApp fc x@(NmRef _ _) [])
+        = pure $ "(force " ++ !(schExp i x) ++ ")"
     schExp i (NmApp fc x [])
         = pure $ "(" ++ !(schExp i x) ++ ")"
     schExp i (NmApp fc x args)
@@ -649,9 +651,9 @@ parameters (schExtPrim : Int -> ExtPrim -> List NamedCExp -> Core String,
 
   schDef : {auto c : Ref Ctxt Defs} ->
            Name -> NamedDef -> Core String
---   schDef n (MkNmFun [] exp)
---      = pure $ "(define " ++ schName !(getFullName n) ++ "(blodwen-lazy (lambda () "
---                       ++ !(schExp 0 exp) ++ ")))\n"
+  schDef n (MkNmFun [] exp)
+     = pure $ "(define " ++ schName !(getFullName n) ++ "(delay "
+                      ++ !(schExp 0 exp) ++ "))\n"
 
   schDef n (MkNmFun args exp)
      = pure $ "(define " ++ schName !(getFullName n) ++ " (lambda (" ++ schArglist args ++ ") "

--- a/src/Compiler/Scheme/Common.idr
+++ b/src/Compiler/Scheme/Common.idr
@@ -654,7 +654,6 @@ parameters (schExtPrim : Int -> ExtPrim -> List NamedCExp -> Core String,
   schDef n (MkNmFun [] exp)
      = pure $ "(define " ++ schName !(getFullName n) ++ "(delay "
                       ++ !(schExp 0 exp) ++ "))\n"
-
   schDef n (MkNmFun args exp)
      = pure $ "(define " ++ schName !(getFullName n) ++ " (lambda (" ++ schArglist args ++ ") "
                       ++ !(schExp 0 exp) ++ "))\n"


### PR DESCRIPTION
As discussed on Discord, using `blodwen-lazy` to lazily compute and memoise top-level constants has a negative impact on performance. With a simple change, we can significantly speed up compiler performance on the Chez backend (other backends are not affected by this). If this would also apply to other scheme backends, I do not know.

- [x] If this is a user-facing change or a compiler change, I have updated
      `CHANGELOG.md` (and potentially also `CONTRIBUTORS.md`).

