### PR TITLE
[ new ] [ proposal ] Allow libraries to ship a data dir

### DIFF
--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -358,6 +358,7 @@ addDeps pkg = do
     | Failed errs => throw $ GenericMsg EmptyFC (printErrs pkg errs)
   log "package.depends" 10 $ "all depends: \{show allPkgs}"
   traverse_ addPackageDir allPkgs
+  traverse_ addDataDir ((</> "data") <$> allPkgs)
   where
     -- Note: findPkgDir throws an error if a package is not found
     -- *unless* --ignore-missing-ipkg is enabled


### PR DESCRIPTION
I propose that we allow library packages to ship "data" to a standard location within their install directory.

Although I am not familiar with the full breadth of uses of what Idris 2 calls "data directories" I do know that one established use is to include support JavaScript libraries into the build output when building an executable with the Node backend.

For example, if you have a foreign pragma such as:
```idris
%foreign "node:support:say_hello,util"
```

Then you should (a) create a file named `util.js`, (b) put it somewhere under a `js` subdirectory (e.g. `<your-project>/support/js/util.js`), and (c) add the parent folder (e.g. `<your-project>/support`) as a data directory when building your executable.

This is all fine when you are writing your support JS as part of the same project as you build your executable from, but what about projects that ship as libraries that have JS FFI support facilitated by such "data" files?

My proposal is the one-line change in this PR that adds the (possibly non-existent) `data` subdirectory of a package's install-location to the list of "data directories" Idris knows about when a package is added as a dependency. This facilitates other projects using that dependency without needing to think about the JS support file at all as long as the dependency's install script copied the support JS into this known standard subdirectory.

If this proposal is well received, I will not only update the CHANGELOG but I will also add some documentation on how one can ship library packages with both JS and/or C support files. To my knowledge, this stuff has been totally undocumented so far (at least I figured out how it worked through trial and error and by analyzing how Idris installs itself). I've shipped a couple of libraries that have their own C shared libraries (`pg-idris` and `ncurses-idris`) and I would be thrilled to add the same capability for JS and then document it for others.

# Should this change go in the CHANGELOG? (yes, definitely)

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a user-facing change or a compiler change, I have updated
      `CHANGELOG.md` (and potentially also `CONTRIBUTORS.md`).

