### PR TITLE
[new] Vect.Quantifiers.All QoL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,11 @@
   convert a `Bits8` to an `Int`), as their values are limited, as opposed to the
   assumption in `setByte` that the value is between 0 and 255.
 * Adds RefC support for 16- and 32-bit access in `Data.Buffer`.
+* Add `Show` instance to `Data.Vect.Quantifiers.All` and add a few helpers for listy
+  computations on the `All` type.
+* Add an alias for `HVect` to `All id` in `Data.Vect.Quantifiers.All`. This is the
+  approach to getting a heterogeneous Vect of elements that is generall preferred by
+  the community vs. a standalone type as seen in `contrib`.
 
 #### System
 

--- a/libs/base/Data/Vect/Quantifiers.idr
+++ b/libs/base/Data/Vect/Quantifiers.idr
@@ -125,3 +125,13 @@ namespace All
   forget : All (const p) {n} xs -> Vect n p
   forget []      = []
   forget (x::xs) = x :: forget xs
+
+  export
+  {0 xs : Vect n _} -> All Show (map p xs) => Show (All p xs) where
+    show pxs = "[" ++ show' "" pxs ++ "]"
+      where
+        show' : {0 xs' : Vect n' _} -> String -> All Show (map p xs') => All p xs' -> String
+        show' acc @{[]} [] = acc
+        show' acc @{[_]} [px] = acc ++ show px
+        show' acc @{_ :: _} (px :: pxs) = show' (acc ++ show px ++ ", ") pxs
+

--- a/libs/base/Data/Vect/Quantifiers.idr
+++ b/libs/base/Data/Vect/Quantifiers.idr
@@ -140,3 +140,28 @@ namespace All
   HVect : Vect n Type -> Type
   HVect = All id
 
+  ||| Take the first element.
+  export
+  head : All p (x :: xs) -> p x
+  head (y :: _) = y
+
+  ||| Take all but the first element.
+  export
+  tail : All p (x :: xs) -> All p xs
+  tail (_ :: ys) = ys
+
+  ||| Drop the first n elements given knowledge that
+  ||| there are at least n elements available.
+  export
+  drop : {0 m : _} -> (n : Nat) -> {0 xs : Vect (n + m) a} -> All p xs -> All p (the (Vect m a) (Vect.drop n xs))
+  drop 0 ys = ys
+  drop (S k) (y :: ys) = drop k ys
+
+  ||| Drop up to the first l elements, stopping early
+  ||| if all elements have been dropped.
+  export
+  drop' : {0 k : _} -> {0 xs : Vect k _} -> (l : Nat) -> All p xs -> All p (Vect.drop' l xs)
+  drop' 0 ys = rewrite minusZeroRight k in ys
+  drop' (S k) [] = []
+  drop' (S k) (y :: ys) = drop' k ys
+

--- a/libs/base/Data/Vect/Quantifiers.idr
+++ b/libs/base/Data/Vect/Quantifiers.idr
@@ -135,3 +135,8 @@ namespace All
         show' acc @{[_]} [px] = acc ++ show px
         show' acc @{_ :: _} (px :: pxs) = show' (acc ++ show px ++ ", ") pxs
 
+  ||| A heterogeneous vector of arbitrary types
+  public export
+  HVect : Vect n Type -> Type
+  HVect = All id
+


### PR DESCRIPTION
I've included 3 separate small commits for QoL improvements on `Data.Vect.Quantifiers.All`. I am ok with these commits being individually approved/denied and will drop any commits that aren't deemed worthwhile.

1. Add a `Show` instance for `Data.Vect.Quantifiers.All`. Super minor, but definitely convenient. Precedent is set here by the `Show` instance for `Data.List.Quantifiers.All`.
2. Add an alias for `HVect` to `Data.Vect.Quantifiers.All`. There is a fully separate `HVect` type in the `contrib` library, but for 95% of operations I don't need the helpers defined against the contrib type (and if I do, they can be written against `All` anyway, so I just do that myself at that time). I've seen `All id` be recommended many times for an `HVect` type in various forums as well, so I believe the alias serves as a nice way to show people that `All id` _is_ `HVect` without them reaching out and asking about it on Discord (or similar). Precedent for this alias is also set by an `HList`  alias in `Data.List.Quantifiers.All`.
3. Add `head`, `tail`, `drop`, and `drop'` to `Data.Vect.Quantifiers.All` to make it more at home in listy computations. This is just something I recently needed so I figured I would pitch it.

# Should this change go in the CHANGELOG?
~I'll update the CHANGELOG once I know which if any of these commits are going to be accepted.~ [EDIT] Done.

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a user-facing change or a compiler change, I have updated
      `CHANGELOG.md` (and potentially also `CONTRIBUTORS.md`).

