### PR TITLE
Remove unused fixity definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@
   dangerous as Idris will pick an arbitrary one and so the meaning of an
   expression can depend e.g. on the order in which modules are imported.
 
+  * Additionally some conflicting fixity declarations in the Idris 2 compiler
+    and libraries have been removed.
+
 ### Library changes
 
 #### Prelude

--- a/src/Compiler/ES/Doc.idr
+++ b/src/Compiler/ES/Doc.idr
@@ -3,7 +3,6 @@ module Compiler.ES.Doc
 import Data.List
 
 infixr 6 <++>
-infixl 8 <?>
 
 public export
 data Doc


### PR DESCRIPTION
This definition conflicts with one in `Data.String.Parser`

# Description


## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

