### PR TITLE
add javascript support to `System.Clock`

### DIFF
--- a/libs/base/System/Clock.idr
+++ b/libs/base/System/Clock.idr
@@ -118,6 +118,7 @@ isClockMandatory _      = Mandatory
 
 %foreign "scheme:blodwen-clock-time-monotonic"
          "RefC:clockTimeMonotonic"
+         "javascript:lambda:()=>performance.now()" -- javascript clocks are represented as milliseconds
 prim__clockTimeMonotonic : PrimIO OSClock
 
 ||| Get the current backend's monotonic time.
@@ -126,6 +127,7 @@ clockTimeMonotonic = fromPrim prim__clockTimeMonotonic
 
 %foreign "scheme:blodwen-clock-time-utc"
          "RefC:clockTimeUtc"
+         "javascript:lambda:()=>Date.now()"
 prim__clockTimeUtc : PrimIO OSClock
 
 ||| Get the current UTC time.
@@ -134,6 +136,7 @@ clockTimeUtc = fromPrim prim__clockTimeUtc
 
 %foreign "scheme:blodwen-clock-time-process"
          "RefC:clockTimeProcess"
+         "javascript:support:clockTimeProcess,support_system_clock"
 prim__clockTimeProcess : PrimIO OSClock
 
 ||| Get the amount of time used by the current process.
@@ -142,6 +145,7 @@ clockTimeProcess = fromPrim prim__clockTimeProcess
 
 %foreign "scheme:blodwen-clock-time-thread"
          "RefC:clockTimeThread"
+         "javascript:support:clockTimeThread,support_system_clock"
 prim__clockTimeThread : PrimIO OSClock
 
 ||| Get the amount of time used by the current thread.
@@ -150,6 +154,7 @@ clockTimeThread = fromPrim prim__clockTimeThread
 
 %foreign "scheme:blodwen-clock-time-gccpu"
          "RefC:clockTimeGcCpu"
+         "javascript:lambda:()=>null"
 prim__clockTimeGcCpu : PrimIO OSClock
 
 ||| Get the amount of the current process's CPU time consumed by the garbage
@@ -159,6 +164,7 @@ clockTimeGcCpu = fromPrim prim__clockTimeGcCpu
 
 %foreign "scheme:blodwen-clock-time-gcreal"
          "RefC:clockTimeGcReal"
+         "javascript:lambda:()=>null"
 prim__clockTimeGcReal : PrimIO OSClock
 
 ||| Get the amount of the current process's real-time consumed by the garbage
@@ -177,6 +183,7 @@ fetchOSClock Duration  = clockTimeMonotonic
 
 %foreign "scheme:blodwen-is-time?"
          "RefC:clockValid"
+         "javascript:lambda:(x)=>x===null?0:1"
 prim__osClockValid : OSClock -> PrimIO Int
 
 ||| A test to determine the status of optional clocks.
@@ -185,6 +192,7 @@ osClockValid clk = fromPrim (prim__osClockValid clk)
 
 %foreign "scheme:blodwen-clock-second"
          "RefC:clockSecond"
+         "javascript:lambda:(x)=>BigInt(Math.floor(x/1000))"
 prim__osClockSecond : OSClock -> PrimIO Bits64
 
 ||| Get the second of time from the given `OSClock`.
@@ -193,6 +201,7 @@ osClockSecond clk = fromPrim (prim__osClockSecond clk)
 
 %foreign "scheme:blodwen-clock-nanosecond"
          "RefC:clockNanosecond"
+         "javascript:lambda:(x)=>BigInt(Math.floor((x%1000)*1000*1000))"
 prim__osClockNanosecond : OSClock -> PrimIO Bits64
 
 ||| Get the nanosecond of time from the given `OSClock`.

--- a/support/js/support_system_clock.js
+++ b/support/js/support_system_clock.js
@@ -1,0 +1,11 @@
+const support_system_clock_process_start_time = performance.now();
+
+function support_system_clock_clockTimeProcess() {
+    return performance.now() - support_system_clock_process_start_time
+}
+
+function support_system_clock_clockTimeThread() {
+    // The JS backend currently doesn't support threads
+    // This may be possible with the WebWorkers api, if so change this implementation
+    return performance.now() - support_system_clock_process_start_time
+}


### PR DESCRIPTION
`clockTimeProcess` and/or `clockTimeThread` may behave incorrectly when used with web workers
As idris doesn't currently have any control over js threads/WebWorkers, I think this is unavoidable

