### PR TITLE
[ refactor ] TTC Integer in terms of TTC Nat

### DIFF
--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -29,7 +29,7 @@ import public Libraries.Utils.Binary
 ||| version number if you're changing the version more than once in the same day.
 export
 ttcVersion : Int
-ttcVersion = 20230118 * 100 + 0
+ttcVersion = 20230224 * 100 + 0
 
 export
 checkTTCVersion : String -> Int -> Int -> Core ()


### PR DESCRIPTION
Implementing TTC Nat in terms of TTC Integer meant having a useless tag
(Nats are always >= 0). Let's do the opposite instead!
