### PR TITLE
[ new ] `popen`/`pclose` for the NodeJS backend.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 #### Node.js
 
 * Generated JavaScript files now include a shebang when using the Node.js backend
+* NodeJS now supports `popen`/`pclose` for the `Read` mode.
 
 ### Compiler changes
 

--- a/libs/base/System/File/Process.idr
+++ b/libs/base/System/File/Process.idr
@@ -9,8 +9,10 @@ import public System.File.Types
 %foreign "C:fflush,libc 6"
 prim__flush : FilePtr -> PrimIO Int
 %foreign supportC "idris2_popen"
+         supportNode "popen"
 prim__popen : String -> String -> PrimIO FilePtr
 %foreign supportC "idris2_pclose"
+         supportNode "pclose"
 prim__pclose : FilePtr -> PrimIO Int
 
 ||| Force a write of all user-space buffered data for the given `File`.
@@ -24,6 +26,11 @@ fflush (FHandle f)
 ||| Create a new unidirectional pipe by invoking the shell, which is passed the
 ||| given command-string using the '-c' flag, in a new process. The pipe is
 ||| opened with the given mode.
+|||
+||| IMPORTANT: The NodeJS backend only currently supports the Read mode. Also with
+|||            the NodeJS backend, the opened process will finish execution before
+|||            popen returns (it blocks on open) which is different than other
+|||            backends which will block on close.
 |||
 ||| @ cmd the command to pass to the shell
 ||| @ m   the mode the pipe should have

--- a/libs/base/System/File/ReadWrite.idr
+++ b/libs/base/System/File/ReadWrite.idr
@@ -30,7 +30,7 @@ prim__readChar : FilePtr -> PrimIO Int
 prim__writeLine : FilePtr -> String -> PrimIO Int
 
 %foreign supportC "idris2_eof"
-         "node:lambda:x=>(x.eof?1:0)"
+         "node:lambda:f=>(f.eof?1:0)"
 prim__eof : FilePtr -> PrimIO Int
 
 %foreign supportC "idris2_removeFile"

--- a/support/js/support_system_file.js
+++ b/support/js/support_system_file.js
@@ -112,12 +112,6 @@ function support_system_file_popen (cmd, m) {
   }
 
   const tmp_file = require('os').tmpdir() + "/" + require('crypto').randomBytes(15).toString('hex')
