### PR TITLE
fix nix/text-editor.nix

### DIFF
--- a/nix/text-editor.nix
+++ b/nix/text-editor.nix
@@ -7,7 +7,7 @@ let
       ${my-emacs}/bin/emacs -q -l ${init-file} $@
     '';
 in rec {
-  idris2-mode = emacsPackages.melpaBuild {
+  idris2-mode = emacsPackages.trivialBuild {
     pname = "idris2-mode";
     src = idris-emacs-src;
     packageRequires = with pkgs.emacsPackages.melpaPackages; [ prop-menu ];


### PR DESCRIPTION
I've fixed the emacs nix expression by using `emacsPackages.trivialBuild` instead of `emacsPackages.elpaBuild`. This fixes #2859