### PR TITLE
[ regression ] Call to `toFullNames` in `log` properly

### DIFF
--- a/src/Compiler/Opts/ConstantFold.idr
+++ b/src/Compiler/Opts/ConstantFold.idr
@@ -173,7 +173,7 @@ constantFold fn = do
         | Nothing => pure ()
     let Just cdef' = constFoldCDef cdef
         | Nothing => pure ()
-    log "compiler.const-fold" 50 $ "constant folding " ++ show !(getFullName fn)
-                                 ++ "\n\told def: " ++ show cdef
-                                 ++ "\n\tnew def: " ++ show cdef'
+    logC "compiler.const-fold" 50 $ do pure $ "constant folding " ++ show !(getFullName fn)
+                                           ++ "\n\told def: " ++ show cdef
+                                           ++ "\n\tnew def: " ++ show cdef'
     setCompiled (Resolved fnIdx) cdef'

--- a/src/Core/Context/Log.idr
+++ b/src/Core/Context/Log.idr
@@ -69,6 +69,12 @@ log' lvl msg
 
 ||| Log a message with the given log level. Use increasingly
 ||| high log level numbers for more granular logging.
+|||
+||| If you want to use some `Core` computation to produce a message string, use `logC`.
+||| I.e. instead of `log "topic" 10 "message \{show !(toFullNames fn)}"` use
+||| `logC "topic" 10 $ do pure ""message \{show !(toFullNames fn)}""`.
+||| This will enfore that additional computation happends only when needed.
+||| `do` before `pure` in this case ensures the correct bounds.
 export
 log : {auto c : Ref Ctxt Defs} ->
       (s : String) ->

--- a/src/Core/LinearCheck.idr
+++ b/src/Core/LinearCheck.idr
@@ -203,7 +203,7 @@ mutual
       used r = if isLinear r then [MkVar prf] else []
 
   lcheck rig erase env (Ref fc nt fn)
-      = do log "quantity" 15 "lcheck Ref \{show (nt)} \{show !(toFullNames fn)}"
+      = do logC "quantity" 15 $ do pure "lcheck Ref \{show (nt)} \{show !(toFullNames fn)}"
            ty <- lcheckDef fc rig erase env fn
            pure (Ref fc nt fn, gnf env (embed ty), [])
 
@@ -317,7 +317,7 @@ mutual
                                  (throw (LinearUsed fc used nm))
 
   lcheck rig erase env (App fc f a)
