### PR TITLE
[ performance ] Compile non-recursive top-level constants to constants in Chez

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
 
 #### Chez
 
-* Use `delay` and `force` to lazily compute top-level constants.
+* Non-recursive top-level constants are compiled to eagerly evaluated
+  constants in Chez Scheme.
 
 ### Compiler changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
   Versions of the flags with the `IDRIS2_` prefix can also be used and take
   precedence.
 
+#### Chez
+
+* Use `delay` and `force` to lazily compute top-level constants.
+
 ### Compiler changes
 
 * If `IAlternative` expression with `FirstSuccess` rule fails to typecheck,

--- a/idris2api.ipkg
+++ b/idris2api.ipkg
@@ -22,6 +22,7 @@ modules =
     Compiler.Opts.ConstantFold,
     Compiler.Opts.Identity,
     Compiler.Opts.InlineHeuristics,
+    Compiler.Opts.ToplevelConstants,
 
     Compiler.ES.Ast,
     Compiler.ES.Codegen,

--- a/src/Compiler/Opts/CSE.idr
+++ b/src/Compiler/Opts/CSE.idr
@@ -37,6 +37,7 @@ import Core.Ord
 import Data.List
 import Data.String
 import Data.Vect
+import Libraries.Data.SortedSet
 import Libraries.Data.SortedMap
 
 ||| Maping from a pairing of closed terms together with
@@ -463,6 +464,87 @@ undefinedCount (_, _, Once) = False
 undefinedCount (_, _, Many) = False
 undefinedCount (_, _, C x)  = True
 
+--------------------------------------------------------------------------------
+--          Sorting Toplevel Defs according tho their call graph
+--------------------------------------------------------------------------------
+
+data SortTag : Type where
+
+record SortST where
+  constructor SST
+  processed : SortedSet Name
+  triples   : SnocList (Name, FC, CDef)
+  map       : SortedMap Name (Name, FC, CDef)
+
+init : List (Name, FC, CDef) -> SortST
+init = SST empty [<] . SortedMap.fromList . map (\t => (fst t, t))
+
+appendDef : Ref SortTag SortST => (Name, FC, CDef) -> Core ()
+appendDef t = do
+  st <- get SortTag
+  put SortTag $ {triples $= (:< t)} st
+
+triple : Ref SortTag SortST => Name -> Core (Maybe (Name, FC, CDef))
+triple n = map (lookup n . map) (get SortTag)
+
+markProcessed : Ref SortTag SortST => Name -> Core ()
+markProcessed n = do
+  st <- get SortTag
+  put SortTag $ {processed $= insert n} st
+
+isProcessed : Ref SortTag SortST => Name -> Core Bool
+isProcessed n = map (contains n . processed) (get SortTag)
+
+sortDefs :
+     Ref SortTag SortST
+  => List (Name, FC, CDef)
+  -> Core (List (Name, FC, CDef))
+
+sortCConAlt : Ref SortTag SortST => CConAlt ns -> Core ()
+
+sortCConstAlt : Ref SortTag SortST => CConstAlt ns -> Core ()
+
+sortCExp : Ref SortTag SortST => CExp ns -> Core ()
+
+sortCExp (CLocal fc p) = pure ()
+sortCExp (CRef fc n)   = do
+  False <- isProcessed n | True => pure ()
+  Just t <- triple n | Nothing => pure ()
+  ignore $ sortDefs [t]
+sortCExp (CLam fc x y) = sortCExp y
+sortCExp (CLet fc x y z w) = sortCExp z >> sortCExp w
+sortCExp (CApp fc x xs) = sortCExp x >> traverse_ sortCExp xs
+sortCExp (CCon fc n x tag xs) = traverse_ sortCExp xs
+sortCExp (COp fc f xs) = traverse_ sortCExp $ toList xs
+sortCExp (CExtPrim fc p xs) = traverse_ sortCExp xs
+sortCExp (CForce fc lz x) = sortCExp x
+sortCExp (CDelay fc lz x) = sortCExp x
+sortCExp (CConCase fc sc xs x) = do
+  sortCExp sc
+  traverse_ sortCConAlt xs
+  traverse_ sortCExp (toList x)
+sortCExp (CConstCase fc sc xs x) = do
+  sortCExp sc
+  traverse_ sortCConstAlt xs
+  traverse_ sortCExp (toList x)
+sortCExp (CPrimVal fc cst) = pure ()
+sortCExp (CErased fc) = pure ()
+sortCExp (CCrash fc str) = pure ()
+
+sortCConAlt (MkConAlt n x tag args y) = sortCExp y
+
+sortCConstAlt (MkConstAlt cst x) = sortCExp x
+
+sortDefs []                  = map ((<>> []) . triples) (get SortTag)
+sortDefs (t@(n, _, x) :: ts) = do
+  False <- isProcessed n | True => sortDefs ts
+  markProcessed n
+  case x of
+    (MkFun args y) => sortCExp y
+    _              => pure ()
+  appendDef t
+  sortDefs ts
+
 ||| Runs the CSE alorithm on all provided names and
 ||| the given main expression.
 export
