### PR TITLE
CI Maintenance

### DIFF
--- a/.github/workflows/ci-bootstrap.yml
+++ b/.github/workflows/ci-bootstrap.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # for pull_request so we can do HEAD^2
           fetch-depth: 2
@@ -53,7 +53,7 @@ jobs:
       SCHEME: scheme
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install build dependencies (LTS versions)
         run: |
           sudo apt-get update

--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -38,7 +38,13 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IDRIS2_VERSION: 0.6.0 # For previous-version build
+  # We aim to keep newest Idris commits buildable by as early of a
+  # previous version as possible. In reality, we bump this regularly
+  # to allow us to use new compiler/library features in the compiler
+  # codebase, but an admirable longterm goal is to support building the
+  # current version of the compiler with a previous version that is older
+  # than its immediate predecessor.
+  IDRIS2_MINIMUM_COMPAT_VERSION: 0.6.0
 
 jobs:
 
@@ -94,19 +100,19 @@ jobs:
         id: previous-version-cache
         uses: actions/cache@v2
         with:
-          path: Idris2-${{ env.IDRIS2_VERSION }}
-          key: ${{ runner.os }}-idris2-bootstrapped-chez-${{ env.IDRIS2_VERSION }}
+          path: Idris2-${{ env.IDRIS2_MINIMUM_COMPAT_VERSION }}
+          key: ${{ runner.os }}-idris2-bootstrapped-chez-${{ env.IDRIS2_MINIMUM_COMPAT_VERSION }}
       - name : Build previous version
         if: steps.previous-version-cache.outputs.cache-hit != 'true'
         run: |
-          wget "https://www.idris-lang.org/idris2-src/idris2-$IDRIS2_VERSION.tgz"
-          tar zxvf "idris2-$IDRIS2_VERSION.tgz"
-          cd "Idris2-$IDRIS2_VERSION"
+          wget "https://www.idris-lang.org/idris2-src/idris2-$IDRIS2_MINIMUM_COMPAT_VERSION.tgz"
+          tar zxvf "idris2-$IDRIS2_MINIMUM_COMPAT_VERSION.tgz"
+          cd "Idris2-$IDRIS2_MINIMUM_COMPAT_VERSION"
           make bootstrap
           cd ..
       - name: Install previous version
         run: |
-          cd "Idris2-$IDRIS2_VERSION"
+          cd "Idris2-$IDRIS2_MINIMUM_COMPAT_VERSION"
           make install
           cd ..
 
@@ -117,7 +123,7 @@ jobs:
       - name: Artifact Idris2 from previous version
         uses: actions/upload-artifact@v2
         with:
-          name: ubuntu-installed-idris2-${{ env.IDRIS2_VERSION }}-chez
+          name: ubuntu-installed-idris2-${{ env.IDRIS2_MINIMUM_COMPAT_VERSION }}-chez
           path: ~/.idris2/
 
   ######################################################################
@@ -378,7 +384,7 @@ jobs:
       - name: Download Idris2 Artifact
         uses: actions/download-artifact@v2
         with:
-          name: ubuntu-installed-idris2-${{ env.IDRIS2_VERSION }}-chez
+          name: ubuntu-installed-idris2-${{ env.IDRIS2_MINIMUM_COMPAT_VERSION }}-chez
           path: ~/.idris2/
       - name: Install build dependencies
         run: |

--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -133,7 +133,7 @@ jobs:
   # CHEZ
 
   ubuntu-bootstrap-chez:
-    needs: quick-check
+    needs: [initialise, quick-check]
     runs-on: ubuntu-latest
     if: |
       !contains(needs.initialise.outputs.commit_message, '[ci:')
@@ -161,7 +161,7 @@ jobs:
           path: ~/.idris2/
 
   macos-bootstrap-chez:
-    needs: quick-check
+    needs: [initialise, quick-check]
     runs-on: macos-latest
     if: |
       !contains(needs.initialise.outputs.commit_message, '[ci:')
@@ -189,7 +189,7 @@ jobs:
           path: ~/.idris2/
 
   windows-bootstrap-chez:
