### PR TITLE
[ performance ] String builder on all scheme backends

### DIFF
--- a/idris2api.ipkg
+++ b/idris2api.ipkg
@@ -177,6 +177,7 @@ modules =
     Libraries.Data.Span,
     Libraries.Data.SortedMap,
     Libraries.Data.SortedSet,
+    Libraries.Data.String.Builder,
     Libraries.Data.String.Extra,
     Libraries.Data.String.Iterator,
     Libraries.Data.StringMap,

--- a/src/Compiler/Common.idr
+++ b/src/Compiler/Common.idr
@@ -531,7 +531,7 @@ copyLib (lib, fullname)
 export
 getExtraRuntime : List String -> Core String
 getExtraRuntime directives
-    = do fileContents <- traverse readPath paths
+    = do fileContents <- traverse Core.readFile paths
          pure $ concat $ intersperse "\n" fileContents
   where
     getArg : String -> Maybe String
@@ -545,35 +545,32 @@ getExtraRuntime directives
     paths : List String
     paths = nub $ mapMaybe getArg $ reverse directives
 
-    readPath : String -> Core String
-    readPath p = do
-      Right contents <- coreLift $ readFile p
-        | Left err => throw (FileErr p err)
-      pure contents
-
 ||| Cast implementations. Values of `ConstantPrimitives` can
 ||| be used in a call to `castInt`, which then determines
 ||| the cast implementation based on the given pair of
 ||| constants.
 public export
-record ConstantPrimitives where
+record ConstantPrimitives' str where
   constructor MkConstantPrimitives
-  charToInt    : IntKind -> String -> Core String
-  intToChar    : IntKind -> String -> Core String
-  stringToInt  : IntKind -> String -> Core String
-  intToString  : IntKind -> String -> Core String
-  doubleToInt  : IntKind -> String -> Core String
-  intToDouble  : IntKind -> String -> Core String
-  intToInt     : IntKind -> IntKind -> String -> Core String
+  charToInt    : IntKind -> str -> Core str
+  intToChar    : IntKind -> str -> Core str
+  stringToInt  : IntKind -> str -> Core str
+  intToString  : IntKind -> str -> Core str
+  doubleToInt  : IntKind -> str -> Core str
+  intToDouble  : IntKind -> str -> Core str
+  intToInt     : IntKind -> IntKind -> str -> Core str
+
+public export
+ConstantPrimitives : Type = ConstantPrimitives' String
 
 ||| Implements casts from and to integral types by using
 ||| the implementations from the provided `ConstantPrimitives`.
 export
-castInt :  ConstantPrimitives
+castInt :  ConstantPrimitives' str
         -> PrimType
         -> PrimType
-        -> String
-        -> Core String
+        -> str
+        -> Core str
 castInt p from to x =
   case ((from, intKind from), (to, intKind to)) of
        ((CharType, _)  , (_, Just k)) => p.charToInt k x

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -15,6 +15,7 @@ import Core.TT
 import Protocol.Hex
 import Libraries.Utils.Path
 import Libraries.Data.SortedSet
+import Libraries.Data.String.Builder
 
 import Data.List
 import Data.List1
@@ -83,9 +84,10 @@ findLibs ds
              then Just (trim (substr 3 (length d) d))
              else Nothing
 
-schHeader : String -> List String -> Bool -> String
+schHeader : String -> List String -> Bool -> Builder
 schHeader chez libs whole
