### PR TITLE
Add HasNamespaces Lifted* implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@
 * Constructors mentioned on the left hand side of functions/case alternatives
   are now included in the `Refers to (runtime)` section of functions debug info.
 
+* The Lifted IR Representation now has a `HasNamespaces` implementation
+  in `Compiler.Separate` so Compilation Units at that stage can be generated.
+
 ### Library changes
 
 #### Prelude


### PR DESCRIPTION
# Description

This adds relevant `HasNamespaces` instances for the Lifted IR - structurally it's almost identical to the Named/Cases stage, minus Force/Delay/Lambdas and plus a split on how function/closure applications are represented.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