-    needs: quick-check
+    needs: [initialise, quick-check]
     runs-on: windows-latest
     if: |
       !contains(needs.initialise.outputs.commit_message, '[ci:')
@@ -239,7 +239,7 @@ jobs:
           path: ${{ env.IDRIS_PREFIX }}
 
   nix-bootstrap-chez:
-    needs: quick-check
+    needs: [initialise, quick-check]
     runs-on: ubuntu-latest
     if: |
       false && (!contains(needs.initialise.outputs.commit_message, '[ci:')
@@ -260,7 +260,7 @@ jobs:
   # RACKET
 
   ubuntu-bootstrap-racket:
-    needs: quick-check
+    needs: [initialise, quick-check]
     runs-on: ubuntu-latest
     if: |
       !contains(needs.initialise.outputs.commit_message, '[ci:')
@@ -370,7 +370,7 @@ jobs:
         run: make ci-ubuntu-test INTERACTIVE=''
 
   ubuntu-self-host-previous-version:
-    needs: quick-check
+    needs: [initialise, quick-check]
     runs-on: ubuntu-latest
     if: |
       !contains(needs.initialise.outputs.commit_message, '[ci:')
@@ -403,7 +403,7 @@ jobs:
           path: ~/.idris2/
 
   windows-self-host-racket:
-    needs: windows-bootstrap-chez
+    needs: [initialise, windows-bootstrap-chez]
     runs-on: windows-latest
     if: |
       !contains(needs.initialise.outputs.commit_message, '[ci:')
@@ -496,7 +496,7 @@ jobs:
   ######################################################################
 
   ubuntu-test-collie:
-    needs: ubuntu-self-host-previous-version
+    needs: [initialise, ubuntu-self-host-previous-version]
     runs-on: ubuntu-latest
     if: |
       !contains(needs.initialise.outputs.commit_message, '[ci:')
@@ -524,7 +524,7 @@ jobs:
           make
 
   ubuntu-test-frex:
-    needs: ubuntu-self-host-previous-version
+    needs: [initialise, ubuntu-self-host-previous-version]
     runs-on: ubuntu-latest
     if: |
       !contains(needs.initialise.outputs.commit_message, '[ci:')
@@ -553,7 +553,7 @@ jobs:
           make test
 
   ubuntu-test-elab:
-    needs: ubuntu-self-host-previous-version
+    needs: [initialise, ubuntu-self-host-previous-version]
     runs-on: ubuntu-latest
     if: |
       !contains(needs.initialise.outputs.commit_message, '[ci:')
@@ -585,7 +585,7 @@ jobs:
   ######################################################################
 
   ubuntu-katla:
-    needs: ubuntu-test-collie
+    needs: [initialise, ubuntu-test-collie]
     runs-on: ubuntu-latest
     if: |
       !contains(needs.initialise.outputs.commit_message, '[ci:')

--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -250,8 +250,6 @@ jobs:
       with:
           fetch-depth: 0
     - uses: cachix/install-nix-action@v18
-#      with:
-#        install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20210126_f15f0b8/install
     - name: Test with nix
       env:
         NIX_CONFIG: "experimental-features = nix-command flakes"

--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -250,8 +250,8 @@ jobs:
       with:
           fetch-depth: 0
     - uses: cachix/install-nix-action@v18
-      with:
-        install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20210126_f15f0b8/install
+#      with:
+#        install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20210126_f15f0b8/install
     - name: Test with nix
       env:
         NIX_CONFIG: "experimental-features = nix-command flakes"

--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -242,14 +242,14 @@ jobs:
     needs: [initialise, quick-check]
     runs-on: ubuntu-latest
     if: |
-      false && (!contains(needs.initialise.outputs.commit_message, '[ci:')
+      (!contains(needs.initialise.outputs.commit_message, '[ci:')
       || contains(needs.initialise.outputs.commit_message, '[ci: nix]')
       || contains(needs.initialise.outputs.commit_message, '[ci: chez]'))
     steps:
     - uses: actions/checkout@v3
       with:
           fetch-depth: 0
-    - uses: cachix/install-nix-action@v12
+    - uses: cachix/install-nix-action@v18
       with:
         install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20210126_f15f0b8/install
     - name: Test with nix

--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # for pull_request so we can do HEAD^2
           fetch-depth: 2
@@ -87,7 +87,7 @@ jobs:
       SCHEME: scheme
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install build dependencies
         run: |
           sudo apt-get update
@@ -98,7 +98,7 @@ jobs:
       # or by rebuilding it if necessary.
       - name: Cache Chez Previous Version
         id: previous-version-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: Idris2-${{ env.IDRIS2_MINIMUM_COMPAT_VERSION }}
           key: ${{ runner.os }}-idris2-bootstrapped-chez-${{ env.IDRIS2_MINIMUM_COMPAT_VERSION }}
@@ -121,7 +121,7 @@ jobs:
         run: |
           make && make install
       - name: Artifact Idris2 from previous version
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ubuntu-installed-idris2-${{ env.IDRIS2_MINIMUM_COMPAT_VERSION }}-chez
           path: ~/.idris2/
@@ -144,7 +144,7 @@ jobs:
       SCHEME: scheme
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install build dependencies
         run: |
           sudo apt-get update
@@ -155,7 +155,7 @@ jobs:
       - name: Build from bootstrap
         run: make bootstrap && make install
       - name: Artifact Bootstrapped Idris2
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ubuntu-installed-bootstrapped-idris2-chez
           path: ~/.idris2/
@@ -171,7 +171,7 @@ jobs:
       SCHEME: chez
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install build dependencies
         run: |
           brew install chezscheme
@@ -183,7 +183,7 @@ jobs:
         run: make bootstrap && make install
         shell: bash
       - name: Artifact Bootstrapped Idris2
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: macos-installed-bootstrapped-idris2-chez
           path: ~/.idris2/
@@ -206,7 +206,7 @@ jobs:
         run: |
           git config --global core.autocrlf false
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Get Chez Scheme
         run: |
           git clone --depth 1 https://github.com/cisco/ChezScheme
@@ -233,7 +233,7 @@ jobs:
       - name: Install
         run: c:\msys64\usr\bin\bash -l -c "cd $env:PWD && make install"
       - name: Artifact Idris2 from chez
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: windows-installed-bootstrapped-idris2-chez
           path: ${{ env.IDRIS_PREFIX }}
@@ -246,7 +246,7 @@ jobs:
       || contains(needs.initialise.outputs.commit_message, '[ci: nix]')
       || contains(needs.initialise.outputs.commit_message, '[ci: chez]'))
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
           fetch-depth: 0
     - uses: cachix/install-nix-action@v12
@@ -271,7 +271,7 @@ jobs:
       IDRIS2_CG: racket
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install build dependencies
         run: |
           sudo apt-get install -y racket
@@ -281,7 +281,7 @@ jobs:
       - name: Build from bootstrap
         run: make bootstrap-racket && make install
       - name: Artifact Bootstrapped Idris2
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ubuntu-installed-bootstrapped-idris2-racket
           path: ~/.idris2/
@@ -300,9 +300,9 @@ jobs:
       SCHEME: scheme
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Download Idris2 Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ubuntu-installed-bootstrapped-idris2-chez
           path: ~/.idris2/
@@ -324,9 +324,9 @@ jobs:
       SCHEME: chez
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Download Idris2 Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: macos-installed-bootstrapped-idris2-chez
           path: ~/.idris2/
@@ -353,9 +353,9 @@ jobs:
       IDRIS2_CG: racket
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Download Idris2 Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ubuntu-installed-bootstrapped-idris2-racket
           path: ~/.idris2/
@@ -380,9 +380,9 @@ jobs:
       IDRIS2_CG: chez
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Download Idris2 Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ubuntu-installed-idris2-${{ env.IDRIS2_MINIMUM_COMPAT_VERSION }}-chez
           path: ~/.idris2/
@@ -397,7 +397,7 @@ jobs:
       - name: Test self-hosted from previous version
         run: make ci-ubuntu-test INTERACTIVE=''
       - name: Artifact Idris2
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: idris2-nightly-chez
           path: ~/.idris2/
@@ -421,7 +421,7 @@ jobs:
           git config --global core.autocrlf false
           echo "PWD=$(c:\msys64\usr\bin\cygpath -u $(pwd))" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Get Chez Scheme
         run: |
           git clone --depth 1 https://github.com/cisco/ChezScheme
@@ -439,7 +439,7 @@ jobs:
           echo "IDRIS_PREFIX=$idris" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "PREFIX=$(c:\msys64\usr\bin\cygpath -u $idris)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Download Idris2 Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: windows-installed-bootstrapped-idris2-chez
           path: ${{ env.IDRIS_PREFIX }}
@@ -469,9 +469,9 @@ jobs:
       IDRIS2_CG: chez
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Download Idris2 Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ubuntu-installed-bootstrapped-idris2-chez
           path: ~/.idris2/
@@ -505,7 +505,7 @@ jobs:
       IDRIS2_CG: chez
     steps:
       - name: Download Idris2 Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: idris2-nightly-chez
           path: ~/.idris2/
@@ -516,7 +516,7 @@ jobs:
           echo "$HOME/.idris2/bin" >> "$GITHUB_PATH"
           chmod +x "$HOME/.idris2/bin/idris2" "$HOME/.idris2/bin/idris2_app/"*
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'ohad/collie'
       - name: Build Collie
@@ -533,7 +533,7 @@ jobs:
       IDRIS2_CG: chez
     steps:
       - name: Download Idris2 Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: idris2-nightly-chez
           path: ~/.idris2/
@@ -544,7 +544,7 @@ jobs:
           echo "$HOME/.idris2/bin" >> "$GITHUB_PATH"
           chmod +x "$HOME/.idris2/bin/idris2" "$HOME/.idris2/bin/idris2_app/"*
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'frex-project/idris-frex'
       - name: Build Frex
@@ -562,7 +562,7 @@ jobs:
       IDRIS2_CG: chez
     steps:
       - name: Download Idris2 Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: idris2-nightly-chez
           path: ~/.idris2/
@@ -573,7 +573,7 @@ jobs:
           echo "$HOME/.idris2/bin" >> "$GITHUB_PATH"
           chmod +x "$HOME/.idris2/bin/idris2" "$HOME/.idris2/bin/idris2_app/"*
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'stefan-hoeck/idris2-elab-util'
       - name: Build idris2-elab-util
@@ -601,7 +601,7 @@ jobs:
           fi
 
       - name: Download Idris2 Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: idris2-nightly-chez
           path: ~/.idris2/
@@ -612,26 +612,26 @@ jobs:
           echo "$HOME/.idris2/bin" >> "$GITHUB_PATH"
           chmod +x "$HOME/.idris2/bin/idris2" "$HOME/.idris2/bin/idris2_app/"*
       - name: Checkout idris2
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build API
         run: make install-api
         shell: bash
       - name: Checkout collie
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'ohad/collie'
       - name: Build and install Collie
         run: |
           make install
       - name: Checkout idrall
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'alexhumphreys/idrall'
       - name: Build and install idrall
         run: |
           make install
       - name: Checkout katla
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'idris-community/katla'
       - name: Build and install katla
@@ -641,7 +641,7 @@ jobs:
           cp -r build/exec/* "${HOME}"/.local/bin/
           echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
       - name: Checkout idris2
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build html doc & landing page
         run: |
           make -C libs/prelude/ install docs IDRIS2=idris2

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Lint the sources
         run: python3 lint/lint.py
         shell: bash

--- a/.github/workflows/ci-sphinx.yml
+++ b/.github/workflows/ci-sphinx.yml
@@ -15,7 +15,7 @@ jobs:
     name: Sphinx
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs/"

--- a/.github/workflows/ci-super-linter.yml
+++ b/.github/workflows/ci-super-linter.yml
@@ -39,7 +39,7 @@ jobs:
       # Checkout the code base #
       ##########################
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
@@ -48,7 +48,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter@v4.8.5
+        uses: github/super-linter@v4
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_CPP: false # C files predate linting


### PR DESCRIPTION
- Update GitHub Action versions.
- Fix logic around `needs.initialise` (the newer version of GitHub's linter actually caught this problem).
- Re-enable a fixed Nix CI stage.
- Rename an ENV var and add clarity to the inline documentation.