### PR TITLE
[ error ] Fix location of type errors in do block pattern matching

### DIFF
--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -609,10 +609,11 @@ mutual
            rest' <- expandDo side ps' topfc ns rest
            let fcOriginal = fc
            let fc = virtualiseFC fc
+           let patFC = virtualiseFC (getFC bpat)
            pure $ bindFun fc ns exp'
                 $ ILam EmptyFC top Explicit (Just (MN "_" 0))
                           (Implicit fc False)
-                          (ICase fc (IVar EmptyFC (MN "_" 0))
+                          (ICase fc (IVar patFC (MN "_" 0))
                                (Implicit fc False)
                                (PatClause fcOriginal bpat rest'
                                   :: alts'))

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -89,6 +89,7 @@ idrisTestsError = MkTestPool "Error messages" [] Nothing
        "error011", "error012", "error013", "error014", "error015",
        "error016", "error017", "error018", "error019", "error020",
        "error021", "error022", "error023", "error024", "error025",
+       "error026",
        -- Parse errors
        "perror001", "perror002", "perror003", "perror004", "perror005",
        "perror006", "perror007", "perror008", "perror009", "perror010",

--- a/tests/idris2/error026/DoBlockFC.idr
+++ b/tests/idris2/error026/DoBlockFC.idr
@@ -1,0 +1,7 @@
+-- We expect the error to occur at a non-empty FC
+bar : Maybe Int
+
+foo : Either String Int
+foo = do
+  Right n <- pure bar | _ => Left "fail"
+  pure 42

--- a/tests/idris2/error026/expected
+++ b/tests/idris2/error026/expected
@@ -1,0 +1,15 @@
+1/1: Building DoBlockFC (DoBlockFC.idr)
+Error: While processing right hand side of foo. When unifying:
+    Maybe Int
+and:
+    Either ?_ ?_
+Mismatch between: Maybe Int and Either ?_ ?_.
+
+DoBlockFC:6:3--6:10
+ 2 | bar : Maybe Int
+ 3 | 
+ 4 | foo : Either String Int
+ 5 | foo = do
+ 6 |   Right n <- pure bar | _ => Left "fail"
+       ^^^^^^^
+

--- a/tests/idris2/error026/run
+++ b/tests/idris2/error026/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --check DoBlockFC.idr


### PR DESCRIPTION
When a type error occurs in a pattern matching bind in a do block, it ends up at the top of the file (EmptyFC), making it hard to locate the issue.  This PR adds the FC of the principal pattern in the assignment to the scrutinee of the generated case statement, which is where the type error ends up occurring.

For example, before this change we have:
```
1/1: Building tests.idris2.error026.DoBlockFC (tests/idris2/error026/DoBlockFC.idr)
Error: While processing right hand side of foo. When unifying:
    Maybe Int
and:
    Either ?_ ?_
Mismatch between: Maybe Int and Either ?_ ?_.
```
After the fix, we get:
```
1/1: Building DoBlockFC (DoBlockFC.idr)
LOG elab:1: pat' (Right n) bpat (Right $n) DoBlockFC:7:3--7:10
Error: While processing right hand side of foo. When unifying:
    Maybe Int
and:
    Either ?_ ?_
Mismatch between: Maybe Int and Either ?_ ?_.

DoBlockFC:7:3--7:10
 3 | bar : Maybe Int
 4 |
 5 | foo : Either String Int
 6 | foo = do
 7 |   Right n <- pure bar | _ => Left "fail"
       ^^^^^^^
```


## Should this change go in the CHANGELOG?

I don't think this is necessary, unless we want to add "improve error messages" to cover this and similar fixes.
