### PR TITLE
make cond's default argument lazy

### DIFF
--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -894,7 +894,7 @@ wrapRef x onClose op
        pure o
 
 export
-cond : List (Lazy Bool, Lazy a) -> a -> a
+cond : List (Lazy Bool, Lazy a) -> Lazy a -> a
 cond [] def = def
 cond ((x, y) :: xs) def = if x then y else cond xs def
 


### PR DESCRIPTION
# Description

`cond` is not Lazy in its second argument, which cause evaluation of default case all the time.
This can be a potential issue in https://github.com/idris-lang/Idris2/blob/main/src/Compiler/Scheme/Common.idr#L568-L572

```haskell
    schExp i (NmConCase fc sc alts def)
        = cond [(recordCase alts, schRecordCase i sc alts def),
                (maybeCase alts, schMaybeCase i sc alts def),
                (listCase alts, schListCase i sc alts def)]
                -- probably more to come here...
                (schCaseTree i sc alts def)
```

Here the default case tree builder is executed, which can be time consuming for a complex, nested case tree.

