### PR TITLE
[ fix #2927 ] Do not eagerly evaluate expressions occurring inside `%delay` block

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -88,6 +88,18 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 * Switch calling conventions based on the number of arguments to avoid limits on
   the number of arguments and to reduce stack usage.
 
+#### Chez
+
+* Fixed CSE soundness bug that caused delayed expressions to sometimes be eagerly
+  evaluated. Now when a delayed expression is lifted by CSE, it is compiled
+  using Scheme's `delay` and `force` to memoize them.
+
+#### Racket
+
+* Fixed CSE soundness bug that caused delayed expressions to sometimes be eagerly
+  evaluated. Now when a delayed expression is lifted by CSE, it is compiled
+  using Scheme's `delay` and `force` to memoize them.
+
 #### NodeJS Backend
 
 * The NodeJS executable output to `build/exec/` now has its executable bit set.

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -48,6 +48,7 @@ schHeader prof libs = fromString """
   (require racket/async-channel)         ; for asynchronous channels
   (require racket/future)                ; for parallelism/concurrency
   (require racket/math)                  ; for math ops
+  (require racket/promise)               ; for delay/force in toplevel defs
   (require racket/system)                ; for system
   (require racket/unsafe/ops)            ; for fast fixnum ops
   (require rnrs/bytevectors-6)           ; for buffers

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -128,7 +128,7 @@ idrisTests = MkTestPool "Misc" [] Nothing
        "import001", "import002", "import003", "import004", "import005", "import006",
        "import007", "import008", "import009",
        -- Implicit laziness, lazy evaluation
-       "lazy001", "lazy002", "lazy003", "lazy004",
+       "lazy001", "lazy002", "lazy003", "lazy004", "lazy005",
        -- Namespace blocks
        "namespace001", "namespace002", "namespace003", "namespace004", "namespace005",
        -- Parameters blocks

--- a/tests/idris2/misc/lazy005/LiftedBot.idr
+++ b/tests/idris2/misc/lazy005/LiftedBot.idr
@@ -1,0 +1,28 @@
+import Data.List.Lazy
+
+import Debug.Trace
+
+showHead : Show a => LazyList a -> String
+showHead [] = "Empty"
+showHead (x::xs) = show x
+
+%inline
+(::) : Maybe a -> Lazy (LazyList a) -> LazyList a
+Nothing :: xs = xs
+Just x  :: xs = x :: xs
+
+bot : a
+bot = bot
+
+fufu : a -> Maybe a
+fufu = Just
+
+g : LazyList Nat
+g = [ fufu 6
+    , fufu bot
+    ]
+
+-- Note that this should finish in finite time, as tail containing
+-- `bot` is lazy and should never be computed
+main : IO Unit
+main = printLn $ showHead g

--- a/tests/idris2/misc/lazy005/LiftedTrace.idr
+++ b/tests/idris2/misc/lazy005/LiftedTrace.idr
@@ -1,0 +1,22 @@
+import Data.List.Lazy
+
+import Debug.Trace
+
+%default total
+
+%inline
+(::) : Maybe a -> Lazy (LazyList a) -> LazyList a
+Nothing :: xs = xs
+Just x  :: xs = x :: xs
+
+fufu : a -> Maybe a
+fufu = Just
+
+g : LazyList Nat
+g = trace "--- outmost ---"
+  [ fufu $ trace "pure 6" 6
+  , fufu $ trace "pure 5" 5
+  ]
+
+main : IO Unit
+main = printLn g

--- a/tests/idris2/misc/lazy005/expected
+++ b/tests/idris2/misc/lazy005/expected
@@ -1,0 +1,5 @@
+pure 6
+--- outmost ---
+pure 5
+[6, 5]
+"6"

--- a/tests/idris2/misc/lazy005/run
+++ b/tests/idris2/misc/lazy005/run
@@ -1,0 +1,4 @@
+. ../../../testutils.sh
+
+idris2 -p contrib --exec main LiftedTrace.idr
+idris2 -p contrib --exec main LiftedBot.idr


### PR DESCRIPTION
# Description

This PR fixes #2927.

Thanks to @stefan-hoeck for his assistance in Discord. He suggested fixing the issue by using Scheme's `delay` and `force` to memoize constants, as in #2807 instead of #2817 that is currently used. However, this solution comes with a performance overhead.

To reduce the overhead, I modified CSE to track whether an expression occurs inside a `%delay` block. If that is the case, the expression is lifted as memoized lazy value using Scheme's `delay` and `force`. Otherwise, it becomes an eagerly evaluated top-level constant. Benchmarking the bootstrapped compiler on `idris2api.ipkg` showed 5% slowdown on my machine, which is an improvement compared to the 8.5% slowdown in #2807.  

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

