### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -36,6 +36,11 @@ else
 	SHLIB_SUFFIX := .so
 endif
 
+ifneq (, $(findstring freebsd, $(MACHINE)))
+	CFLAGS += -I/usr/local/include
+	LDFLAGS += -L/usr/local/lib
+endif
+
 ifneq ($(OS),windows)
 	CFLAGS += -fPIC
 else ifneq (, $(findstring NT-6.1,$(shell uname)))

--- a/config.mk
+++ b/config.mk
@@ -37,8 +37,8 @@ else
 endif
 
 ifneq (, $(findstring freebsd, $(MACHINE)))
-	CFLAGS += -I/usr/local/include
-	LDFLAGS += -L/usr/local/lib
+	CFLAGS += -I$(shell /sbin/sysctl -n user.localbase)/include
+	LDFLAGS += -L$(shell /sbin/sysctl -n user.localbase)/lib
 endif
 
 ifneq ($(OS),windows)


### PR DESCRIPTION
gmp is located in `/usr/local/{include,lib}`.

With this patch, to build on FreeBSD:

```
$ sudo pkg ins chez-scheme gmp
$ cd Idris2 && gmake bootstrap SCHEME=chez-scheme && gmake install
```

# Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a user-facing change or a compiler change, I have updated
      `CHANGELOG.md` (and potentially also `CONTRIBUTORS.md`).

