### PR TITLE
Collect constructors on the left hand side of case alternatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@
   * Additionally some conflicting fixity declarations in the Idris 2 compiler
     and libraries have been removed.
 
+* Constructors mentioned on the left hand side of functions/case alternatives
+  are now included in the `Refers to (runtime)` section of functions debug info.
+
 ### Library changes
 
 #### Prelude

--- a/src/Compiler/Inline.idr
+++ b/src/Compiler/Inline.idr
@@ -496,8 +496,8 @@ mutual
 
   addRefsConAlts : NameMap Bool -> List (CConAlt vars) -> NameMap Bool
   addRefsConAlts ds [] = ds
-  addRefsConAlts ds (MkConAlt _ _ _ _ sc :: rest)
-      = addRefsConAlts (addRefs ds sc) rest
+  addRefsConAlts ds (MkConAlt n _ _ _ sc :: rest)
+      = addRefsConAlts (addRefs (insert n False ds) sc) rest
 
   addRefsConstAlts : NameMap Bool -> List (CConstAlt vars) -> NameMap Bool
   addRefsConstAlts ds [] = ds

--- a/tests/codegen/con001/expected
+++ b/tests/codegen/con001/expected
@@ -9,4 +9,6 @@ Prelude.Num.MkIntegral = Constructor tag Just 0 arity 3
 Prelude.EqOrd.MkOrd = Constructor tag Just 0 arity 8
 Prelude.EqOrd.MkEq = Constructor tag Just 0 arity 2
 Prelude.Interfaces.MkMonoid = Constructor tag Just 0 arity 2
+Prelude.Interfaces.MkMonad = Constructor tag Just 0 arity 3
 Prelude.Interfaces.MkFoldable = Constructor tag Just 0 arity 6
+Prelude.Interfaces.MkApplicative = Constructor tag Just 0 arity 3

--- a/tests/idris2/casetree003/expected
+++ b/tests/idris2/casetree003/expected
@@ -12,7 +12,7 @@ Compiled: \ {arg:1}, {arg:2} => case {arg:2} of
   ; Main.(::) {tag = 1} [cons] {e:2} {e:3} => Prelude.Basics.(::) {tag = 1} [cons] {e:2} (Main.idL {e:3} (Main.view {e:3}))
   }
 Refers to: Main.view, Main.idL, Prelude.Basics.Nil, Prelude.Basics.(::)
-Refers to (runtime): Main.view, Main.idL, Prelude.Basics.Nil, Prelude.Basics.(::)
+Refers to (runtime): Main.view, Main.idL, Main.Nil, Main.(::), Prelude.Basics.Nil, Prelude.Basics.(::)
 Flags: covering
 Size change: Main.idL: [Just (0, Same), Just (2, Smaller), Nothing]
 Main> 

--- a/tests/idris2/debug001/expected
+++ b/tests/idris2/debug001/expected
@@ -9,6 +9,7 @@ Compiled: \ {arg:0} => case {arg:0} of
   ; _ => 0
   }
 Refers to: Prelude.Basics.True, Prelude.Basics.False
+Refers to (runtime): Prelude.Types.Nat
 Flags: allguarded, covering
 Main> Main.isInt32
 Arguments [{arg:0}]
@@ -20,6 +21,7 @@ Compiled: \ {arg:0} => case {arg:0} of
   ; _ => 0
   }
 Refers to: Prelude.Basics.True, Prelude.Basics.False
+Refers to (runtime): Int32
 Flags: allguarded, covering
 Main> Prelude.Types.plus
 Arguments [{arg:0}, {arg:1}]


### PR DESCRIPTION
# Description
When collecting names referred to at runtime (after optimising) constructors on the left hand side of case alts should be collected too.

(see the somehow almost 2 year old #1378)

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

Note: you may need to rebuild libs to see all effects of this