### PR TITLE
[ parser ] Improve error message for missing comma or period in forall. #2940

### DIFF
--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -702,7 +702,8 @@ mutual
                                     , map (Just . UN . Basic) n
                                     , PImplicit (boundToFC fname n))
                              ) (forget ns)
-           mustWorkBecause b.bounds "Cannot return a forall quantifier"
+           b' <- bounds peek
+           mustWorkBecause b'.bounds "Expected ',' or '.'"
              $ decoratedSymbol fname "."
            scope <- mustWork $ typeExpr pdef fname indents
            pure (pibindAll fname Implicit b.val scope)

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -95,7 +95,8 @@ idrisTestsError = MkTestPool "Error messages" [] Nothing
        "perror006", "perror007", "perror008", "perror009", "perror010",
        "perror011", "perror012", "perror013", "perror014", "perror015",
        "perror016", "perror017", "perror018", "perror019", "perror020",
-       "perror021", "perror022", "perror023", "perror024", "perror025"]
+       "perror021", "perror022", "perror023", "perror024", "perror025",
+       "perror026"]
 
 idrisTestsInteractive : TestPool
 idrisTestsInteractive = MkTestPool "Interactive editing" [] Nothing

--- a/tests/idris2/perror026/Micro.idr
+++ b/tests/idris2/perror026/Micro.idr
@@ -1,0 +1,5 @@
+module Micro
+
+f : forall a b. (Unit -> Unit) -> Unit -> Unit
+f = id
+

--- a/tests/idris2/perror026/expected
+++ b/tests/idris2/perror026/expected
@@ -1,0 +1,9 @@
+1/1: Building Micro (Micro.idr)
+Error: Expected ',' or '.'.
+
+Micro:3:14--3:15
+ 1 | module Micro
+ 2 | 
+ 3 | f : forall a b. (Unit -> Unit) -> Unit -> Unit
+                  ^
+

--- a/tests/idris2/perror026/run
+++ b/tests/idris2/perror026/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --check Micro.idr


### PR DESCRIPTION
This PR addresses the confusing parser error message reported in #2940, which occurs when a user forgets the comma between identifiers in a `forall` statement.

We now get the error message:
```
1/1: Building Forall (Forall.idr)
Error: Expected ',' or '.'.

Forall:3:14--3:15
 1 | module Micro
 2 |
 3 | f : forall a b. (Unit -> Unit) -> Unit -> Unit
                  ^
```
instead of
```
1/1: Building Forall (Forall.idr)
Error: Cannot return a forall quantifier.

Forall:3:5--3:13
 1 | module Micro
 2 | 
 3 | f : forall a b. (Unit -> Unit) -> Unit -> Unit
         ^^^^^^^^
```
I'm not sure why the original error message was worded that way, is there a case I missed where that wording was appropriate?

I had to do a `bounds peek` to get the `mustUseBecause` to point at the right spot - there might be a more elegant way to do this.
 