@@ -485,4 +567,7 @@ cse defs me = do
     ::  map (\(name,(_,cnt)) =>
                   show name ++ ": count " ++ show cnt
            ) filtered
-  pure (newToplevelDefs replaceMap ++ replacedDefs, replacedMain)
+  let newDefs := newToplevelDefs replaceMap ++ replacedDefs
+  sortSt       <- newRef SortTag (init newDefs)
+  sortedDefs   <- sortDefs newDefs
+  pure (sortedDefs, replacedMain)

--- a/src/Compiler/Opts/ToplevelConstants.idr
+++ b/src/Compiler/Opts/ToplevelConstants.idr
@@ -1,0 +1,125 @@
+module Compiler.Opts.ToplevelConstants
+
+import Core.CompileExpr
+import Core.Context
+import Core.Name
+import Core.TT
+
+import Data.List1
+import Data.Vect
+import Libraries.Data.Graph
+import Libraries.Data.SortedSet
+import Libraries.Data.SortedMap
+
+--------------------------------------------------------------------------------
+--          Call Graph
+--------------------------------------------------------------------------------
+
+-- direct calls from a top-level funtion's expression to other
+-- top-level functions.
+0 CallGraph : Type
+CallGraph = SortedMap Name (SortedSet Name)
+
+-- top-level functions called by an expression
+calls : NamedCExp -> SortedSet Name
+calls (NmLocal fc p) = empty
+calls (NmRef fc n1) = singleton n1
+calls (NmLam fc x y) = calls y
+calls (NmLet fc x z w) = calls w <+> calls z
+calls (NmApp fc x xs) = calls x <+> concatMap calls xs
+calls (NmCon fc n1 x tag xs) = concatMap calls xs
+calls (NmOp fc f xs) = concatMap calls xs
+calls (NmExtPrim fc p xs) = concatMap calls xs
+calls (NmForce fc lz x) = calls x
+calls (NmDelay fc lz x) = calls x
+calls (NmConCase fc sc xs x) =
+  concatMap (\(MkNConAlt _ _ _ _ y) => calls y) xs <+>
+  concatMap calls x
+calls (NmConstCase fc sc xs x) =
+  concatMap (\(MkNConstAlt _ y) => calls y) xs <+>
+  concatMap calls x
+calls (NmPrimVal fc cst) = empty
+calls (NmErased fc) = empty
+calls (NmCrash fc str) = empty
+
+defCalls : NamedDef -> SortedSet Name
+defCalls (MkNmFun args x) = calls x
+defCalls (MkNmCon tag arity nt) = empty
+defCalls (MkNmForeign ccs fargs x) = empty
+defCalls (MkNmError x) = calls x
+
+callGraph : List (Name, FC, NamedDef) -> CallGraph
+callGraph = fromList . map (\(n,_,d) => (n, defCalls d))
+
+isRecursive : CallGraph -> List1 Name -> Bool
+isRecursive g (x ::: Nil) = maybe False (contains x) $ lookup x g
+isRecursive _ _           = True
+
+recursiveFunctions : CallGraph -> SortedSet Name
+recursiveFunctions graph =
+  let groups := filter (isRecursive graph) $ tarjan graph
+   in concatMap (SortedSet.fromList . forget) groups
+
+--------------------------------------------------------------------------------
+--          Sorting Functions
+--------------------------------------------------------------------------------
+
+data SortTag : Type where
+
+record SortST where
+  constructor SST
+  processed : SortedSet Name
+  triples   : SnocList (Name, FC, NamedDef)
+  map       : SortedMap Name (Name, FC, NamedDef)
+  graph     : CallGraph
+
+appendDef : Ref SortTag SortST => (Name, FC, NamedDef) -> Core ()
+appendDef t = do
+  st <- get SortTag
+  put SortTag $ {triples $= (:< t)} st
+
+getCalls : Ref SortTag SortST => Name -> Core (List Name)
+getCalls n = map (maybe [] SortedSet.toList . lookup n . graph) (get SortTag)
+
+getTriple : Ref SortTag SortST => Name -> Core (Maybe (Name,FC,NamedDef))
+getTriple n = map (lookup n . map) (get SortTag)
+
+markProcessed : Ref SortTag SortST => Name -> Core ()
+markProcessed n = do
+  st <- get SortTag
+  put SortTag $ {processed $= insert n} st
+
+isProcessed : Ref SortTag SortST => Name -> Core Bool
+isProcessed n = map (contains n . processed) (get SortTag)
+
+sortDef : Ref SortTag SortST => Name -> Core ()
+sortDef n = do
+  False  <- isProcessed n | True => pure ()
+  markProcessed n
+  cs     <- getCalls n
+  traverse_ sortDef cs
+  Just t <- getTriple n | Nothing => pure ()
+  appendDef t
+
+isConstant : (recursiveFunctions : SortedSet Name) -> (Name,FC,NamedDef) -> Bool
+isConstant rec (n, _, MkNmFun [] _) = not $ contains n rec
+isConstant _   _                  = False
+
+export
+sortDefs : List (Name, FC, NamedDef) -> Core (List (Name, FC, NamedDef), SortedSet Name)
+sortDefs ts =
+  let graph   := callGraph ts
+      rec     := recursiveFunctions graph
+      (cs,fs) := partition (isConstant rec) ts
+      init    := SST {
+                   processed = fromList (map fst fs)
+                 , triples   = Lin <>< fs
+                 , map       = fromList (map (\t => (fst t, t)) ts)
+                 , graph     = graph
+                 }
+      consts  := map fst cs
+   in do
+     s       <- newRef SortTag init
+     traverse_ sortDef consts
+     sorted  <- map ((<>> []) . triples) (get SortTag)
+     pure (sorted, fromList consts)

