### PR TITLE
[ base ] Support unbuffered reading of stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,8 @@
 * Adds `Vect.allFins` for generating all the `Fin` elements as a `Vect` with
   matching length to the number of elements.
 
+* Add `withRawMode`, `enableRawMode`, `resetRawMode` for character at a time input on stdin.
+
 #### System
 
 * Changes `getNProcessors` to return the number of online processors rather than

--- a/src/Compiler/Common.idr
+++ b/src/Compiler/Common.idr
@@ -561,7 +561,8 @@ record ConstantPrimitives' str where
   intToInt     : IntKind -> IntKind -> str -> Core str
 
 public export
-ConstantPrimitives : Type = ConstantPrimitives' String
+ConstantPrimitives : Type
+ConstantPrimitives = ConstantPrimitives' String
 
 ||| Implements casts from and to integral types by using
 ||| the implementations from the provided `ConstantPrimitives`.


### PR DESCRIPTION
# Description

Currently `getChar` doesn't return a character until the user presses return, because stdin defaults to "cooked" mode.  This PR adds `enableRawMode` and `disableRawMode` primitive functions to allow reading stdin character by character with `getChar`. 

This works on Linux and MacOS, but I was unable to find an acceptable solution for windows.

- [x] I have updated `CHANGELOG.md`