-  = (if os /= "windows"
+  = fromString $
+    (if os /= "windows"
         then "#!" ++ chez ++ (if whole then " --program\n\n" else " --script\n\n")
         else "") ++ """
     ;; \{ generatedString "Chez" }
@@ -106,8 +108,8 @@ schHeader chez libs whole
 
     """
 
-schFooter : Bool -> Bool -> String
-schFooter prof whole = """
+schFooter : Bool -> Bool -> Builder
+schFooter prof whole = fromString """
 
     (collect 4)
     (blodwen-run-finalisers)
@@ -115,25 +117,25 @@ schFooter prof whole = """
     \{ ifThenElse whole ")" "" }
   """
 
-showChezChar : Char -> String -> String
-showChezChar '\\' = ("\\\\" ++)
-showChezChar c
-   = if c < chr 32 || c > chr 126
-        then (("\\x" ++ asHex (cast c) ++ ";") ++)
-        else strCons c
+showChezChar : Char -> Builder -> Builder
+showChezChar '\\' acc = "\\\\" ++ acc
+showChezChar c acc
+   = if ord c < 32 || ord c > 126
+        then fromString ("\\x" ++ asHex (cast c) ++ ";") ++ acc
+        else char c ++ acc
 
-showChezString : List Char -> String -> String
-showChezString [] = id
-showChezString ('"'::cs) = ("\\\"" ++) . showChezString cs
-showChezString (c ::cs) = (showChezChar c) . showChezString cs
+showChezString : List Char -> Builder -> Builder
+showChezString [] acc = acc
+showChezString ('"' :: cs) acc = "\\\"" ++ showChezString cs acc
+showChezString (c :: cs) acc = showChezChar c $ showChezString cs acc
 
 export
-chezString : String -> String
-chezString cs = strCons '"' (showChezString (unpack cs) "\"")
+chezString : String -> Builder
+chezString cs = "\"" ++ showChezString (unpack cs) "\""
 
 mutual
-  handleRet : String -> String -> String
-  handleRet "void" op = op ++ " " ++ mkWorld (schConstructor chezString (UN $ Basic "") (Just 0) [])
+  handleRet : CFType -> Builder -> Builder
+  handleRet CFUnit op = op ++ " " ++ mkWorld (schConstructor chezString (UN Underscore) (Just 0) [])
   handleRet _ op = mkWorld op
 
   getFArgs : NamedCExp -> Core (List (NamedCExp, NamedCExp))
@@ -142,11 +144,11 @@ mutual
   getFArgs arg = throw (GenericMsg (getFC arg) ("Badly formed c call argument list " ++ show arg))
 
   export
-  chezExtPrim : SortedSet Name -> Int -> ExtPrim -> List NamedCExp -> Core String
+  chezExtPrim : SortedSet Name -> Nat -> ExtPrim -> List NamedCExp -> Core Builder
   chezExtPrim cs i GetField [NmPrimVal _ (Str s), _, _, struct,
                           NmPrimVal _ (Str fld), _]
       = do structsc <- schExp cs (chezExtPrim cs) chezString 0 struct
-           pure $ "(ftype-ref " ++ s ++ " (" ++ fld ++ ") " ++ structsc ++ ")"
+           pure $ "(ftype-ref " ++ fromString s ++ " (" ++ fromString fld ++ ") " ++ structsc ++ ")"
   chezExtPrim cs i GetField [_,_,_,_,_,_]
       = pure "(blodwen-error-quit \"bad getField\")"
   chezExtPrim cs i SetField [NmPrimVal _ (Str s), _, _, struct,
@@ -154,7 +156,7 @@ mutual
       = do structsc <- schExp cs (chezExtPrim cs) chezString 0 struct
            valsc <- schExp cs (chezExtPrim cs) chezString 0 val
            pure $ mkWorld $
-              "(ftype-set! " ++ s ++ " (" ++ fld ++ ") " ++ structsc ++
+              "(ftype-set! " ++ fromString s ++ " (" ++ fromString fld ++ ") " ++ structsc ++
               " " ++ valsc ++ ")"
   chezExtPrim cs i SetField [_,_,_,_,_,_,_,_]
       = pure "(blodwen-error-quit \"bad setField\")"
@@ -182,7 +184,7 @@ data Loaded : Type where
 export
 data Structs : Type where
 
-cftySpec : FC -> CFType -> Core String
+cftySpec : FC -> CFType -> Core Builder
 cftySpec fc CFUnit = pure "void"
 cftySpec fc CFInt = pure "int"
 cftySpec fc CFInt8 = pure "integer-8"
@@ -201,7 +203,7 @@ cftySpec fc CFGCPtr = pure "void*"
 cftySpec fc CFBuffer = pure "u8*"
 cftySpec fc (CFFun s t) = pure "void*"
 cftySpec fc (CFIORes t) = cftySpec fc t
-cftySpec fc (CFStruct n t) = pure $ "(* " ++ n ++ ")"
+cftySpec fc (CFStruct n t) = pure $ "(* " ++ fromString n ++ ")"
 cftySpec fc t = throw (GenericMsg fc ("Can't pass argument of type " ++ show t ++
                          " to foreign function"))
 
@@ -245,7 +247,7 @@ cCall : {auto c : Ref Ctxt Defs}
      -> List (Name, CFType)
      -> CFType
      -> (collectSafe : Bool)
-     -> Core (Maybe String, String)
+     -> Core (Maybe String, Builder)
 cCall fc cfn clib args (CFIORes CFGCPtr) _
     = throw (GenericMsg fc "Can't return GCPtr from a foreign function")
 cCall fc cfn clib args CFGCPtr _
@@ -263,38 +265,38 @@ cCall fc cfn clib args ret collectSafe
          argTypes <- traverse (cftySpec fc . snd) args
          retType <- cftySpec fc ret
          let callConv = if collectSafe then " __collect_safe" else ""
-         let call = "((foreign-procedure" ++ callConv ++ " " ++ show cfn ++ " ("
-                      ++ showSep " " argTypes ++ ") " ++ retType ++ ") "
-                      ++ showSep " " !(traverse buildArg args) ++ ")"
+         let call = "((foreign-procedure" ++ callConv ++ " " ++ showB cfn ++ " ("
+                      ++ sepBy " " argTypes ++ ") " ++ retType ++ ") "
+                      ++ sepBy " " !(traverse buildArg args) ++ ")"
 
          pure (lib, case ret of
-                         CFIORes _ => handleRet retType call
+                         CFIORes _ => handleRet ret call
                          _ => call)
   where
-    mkNs : Int -> List CFType -> List (Maybe String)
+    mkNs : Int -> List CFType -> List (Maybe Builder)
     mkNs i [] = []
     mkNs i (CFWorld :: xs) = Nothing :: mkNs i xs
-    mkNs i (x :: xs) = Just ("cb" ++ show i) :: mkNs (i + 1) xs
+    mkNs i (x :: xs) = Just (fromString $ "cb" ++ show i) :: mkNs (i + 1) xs
 
-    applyLams : String -> List (Maybe String) -> String
+    applyLams : Builder -> List (Maybe Builder) -> Builder
     applyLams n [] = n
     applyLams n (Nothing :: as) = applyLams ("(" ++ n ++ " #f)") as
     applyLams n (Just a :: as) = applyLams ("(" ++ n ++ " " ++ a ++ ")") as
 
-    getVal : String -> String
+    getVal : Builder -> Builder
     getVal str = "(vector-ref " ++ str ++ "1)"
 
-    mkFun : List CFType -> CFType -> String -> String
+    mkFun : List CFType -> CFType -> Builder -> Builder
     mkFun args ret n
         = let argns = mkNs 0 args in
-              "(lambda (" ++ showSep " " (mapMaybe id argns) ++ ") " ++
+              "(lambda (" ++ sepBy " " (catMaybes argns) ++ ") " ++
               (applyLams n argns ++ ")")
 
     notWorld : CFType -> Bool
     notWorld CFWorld = False
     notWorld _ = True
 
-    callback : String -> List CFType -> CFType -> Core String
+    callback : Builder -> List CFType -> CFType -> Core Builder
     callback n args (CFFun s t) = callback n (s :: args) t
     callback n args_rev retty
         = do let args = reverse args_rev
@@ -303,18 +305,18 @@ cCall fc cfn clib args ret collectSafe
              pure $
                  "(let ([c-code (foreign-callable #f " ++
                        mkFun args retty n ++
-                       " (" ++ showSep " " argTypes ++ ") " ++ retType ++ ")])" ++
+                       " (" ++ sepBy " " argTypes ++ ") " ++ retType ++ ")])" ++
                        " (lock-object c-code) (foreign-callable-entry-point c-code))"
 
-    buildArg : (Name, CFType) -> Core String
+    buildArg : (Name, CFType) -> Core Builder
     buildArg (n, CFFun s t) = callback (schName n) [s] t
     buildArg (n, CFGCPtr) = pure $ "(car " ++ schName n ++ ")"
     buildArg (n, _) = pure $ schName n
 
 schemeCall : FC -> (sfn : String) ->
-             List Name -> CFType -> Core String
+             List Name -> CFType -> Core Builder
 schemeCall fc sfn argns ret
-    = let call = "(" ++ sfn ++ " " ++ showSep " " (map schName argns) ++ ")" in
+    = let call = "(" ++ fromString sfn ++ " " ++ sepBy " " (map schName argns) ++ ")" in
           case ret of
                CFIORes _ => pure $ mkWorld call
                _ => pure call
@@ -325,7 +327,7 @@ schemeCall fc sfn argns ret
 useCC : {auto c : Ref Ctxt Defs} ->
         {auto l : Ref Loaded (List String)} ->
         FC -> List String -> List (Name, CFType) -> CFType ->
-        Maybe Version -> Core (Maybe String, String)
+        Maybe Version -> Core (Maybe String, Builder)
 useCC fc ccs args ret version
     = case parseCC ["scheme,chez", "scheme", "C__collect_safe", "C"] ccs of
            Just ("scheme,chez", [sfn]) =>
@@ -350,18 +352,18 @@ mkArgs i (CFWorld :: cs) = (MN "farg" i, False) :: mkArgs i cs
 mkArgs i (c :: cs) = (MN "farg" i, True) :: mkArgs (i + 1) cs
 
 mkStruct : {auto s : Ref Structs (List String)} ->
-           CFType -> Core String
+           CFType -> Core Builder
 mkStruct (CFStruct n flds)
     = do defs <- traverse mkStruct (map snd flds)
          strs <- get Structs
          if n `elem` strs
             then pure (concat defs)
             else do put Structs (n :: strs)
-                    pure $ concat defs ++ "(define-ftype " ++ n ++ " (struct\n\t"
-                           ++ showSep "\n\t" !(traverse showFld flds) ++ "))\n"
+                    pure $ concat defs ++ "(define-ftype " ++ fromString n ++ " (struct\n\t"
+                           ++ sepBy "\n\t" !(traverse showFld flds) ++ "))\n"
   where
-    showFld : (String, CFType) -> Core String
-    showFld (n, ty) = pure $ "[" ++ n ++ " " ++ !(cftySpec emptyFC ty) ++ "]"
+    showFld : (String, CFType) -> Core Builder
+    showFld (n, ty) = pure $ "[" ++ fromString n ++ " " ++ !(cftySpec emptyFC ty) ++ "]"
 mkStruct (CFIORes t) = mkStruct t
 mkStruct (CFFun a b) = do ignore (mkStruct a); mkStruct b
 mkStruct _ = pure ""
@@ -370,7 +372,7 @@ schFgnDef : {auto c : Ref Ctxt Defs} ->
             {auto l : Ref Loaded (List String)} ->
             {auto s : Ref Structs (List String)} ->
             FC -> Name -> NamedDef -> Maybe Version ->
-            Core (Maybe String, String)
+            Core (Maybe String, Builder)
 schFgnDef fc n (MkNmForeign cs args ret) version
     = do let argns = mkArgs 0 args
          let allargns = map fst argns
@@ -382,7 +384,7 @@ schFgnDef fc n (MkNmForeign cs args ret) version
          pure (load,
                 concat argStrs ++ retStr ++
                 "(define " ++ schName !(full (gamma defs) n) ++
-                " (lambda (" ++ showSep " " (map schName allargns) ++ ") " ++
+                " (lambda (" ++ sepBy " " (map schName allargns) ++ ") " ++
                 body ++ "))\n")
 schFgnDef _ _ _ _ = pure (Nothing, "")
 
@@ -391,7 +393,7 @@ getFgnCall : {auto c : Ref Ctxt Defs} ->
              {auto l : Ref Loaded (List String)} ->
              {auto s : Ref Structs (List String)} ->
              Maybe Version -> (Name, FC, NamedDef) ->
-             Core (Maybe String, String)
+             Core (Maybe String, Builder)
 getFgnCall version (n, fc, d) = schFgnDef fc n d version
 
 export
@@ -468,16 +470,21 @@ compileToSS c prof appdir tm outfile
          loadlibs <- traverse (locateLib appdir) (mapMaybe fst fgndefs)
 
          (sortedDefs, constants) <- sortDefs ndefs
-         compdefs <- traverse (getScheme constants (chezExtPrim constants) chezString) sortedDefs
-         let code = fastConcat (map snd fgndefs ++ compdefs)
+         compdefs <- logTime 3 "Print as scheme" $ traverse (getScheme constants (chezExtPrim constants) chezString) sortedDefs
+         let code = concat (map snd fgndefs) ++ concat compdefs
          main <- schExp constants (chezExtPrim constants) chezString 0 ctm
          support <- readDataFile "chez/support.ss"
          extraRuntime <- getExtraRuntime ds
-         let scm = schHeader chez (map snd libs ++ loadlibs) True ++
-                   support ++ extraRuntime ++ code ++
-                   "(collect-request-handler (lambda () (collect) (blodwen-run-finalisers)))\n" ++
-                   main ++ schFooter prof True
-         Right () <- coreLift $ writeFile outfile scm
+         let scm = concat $ the (List _)
+                   [ schHeader chez (map snd libs ++ loadlibs) True
+                   , fromString support
+                   , fromString extraRuntime
+                   , code
+                   , "(collect-request-handler (lambda () (collect) (blodwen-run-finalisers)))\n"
+                   , main
+                   , schFooter prof True
+                   ]
+         Right () <- coreLift $ writeFile outfile $ build scm
             | Left err => throw (FileErr outfile err)
          coreLift_ $ chmodRaw outfile 0o755
 
@@ -508,20 +515,20 @@ compileToSSInc c mods libs appdir tm outfile
          tmcexp <- compileTerm tm
          let ctm = forget tmcexp
 
-         loadlibs <- traverse (loadLib appdir) (nub libs)
-         loadsos <- traverse (loadSO appdir) (nub mods)
+         loadlibs <- traverse (map fromString . loadLib appdir) (nub libs)
+         loadsos <- traverse (map fromString . loadSO appdir) (nub mods)
 
          main <- schExp empty (chezExtPrim empty) chezString 0 ctm
          support <- readDataFile "chez/support.ss"
 
          let scm = schHeader chez [] False ++
-                   support ++
+                   fromString support ++
                    concat loadlibs ++
                    concat loadsos ++
                    "(collect-request-handler (lambda () (collect) (blodwen-run-finalisers)))\n" ++
                    main ++ schFooter False False
 
-         Right () <- coreLift $ writeFile outfile scm
+         Right () <- coreLift $ writeFile outfile $ build scm
             | Left err => throw (FileErr outfile err)
          coreLift_ $ chmodRaw outfile 0o755
          pure ()
@@ -561,7 +568,7 @@ compileExprWhole makeitso c s tmpDir outputDir tm outfile
          let outSoAbs = cwd </> outputDir </> outSoFile
          chez <- coreLift $ findChez
          let prof = profile !getSession
-         compileToSS c (makeitso && prof) appDirGen tm outSsAbs
+         logTime 2 "Compile to scheme" $ compileToSS c (makeitso && prof) appDirGen tm outSsAbs
          logTime 2 "Make SO" $ when makeitso $
            compileToSO prof chez appDirGen outSsAbs
          let outShRel = outputDir </> outfile
@@ -652,8 +659,8 @@ incCompile c s sourceFile
                fgndefs <- traverse (getFgnCall version) ndefs
                (sortedDefs, constants) <- sortDefs ndefs
                compdefs <- traverse (getScheme constants (chezExtPrim constants) chezString) sortedDefs
-               let code = fastConcat (map snd fgndefs ++ compdefs)
-               Right () <- coreLift $ writeFile ssFile code
+               let code = concat $ map snd fgndefs ++ compdefs
+               Right () <- coreLift $ writeFile ssFile $ build code
                   | Left err => throw (FileErr ssFile err)
 
                -- Compile to .so

--- a/src/Compiler/Scheme/Gambit.idr
+++ b/src/Compiler/Scheme/Gambit.idr
@@ -14,6 +14,7 @@ import Core.TT
 import Protocol.Hex
 import Libraries.Utils.Path
 import Libraries.Data.SortedSet
+import Libraries.Data.String.Builder
 
 import Data.List
 import Data.Maybe
@@ -46,8 +47,8 @@ findGSCBackend =
               Nothing => []
               Just e => ["-cc", e]
 
-schHeader : String
-schHeader = """
+schHeader : Builder
+schHeader = fromString """
   ;; \{ generatedString "Gambit" }
   (declare (block)
     (inlining-limit 450)
@@ -58,24 +59,24 @@ schHeader = """
 
   """
 
-showGambitChar : Char -> String -> String
-showGambitChar '\\' = ("\\\\" ++)
-showGambitChar c
-   = if c < chr 32 -- XXX
-        then (("\\x" ++ asHex (cast c) ++ ";") ++)
-        else strCons c
+showGambitChar : Char -> Builder -> Builder
+showGambitChar '\\' acc = "\\\\" ++ acc
+showGambitChar c acc
+   = if ord c < 32 -- XXX
+        then fromString ("\\x" ++ fromString (asHex (cast c)) ++ ";") ++ acc
+        else char c ++ acc
 
-showGambitString : List Char -> String -> String
-showGambitString [] = id
-showGambitString ('"'::cs) = ("\\\"" ++) . showGambitString cs
-showGambitString (c::cs) = (showGambitChar c) . showGambitString cs
+showGambitString : List Char -> Builder -> Builder
+showGambitString [] acc = acc
+showGambitString ('"' :: cs) acc = "\\\"" ++ showGambitString cs acc
+showGambitString (c :: cs) acc = showGambitChar c $ showGambitString cs acc
 
-gambitString : String -> String
-gambitString cs = strCons '"' (showGambitString (unpack cs) "\"")
+gambitString : String -> Builder
+gambitString cs = "\"" ++ showGambitString (unpack cs) "\""
 
 mutual
-  handleRet : String -> String -> String
-  handleRet "void" op = op ++ " " ++ mkWorld (schConstructor gambitString (UN $ Basic "") (Just 0) [])
+  handleRet : CFType -> Builder -> Builder
+  handleRet CFUnit op = op ++ " " ++ mkWorld (schConstructor gambitString (UN $ Basic "") (Just 0) [])
   handleRet _ op = mkWorld op
 
   getFArgs : NamedCExp -> Core (List (NamedCExp, NamedCExp))
@@ -83,11 +84,11 @@ mutual
   getFArgs (NmCon fc _ _ (Just 1) [ty, val, rest]) = pure $ (ty, val) :: !(getFArgs rest)
   getFArgs arg = throw (GenericMsg (getFC arg) ("Badly formed c call argument list " ++ show arg))
 
-  gambitPrim : SortedSet Name -> Int -> ExtPrim -> List NamedCExp -> Core String
+  gambitPrim : SortedSet Name -> Nat -> ExtPrim -> List NamedCExp -> Core Builder
   gambitPrim cs i GetField [NmPrimVal _ (Str s), _, _, struct,
                          NmPrimVal _ (Str fld), _]
       = do structsc <- schExp cs (gambitPrim cs) gambitString 0 struct
-           pure $ "(" ++ s ++ "-" ++ fld ++ " " ++ structsc ++ ")"
+           pure $ "(" ++ fromString s ++ "-" ++ fromString fld ++ " " ++ structsc ++ ")"
   gambitPrim cs i GetField [_,_,_,_,_,_]
       = pure "(error \"bad getField\")"
   gambitPrim cs i SetField [NmPrimVal _ (Str s), _, _, struct,
@@ -95,7 +96,7 @@ mutual
       = do structsc <- schExp cs (gambitPrim cs) gambitString 0 struct
            valsc <- schExp cs (gambitPrim cs) gambitString 0 val
            pure $ mkWorld $
-                "(" ++ s ++ "-" ++ fld ++ "-set! " ++ structsc ++ " " ++ valsc ++ ")"
+                "(" ++ fromString s ++ "-" ++ fromString fld ++ "-set! " ++ structsc ++ " " ++ valsc ++ ")"
   gambitPrim cs i SetField [_,_,_,_,_,_,_,_]
       = pure "(error \"bad setField\")"
   gambitPrim cs i SysCodegen []
@@ -113,7 +114,7 @@ notWorld : CFType -> Bool
 notWorld CFWorld = False
 notWorld _ = True
 
-cType : FC -> CFType -> Core String
+cType : FC -> CFType -> Core Builder
 cType fc CFUnit = pure "void"
 cType fc CFInt = pure "int"
 cType fc CFString = pure "char *"
@@ -121,20 +122,20 @@ cType fc CFDouble = pure "double"
 cType fc CFChar = pure "char"
 cType fc CFPtr = pure "void *"
 cType fc (CFIORes t) = cType fc t
-cType fc (CFStruct n t) = pure $ "struct " ++ n
+cType fc (CFStruct n t) = pure $ "struct " ++ fromString n
 cType fc (CFFun s t) = funTySpec [s] t
   where
-    funTySpec : List CFType -> CFType -> Core String
+    funTySpec : List CFType -> CFType -> Core Builder
     funTySpec args (CFFun CFWorld t) = funTySpec args t
     funTySpec args (CFFun s t) = funTySpec (s :: args) t
     funTySpec args retty
         = do rtyspec <- cType fc retty
              argspecs <- traverse (cType fc) (reverse . filter notWorld $ args)
-             pure $ rtyspec ++ " (*)(" ++ showSep ", " argspecs ++ ")"
+             pure $ rtyspec ++ " (*)(" ++ sepBy ", " argspecs ++ ")"
 cType fc t = throw (GenericMsg fc ("Can't pass argument of type " ++ show t ++
                        " to foreign function"))
 
-cftySpec : FC -> CFType -> Core String
+cftySpec : FC -> CFType -> Core Builder
 cftySpec fc CFUnit = pure "void"
 cftySpec fc CFInt = pure "int"
 cftySpec fc CFInt8 = pure "char"
@@ -150,38 +151,38 @@ cftySpec fc CFDouble = pure "double"
 cftySpec fc CFChar = pure "char"
 cftySpec fc CFPtr = pure "(pointer void)"
 cftySpec fc (CFIORes t) = cftySpec fc t
-cftySpec fc (CFStruct n t) = pure $ n ++ "*/nonnull"
+cftySpec fc (CFStruct n t) = pure $ fromString n ++ "*/nonnull"
 cftySpec fc (CFFun s t) = funTySpec [s] t
   where
-    funTySpec : List CFType -> CFType -> Core String
+    funTySpec : List CFType -> CFType -> Core Builder
     funTySpec args (CFFun CFWorld t) = funTySpec args t
     funTySpec args (CFFun s t) = funTySpec (s :: args) t
     funTySpec args retty
         = do rtyspec <- cftySpec fc retty
              argspecs <- traverse (cftySpec fc) (reverse . filter notWorld $ args)
-             pure $ "(function (" ++ showSep " " argspecs ++ ") " ++ rtyspec ++ ")"
+             pure $ "(function (" ++ sepBy " " argspecs ++ ") " ++ rtyspec ++ ")"
 cftySpec fc t = throw (GenericMsg fc ("Can't pass argument of type " ++ show t ++
                          " to foreign function"))
 
 
 record CCallbackInfo where
   constructor MkCCallbackInfo
-  schemeArgName : String
+  schemeArgName : Builder
   schemeWrapName : String
-  callbackBody : String
-  argTypes : List String
-  retType : String
+  callbackBody : Builder
+  argTypes : List Builder
+  retType : Builder
 
 record CWrapperDefs where
   constructor MkCWrapperDefs
-  setBox : String
-  boxDef : String
-  cWrapDef : String
+  setBox : Builder
+  boxDef : Builder
+  cWrapDef : Builder
 
 cCall : {auto c : Ref Ctxt Defs} ->
         {auto l : Ref Loaded (List String)} ->
         FC -> (cfn : String) -> (fnWrapName : String -> String) -> (clib : String) ->
-        List (Name, CFType) -> CFType -> Core (String, String)
+        List (Name, CFType) -> CFType -> Core (Builder, Builder)
 cCall fc cfn fnWrapName clib args ret
     = do -- loaded <- get Loaded
          -- lib <- if clib `elem` loaded
@@ -198,27 +199,27 @@ cCall fc cfn fnWrapName clib args ret
          retCType <- cType fc ret
 
          let cWrapperDefs = map buildCWrapperDefs $ mapMaybe snd argsInfo
-         let cFunWrapDeclaration = buildCFunWrapDeclaration cfn retCType argCTypes
+         let cFunWrapDeclaration = buildCFunWrapDeclaration (fromString cfn) retCType argCTypes
          let wrapDeclarations = cFunWrapDeclaration
                                 ++ concatMap (.boxDef) cWrapperDefs
                                 ++ concatMap (.cWrapDef) cWrapperDefs
 
          let setBoxes = concatMap (.setBox) cWrapperDefs
-         let call = " ((c-lambda (" ++ showSep " " argTypes ++ ") "
-                      ++ retType ++ " " ++ show cfn ++ ") "
-                      ++ showSep " " (map fst argsInfo) ++ ")"
+         let call = " ((c-lambda (" ++ sepBy " " argTypes ++ ") "
+                      ++ retType ++ " " ++ showB cfn ++ ") "
+                      ++ sepBy " " (map fst argsInfo) ++ ")"
          let body = setBoxes ++ "\n" ++ call
 
          pure $ case ret of -- XXX
-                     CFIORes _ => (handleRet retType body, wrapDeclarations)
+                     CFIORes _ => (handleRet ret body, wrapDeclarations)
                      _ => (body, wrapDeclarations)
   where
-    mkNs : Int -> List CFType -> List (Maybe String)
+    mkNs : Int -> List CFType -> List (Maybe Builder)
     mkNs i [] = []
     mkNs i (CFWorld :: xs) = Nothing :: mkNs i xs
-    mkNs i (x :: xs) = Just ("cb" ++ show i) :: mkNs (i + 1) xs
+    mkNs i (x :: xs) = Just (fromString $ "cb" ++ show i) :: mkNs (i + 1) xs
 
-    applyLams : String -> List (Maybe String) -> String
+    applyLams : Builder -> List (Maybe Builder) -> Builder
     applyLams n [] = n
     applyLams n (Nothing :: as) = applyLams ("(" ++ n ++ " #f)") as
     applyLams n (Just a :: as) = applyLams ("(" ++ n ++ " " ++ a ++ ")") as
@@ -228,39 +229,39 @@ cCall fc cfn fnWrapName clib args ret
 
     buildCWrapperDefs : CCallbackInfo -> CWrapperDefs
     buildCWrapperDefs (MkCCallbackInfo arg schemeWrap callbackStr argTypes retType) =
-      let box = schemeWrap ++ "-box"
+      let box = fromString $ schemeWrap ++ "-box"
           setBox = "\n (set-box! " ++ box ++ " " ++ callbackStr ++ ")"
           cWrapName = replaceChar '-' '_' schemeWrap
           boxDef = "\n(define " ++ box ++ " (box #f))\n"
 
           args =
             if length argTypes > 0
-              then " " ++ (showSep " " $ map (\i => "farg-" ++ show i) [0 .. (natToInteger $ length argTypes) - 1])
+              then " " ++ (sepBy " " $ map (\i => fromString $ "farg-" ++ show i) [0 .. (natToInteger $ length argTypes) - 1])
               else ""
 
-          cWrapDef =
+          cWrapDef : Builder =
             "\n(c-define " ++
-            "(" ++ schemeWrap ++ args ++ ")" ++
-            " (" ++ showSep " " argTypes ++ ")" ++
+            "(" ++ fromString schemeWrap ++ args ++ ")" ++
+            " (" ++ sepBy " " argTypes ++ ")" ++
             " " ++ retType ++
-            " \"" ++ cWrapName ++ "\"" ++ " \"\"" ++
+            " \"" ++ fromString cWrapName ++ "\"" ++ " \"\"" ++
             "\n ((unbox " ++ box ++ ")" ++ args ++ ")" ++
             "\n)\n"
       in MkCWrapperDefs setBox boxDef cWrapDef
 
-    buildCFunWrapDeclaration : String -> String -> List String -> String
+    buildCFunWrapDeclaration : Builder -> Builder -> List Builder -> Builder
     buildCFunWrapDeclaration name ret args =
       "\n(c-declare #<<c-declare-end\n" ++
-      ret ++ " " ++ name ++ "(" ++ showSep ", " args ++ ");" ++
+      ret ++ " " ++ name ++ "(" ++ sepBy ", " args ++ ");" ++
       "\nc-declare-end\n)\n"
 
-    mkFun : List CFType -> CFType -> String -> String
+    mkFun : List CFType -> CFType -> Builder -> Builder
     mkFun args ret n
         = let argns = mkNs 0 args in
-              "(lambda (" ++ showSep " " (mapMaybe id argns) ++ ") "
+              "(lambda (" ++ sepBy " " (mapMaybe id argns) ++ ") "
               ++ (applyLams n argns ++ ")")
 
-    callback : String -> List CFType -> CFType -> Core (String, List String, String)
+    callback : Builder -> List CFType -> CFType -> Core (Builder, List Builder, Builder)
     callback n args (CFFun s t) = callback n (s :: args) t
     callback n args_rev retty
         = do let args = reverse args_rev
@@ -268,18 +269,18 @@ cCall fc cfn fnWrapName clib args ret
              retType <- cftySpec fc retty
              pure (mkFun args retty n, argTypes, retType)
 
-    buildArg : (Name, CFType) -> Core (String, Maybe CCallbackInfo)
+    buildArg : (Name, CFType) -> Core (Builder, Maybe CCallbackInfo)
     buildArg (n, CFFun s t) = do
       let arg = schName n
-      let schemeWrap = fnWrapName arg
+      let schemeWrap = fnWrapName $ build arg
       (callbackBody, argTypes, retType) <- callback arg [s] t
-      pure (schemeWrap, Just $ MkCCallbackInfo arg schemeWrap callbackBody argTypes retType)
+      pure (fromString schemeWrap, Just $ MkCCallbackInfo arg schemeWrap callbackBody argTypes retType)
     buildArg (n, _) = pure (schName n, Nothing)
 
 schemeCall : FC -> (sfn : String) ->
-             List Name -> CFType -> Core String
+             List Name -> CFType -> Core Builder
 schemeCall fc sfn argns ret
-    = let call = "(" ++ sfn ++ " " ++ showSep " " (map schName argns) ++ ")" in
+    = let call = "(" ++ fromString sfn ++ " " ++ sepBy " " (map schName argns) ++ ")" in
           case ret of
                CFIORes _ => pure $ mkWorld call
                _ => pure call
@@ -289,19 +290,22 @@ schemeCall fc sfn argns ret
 -- of the function call.
 useCC : {auto c : Ref Ctxt Defs} ->
         {auto l : Ref Loaded (List String)} ->
-        FC -> List String -> List (Name, CFType) -> CFType -> Core (Maybe String, (String, String))
+        FC -> List String -> List (Name, CFType) -> CFType -> Core (Maybe String, Builder, Builder)
 useCC fc ccs args ret
     = case parseCC ["scheme,gambit", "scheme", "C"] ccs of
            Nothing => throw (NoForeignCC fc ccs)
-           Just ("scheme,gambit", [sfn]) => pure (Nothing, (!(schemeCall fc sfn (map fst args) ret), ""))
-           Just ("scheme", [sfn]) => pure (Nothing, (!(schemeCall fc sfn (map fst args) ret), ""))
-           Just ("C", [cfn, clib]) => pure (Just clib, !(cCall fc cfn (fnWrapName cfn) clib args ret))
-           Just ("C", [cfn, clib, chdr]) => pure (Just clib, !(cCall fc cfn (fnWrapName cfn) clib args ret))
+           Just ("scheme,gambit", [sfn]) => pure (Nothing, !(schemeCall fc sfn (map fst args) ret), "")
+           Just ("scheme", [sfn]) => pure (Nothing, !(schemeCall fc sfn (map fst args) ret), "")
+           Just ("C", [cfn, clib]) => do
+               (call, decl) <- cCall fc cfn (fnWrapName cfn) clib args ret
+               pure (Just clib, call, decl)
+           Just ("C", [cfn, clib, chdr]) => do
+               (call, decl) <- cCall fc cfn (fnWrapName cfn) clib args ret
+               pure (Just clib, call, decl)
            _ => throw (NoForeignCC fc ccs)
   where
     fnWrapName : String -> String -> String
-    fnWrapName cfn schemeArgName = schemeArgName ++ "-" ++ cfn ++ "-cFunWrap"
-
+    fnWrapName cfn schemeArgName = schemeArgName ++ "-" ++ fromString cfn ++ "-cFunWrap"
 
 -- For every foreign arg type, return a name, and whether to pass it to the
 -- foreign call (we don't pass '%World')
@@ -311,18 +315,18 @@ mkArgs i (CFWorld :: cs) = (MN "farg" i, False) :: mkArgs i cs
 mkArgs i (c :: cs) = (MN "farg" i, True) :: mkArgs (i + 1) cs
 
 mkStruct : {auto s : Ref Structs (List String)} ->
-           CFType -> Core String
+           CFType -> Core Builder
 mkStruct (CFStruct n flds)
     = do defs <- traverse mkStruct (map snd flds)
          strs <- get Structs
          if n `elem` strs
             then pure (concat defs)
             else do put Structs (n :: strs)
-                    pure $ concat defs ++ "(define-c-struct " ++ n ++ " "
-                           ++ showSep " " !(traverse showFld flds) ++ ")\n"
+                    pure $ concat defs ++ "(define-c-struct " ++ fromString n ++ " "
+                           ++ sepBy " " !(traverse showFld flds) ++ ")\n"
   where
-    showFld : (String, CFType) -> Core String
-    showFld (n, ty) = pure $ "(" ++ n ++ " " ++ !(cftySpec emptyFC ty) ++ ")"
+    showFld : (String, CFType) -> Core Builder
+    showFld (n, ty) = pure $ "(" ++ fromString n ++ " " ++ !(cftySpec emptyFC ty) ++ ")"
 mkStruct (CFIORes t) = mkStruct t
 mkStruct (CFFun a b) = do ignore (mkStruct a); mkStruct b
 mkStruct _ = pure ""
@@ -330,27 +334,27 @@ mkStruct _ = pure ""
 schFgnDef : {auto c : Ref Ctxt Defs} ->
             {auto l : Ref Loaded (List String)} ->
             {auto s : Ref Structs (List String)} ->
-            FC -> Name -> NamedDef -> Core (Maybe String, String)
+            FC -> Name -> NamedDef -> Core (Maybe String, Builder)
 schFgnDef fc n (MkNmForeign cs args ret)
     = do let argns = mkArgs 0 args
          let allargns = map fst argns
          let useargns = map fst (filter snd argns)
          argStrs <- traverse mkStruct args
          retStr <- mkStruct ret
-         (lib, (body, wrapDeclarations)) <- useCC fc cs (zip useargns args) ret
+         (lib, body, wrapDeclarations) <- useCC fc cs (zip useargns args) ret
          defs <- get Ctxt
          pure (lib,
                 concat argStrs ++ retStr ++
                 wrapDeclarations ++
                 "(define " ++ schName !(full (gamma defs) n) ++
-                " (lambda (" ++ showSep " " (map schName allargns) ++ ") " ++
+                " (lambda (" ++ sepBy " " (map schName allargns) ++ ") " ++
                 body ++ "))\n")
 schFgnDef _ _ _ = pure (Nothing, "")
 
 getFgnCall : {auto c : Ref Ctxt Defs} ->
              {auto l : Ref Loaded (List String)} ->
              {auto s : Ref Structs (List String)} ->
-             (Name, FC, NamedDef) -> Core (Maybe String, String)
+             (Name, FC, NamedDef) -> Core (Maybe String, Builder)
 getFgnCall (n, fc, d) = schFgnDef fc n d
 
 compileToSCM : Ref Ctxt Defs ->
@@ -367,14 +371,14 @@ compileToSCM c tm outfile
          fgndefs <- traverse getFgnCall ndefs
          (sortedDefs, constants) <- sortDefs ndefs
          compdefs <- traverse (getScheme constants (gambitPrim constants) gambitString) ndefs
-         let code = fastConcat (map snd fgndefs ++ compdefs)
+         let code = concat (map snd fgndefs) ++ concat compdefs
          main <- schExp constants (gambitPrim constants) gambitString 0 ctm
          support <- readDataFile "gambit/support.scm"
          ds <- getDirectives Gambit
          extraRuntime <- getExtraRuntime ds
          foreign <- readDataFile "gambit/foreign.scm"
-         let scm = showSep "\n" [schHeader, support, extraRuntime, foreign, code, main]
-         Right () <- coreLift $ writeFile outfile scm
+         let scm = sepBy "\n" [schHeader, fromString support, fromString extraRuntime, fromString foreign, code, main]
+         Right () <- coreLift $ writeFile outfile $ build scm
             | Left err => throw (FileErr outfile err)
          pure $ mapMaybe fst fgndefs
 

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -56,9 +56,9 @@ schHeader prof libs = fromString """
   (require ffi/unsafe ffi/unsafe/define) ; for calling C
   \{ ifThenElse prof "(require profile)" "" }
   (require racket/flonum)                ; for float-typed transcendental functions
-  """
-  ++ libs ++
-  """
+
+  """ ++ libs ++ """
+
   (let ()
 
   """

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -14,6 +14,7 @@ import Core.Name
 import Core.TT
 import Protocol.Hex
 import Libraries.Data.SortedSet
+import Libraries.Data.String.Builder
 import Libraries.Utils.Path
 
 import Data.List
@@ -40,8 +41,8 @@ findRacoExe =
   do env <- idrisGetEnv "RACKET_RACO"
      pure $ (maybe ["/usr/bin/env", "raco"] singleton env) ++ ["exe"]
 
-schHeader : Bool -> String -> String
-schHeader prof libs = """
+schHeader : Bool -> Builder -> Builder
+schHeader prof libs = fromString """
   #lang racket/base
   ;; \{ generatedString "Racket" }
   (require racket/async-channel)         ; for asynchronous channels
@@ -55,38 +56,40 @@ schHeader prof libs = """
   (require ffi/unsafe ffi/unsafe/define) ; for calling C
   \{ ifThenElse prof "(require profile)" "" }
   (require racket/flonum)                ; for float-typed transcendental functions
-  \{ libs }
+  """
+  ++ libs ++
+  """
   (let ()
 
   """
 
-schFooter : String
+schFooter : Builder
 schFooter = """
   )
   (collect-garbage)
   """
 
-showRacketChar : Char -> String -> String
-showRacketChar '\\' = ("\\\\" ++)
-showRacketChar c
-   = if c < chr 32 || c > chr 126
-        then (("\\u" ++ leftPad '0' 4 (asHex (cast c))) ++)
-        else strCons c
+showRacketChar : Char -> Builder -> Builder
+showRacketChar '\\' acc = "\\\\" ++ acc
+showRacketChar c acc
+   = if ord c < 32 || ord c > 126
+        then fromString ("\\u" ++ leftPad '0' 4 (asHex (cast c))) ++ acc
+        else char c ++ acc
 
-showRacketString : List Char -> String -> String
-showRacketString [] = id
-showRacketString ('"'::cs) = ("\\\"" ++) . showRacketString cs
-showRacketString (c ::cs) = (showRacketChar c) . showRacketString cs
+showRacketString : List Char -> Builder -> Builder
+showRacketString [] acc = acc
+showRacketString ('"' :: cs) acc = "\\\"" ++ showRacketString cs acc
+showRacketString (c :: cs) acc = showRacketChar c $ showRacketString cs acc
 
-racketString : String -> String
-racketString cs = strCons '"' (showRacketString (unpack cs) "\"")
+racketString : String -> Builder
+racketString cs = "\"" ++ showRacketString (unpack cs) "\""
 
 mutual
-  racketPrim : SortedSet Name -> Int -> ExtPrim -> List NamedCExp -> Core String
+  racketPrim : SortedSet Name -> Nat -> ExtPrim -> List NamedCExp -> Core Builder
   racketPrim cs i GetField [NmPrimVal _ (Str s), _, _, struct,
                          NmPrimVal _ (Str fld), _]
       = do structsc <- schExp cs (racketPrim cs) racketString 0 struct
-           pure $ "(" ++ s ++ "-" ++ fld ++ " " ++ structsc ++ ")"
+           pure $ "(" ++ fromString s ++ "-" ++ fromString fld ++ " " ++ structsc ++ ")"
   racketPrim cs i GetField [_,_,_,_,_,_]
       = pure "(error \"bad getField\")"
   racketPrim cs i SetField [NmPrimVal _ (Str s), _, _, struct,
@@ -94,7 +97,7 @@ mutual
       = do structsc <- schExp cs (racketPrim cs) racketString 0 struct
            valsc <- schExp cs (racketPrim cs) racketString 0 val
            pure $ mkWorld $
-                "(set-" ++ s ++ "-" ++ fld ++ "! " ++ structsc ++ " " ++ valsc ++ ")"
+                "(set-" ++ fromString s ++ "-" ++ fromString fld ++ "! " ++ structsc ++ " " ++ valsc ++ ")"
   racketPrim cs i SetField [_,_,_,_,_,_,_,_]
       = pure "(error \"bad setField\")"
   racketPrim cs i SysCodegen []
@@ -122,7 +125,7 @@ data Structs : Type where
 -- Label for noting which foreign names are declared
 data Done : Type where
 
-cftySpec : FC -> CFType -> Core String
+cftySpec : FC -> CFType -> Core Builder
 cftySpec fc CFUnit = pure "_void"
 cftySpec fc CFInt = pure "_int"
 cftySpec fc CFInt8 = pure "_int8"
@@ -140,16 +143,16 @@ cftySpec fc CFPtr = pure "_pointer"
 cftySpec fc CFGCPtr = pure "_pointer"
 cftySpec fc CFBuffer = pure "_bytes"
 cftySpec fc (CFIORes t) = cftySpec fc t
-cftySpec fc (CFStruct n t) = pure $ "_" ++ n ++ "-pointer"
+cftySpec fc (CFStruct n t) = pure $ "_" ++ fromString n ++ "-pointer"
 cftySpec fc (CFFun s t) = funTySpec [s] t
   where
-    funTySpec : List CFType -> CFType -> Core String
+    funTySpec : List CFType -> CFType -> Core Builder
     funTySpec args (CFFun CFWorld t) = funTySpec args t
     funTySpec args (CFFun s t) = funTySpec (s :: args) t
     funTySpec args retty
         = do rtyspec <- cftySpec fc retty
              argspecs <- traverse (cftySpec fc) (reverse args)
-             pure $ "(_fun " ++ showSep " " argspecs ++ " -> " ++ rtyspec ++ ")"
+             pure $ "(_fun " ++ sepBy " " argspecs ++ " -> " ++ rtyspec ++ ")"
 cftySpec fc t = throw (GenericMsg fc ("Can't pass argument of type " ++ show t ++
                          " to foreign function"))
 
@@ -169,15 +172,15 @@ getLibVers libspec
                (fst (span (/='.') fn),
                   "'(" ++ showSep " " (map show vers) ++ " #f)" )
 
-cToRkt : CFType -> String -> String
+cToRkt : CFType -> Builder -> Builder
 cToRkt CFChar op = "(integer->char " ++ op ++ ")"
 cToRkt _ op = op
 
-rktToC : CFType -> String -> String
+rktToC : CFType -> Builder -> Builder
 rktToC CFChar op = "(char->integer " ++ op ++ ")"
 rktToC _ op = op
 
-handleRet : CFType -> String -> String
+handleRet : CFType -> Builder -> Builder
 handleRet CFUnit op = op ++ " " ++ mkWorld (schConstructor racketString (UN $ Basic "") (Just 0) [])
 handleRet ret op = mkWorld (cToRkt ret op)
 
@@ -185,7 +188,7 @@ cCall : {auto f : Ref Done (List String) } ->
         {auto c : Ref Ctxt Defs} ->
         {auto l : Ref Loaded (List String)} ->
         String -> FC -> (cfn : String) -> (clib : String) ->
-        List (Name, CFType) -> CFType -> Core (String, String)
+        List (Name, CFType) -> CFType -> Core (Builder, Builder)
 cCall appdir fc cfn clib args (CFIORes CFGCPtr)
     = throw (GenericMsg fc "Can't return GCPtr from a foreign function")
 cCall appdir fc cfn clib args CFGCPtr
@@ -212,38 +215,38 @@ cCall appdir fc cfn libspec args ret
          cbind <- if cfn `elem` bound
                      then pure ""
                      else do put Done (cfn :: bound)
-                             pure $ "(define-" ++ libn ++ " " ++ cfn ++
-                                    " (_fun " ++ showSep " " (map snd argTypes) ++ " -> " ++
+                             pure $ "(define-" ++ fromString libn ++ " " ++ fromString cfn ++
+                                    " (_fun " ++ sepBy " " (map snd argTypes) ++ " -> " ++
                                         retType ++ "))\n"
-         let call = "(" ++ cfn ++ " " ++
-                    showSep " " !(traverse useArg (map fst argTypes)) ++ ")"
+         let call = "(" ++ fromString cfn ++ " " ++
+                    sepBy " " !(traverse useArg (map fst argTypes)) ++ ")"
 
-         pure (lib ++ cbind, case ret of
+         pure (fromString lib ++ cbind, case ret of
                                   CFIORes rt => handleRet rt call
                                   _ => call)
   where
-    mkNs : Int -> List CFType -> List (Maybe (String, CFType))
+    mkNs : Int -> List CFType -> List (Maybe (Builder, CFType))
     mkNs i [] = []
     mkNs i (CFWorld :: xs) = Nothing :: mkNs i xs
-    mkNs i (x :: xs) = Just ("cb" ++ show i, x) :: mkNs (i + 1) xs
+    mkNs i (x :: xs) = Just (fromString ("cb" ++ show i), x) :: mkNs (i + 1) xs
 
-    applyLams : String -> List (Maybe (String, CFType)) -> String
+    applyLams : Builder -> List (Maybe (Builder, CFType)) -> Builder
     applyLams n [] = n
     applyLams n (Nothing :: as) = applyLams ("(" ++ n ++ " #f)") as
     applyLams n (Just (a, ty) :: as)
         = applyLams ("(" ++ n ++ " " ++ cToRkt ty a ++ ")") as
 
-    mkFun : List CFType -> CFType -> String -> String
+    mkFun : List CFType -> CFType -> Builder -> Builder
     mkFun args ret n
         = let argns = mkNs 0 args in
-              "(lambda (" ++ showSep " " (map fst (mapMaybe id argns)) ++ ") " ++
+              "(lambda (" ++ sepBy " " (map fst (catMaybes argns)) ++ ") " ++
               (applyLams n argns ++ ")")
 
     notWorld : CFType -> Bool
     notWorld CFWorld = False
     notWorld _ = True
 
-    callback : String -> List CFType -> CFType -> Core String
+    callback : Builder -> List CFType -> CFType -> Core Builder
     callback n args (CFFun s t) = callback n (s :: args) t
     callback n args_rev retty
         = do let args = reverse args_rev
@@ -251,18 +254,18 @@ cCall appdir fc cfn libspec args ret
              retType <- cftySpec fc retty
              pure $ mkFun args retty n
 
-    useArg : (Name, CFType) -> Core String
+    useArg : (Name, CFType) -> Core Builder
     useArg (n, CFFun s t) = callback (schName n) [s] t
     useArg (n, ty)
         = pure $ rktToC ty (schName n)
 
 schemeCall : FC -> (sfn : String) ->
-             List Name -> CFType -> Core String
+             List Name -> CFType -> Builder
 schemeCall fc sfn argns ret
-    = let call = "(" ++ sfn ++ " " ++ showSep " " (map schName argns) ++ ")" in
+    = let call = "(" ++ fromString sfn ++ " " ++ sepBy " " (map schName argns) ++ ")" in
           case ret of
-               CFIORes _ => pure $ mkWorld call
-               _ => pure call
+               CFIORes _ => mkWorld call
+               _ => call
 
 -- Use a calling convention to compile a foreign def.
 -- Returns any preamble needed for loading libraries, and the body of the
@@ -270,15 +273,15 @@ schemeCall fc sfn argns ret
 useCC : {auto f : Ref Done (List String) } ->
         {auto c : Ref Ctxt Defs} ->
         {auto l : Ref Loaded (List String)} ->
-        String -> FC -> List String -> List (Name, CFType) -> CFType -> Core (String, String)
+        String -> FC -> List String -> List (Name, CFType) -> CFType -> Core (Builder, Builder)
 useCC appdir fc ccs args ret
     = case parseCC ["scheme,racket", "scheme", "C"] ccs of
            Nothing => throw (NoForeignCC fc ccs)
            Just ("scheme,racket", [sfn]) =>
-               do body <- schemeCall fc sfn (map fst args) ret
+               do let body = schemeCall fc sfn (map fst args) ret
                   pure ("", body)
            Just ("scheme", [sfn]) =>
-               do body <- schemeCall fc sfn (map fst args) ret
+               do let body = schemeCall fc sfn (map fst args) ret
                   pure ("", body)
            Just ("C", [cfn, clib]) => cCall appdir fc cfn clib args ret
            Just ("C", [cfn, clib, chdr]) => cCall appdir fc cfn clib args ret
@@ -292,18 +295,18 @@ mkArgs i (CFWorld :: cs) = (MN "farg" i, False) :: mkArgs i cs
 mkArgs i (c :: cs) = (MN "farg" i, True) :: mkArgs (i + 1) cs
 
 mkStruct : {auto s : Ref Structs (List String)} ->
-           CFType -> Core String
+           CFType -> Core Builder
 mkStruct (CFStruct n flds)
     = do defs <- traverse mkStruct (map snd flds)
          strs <- get Structs
          if n `elem` strs
             then pure (concat defs)
             else do put Structs (n :: strs)
-                    pure $ concat defs ++ "(define-cstruct _" ++ n ++ " ("
-                           ++ showSep "\n\t" !(traverse showFld flds) ++ "))\n"
+                    pure $ concat defs ++ "(define-cstruct _" ++ fromString n ++ " ("
+                           ++ sepBy "\n\t" !(traverse showFld flds) ++ "))\n"
   where
-    showFld : (String, CFType) -> Core String
-    showFld (n, ty) = pure $ "[" ++ n ++ " " ++ !(cftySpec emptyFC ty) ++ "]"
+    showFld : (String, CFType) -> Core Builder
+    showFld (n, ty) = pure $ "[" ++ fromString n ++ " " ++ !(cftySpec emptyFC ty) ++ "]"
 mkStruct (CFIORes t) = mkStruct t
 mkStruct (CFFun a b) = do ignore (mkStruct a); mkStruct b
 mkStruct _ = pure ""
@@ -312,7 +315,7 @@ schFgnDef : {auto f : Ref Done (List String) } ->
             {auto c : Ref Ctxt Defs} ->
             {auto l : Ref Loaded (List String)} ->
             {auto s : Ref Structs (List String)} ->
-            String -> FC -> Name -> NamedDef -> Core (String, String)
+            String -> FC -> Name -> NamedDef -> Core (Builder, Builder)
 schFgnDef appdir fc n (MkNmForeign cs args ret)
     = do let argns = mkArgs 0 args
          let allargns = map fst argns
@@ -323,7 +326,7 @@ schFgnDef appdir fc n (MkNmForeign cs args ret)
          defs <- get Ctxt
          pure (concat argStrs ++ retStr ++ load,
                 "(define " ++ schName !(full (gamma defs) n) ++
-                " (lambda (" ++ showSep " " (map schName allargns) ++ ") " ++
+                " (lambda (" ++ sepBy " " (map schName allargns) ++ ") " ++
                 body ++ "))\n")
 schFgnDef _ _ _ _ = pure ("", "")
 
@@ -331,7 +334,7 @@ getFgnCall : {auto f : Ref Done (List String) } ->
              {auto c : Ref Ctxt Defs} ->
              {auto l : Ref Loaded (List String)} ->
              {auto s : Ref Structs (List String)} ->
-             String -> (Name, FC, NamedDef) -> Core (String, String)
+             String -> (Name, FC, NamedDef) -> Core (Builder, Builder)
 getFgnCall appdir (n, fc, d) = schFgnDef appdir fc n d
 
 startRacket : String -> String -> String -> String
@@ -392,7 +395,7 @@ compileToRKT c appdir tm outfile
          fgndefs <- traverse (getFgnCall appdir) ndefs
          (sortedDefs, constants) <- sortDefs ndefs
          compdefs <- traverse (getScheme constants (racketPrim constants) racketString) sortedDefs
-         let code = fastConcat (map snd fgndefs ++ compdefs)
+         let code = concat (map snd fgndefs) ++ concat compdefs
          main <- schExp constants (racketPrim constants) racketString 0 ctm
          support <- readDataFile "racket/support.rkt"
          ds <- getDirectives Racket
@@ -403,9 +406,9 @@ compileToRKT c appdir tm outfile
                      then "(profile (void " ++ main ++ ") #:order 'self)\n"
                      else "(void " ++ main ++ ")\n"
          let scm = schHeader prof (concat (map fst fgndefs)) ++
-                   support ++ extraRuntime ++ code ++
+                   fromString support ++ fromString extraRuntime ++ code ++
                    runmain ++ schFooter
-         Right () <- coreLift $ writeFile outfile scm
+         Right () <- coreLift $ writeFile outfile $ build scm
             | Left err => throw (FileErr outfile err)
          coreLift_ $ chmodRaw outfile 0o755
          pure ()

--- a/src/Libraries/Data/String/Builder.idr
+++ b/src/Libraries/Data/String/Builder.idr
@@ -1,0 +1,95 @@
+||| This module contains a implementation of diff-lists
+||| and an efficient string builder using them
+module Libraries.Data.String.Builder
+
+import Data.List
+
+public export
+record DiffList a where
+    constructor MkDiffList
+    append : List a -> List a
+
+public export
+(++) : DiffList a -> DiffList a -> DiffList a
+xs ++ ys = MkDiffList $ \zs => xs.append (ys.append zs)
+
+public export
+toList : DiffList a -> List a
+toList xs = xs.append []
+
+public export
+fromList : List a -> DiffList a
+fromList xs = MkDiffList $ \ys => xs ++ ys
+
+public export
+Nil : DiffList a
+Nil = MkDiffList id
+
+public export
+(::) : a -> DiffList a -> DiffList a
+x :: xs = MkDiffList $ \ys => x :: xs.append ys
+
+public export
+singleton : a -> DiffList a
+singleton x = MkDiffList $ \xs => x :: xs
+
+export
+intersperse : a -> List a -> DiffList a
+intersperse sep [] = []
+intersperse sep [x] = [x]
+intersperse sep (x :: xs) = MkDiffList $ \ys => x :: go sep xs ys
+  where
+    go : a -> List a -> List a -> List a
+    go sep [] ys = ys
+    go sep (x :: xs) ys = sep :: x :: go sep xs ys
+
+public export %inline
+Semigroup (DiffList a) where
+    xs <+> ys = xs ++ ys
+
+public export %inline
+Monoid (DiffList a) where
+    neutral = []
+
+public export
+Builder : Type
+Builder = DiffList String
+
+public export %inline
+FromString Builder where
+    fromString = singleton
+
+public export
+char : Char -> Builder
+char c = fromString $ cast c
+
+export
+sepBy : String -> List Builder -> Builder
+sepBy sep [] = []
+sepBy sep [x] = x
+sepBy sep (x :: xs) = MkDiffList $ \ys => x.append $ go sep xs ys
+  where
+    go : String -> List Builder -> List String -> List String
+    go sep [] ys = ys
+    go sep (x :: xs) ys = sep :: x.append (go sep xs ys)
+
+public export
+build : Builder -> String
+build = fastConcat . Builder.toList
+
+public export
+showB : Show a => a -> Builder
+showB = singleton . show
+
+export
+toListFromListId : (xs : _) -> Builder.toList (Builder.fromList xs) === xs   
+toListFromListId [] = Refl
+toListFromListId (x :: xs) = rewrite appendNilRightNeutral xs in Refl
+
+export
+toListNil : Builder.toList Nil = Nil
+toListNil = Refl
+
+export
+appendCorrect : (xs, ys : _) -> Builder.toList (fromList xs ++ fromList ys) = xs ++ ys
+appendCorrect xs ys = rewrite appendNilRightNeutral ys in Refl

--- a/src/Libraries/Data/String/Builder.idr
+++ b/src/Libraries/Data/String/Builder.idr
@@ -82,7 +82,7 @@ showB : Show a => a -> Builder
 showB = singleton . show
 
 export
-toListFromListId : (xs : _) -> Builder.toList (Builder.fromList xs) === xs   
+toListFromListId : (xs : _) -> Builder.toList (Builder.fromList xs) === xs
 toListFromListId [] = Refl
 toListFromListId (x :: xs) = rewrite appendNilRightNeutral xs in Refl
 


### PR DESCRIPTION
this makes it about 50x faster at printing scheme code

I used this python script to generate a huge idris file:
```python
count = 100

out = "" 

out += "plus : Nat -> Nat = (+)\n"
out += "%noinline\n"

for i in range(count):
    out += "f" + str(i)
    if i < count - 1:
        out += ", "
out += " : Nat -> Nat\n"

pluses = "x"
for i in range(500):
    pluses = "plus x (" + pluses + ")"

for i in range(count):
    out += "f" + str(i) + " x = " + pluses + "\n"

out += "main : IO ()\n"
out += "main = do\n"
for i in range(count):
    out += "    printLn $ f" + str(i) + " 100\n"

print(out)
```

I added a call to `logTime` to this line: https://github.com/idris-lang/Idris2/blob/main/src/Compiler/Scheme/Chez.idr#L564

Previously it took 1.193s to pretty print the scheme code, with this change it takes 0.026s, a roughly 50x improvement

I also took the opportunity to clean up the code a little

# Should this change go in the CHANGELOG?

Not necessary, it just makes things faster