-  try {
-    support_system_file_fs.writeFileSync(tmp_file, '')
-  } catch (e) {
-    process.__lasterr = e
-    return null
-  }
   const write_fd = support_system_file_fs.openSync(
     tmp_file,
     'w'
@@ -126,10 +120,10 @@ function support_system_file_popen (cmd, m) {
   var io_setting
   switch (mode) {
     case "r":
-      io_setting = ['inherit', write_fd, 2]
+      io_setting = ['ignore', write_fd, 2]
       break
     case "w", "a":
-      io_setting = [write_fd, 'inherit', 2]
+      io_setting = [write_fd, 'ignore', 2]
       break
     default:
       process.__lasterr = 'The popen function cannot be used for reading and writing simultaneously.'
@@ -142,11 +136,13 @@ function support_system_file_popen (cmd, m) {
     { stdio: io_setting, shell: true }
   )
 
+  support_system_file_fs.closeSync(write_fd)
+
   if (error) {
     process.__lasterr = error
+    return null
   }
 
-  support_system_file_fs.closeSync(write_fd)
   const read_ptr = support_system_file_openFile(
     tmp_file,
     'r'

--- a/support/js/support_system_file.js
+++ b/support/js/support_system_file.js
@@ -1,5 +1,5 @@
 const support_system_file_fs = require('fs')
-
+const support_system_file_child_process = require('child_process')
 
 function support_system_file_fileErrno(){
   const n = process.__lasterr===undefined?0:process.__lasterr.errno || 0
@@ -62,9 +62,13 @@ function support_system_file_getStr () {
   return support_system_file_readLine({ fd: 0, buffer: Buffer.alloc(0), name: '<stdin>', eof: false })
 }
 
+function support_system_file_parseMode(mode) {
+  return mode.replace('b', '')
+}
+
 function support_system_file_openFile (n, m) {
   try {
-    const fd = support_system_file_fs.openSync(n, m.replace('b', ''))
+    const fd = support_system_file_fs.openSync(n, support_system_file_parseMode(m))
     return { fd: fd, buffer: Buffer.alloc(0), name: n, eof: false }
   } catch (e) {
     process.__lasterr = e
@@ -90,4 +94,70 @@ function support_system_file_removeFile (filename) {
     process.__lasterr = e
     return 1
   }
+}
+
+// IMPLEMENTATION NOTE:
+// If in the future Idris's NodeJS backend supports executing async code, the
+// far superior and more true-to-C way to implement popen/pclose would be to
+// spawn in popen (instead of spawnSync) and then in pclose await the processes
+// completion.
+//
+// Note doing the above makes it impossible to support the use-case for popen of
+// writing to the child process's stdin between popen and pclose.
+function support_system_file_popen (cmd, m) {
+  const mode = support_system_file_parseMode(m)
+  if (mode != 'r') {
+    process.__lasterr = 'The NodeJS popen FFI only supports opening for reading currently.'
+    return null
+  }
+
+  const tmp_file = require('os').tmpdir() + "/" + require('crypto').randomBytes(15).toString('hex')
+  try {
+    support_system_file_fs.writeFileSync(tmp_file, '')
+  } catch (e) {
+    process.__lasterr = e
+    return null
+  }
+  const write_fd = support_system_file_fs.openSync(
+    tmp_file,
+    'w'
+  )
+
+  var io_setting
+  switch (mode) {
+    case "r":
+      io_setting = ['inherit', write_fd, 2]
+      break
+    case "w", "a":
+      io_setting = [write_fd, 'inherit', 2]
+      break
+    default:
+      process.__lasterr = 'The popen function cannot be used for reading and writing simultaneously.'
+      return null
+  }
+
+  const { status, error  } = support_system_file_child_process.spawnSync(
+    cmd,
+    [],
+    { stdio: io_setting, shell: true }
+  )
+
+  if (error) {
+    process.__lasterr = error
+  }
+
+  support_system_file_fs.closeSync(write_fd)
+  const read_ptr = support_system_file_openFile(
+    tmp_file,
+    'r'
+  )
+
+  return { ...read_ptr, exit_code: status }
+}
+
+function support_system_file_pclose (file_ptr) {
+  const { fd, name, exit_code } = file_ptr
+  support_system_file_fs.closeSync(fd)
+  support_system_file_removeFile(name)
+  return exit_code
 }

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -334,10 +334,10 @@ nodeTests : TestPool
 nodeTests = MkTestPool "Node backend" [] (Just Node)
     [ "node001", "node002", "node003", "node004", "node005", "node006"
     , "node007", "node008", "node009", "node011", "node012", "node015"
-    , "node017", "node018", "node019", "node021", "node022", "node023"
-    , "node024", "node025", "node026", "node027"
+    , "node017", "node018", "node019", "node020", "node021", "node022"
+    , "node023", "node024", "node025", "node026", "node027"
     , "perf001"
-    -- , "node14", "node020"
+    -- , "node14"
     , "args"
     , "bitops"
     , "casts"

--- a/tests/node/node020/Popen.idr
+++ b/tests/node/node020/Popen.idr
@@ -26,5 +26,4 @@ main = do
     ignore $ pclose fh
     putStrLn "closed"
     let (idris2 ::: _) = split ((==) ',') output
-        | _ => printLn "Unexpected result"
     putStrLn idris2

--- a/tests/node/node020/Popen.idr
+++ b/tests/node/node020/Popen.idr
@@ -2,6 +2,7 @@ import System
 import System.File
 import System.Info
 import Data.String
+import Data.List1
 
 windowsPath : String -> String
 windowsPath path =
@@ -24,6 +25,6 @@ main = do
         | Left err => printLn err
     ignore $ pclose fh
     putStrLn "closed"
-    let [idris2, _] = split ((==) ',') output
+    let (idris2 ::: _) = split ((==) ',') output
         | _ => printLn "Unexpected result"
     putStrLn idris2

--- a/tests/node/node020/expected
+++ b/tests/node/node020/expected
@@ -1,5 +1,5 @@
-opened
+1/1: Building Popen (Popen.idr)
+Main> opened
 closed
 Idris 2
-1/1: Building Popen (Popen.idr)
-Main> Main> Bye for now!
+Main> Bye for now!

--- a/tests/node/node020/run
+++ b/tests/node/node020/run
@@ -1,4 +1,4 @@
 rm -rf build
 
-POPEN_CMD="$1 --version" $1 --no-color --console-width 0 --cg node --no-banner Popen.idr < input
+POPEN_CMD="echo 'Idris 2'" $1 --no-color --console-width 0 --cg node --no-banner Popen.idr < input
 

--- a/tests/node/node020/run
+++ b/tests/node/node020/run
@@ -1,4 +1,4 @@
 rm -rf build
 
-POPEN_CMD="echo 'Idris 2'" $1 --no-color --console-width 0 --cg node --no-banner Popen.idr < input
+POPEN_CMD="$1 --version" $1 --no-color --console-width 0 --cg node --no-banner Popen.idr < input
 


### PR DESCRIPTION
I've added support for `popen` and `pclose` to the NodeJS backend. I could not find a way to use the asynchronous `spawn` function for `popen` because there is no way (without using `await`) to block until the child process is done in `pclose`. This means the functionality is slightly different for NodeJS than for C/Chez, but I think it's still better to have `popen` than not -- especially with some really nice base library functions like `run` built on top of `popen`.

My seemingly random changes to CHANGELOG are in response to Super Linter becoming more opinionated in a recent release and this being the first PR that changed the CHANGELOG since then. It literally says to use "filename" instead of "file name" and "built-in" instead of "built in."

### Should this change go in the CHANGELOG?
<!-- Please delete this section if it doesn't apply -->
- [x] If this is a user-facing change or a compiler change, I have updated
      `CHANGELOG.md` (and potentially also `CONTRIBUTORS.md`).

