### PR TITLE
[ docs ] Build IdrisDoc in a namespace.

### DIFF
--- a/.github/scripts/katla.sh
+++ b/.github/scripts/katla.sh
@@ -20,7 +20,7 @@ rm tmp
 find "$prefix"/* -maxdepth 0 -type d >tmp
 while IFS= read -r libdirectory; do
     libname=$(echo "$libdirectory" | sed "s|$prefix/||")
-    cp -r "$prefix"/"$libname"/build/docs/* html/"$libname"
+    cp -r "$prefix"/"$libname"/build/docs/"$libname"/* html/"$libname"
     find html/"$libname"/docs/ -name "*.html" >tmp2
     while IFS= read -r file; do
         filename=$(basename "$file" ".html")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
   location, file name, line or column number associated to the
   magic constant's position.
 
+### Package Management
+
+* `--makedoc` now builds documentation in `${buildir}/docs/<package name>`.
+  Typically this will be `build/docs/<package name>`.
+
 ### REPL changes
 
 * Adds documentation for unquotes `~( )`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Package Management
 
-* `--makedoc` now builds documentation in `${buildir}/docs/<package name>`.
+* `--mkdoc` now builds documentation in `${buildir}/docs/<package name>`.
   Typically this will be `build/docs/<package name>`.
 
 ### REPL changes

--- a/Makefile
+++ b/Makefile
@@ -238,19 +238,14 @@ install-with-src-libs:
 	${MAKE} -C libs/linear install-with-src  IDRIS2=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH} IDRIS2_INC_CGS=${IDRIS2_CG}
 
 install-libdocs: libdocs
-	mkdir -p ${PREFIX}/${NAME_VERSION}/docs/prelude
-	mkdir -p ${PREFIX}/${NAME_VERSION}/docs/base
-	mkdir -p ${PREFIX}/${NAME_VERSION}/docs/contrib
-	mkdir -p ${PREFIX}/${NAME_VERSION}/docs/network
-	mkdir -p ${PREFIX}/${NAME_VERSION}/docs/test
-	mkdir -p ${PREFIX}/${NAME_VERSION}/docs/linear
-	cp -r libs/prelude/build/docs/* ${PREFIX}/${NAME_VERSION}/docs/prelude
-	cp -r libs/base/build/docs/*    ${PREFIX}/${NAME_VERSION}/docs/base
-	cp -r libs/contrib/build/docs/* ${PREFIX}/${NAME_VERSION}/docs/contrib
-	cp -r libs/network/build/docs/* ${PREFIX}/${NAME_VERSION}/docs/network
-	cp -r libs/test/build/docs/*    ${PREFIX}/${NAME_VERSION}/docs/test
-	cp -r libs/linear/build/docs/*  ${PREFIX}/${NAME_VERSION}/docs/linear
-	install -m 644 support/docs/*   ${PREFIX}/${NAME_VERSION}/docs
+	mkdir -p ${PREFIX}/${NAME_VERSION}/docs/
+	cp -r libs/prelude/build/docs/prelude/ ${PREFIX}/${NAME_VERSION}/docs/
+	cp -r libs/base/build/docs/base/       ${PREFIX}/${NAME_VERSION}/docs/
+	cp -r libs/contrib/build/docs/contrib/ ${PREFIX}/${NAME_VERSION}/docs/
+	cp -r libs/network/build/docs/network/ ${PREFIX}/${NAME_VERSION}/docs/
+	cp -r libs/test/build/docs/test/       ${PREFIX}/${NAME_VERSION}/docs/
+	cp -r libs/linear/build/docs/linear/   ${PREFIX}/${NAME_VERSION}/docs/
+	install -m 644 support/docs/*  ${PREFIX}/${NAME_VERSION}/docs
 
 
 .PHONY: bootstrap bootstrap-build bootstrap-racket bootstrap-racket-build bootstrap-test bootstrap-clean

--- a/docs/source/reference/packages.rst
+++ b/docs/source/reference/packages.rst
@@ -134,7 +134,7 @@ Given an Idris package file ``test.ipkg`` it can be used with the Idris compiler
 + ``idris2 --clean test.ipkg`` will clean the intermediate build files.
 
 + ``idris2 --mkdoc test.ipkg`` will generate HTML documentation for the
-  package, output to ``build/docs``
+  package, output to ``build/docs/<package name>``
 
 Once the test package has been installed, the command line option
 ``--package test`` makes it accessible (abbreviated to ``-p test``).

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -659,7 +659,7 @@ makeDoc pkg opts =
 
        defs <- get Ctxt
        let build = build_dir (dirs (options defs))
-       let docBase = build </> "docs"
+       let docBase = build </> "docs" </> (name pkg)
        let docDir = docBase </> "docs"
        Right () <- coreLift $ mkdirAll docDir
          | Left err => fileError docDir err


### PR DESCRIPTION
When invoking `idris2 --mkdocs foobar.ipkg`, the current behaviour is for the compiler to dump the documentation in `${builddir}/docs`. The location `${builddir}/docs` is used regardless of the package name. Thus for projects that present multiple packages the `docs` build directory will become polluted and corrupt if the developer is not careful. This one change ensures that for package `x` the documentation is generated in the directory: `${builddir}/docs/x`.

Idris2 `Makefile` has been updated to reflect the change.

# Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a user-facing change or a compiler change, I have updated
      `CHANGELOG.md` (and potentially also `CONTRIBUTORS.md`).