-      = do log "quantity" 15 "lcheck App \{show !(toFullNames f)} \{show !(toFullNames a)}"
+      = do logC "quantity" 15 $ do pure "lcheck App \{show !(toFullNames f)} \{show !(toFullNames a)}"
            (f', gfty, fused) <- lcheck rig erase env f
            defs <- get Ctxt
            fty <- getNF gfty

--- a/src/Core/Termination.idr
+++ b/src/Core/Termination.idr
@@ -22,7 +22,7 @@ export
 checkIfGuarded : {auto c : Ref Ctxt Defs} ->
                  FC -> Name -> Core ()
 checkIfGuarded fc n
-    = do log "totality.termination.guarded" 6 $ "Check if Guarded: " ++ show !(toFullNames n)
+    = do logC "totality.termination.guarded" 6 $ do pure $ "Check if Guarded: " ++ show !(toFullNames n)
          defs <- get Ctxt
          Just (PMDef _ _ _ _ pats) <- lookupDefExact n (gamma defs)
               | _ => pure ()
@@ -70,7 +70,7 @@ checkTerminating : {auto c : Ref Ctxt Defs} ->
                    FC -> Name -> Core Terminating
 checkTerminating loc n
     = do tot <- getTotality loc n
-         log "totality.termination" 6 $ "Checking termination: " ++ show !(toFullNames n)
+         logC "totality.termination" 6 $ do pure $ "Checking termination: " ++ show !(toFullNames n)
          case isTerminating tot of
               Unchecked =>
                  do tot' <- calcTerminating loc n
@@ -86,7 +86,7 @@ checkPositive : {auto c : Ref Ctxt Defs} ->
 checkPositive loc n_in
     = do n <- toResolvedNames n_in
          tot <- getTotality loc n
-         log "totality.positivity" 6 $ "Checking positivity: " ++ show !(toFullNames n)
+         logC "totality.positivity" 6 $ do pure $ "Checking positivity: " ++ show !(toFullNames n)
          case isTerminating tot of
               Unchecked =>
                   do (tot', cons) <- calcPositive loc n
@@ -107,7 +107,7 @@ checkTotal loc n_in
              | Nothing => undefinedName loc n_in
          let n = Resolved nidx
          tot <- getTotality loc n
-         log "totality" 5 $ "Checking totality: " ++ show !(toFullNames n)
+         logC "totality" 5 $ do pure $ "Checking totality: " ++ show !(toFullNames n)
          defs <- get Ctxt
          case isTerminating tot of
               Unchecked => do

--- a/src/Core/Termination/CallGraph.idr
+++ b/src/Core/Termination/CallGraph.idr
@@ -299,7 +299,7 @@ mutual
         -- Under 'assert_total' we assume that all calls are fine, so leave
         -- the size change list empty
       = do fn <- getFullName fn_in
-           log "totality.termination.sizechange" 10 $ "Looking under " ++ show !(toFullNames fn)
+           logC "totality.termination.sizechange" 10 $ do pure $ "Looking under " ++ show !(toFullNames fn)
            aSmaller <- resolved (gamma defs) (NS builtinNS (UN $ Basic "assert_smaller"))
            cond [(fn == NS builtinNS (UN $ Basic "assert_total"), pure [])
                 ,(caseFn fn,
@@ -347,7 +347,7 @@ export
 calculateSizeChange : {auto c : Ref Ctxt Defs} ->
                       FC -> Name -> Core (List SCCall)
 calculateSizeChange loc n
-    = do log "totality.termination.sizechange" 5 $ "Calculating Size Change: " ++ show !(toFullNames n)
+    = do logC "totality.termination.sizechange" 5 $ do pure $ "Calculating Size Change: " ++ show !(toFullNames n)
          defs <- get Ctxt
          Just def <- lookupCtxtExact n (gamma defs)
               | Nothing => undefinedName loc n

--- a/src/Core/Termination/Positivity.idr
+++ b/src/Core/Termination/Positivity.idr
@@ -163,7 +163,7 @@ calcPositive : {auto c : Ref Ctxt Defs} ->
                FC -> Name -> Core (Terminating, List Name)
 calcPositive loc n
     = do defs <- get Ctxt
-         log "totality.positivity" 6 $ "Calculating positivity: " ++ show !(toFullNames n)
+         logC "totality.positivity" 6 $ do pure $ "Calculating positivity: " ++ show !(toFullNames n)
          case !(lookupDefTyExact n (gamma defs)) of
               Just (TCon _ _ _ _ _ tns dcons _, ty) =>
                   case !(totRefsIn defs ty) of

--- a/src/Core/Termination/References.idr
+++ b/src/Core/Termination/References.idr
@@ -17,7 +17,7 @@ totRefs defs (n :: ns)
          case isTerminating (totality d) of
               IsTerminating => pure rest
               Unchecked => do
-                log "totality" 20 $ "Totality unchecked for " ++ show !(toFullNames n)
+                logC "totality" 20 $ do pure $ "Totality unchecked for " ++ show !(toFullNames n)
                 pure rest
               _ => case rest of
                           NotTerminating (BadCall ns)

--- a/src/Core/Termination/SizeChange.idr
+++ b/src/Core/Termination/SizeChange.idr
@@ -310,7 +310,7 @@ calcTerminating : {auto c : Ref Ctxt Defs} ->
                   FC -> Name -> Core Terminating
 calcTerminating loc n
     = do defs <- get Ctxt
-         log "totality.termination.calc" 7 $ "Calculating termination: " ++ show !(toFullNames n)
+         logC "totality.termination.calc" 7 $ do pure $ "Calculating termination: " ++ show !(toFullNames n)
          Just def <- lookupCtxtExact n (gamma defs)
             | Nothing => undefinedName loc n
          IsTerminating <- totRefs defs (nub !(addCases defs (keys (refersTo def))))

--- a/src/Core/Unify.idr
+++ b/src/Core/Unify.idr
@@ -1173,7 +1173,7 @@ mutual
                      {-
                      ust <- get UST
                      when (logging ust) $
-                        do log "unify" 20 $ "Constructor " ++ show !(toFullNames x) ++ " " ++ show loc
+                        do logC "unify" 20 $ do pure $ "Constructor " ++ show !(toFullNames x) ++ " " ++ show loc
                            log "unify" 20 "ARGUMENTS:"
                            traverse_ (dumpArg env) xs
                            log "unify" 20 "WITH:"

--- a/src/TTImp/Elab/Delayed.idr
+++ b/src/TTImp/Elab/Delayed.idr
@@ -247,7 +247,7 @@ retryDelayed' errmode p acc (d@(_, i, hints, elab) :: ds)
               | _ => retryDelayed' errmode p acc ds
          handle
            (do est <- get EST
-               log "elab.retry" 5 (show (delayDepth est) ++ ": Retrying delayed hole " ++ show !(getFullName (Resolved i)))
+               logC "elab.retry" 5 $ do pure $ show (delayDepth est) ++ ": Retrying delayed hole " ++ show !(getFullName (Resolved i))
                -- elab itself might have delays internally, so keep track of them
                update UST { delayedElab := [] }
                update Ctxt { localHints := hints }
@@ -263,8 +263,8 @@ retryDelayed' errmode p acc (d@(_, i, hints, elab) :: ds)
                logTermNF "elab.update" 5 ("Resolved delayed hole NF " ++ show i) [] tm
                removeHole i
                retryDelayed' errmode True acc ds')
-           (\err => do log "elab" 5 $ show errmode ++ ":Error in " ++ show !(getFullName (Resolved i))
-                                ++ "\n" ++ show err
+           (\err => do logC "elab" 5 $ do pure $ show errmode ++ ":Error in " ++ show !(getFullName (Resolved i))
+                                              ++ "\n" ++ show err
                        case errmode of
                          RecoverableErrors =>
                             if not !(recoverable err)

--- a/src/TTImp/Interactive/ExprSearch.idr
+++ b/src/TTImp/Interactive/ExprSearch.idr
@@ -677,7 +677,7 @@ tryIntermediateRec fc rig opts hints env ty topty (Just rd)
          let opts' = { inUnwrap := True,
                        recData := Nothing } opts
          logTerm "interaction.search" 10 "Trying recursive search for" ty
-         log "interaction.search" 10 $ show !(toFullNames (recname rd))
+         logC "interaction.search" 10 $ show <$> toFullNames (recname rd)
          logTerm "interaction.search" 10 "LHS" !(toFullNames (lhsapp rd))
          recsearch <- tryRecursive fc rig opts' hints env letty topty rd
          makeHelper fc rig opts' env letty ty recsearch

--- a/src/TTImp/PartialEval.idr
+++ b/src/TTImp/PartialEval.idr
@@ -289,8 +289,8 @@ mkSpecDef {vars} fc gdef pename sargs fn stk
            -- if it fails, but I don't want the whole system to be dependent on
            -- the correctness of PE!
         (\err =>
-           do log "specialise" 1 $ "Partial evaluation of " ++ show !(toFullNames fn) ++ " failed" ++
-                      "\n" ++ show err
+           do logC "specialise" 1 $ do pure $ "Partial evaluation of " ++ show !(toFullNames fn) ++ " failed" ++
+                                              "\n" ++ show err
               update Ctxt { peFailures $= insert pename () }
               pure (applyWithFC (Ref fc Func fn) stk))
   where

--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -785,7 +785,7 @@ mkRunTime : {auto c : Ref Ctxt Defs} ->
             {auto o : Ref ROpts REPLOpts} ->
             FC -> Name -> Core ()
 mkRunTime fc n
-    = do log "compile.casetree" 5 $ "Making run time definition for " ++ show !(toFullNames n)
+    = do logC "compile.casetree" 5 $ do pure $ "Making run time definition for " ++ show !(toFullNames n)
          defs <- get Ctxt
          Just gdef <- lookupCtxtExact n (gamma defs)
               | _ => pure ()
@@ -826,7 +826,7 @@ mkRunTime fc n
            when (caseName !(toFullNames n) && noInline (flags gdef)) $
              do inl <- canInlineCaseBlock n
                 when inl $ do
-                  log "compiler.inline.eval" 5 "Marking \{show !(toFullNames n)} for inlining in runtime case tree."
+                  logC "compiler.inline.eval" 5 $ do pure "Marking \{show !(toFullNames n)} for inlining in runtime case tree."
                   setFlag fc n Inline
   where
     -- check if the flags contain explicit inline or noinline directives:
@@ -1137,7 +1137,7 @@ processDef opts nest env fc n_in cs_in
              let covcs = mapMaybe id covcs'
              (_ ** (ctree, _)) <-
                  getPMDef fc (CompileTime mult) (Resolved n) ty covcs
-             log "declare.def" 3 $ "Working from " ++ show !(toFullNames ctree)
+             logC "declare.def" 3 $ do pure $ "Working from " ++ show !(toFullNames ctree)
              missCase <- if any catchAll covcs
                             then do log "declare.def" 3 $ "Catch all case in " ++ show n
                                     pure []

--- a/src/TTImp/ProcessType.idr
+++ b/src/TTImp/ProcessType.idr
@@ -59,7 +59,7 @@ processFnOpt fc True ndef (Hint d)
          target <- getRetTy defs !(nf defs [] ty)
          addHintFor fc target ndef d False
 processFnOpt fc _ ndef (Hint d)
-    = do log "elab" 5 $ "Adding local hint " ++ show !(toFullNames ndef)
+    = do logC "elab" 5 $ do pure $ "Adding local hint " ++ show !(toFullNames ndef)
          addLocalHint ndef
 processFnOpt fc True ndef (GlobalHint a)
     = addGlobalHint ndef a

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -162,7 +162,7 @@ idrisTestsRegression = MkTestPool "Various regressions" [] Nothing
        "reg029", "reg030", "reg031", "reg032", "reg033", "reg034", "reg035",
        "reg036", "reg037", "reg038", "reg039", "reg040", "reg041", "reg042",
        "reg043", "reg044", "reg045", "reg046", "reg047", "reg048", "reg049",
-       "reg050"]
+       "reg050", "reg051"]
 
 idrisTestsData : TestPool
 idrisTestsData = MkTestPool "Data and record types" [] Nothing

--- a/tests/idris2/reg051/BigFins.idr
+++ b/tests/idris2/reg051/BigFins.idr
@@ -1,0 +1,29 @@
+module BigFins
+
+import Control.Monad.State
+
+import Data.Fin
+
+%default total
+
+public export
+interface I a where
+  fun : (a, a) -> a
+
+export
+{n : Nat} -> I (Fin $ S n) where
+  fun = ?fin_rhs
+
+export
+printVerdict : HasIO m => a -> m ()
+printVerdict it = ?printVerdict_rhs
+
+N : Nat
+N = 100000
+
+St, D : Fin $ S N
+St = 2000
+D = 2004
+
+main : IO ()
+main = printVerdict $ fun {a=Fin $ S N} (St, St + D)

--- a/tests/idris2/reg051/expected
+++ b/tests/idris2/reg051/expected
@@ -1,0 +1,1 @@
+1/1: Building BigFins (BigFins.idr)

--- a/tests/idris2/reg051/run
+++ b/tests/idris2/reg051/run
@@ -1,0 +1,2 @@
+rm -rf build
+$1 --no-banner --no-color --console-width 0 BigFins.idr --check

--- a/tests/idris2/reg051/test.ipkg
+++ b/tests/idris2/reg051/test.ipkg
@@ -1,0 +1,1 @@
+package a-test


### PR DESCRIPTION
This is a fix of a regression appeared in #2900, that (how I knew it) caused tests of [random-pure](https://github.com/buzden/idris2-random-pure) library to run (compile) hours instead of minutes.

As far as I found, the cause is too early call for `toFullNames` when logging: that call happened even if no logging was present. This is because proper `logC` was not used when it should. So, this PR in one commit changes the particular cause of a regression, and the other commit tries to find out similar cases and to fix them.