### PR TITLE
[ base ] fix the definition of die

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,10 @@
   release. Use `setBits8` and `getBits8` instead (with `cast` if you need to
   convert a `Bits8` to an `Int`), as their values are limited, as opposed to the
   assumption in `setByte` that the value is between 0 and 255.
+
 * Adds RefC support for 16- and 32-bit access in `Data.Buffer`.
+
+* `System`'s `die` now prints the error message on stderr rather than stdout
 
 #### System
 

--- a/libs/base/System.idr
+++ b/libs/base/System.idr
@@ -273,4 +273,12 @@ exitSuccess = exitWith ExitSuccess
 ||| Print the error message and call exitFailure
 export
 die : HasIO io => String -> io a
-die str = do putStrLn str; exitFailure
+die str
+  = do Right () <- fPutStrLn stderr str
+         | Left err => assert_total $ die
+           """
+           Error \{show err}
+           when printing the error
+           \{str}
+           """
+       exitFailure

--- a/libs/base/System.idr
+++ b/libs/base/System.idr
@@ -274,11 +274,5 @@ exitSuccess = exitWith ExitSuccess
 export
 die : HasIO io => String -> io a
 die str
-  = do Right () <- fPutStrLn stderr str
-         | Left err => assert_total $ die
-           """
-           Error \{show err}
-           when printing the error
-           \{str}
-           """
+  = do ignore $ fPutStrLn stderr str
        exitFailure


### PR DESCRIPTION
We should not print error messages to stdout