--- a/src/Compiler/Opts/ToplevelConstants.idr
+++ b/src/Compiler/Opts/ToplevelConstants.idr
@@ -114,11 +114,11 @@ sortDefs ts =
       rec    := recursiveFunctions graph
       consts := map fst $ filter (isConstant rec) ts
       init   := SST {
-                  processed = empty
-                , triples   = Lin
-                , map       = fromList (map (\t => (fst t, t)) ts)
-                , graph     = graph
-                }
+                    processed = empty
+                  , triples   = Lin
+                  , map       = fromList (map (\t => (fst t, t)) ts)
+                  , graph     = graph
+                  }
    in do
      s       <- newRef SortTag init
      traverse_ sortDef (map fst ts)

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -469,8 +469,8 @@ compileToSS c prof appdir tm outfile
          support <- readDataFile "chez/support.ss"
          extraRuntime <- getExtraRuntime ds
          let scm = schHeader chez (map snd libs) True ++
-                   support ++ extraRuntime ++ code ++
-                   concat loadlibs ++
+                   support ++ extraRuntime ++
+                   concat loadlibs ++ code ++
                    "(collect-request-handler (lambda () (collect) (blodwen-run-finalisers)))\n" ++
                    main ++ schFooter prof True
          Right () <- coreLift $ writeFile outfile scm

--- a/src/Compiler/Scheme/ChezSep.idr
+++ b/src/Compiler/Scheme/ChezSep.idr
@@ -14,6 +14,7 @@ import Core.Context.Log
 import Core.Directory
 import Core.Options
 import Core.TT
+import Libraries.Data.SortedSet
 import Libraries.Utils.Path
 
 import Data.List
@@ -221,7 +222,7 @@ compileToSS c chez appdir tm = do
       let footer = ")"
 
       fgndefs <- traverse (Chez.getFgnCall version) cu.definitions
-      compdefs <- traverse (getScheme Chez.chezExtPrim Chez.chezString) cu.definitions
+      compdefs <- traverse (getScheme empty (Chez.chezExtPrim empty) Chez.chezString) cu.definitions
       loadlibs <- traverse (loadLib appdir) (mapMaybe fst fgndefs)
 
       -- write the files
@@ -238,7 +239,7 @@ compileToSS c chez appdir tm = do
     pure (MkChezLib chezLib hashChanged)
 
   -- main module
