### PR TITLE
[ fix #2087 ] Fix multiline string with CRLF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@
   the number of configured processors.
 
 #### Contrib
+
 * Remove Data.List.HasLength from contrib library but add it to the base library
   with the type signature from the compiler codebase and some of the naming
   from the contrib library. The type ended up being `HasLength n xs` rather than
@@ -112,6 +113,7 @@
   J. Garret Morris, and Aaron Stump
 
 ### Other Changes
+
 * The `data` subfolder of an installed or local dependency package is now automatically
   recognized as a "data" directory by Idris 2. See the
   [documentation on Packages](https://idris2.readthedocs.io/en/latest/reference/packages.html)

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -27,6 +27,7 @@ import Idris.Elab.Interface
 import Idris.Desugar.Mutual
 
 import Parser.Lexer.Source
+import Parser.Support
 
 import TTImp.BindImplicits
 import TTImp.Parser
@@ -329,19 +330,21 @@ mutual
     = do when (side == LHS) $
            throw (GenericMsg fc "? is not a valid pattern")
          pure $ Implicit fc False
-  desugarB side ps (PMultiline fc indent lines)
-      = addFromString fc !(expandString side ps fc !(trimMultiline fc indent lines))
+  desugarB side ps (PMultiline fc hashtag indent lines)
+      = addFromString fc !(expandString side ps fc hashtag !(trimMultiline fc indent lines))
 
   -- We only add `fromString` if we are looking at a plain string literal.
   -- Interpolated string literals don't have a `fromString` call since they
   -- are always concatenated with other strings and therefore can never use
   -- another `fromString` implementation that differs from `id`.
-  desugarB side ps (PString fc [])
+  desugarB side ps (PString fc hashtag [])
       = addFromString fc (IPrimVal fc (Str ""))
-  desugarB side ps (PString fc [StrLiteral fc' str])
-      = addFromString fc (IPrimVal fc' (Str str))
-  desugarB side ps (PString fc strs)
-      = expandString side ps fc strs
+  desugarB side ps (PString fc hashtag [StrLiteral fc' str])
+      = case unescape hashtag str of
+             Just str => addFromString fc (IPrimVal fc' (Str str))
+             Nothing => throw (GenericMsg fc "Invalid escape sequence: \{show str}")
+  desugarB side ps (PString fc hashtag strs)
+      = expandString side ps fc hashtag strs
 
   desugarB side ps (PDoBlock fc ns block)
       = expandDo side ps fc ns block
@@ -491,8 +494,8 @@ mutual
                  {auto m : Ref MD Metadata} ->
                  {auto u : Ref UST UState} ->
                  {auto o : Ref ROpts REPLOpts} ->
-                 Side -> List Name -> FC -> List PStr -> Core RawImp
-  expandString side ps fc xs
+                 Side -> List Name -> FC -> Nat -> List PStr -> Core RawImp
+  expandString side ps fc hashtag xs
     = do xs <- traverse toRawImp (filter notEmpty $ mergeStrLit xs)
          pure $ case xs of
            [] => IPrimVal fc (Str "")
@@ -506,7 +509,10 @@ mutual
                (strInterpolate xs)
     where
       toRawImp : PStr -> Core RawImp
-      toRawImp (StrLiteral fc str) = pure $ IPrimVal fc (Str str)
+      toRawImp (StrLiteral fc str) =
+        case unescape hashtag str of
+             Just str => pure $ IPrimVal fc (Str str)
+             Nothing => throw (GenericMsg fc "Invalid escape sequence: \{show str}")
       toRawImp (StrInterp fc tm) = desugarB side ps tm
 
       -- merge neighbouring StrLiteral
@@ -537,16 +543,14 @@ mutual
 
   trimMultiline : FC -> Nat -> List (List PStr) -> Core (List PStr)
   trimMultiline fc indent lines
-      = if indent == 0
-           then pure $ dropLastNL $ concat lines
-           else do
-             lines <- trimLast fc lines
-             lines <- traverse (trimLeft indent) lines
-             pure $ dropLastNL $ concat lines
+      = do lines <- trimLast fc lines
+           lines <- traverse (trimLeft indent) lines
+           pure $ concat $ dropLastNL lines
+
     where
       trimLast : FC -> List (List PStr) -> Core (List (List PStr))
       trimLast fc lines with (snocList lines)
-        trimLast fc [] | Empty = throw $ BadMultiline fc "Expected line wrap"
+        trimLast fc [] | Empty = throw $ BadMultiline fc "Expected new line"
         trimLast _ (initLines `snoc` []) | Snoc [] initLines _ = pure lines
         trimLast _ (initLines `snoc` [StrLiteral fc str]) | Snoc [(StrLiteral _ _)] initLines _
             = if any (not . isSpace) (fastUnpack str)
@@ -555,13 +559,6 @@ mutual
         trimLast _ (initLines `snoc` xs) | Snoc xs initLines _
             = let fc = fromMaybe fc $ findBy isStrInterp xs in
                   throw $ BadMultiline fc "Closing delimiter of multiline strings cannot be preceded by non-whitespace characters"
-
-      dropLastNL : List PStr -> List PStr
-      dropLastNL pstrs with (snocList pstrs)
-        dropLastNL [] | Empty = []
-        dropLastNL (initLines `snoc` (StrLiteral fc str)) | Snoc (StrLiteral _ _) initLines _
-            = initLines `snoc` (StrLiteral fc (fst $ break isNL str))
-        dropLastNL pstrs | _ = pstrs
 
       trimLeft : Nat -> List PStr -> Core (List PStr)
       trimLeft indent [] = pure []
@@ -577,6 +574,17 @@ mutual
               then throw $ BadMultiline fc "Line is less indented than the closing delimiter"
              else pure $ (StrLiteral fc (fastPack rest))::xs
       trimLeft indent xs = throw $ BadMultiline fc "Line is less indented than the closing delimiter"
+
+      mapLast : (a -> a) -> List a -> List a
+      mapLast f [] = []
+      mapLast f [x] = [f x]
+      mapLast f (x :: xs) = x :: mapLast f xs
+
+      dropLastNL : List (List PStr) -> List (List PStr)
+      dropLastNL
+          = mapLast $ mapLast $
+              \case StrLiteral fc str => StrLiteral fc (fst $ break isNL str)
+                    other => other
 
   expandDo : {auto s : Ref Syn SyntaxInfo} ->
              {auto c : Ref Ctxt Defs} ->

--- a/src/Idris/Doc/String.idr
+++ b/src/Idris/Doc/String.idr
@@ -549,7 +549,7 @@ getDocsForPTerm (PType _) = pure $ vcat
   [ "Type : Type"
   , indent 2 "The type of all types is Type. The type of Type is Type."
   ]
-getDocsForPTerm (PString _ _) = pure $ vcat
+getDocsForPTerm (PString _ _ _) = pure $ vcat
   [ "String Literal"
   , indent 2 "Desugars to a fromString call"
   ]

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1010,8 +1010,9 @@ mutual
                                           Left err => fatalLoc begin.bounds err
                                           Right pstrs => pure $ pstrs
                             strEnd
-                            pure pstrs
-           pure $ PString (boundToFC fname b) b.val
+                            pure (begin.val, pstrs)
+           pure $ let (hashtag, str) = b.val in
+                      PString (boundToFC fname b) hashtag str
     where
       toPStr : (WithBounds $ Either PTerm (List1 String)) -> Either String PStr
       toPStr x = case x.val of
@@ -1023,14 +1024,14 @@ mutual
   multilineStr : ParseOpts -> OriginDesc -> IndentInfo -> Rule PTerm
   multilineStr q fname idents
       = decorate fname Data $
-        do b <- bounds $ do multilineBegin
+        do b <- bounds $ do hashtag <- multilineBegin
                             commit
                             xs <- many $ bounds $ (interpBlock q fname idents) <||> strLitLines
                             endloc <- location
                             strEnd
-                            pure (endloc, toLines xs [<] [<])
-           pure $ let ((_, col), xs) = b.val in
-                      PMultiline (boundToFC fname b) (fromInteger $ cast col) xs
+                            pure (hashtag, endloc, toLines xs [<] [<])
+           pure $ let (hashtag, (_, col), xs) = b.val in
+                      PMultiline (boundToFC fname b) hashtag (fromInteger $ cast col) xs
     where
       toLines : List (WithBounds $ Either PTerm (List1 String)) ->
                 SnocList PStr -> SnocList (List PStr) -> List (List PStr)

--- a/src/Idris/Pretty.idr
+++ b/src/Idris/Pretty.idr
@@ -342,8 +342,8 @@ mutual
     prettyPrec d (PSectionR _ _ x op) = parens (pretty x <++> prettyOp op)
     prettyPrec d (PEq fc l r) = parenthesise (d > startPrec) $ prettyPrec Equal l <++> equals <++> prettyPrec Equal r
     prettyPrec d (PBracketed _ tm) = parens (pretty tm)
-    prettyPrec d (PString _ xs) = parenthesise (d > startPrec) $ hsep $ punctuate "++" (prettyPStr <$> xs)
-    prettyPrec d (PMultiline _ indent xs) =
+    prettyPrec d (PString _ _ xs) = parenthesise (d > startPrec) $ hsep $ punctuate "++" (prettyPStr <$> xs)
+    prettyPrec d (PMultiline _ _ indent xs) =
       "multiline" <++>
         (parenthesise (d > startPrec) $
            hsep $ punctuate "++" (prettyPStr <$> concat xs))

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -111,8 +111,8 @@ mutual
        PBracketed : FC -> PTerm' nm -> PTerm' nm
 
        -- Syntactic sugar
-       PString : FC -> List (PStr' nm) -> PTerm' nm
-       PMultiline : FC -> (indent : Nat) -> List (List (PStr' nm)) -> PTerm' nm
+       PString : FC -> (hashtag : Nat) -> List (PStr' nm) -> PTerm' nm
+       PMultiline : FC -> (hashtag : Nat) -> (indent : Nat) -> List (List (PStr' nm)) -> PTerm' nm
        PDoBlock : FC -> Maybe Namespace -> List (PDo' nm) -> PTerm' nm
        PBang : FC -> PTerm' nm -> PTerm' nm
        PIdiom : FC -> Maybe Namespace -> PTerm' nm -> PTerm' nm
@@ -175,8 +175,8 @@ mutual
   getPTermLoc (PSectionR fc _ _ _) = fc
   getPTermLoc (PEq fc _ _) = fc
   getPTermLoc (PBracketed fc _) = fc
-  getPTermLoc (PString fc _) = fc
-  getPTermLoc (PMultiline fc _ _) = fc
+  getPTermLoc (PString fc _ _) = fc
+  getPTermLoc (PMultiline fc _ _ _) = fc
   getPTermLoc (PDoBlock fc _ _) = fc
   getPTermLoc (PBang fc _) = fc
   getPTermLoc (PIdiom fc _ _) = fc
@@ -776,8 +776,8 @@ parameters {0 nm : Type} (toName : nm -> Name)
   showPTermPrec d (PSectionR _ _ x op) = "(" ++ showPTermPrec d x ++ " " ++ showOpPrec d op ++ ")"
   showPTermPrec d (PEq fc l r) = showPTermPrec d l ++ " = " ++ showPTermPrec d r
   showPTermPrec d (PBracketed _ tm) = "(" ++ showPTermPrec d tm ++ ")"
-  showPTermPrec d (PString _ xs) = join " ++ " $ showPStr <$> xs
-  showPTermPrec d (PMultiline _ indent xs) = "multiline (" ++ (join " ++ " $ showPStr <$> concat xs) ++ ")"
+  showPTermPrec d (PString _ _ xs) = join " ++ " $ showPStr <$> xs
+  showPTermPrec d (PMultiline _ _ indent xs) = "multiline (" ++ (join " ++ " $ showPStr <$> concat xs) ++ ")"
   showPTermPrec d (PDoBlock _ ns ds)
         = "do " ++ showSep " ; " (map showDo ds)
   showPTermPrec d (PBang _ tm) = "!" ++ showPTermPrec d tm

--- a/src/Idris/Syntax/Traversals.idr
+++ b/src/Idris/Syntax/Traversals.idr
@@ -119,11 +119,11 @@ mapPTermM f = goPTerm where
     goPTerm (PBracketed fc x) =
       PBracketed fc <$> goPTerm x
       >>= f
-    goPTerm (PString fc xs) =
-      PString fc <$> goPStrings xs
+    goPTerm (PString fc x ys) =
+      PString fc x <$> goPStrings ys
       >>= f
-    goPTerm (PMultiline fc x ys) =
-      PMultiline fc x <$> goPStringLines ys
+    goPTerm (PMultiline fc x y zs) =
+      PMultiline fc x y <$> goPStringLines zs
       >>= f
     goPTerm (PDoBlock fc ns xs) =
       PDoBlock fc ns <$> goPDos xs
@@ -446,10 +446,10 @@ mapPTerm f = goPTerm where
       = f $ PEq fc (goPTerm x) (goPTerm y)
     goPTerm (PBracketed fc x)
       = f $ PBracketed fc $ goPTerm x
-    goPTerm (PString fc xs)
-      = f $ PString fc $ goPStr <$> xs
-    goPTerm (PMultiline fc x ys)
-      = f $  PMultiline fc x $ map (map goPStr) ys
+    goPTerm (PString fc x ys)
+      = f $ PString fc x $ goPStr <$> ys
+    goPTerm (PMultiline fc x y zs)
+      = f $  PMultiline fc x y $ map (map goPStr) zs
     goPTerm (PDoBlock fc ns xs)
       = f $ PDoBlock fc ns $ goPDo <$> xs
     goPTerm (PBang fc x)
@@ -625,8 +625,8 @@ substFC fc = mapPTerm $ \case
   PSectionR _ _ x y => PSectionR fc fc x y
   PEq _ x y => PEq fc x y
   PBracketed _ x => PBracketed fc x
-  PString _ xs => PString fc xs
-  PMultiline _ indent xs => PMultiline fc indent xs
+  PString _ x ys => PString fc x ys
+  PMultiline _ x y zs => PMultiline fc x y zs
   PDoBlock _ x xs => PDoBlock fc x xs
   PBang _ x => PBang fc x
   PIdiom _ x y => PIdiom fc x y

--- a/src/Protocol/SExp/Parser.idr
+++ b/src/Protocol/SExp/Parser.idr
@@ -33,14 +33,14 @@ symbol req
 
 stringTokens : Tokenizer Token
 stringTokens
-    = match (someUntil (is '"') (escape (is '\\') any <|> any)) $ StringLit 0
+    = match (someUntil (is '"') (escape (is '\\') any <|> any)) StringLit
 
 ideTokens : Tokenizer Token
 ideTokens =
       match (choice $ exact <$> symbols) Symbol
   <|> match digits (IntegerLit . cast)
   <|> compose (is '"')
-              (const $ StringBegin Single)
+              (const $ StringBegin 0 Single)
               (const ())
               (const stringTokens)
               (const $ is '"')


### PR DESCRIPTION
This patch resolves issue #2087 and enhances the handling of multiline string literals:

1. Recognize `\r\n` at the end of a line, which was recognized as `\n\n` for two lines.
2. Dectect padding error before unescaping the literal, therefore this case becomes invalid:
```idirs
"""
    A line
\n
    Another line
    """
```

Closes https://github.com/idris-lang/Idris2/issues/2087

