### PR TITLE
[ fix ] make color output toggling simpler and also more robust.

### DIFF
--- a/libs/test/Test/Golden.idr
+++ b/libs/test/Test/Golden.idr
@@ -195,7 +195,7 @@ options args = case args of
 
     mkOptions : String -> List String -> IO (Maybe Options)
     mkOptions exe rest
-      = do color <- (Just "DUMB" /=) <$> getEnv "TERM"
+      = do color <- [ (isNothing noc) && tty | noc <- getEnv "NO_COLOR", tty <- isTTY stdout ]
            let Just (acc, opts) = go rest initAcc (initOptions exe color)
                  | Nothing => pure Nothing
            extraOnlyNames <- the (IO (List String)) $ case acc.onlyFile of

--- a/src/Idris/Driver.idr
+++ b/src/Idris/Driver.idr
@@ -28,6 +28,8 @@ import Data.List
 import Data.String
 import System
 import System.Directory
+import System.File.Meta
+import System.File.Virtual
 import Libraries.Utils.Path
 import Libraries.Utils.Term
 
@@ -49,6 +51,8 @@ updateEnv : {auto c : Ref Ctxt Defs} ->
             Core ()
 updateEnv
     = do defs <- get Ctxt
+         noColor <- coreLift [ isJust noc || not tty | noc <- idrisGetEnv "NO_COLOR", tty <- isTTY stdout ]
+         when noColor $ setColor False
          bprefix <- coreLift $ idrisGetEnv "IDRIS2_PREFIX"
          setPrefix (fromMaybe yprefix bprefix)
          bpath <- coreLift $ idrisGetEnv "IDRIS2_PATH"

--- a/src/Idris/Env.idr
+++ b/src/Idris/Env.idr
@@ -43,7 +43,8 @@ envs = [
     MkEnvDesc "CPPFLAGS"             "RefC backend: C preprocessor flags (IDRIS2_CPPFLAGS takes precedence).",
     MkEnvDesc "LDFLAGS"              "RefC backend: C linker flags (IDRIS2_LDFLAGS takes precedence).",
     MkEnvDesc "NODE"                 "NodeJS backend: NodeJS executable.",
-    MkEnvDesc "PATH"                 "PATH variable is used to search for executables in certain codegens."]
+    MkEnvDesc "PATH"                 "PATH variable is used to search for executables in certain codegens.",
+    MkEnvDesc "NO_COLOR"             "Instruct Idris not to print color to stdout. Passing the --color/--colour option will supercede this env var."]
 
 --- `public export` only for `auto` to work in `idrisGetEnv`
 public export

--- a/src/Idris/Env.idr
+++ b/src/Idris/Env.idr
@@ -44,7 +44,7 @@ envs = [
     MkEnvDesc "LDFLAGS"              "RefC backend: C linker flags (IDRIS2_LDFLAGS takes precedence).",
     MkEnvDesc "NODE"                 "NodeJS backend: NodeJS executable.",
     MkEnvDesc "PATH"                 "PATH variable is used to search for executables in certain codegens.",
-    MkEnvDesc "NO_COLOR"             "Instruct Idris not to print color to stdout. Passing the --color/--colour option will supercede this env var."]
+    MkEnvDesc "NO_COLOR"             "Instruct Idris not to print color to stdout. Passing the --color/--colour option will supersede this env var."]
 
 --- `public export` only for `auto` to work in `idrisGetEnv`
 public export

--- a/src/Idris/Pretty/Render.idr
+++ b/src/Idris/Pretty/Render.idr
@@ -29,14 +29,11 @@ render : {auto o : Ref ROpts REPLOpts} ->
          Doc ann -> Core String
 render stylerAnn doc = do
   color <- getColor
-  isDumb <- (Just "dumb" ==) <$> coreLift (getEnv "TERM")
-  -- ^-- emacs sets the TERM variable to `dumb` and expects the compiler
-  --     to not emit any ANSI escape codes
   pageWidth <- getPageWidth
   let opts = MkLayoutOptions pageWidth
   let layout = layoutPretty opts doc
   pure $ renderString $
-    if color && not isDumb
+    if color
       then reAnnotateS stylerAnn layout
       else unAnnotateS layout
 

--- a/tests/idris2/pkg006/expected
+++ b/tests/idris2/pkg006/expected
@@ -4,4 +4,4 @@ Uncaught error: EmptyFC:Failed to resolve the dependencies for test3:
 Uncaught error: EmptyFC:Failed to resolve the dependencies for test4:
   required baz any but no matching version is installed
 
-[38;5;3;1mWarning:[0m Deprecation warning: version numbers must now be of the form x.y.z
+Warning: Deprecation warning: version numbers must now be of the form x.y.z

--- a/tests/idris2/pkg006/run
+++ b/tests/idris2/pkg006/run
@@ -1,8 +1,8 @@
 rm -rf build
 
-$1 --build test1.ipkg
-$1 --build test2.ipkg
-$1 --build test3.ipkg
-$1 --build test4.ipkg
-$1 --build test5.ipkg
+$1 --no-color --build test1.ipkg
+$1 --no-color --build test2.ipkg
+$1 --no-color --build test3.ipkg
+$1 --no-color --build test4.ipkg
+$1 --no-color --build test5.ipkg
 


### PR DESCRIPTION
Closes https://github.com/idris-lang/Idris2/issues/1917.

I know that this works well in my testing of various Idris 2 CLI options and the REPL.

Would someone be willing to sanity check this works for IDE mode / emacs? It absolutely ought to, but seeing as how that was the express reason for checking `TERM` for "dumb" I'd like to be more confident than I am as a non-emacs user.