-  main <- schExp Chez.chezExtPrim Chez.chezString 0 ctm
+  main <- schExp empty (Chez.chezExtPrim empty) Chez.chezString 0 ctm
   Core.writeFile (appdir </> "mainprog.ss") $ unlines $
     [ schHeader (map snd libs) [lib.name | lib <- chezLibs]
     , "(collect-request-handler (lambda () (collect) (blodwen-run-finalisers)))"

--- a/src/Compiler/Scheme/Common.idr
+++ b/src/Compiler/Scheme/Common.idr
@@ -652,6 +652,7 @@ parameters (schExtPrim : Int -> ExtPrim -> List NamedCExp -> Core String,
 --   schDef n (MkNmFun [] exp)
 --      = pure $ "(define " ++ schName !(getFullName n) ++ "(blodwen-lazy (lambda () "
 --                       ++ !(schExp 0 exp) ++ ")))\n"
+
   schDef n (MkNmFun args exp)
      = pure $ "(define " ++ schName !(getFullName n) ++ " (lambda (" ++ schArglist args ++ ") "
                       ++ !(schExp 0 exp) ++ "))\n"

--- a/src/Compiler/Scheme/Common.idr
+++ b/src/Compiler/Scheme/Common.idr
@@ -649,9 +649,9 @@ parameters (schExtPrim : Int -> ExtPrim -> List NamedCExp -> Core String,
 
   schDef : {auto c : Ref Ctxt Defs} ->
            Name -> NamedDef -> Core String
-  schDef n (MkNmFun [] exp)
-     = pure $ "(define " ++ schName !(getFullName n) ++ "(blodwen-lazy (lambda () "
-                      ++ !(schExp 0 exp) ++ ")))\n"
+--   schDef n (MkNmFun [] exp)
+--      = pure $ "(define " ++ schName !(getFullName n) ++ "(blodwen-lazy (lambda () "
+--                       ++ !(schExp 0 exp) ++ ")))\n"
   schDef n (MkNmFun args exp)
      = pure $ "(define " ++ schName !(getFullName n) ++ " (lambda (" ++ schArglist args ++ ") "
                       ++ !(schExp 0 exp) ++ "))\n"

--- a/src/Compiler/Scheme/Common.idr
+++ b/src/Compiler/Scheme/Common.idr
@@ -653,6 +653,7 @@ parameters (schExtPrim : Int -> ExtPrim -> List NamedCExp -> Core String,
   schDef n@(MN _ _) (MkNmFun [] exp)
      = pure $ "(define " ++ schName !(getFullName n) ++ " "
                       ++ !(schExp 0 exp) ++ ")\n"
+
   schDef n (MkNmFun args exp)
      = pure $ "(define " ++ schName !(getFullName n) ++ " (lambda (" ++ schArglist args ++ ") "
                       ++ !(schExp 0 exp) ++ "))\n"

--- a/src/Compiler/Scheme/Common.idr
+++ b/src/Compiler/Scheme/Common.idr
@@ -531,8 +531,7 @@ parameters (schExtPrim : Int -> ExtPrim -> List NamedCExp -> Core String,
        = do val' <- schExp i val
             sc' <- schExp i sc
             pure $ "(let ((" ++ schName x ++ " " ++ val' ++ ")) " ++ sc' ++ ")"
-    schExp i (NmApp fc x@(NmRef _ _) [])
-        = pure $ "(force " ++ !(schExp i x) ++ ")"
+    schExp i (NmApp fc x@(NmRef _ (MN _ _)) []) = schExp i x
     schExp i (NmApp fc x [])
         = pure $ "(" ++ !(schExp i x) ++ ")"
     schExp i (NmApp fc x args)
@@ -651,9 +650,9 @@ parameters (schExtPrim : Int -> ExtPrim -> List NamedCExp -> Core String,
 
   schDef : {auto c : Ref Ctxt Defs} ->
            Name -> NamedDef -> Core String
-  schDef n (MkNmFun [] exp)
-     = pure $ "(define " ++ schName !(getFullName n) ++ "(delay "
-                      ++ !(schExp 0 exp) ++ "))\n"
+  schDef n@(MN _ _) (MkNmFun [] exp)
+     = pure $ "(define " ++ schName !(getFullName n) ++ " "
+                      ++ !(schExp 0 exp) ++ ")\n"
   schDef n (MkNmFun args exp)
      = pure $ "(define " ++ schName !(getFullName n) ++ " (lambda (" ++ schArglist args ++ ") "
                       ++ !(schExp 0 exp) ++ "))\n"

--- a/src/Compiler/Scheme/Common.idr
+++ b/src/Compiler/Scheme/Common.idr
@@ -531,6 +531,8 @@ parameters (schExtPrim : Int -> ExtPrim -> List NamedCExp -> Core String,
        = do val' <- schExp i val
             sc' <- schExp i sc
             pure $ "(let ((" ++ schName x ++ " " ++ val' ++ ")) " ++ sc' ++ ")"
+    schExp i (NmApp fc x@(NmRef _ _) [])
+        = pure $ "(force " ++ !(schExp i x) ++ ")"
     schExp i (NmApp fc x [])
         = pure $ "(" ++ !(schExp i x) ++ ")"
     schExp i (NmApp fc x args)
@@ -649,9 +651,9 @@ parameters (schExtPrim : Int -> ExtPrim -> List NamedCExp -> Core String,
 
   schDef : {auto c : Ref Ctxt Defs} ->
            Name -> NamedDef -> Core String
---   schDef n (MkNmFun [] exp)
---      = pure $ "(define " ++ schName !(getFullName n) ++ "(blodwen-lazy (lambda () "
---                       ++ !(schExp 0 exp) ++ ")))\n"
+  schDef n (MkNmFun [] exp)
+     = pure $ "(define " ++ schName !(getFullName n) ++ "(delay "
+                      ++ !(schExp 0 exp) ++ "))\n"
 
   schDef n (MkNmFun args exp)
      = pure $ "(define " ++ schName !(getFullName n) ++ " (lambda (" ++ schArglist args ++ ") "

--- a/src/Compiler/Scheme/Common.idr
+++ b/src/Compiler/Scheme/Common.idr
@@ -658,6 +658,7 @@ parameters (constants : SortedSet Name,
      = if contains n constants
           then pure $ "(define " ++ schName !(getFullName n) ++ " " ++ !(schExp 0 exp) ++ ")\n"
           else pure $ "(define " ++ schName !(getFullName n) ++ " (lambda () " ++ !(schExp 0 exp) ++ "))\n"
+
   schDef n (MkNmFun args exp)
      = pure $ "(define " ++ schName !(getFullName n) ++ " (lambda (" ++ schArglist args ++ ") "
                       ++ !(schExp 0 exp) ++ "))\n"

--- a/src/Compiler/Scheme/Common.idr
+++ b/src/Compiler/Scheme/Common.idr
@@ -658,7 +658,6 @@ parameters (constants : SortedSet Name,
      = if contains n constants
           then pure $ "(define " ++ schName !(getFullName n) ++ " " ++ !(schExp 0 exp) ++ ")\n"
           else pure $ "(define " ++ schName !(getFullName n) ++ " (lambda () " ++ !(schExp 0 exp) ++ "))\n"
-
   schDef n (MkNmFun args exp)
      = pure $ "(define " ++ schName !(getFullName n) ++ " (lambda (" ++ schArglist args ++ ") "
                       ++ !(schExp 0 exp) ++ "))\n"

--- a/src/Compiler/Scheme/Common.idr
+++ b/src/Compiler/Scheme/Common.idr
@@ -655,8 +655,9 @@ parameters (constants : SortedSet Name,
   schDef : {auto c : Ref Ctxt Defs} ->
            Name -> NamedDef -> Core String
   schDef n (MkNmFun [] exp)
-     = let pre := if contains n constants then " " else "lambda () "
-        in pure $ "(define " ++ schName !(getFullName n) ++ pre ++ !(schExp 0 exp) ++ ")\n"
+     = if contains n constants
+          then pure $ "(define " ++ schName !(getFullName n) ++ " " ++ !(schExp 0 exp) ++ ")\n"
+          else pure $ "(define " ++ schName !(getFullName n) ++ " (lambda () " ++ !(schExp 0 exp) ++ "))\n"
 
   schDef n (MkNmFun args exp)
      = pure $ "(define " ++ schName !(getFullName n) ++ " (lambda (" ++ schArglist args ++ ") "

--- a/src/Compiler/Scheme/Common.idr
+++ b/src/Compiler/Scheme/Common.idr
@@ -654,7 +654,6 @@ parameters (schExtPrim : Int -> ExtPrim -> List NamedCExp -> Core String,
   schDef n (MkNmFun [] exp)
      = pure $ "(define " ++ schName !(getFullName n) ++ "(delay "
                       ++ !(schExp 0 exp) ++ "))\n"
-
   schDef n (MkNmFun args exp)
      = pure $ "(define " ++ schName !(getFullName n) ++ " (lambda (" ++ schArglist args ++ ") "
                       ++ !(schExp 0 exp) ++ "))\n"


### PR DESCRIPTION
This replaces #2807 : Non-recursive top-level constants are compiled to eagerly evaluated constants in Chez Scheme. In order to do this, they have to be added in the correct order. In addition, shared objects need to be loaded *before* the actual code, because they might already be needed when constants get eagerly evaluated.

This has a significant impact on performance: On my system, typechecking `idris2api.ipkg` goes from 3:40 minutes down to slightly below 3 minutes.

# Should this change go in the CHANGELOG?

- [x] If this is a user-facing change or a compiler change, I have updated
      `CHANGELOG.md` (and potentially also `CONTRIBUTORS.md`).

