### PR TITLE
[ fix #2895 ] don't erase argument when type is erased

### DIFF
--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -2387,6 +2387,15 @@ addLogLevel Nothing  = update Ctxt { options->session->logEnabled := False, opti
 addLogLevel (Just l) = update Ctxt { options->session->logEnabled := True, options->session->logLevel $= insertLogLevel l }
 
 export
+setLogLevel : {auto c : Ref Ctxt Defs} ->
+              LogLevel -> Core ()
+setLogLevel = addLogLevel . Just
+
+export
+stopLogging : {auto c : Ref Ctxt Defs} -> Core ()
+stopLogging = addLogLevel Nothing
+
+export
 withLogLevel : {auto c : Ref Ctxt Defs} ->
                LogLevel -> Core a -> Core a
 withLogLevel l comp = do

--- a/src/Core/TT.idr
+++ b/src/Core/TT.idr
@@ -854,6 +854,12 @@ data WhyErased a
   | Impossible
   | Dotted a
 
+export
+Show a => Show (WhyErased a) where
+  show Placeholder = "placeholder"
+  show Impossible = "impossible"
+  show (Dotted x) = "dotted \{show x}"
+
 %name WhyErased why
 
 export

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -132,7 +132,7 @@ idrisTestsLinear = MkTestPool "Quantities" [] Nothing
        ["linear001", "linear002", "linear003", -- "linear004" -- disabled due to requiring linearity subtyping
         "linear005", "linear006", "linear007", "linear008",
         "linear009", "linear010", "linear011", "linear012",
-        "linear013", "linear014", "linear015"]
+        "linear013", "linear014", "linear015", "linear016"]
 
 idrisTestsLiterate : TestPool
 idrisTestsLiterate = MkTestPool "Literate programming" [] Nothing

--- a/tests/idris2/linear016/Issue2895.idr
+++ b/tests/idris2/linear016/Issue2895.idr
@@ -1,0 +1,17 @@
+record Ty where
+  constructor MkTy
+  0 obj : Type
+
+record TyProj (d: Ty) where
+  constructor MkTyProj
+  proj : d.obj
+
+record Id (x : Type) where
+  constructor MkId
+  getId : x
+
+DepLensToDepOptic :
+  {c1 : TyProj (MkTy (Nat -> Type))} ->
+  Id (c1.proj 3) -> -- remove the Id works
+  Type
+DepLensToDepOptic (MkId b') = ?hu

--- a/tests/idris2/linear016/Issue2895.idr
+++ b/tests/idris2/linear016/Issue2895.idr
@@ -12,6 +12,6 @@ record Id (x : Type) where
 
 DepLensToDepOptic :
   {c1 : TyProj (MkTy (Nat -> Type))} ->
-  Id (c1.proj 3) -> -- remove the Id works
+  Id (proj c1 3) -> -- remove the Id works
   Type
 DepLensToDepOptic (MkId b') = ?hu

--- a/tests/idris2/linear016/Issue2895_2.idr
+++ b/tests/idris2/linear016/Issue2895_2.idr
@@ -9,7 +9,7 @@ record TyProj (d: Ty) where
 
 DepLensToDepOptic :
   {c1 : TyProj (MkTy (Nat -> Type))} ->
-  (c1.proj 3) ->
+  (proj c1 3) ->
   Type
 DepLensToDepOptic =
    (\(b) => ?mmm)

--- a/tests/idris2/linear016/Issue2895_2.idr
+++ b/tests/idris2/linear016/Issue2895_2.idr
@@ -1,0 +1,15 @@
+
+record Ty where
+  constructor MkTy
+  0 obj : Type
+
+record TyProj (d: Ty) where
+  constructor MkTyProj
+  proj : d.obj
+
+DepLensToDepOptic :
+  {c1 : TyProj (MkTy (Nat -> Type))} ->
+  (c1.proj 3) ->
+  Type
+DepLensToDepOptic =
+   (\(b) => ?mmm)

--- a/tests/idris2/linear016/expected
+++ b/tests/idris2/linear016/expected
@@ -1,0 +1,2 @@
+1/1: Building Issue2895 (Issue2895.idr)
+1/1: Building Issue2895_2 (Issue2895_2.idr)

--- a/tests/idris2/linear016/run
+++ b/tests/idris2/linear016/run
@@ -1,0 +1,4 @@
+$1 --no-color --console-width 0 --no-banner --check Issue2895.idr
+$1 --no-color --console-width 0 --no-banner --check Issue2895_2.idr
+
+rm -r build


### PR DESCRIPTION
A much better solution would be to separate linearity checking and erasure of function arguments entirely.

Fortunately, this is no longer an issue in Yaffle since we are caching quantities on the application itself, making the type lookup redundant.

(This PR builds on #2896.)