### PR TITLE
[ base ] Add extraction functions to `Data.Singleton`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,8 @@
 
 * Add `withRawMode`, `enableRawMode`, `resetRawMode` for character at a time input on stdin.
 
+* Adds extraction functions to `Data.Singleton`.
+
 #### System
 
 * Changes `getNProcessors` to return the number of online processors rather than

--- a/libs/base/Data/Singleton.idr
+++ b/libs/base/Data/Singleton.idr
@@ -6,6 +6,14 @@ public export
 data Singleton : a -> Type where
      Val : (x : a) -> Singleton x
 
+public export %inline
+unVal : Singleton {a} x -> a
+unVal $ Val x = x
+
+public export %inline
+(.unVal) : Singleton {a} x -> a
+(.unVal) = unVal
+
 -- pure and <*> implementations for idiom bracket notation
 
 public export


### PR DESCRIPTION
Without them it's not convenient to use `Singleton` in tacit expressions

