### PR TITLE
[ fix ] at-pattern leak in recursive with blocks (#2834)

### DIFF
--- a/src/TTImp/WithClause.idr
+++ b/src/TTImp/WithClause.idr
@@ -84,9 +84,9 @@ mutual
       = matchAll True [(f, f'), (a, a)]
   -- On RHS: Rely on unification to fill in the implicit
   getMatch False (INamedApp fc f n a) f'
-      = getMatch False f f
+      = getMatch False f f'
   getMatch False (IAutoApp fc f a) f'
-      = getMatch False f f
+      = getMatch False f f'
   -- Can't have an implicit in the clause if there wasn't a matching
   -- implicit in the parent
   getMatch lhs f (INamedApp fc f' n a)

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -246,7 +246,7 @@ idrisTestsReflection = MkTestPool "Quotation and Reflection" [] Nothing
 idrisTestsWith : TestPool
 idrisTestsWith = MkTestPool "With abstraction" [] Nothing
       [ "with001", "with002", "with004", "with005", "with006", "with007",
-        "with008", "with009", "with010"
+        "with008", "with009", "with010", "with011"
       ]
 
 idrisTestsIPKG : TestPool

--- a/tests/idris2/with011/WithImplicits.idr
+++ b/tests/idris2/with011/WithImplicits.idr
@@ -1,0 +1,9 @@
+import Data.Vect
+import Data.Vect.Views.Extra
+
+mergeSort : Ord a => {n : _} -> Vect n a -> Vect n a
+mergeSort input with (splitRec input)
+  mergeSort [] | SplitRecNil = []
+  mergeSort [x] | SplitRecOne = [x]
+  mergeSort (xs ++ ys) | (SplitRecPair {xs} {ys} xs_rec ys_rec) =
+    merge (mergeSort xs | xs_rec) (mergeSort ys | ys_rec)

--- a/tests/idris2/with011/expected
+++ b/tests/idris2/with011/expected
@@ -1,0 +1,1 @@
+1/1: Building WithImplicits (WithImplicits.idr)

--- a/tests/idris2/with011/run
+++ b/tests/idris2/with011/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --no-banner -p contrib --check WithImplicits.idr


### PR DESCRIPTION
Fix an issue where an @-pattern is leaked into the right side.  It occurs in a recursive call to a `with` clause if there are @ patterns and implicits. A typo in the function `getMatch` causes the left hand side to be used for the right hand side after an implicit is hit. 


**Should this change go in the CHANGELOG?**

This PR is just a bug fix, so it probably doesn't need a change log entry.  Let me know if it should have one.
