### PR TITLE
[ contrib ] Add modFin and strengthenMod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,10 @@
 
 * Adds an implementation for `Functor Text.Lexer.Tokenizer.Tokenizer`.
 
+* Adds `modFin` and `strengthenMod` to `Data.Fin.Extra`. These functions reason
+  about the modulo operator's upper bound, which can be useful when working with
+  indices (for example).
+
 #### Papers
 
 * In `Control.DivideAndConquer`: a port of the paper


### PR DESCRIPTION
# Description

These were two functions that I found useful when working with vectors of different sizes, but whose indices were related. I know `contrib` should ideally be its own thing, but when that happens I would really like these to be part of `Data.Fin.Extra` ^^

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

