### PR TITLE
[ new ] Add support for bi-directional pipes on POSIX systems (resolves #2935)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,8 @@
 * Changes `getNProcessors` to return the number of online processors rather than
   the number of configured processors.
 
+* Adds `popen2` to run a subprocess with bi-directional pipes.
+
 ### Contrib
 
 * Adds `Data.List.Sufficient`, a small library defining a structurally inductive view of lists.

--- a/libs/base/System/File/Process.idr
+++ b/libs/base/System/File/Process.idr
@@ -3,6 +3,7 @@ module System.File.Process
 import public System.Escape
 import public System.File.Error
 import public System.File.Mode
+import System.FFI
 import System.File.Support
 import public System.File.Types
 
@@ -14,6 +15,20 @@ prim__popen : String -> String -> PrimIO FilePtr
 %foreign supportC "idris2_pclose"
          supportNode "pclose"
 prim__pclose : FilePtr -> PrimIO Int
+
+data Popen2Result : Type where
+
+%foreign supportC "idris2_popen2"
+prim__popen2 : String -> PrimIO (Ptr Popen2Result)
+
+%foreign supportC "idris2_popen2ChildPid"
+prim__popen2ChildPid : Ptr Popen2Result -> Int
+
+%foreign supportC "idris2_popen2FileIn"
+prim__popen2FileIn : Ptr Popen2Result -> PrimIO FilePtr
+
+%foreign supportC "idris2_popen2FileOut"
+prim__popen2FileOut : Ptr Popen2Result -> PrimIO FilePtr
 
 ||| Force a write of all user-space buffered data for the given `File`.
 |||
@@ -53,3 +68,25 @@ namespace Escaped
 export
 pclose : HasIO io => (fh : File) -> io Int
 pclose (FHandle h) = primIO (prim__pclose h)
+
+||| Create a new bidirectional pipe by invoking the shell, which is passed the
+||| given command-string using the '-c' flag, in a new process. On success
+||| a pair of File is returned. The first File is used for reading from the
+||| process, and the second is used for writing to the process. Caller is
+||| responsible for closing them.
+|||
+||| IMPORTANT: You may deadlock if write to a process which is waiting to flush
+|||            its output.  It is recommended to read and write from separate threads.
+|||
+||| This function is not supported on windows or node at this time.
+export
+popen2 : HasIO io => (cmd : String) -> io (Either FileError (File,File))
+popen2 cmd = do
+  ptr <- primIO (prim__popen2 cmd)
+  if prim__nullPtr ptr /= 0
+    then returnError
+    else do
+      inFile <- primIO (prim__popen2FileIn ptr)
+      outFile <- primIO (prim__popen2FileOut ptr)
+      free (prim__forgetPtr ptr)
+      pure $ Right (FHandle inFile, FHandle outFile)

--- a/libs/base/System/File/Process.idr
+++ b/libs/base/System/File/Process.idr
@@ -84,7 +84,7 @@ record SubProcess where
 ||| IMPORTANT: You may deadlock if write to a process which is waiting to flush
 |||            its output.  It is recommended to read and write from separate threads.
 |||
-||| This function is not supported on windows or node at this time.
+||| This function is not supported on node at this time.
 export
 popen2 : HasIO io => (cmd : String) -> io (Either FileError SubProcess)
 popen2 cmd = do

--- a/libs/base/System/File/Process.idr
+++ b/libs/base/System/File/Process.idr
@@ -22,7 +22,7 @@ data Popen2Result : Type where
 prim__popen2 : String -> PrimIO (Ptr Popen2Result)
 
 %foreign supportC "idris2_popen2ChildPid"
-prim__popen2ChildPid : Ptr Popen2Result -> Int
+prim__popen2ChildPid : Ptr Popen2Result -> PrimIO Int
 
 %foreign supportC "idris2_popen2FileIn"
 prim__popen2FileIn : Ptr Popen2Result -> PrimIO FilePtr
@@ -57,10 +57,6 @@ popen cmd m = do
         then returnError
         else pure (Right (FHandle ptr))
 
-namespace Escaped
-  export
-  popen : HasIO io => (cmd : List String) -> (m : Mode) -> io (Either FileError File)
-  popen = popen . escapeCmd
 
 ||| Wait for the process associated with the pipe to terminate.
 |||
@@ -69,24 +65,44 @@ export
 pclose : HasIO io => (fh : File) -> io Int
 pclose (FHandle h) = primIO (prim__pclose h)
 
+||| Result of a popen2 command, containing the
+public export
+record SubProcess where
+  constructor MkSubProcess
+  ||| Process id of the spawned process
+  pid : Int
+  ||| The input stream of the spawned process
+  input : File
+  ||| The output stream of the spawned process
+  output : File
+
 ||| Create a new bidirectional pipe by invoking the shell, which is passed the
 ||| given command-string using the '-c' flag, in a new process. On success
-||| a pair of File is returned. The first File is used for reading from the
-||| process, and the second is used for writing to the process. Caller is
-||| responsible for closing them.
+||| a SubProcess is returned which holds the process id and file handles
+||| for input and output.
 |||
 ||| IMPORTANT: You may deadlock if write to a process which is waiting to flush
 |||            its output.  It is recommended to read and write from separate threads.
 |||
 ||| This function is not supported on windows or node at this time.
 export
-popen2 : HasIO io => (cmd : String) -> io (Either FileError (File,File))
+popen2 : HasIO io => (cmd : String) -> io (Either FileError SubProcess)
 popen2 cmd = do
   ptr <- primIO (prim__popen2 cmd)
   if prim__nullPtr ptr /= 0
     then returnError
     else do
-      inFile <- primIO (prim__popen2FileIn ptr)
-      outFile <- primIO (prim__popen2FileOut ptr)
+      pid <- primIO (prim__popen2ChildPid ptr)
+      input <- primIO (prim__popen2FileIn ptr)
+      output <- primIO (prim__popen2FileOut ptr)
       free (prim__forgetPtr ptr)
-      pure $ Right (FHandle inFile, FHandle outFile)
+      pure $ Right (MkSubProcess pid (FHandle input) (FHandle output))
+
+namespace Escaped
+  export
+  popen : HasIO io => (cmd : List String) -> (m : Mode) -> io (Either FileError File)
+  popen = popen . escapeCmd
+
+  export
+  popen2 : HasIO io => (cmd : List String) -> io (Either FileError SubProcess)
+  popen2 = popen2 . escapeCmd

--- a/support/c/idris_file.h
+++ b/support/c/idris_file.h
@@ -47,3 +47,10 @@ int idris2_fileIsTTY(FILE *f);
 FILE *idris2_stdin();
 FILE *idris2_stdout();
 FILE *idris2_stderr();
+
+struct child_process;
+
+struct child_process *idris2_popen2(char *cmd);
+int idris2_popen2ChildPid(struct child_process *ptr);
+FILE *idris2_popen2FileIn(struct child_process *ptr);
+FILE *idris2_popen2FileOut(struct child_process *ptr);

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -3,7 +3,6 @@ module Main
 import System
 import System.Directory
 import System.File
-import System.Info
 
 import Test.Golden
 
@@ -215,7 +214,7 @@ idrisTestsAllBackends cg = MkTestPool
        -- RefC implements IEEE standard and distinguishes between 0.0 and -0.0
        -- unlike other backends. So turn this test for now.
       $ ([ "issue2362" ] <* guard (cg /= C))
-      ++ ([ "popen2" ] <* guard (cg /= Node && not isWindows))
+      ++ ([ "popen2" ] <* guard (cg /= Node))
       ++ [ -- Evaluator
        "evaluator004",
        -- Unfortunately the behaviour of Double is platform dependent so the

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -3,6 +3,7 @@ module Main
 import System
 import System.Directory
 import System.File
+import System.Info
 
 import Test.Golden
 
@@ -214,6 +215,7 @@ idrisTestsAllBackends cg = MkTestPool
        -- RefC implements IEEE standard and distinguishes between 0.0 and -0.0
        -- unlike other backends. So turn this test for now.
       $ ([ "issue2362" ] <* guard (cg /= C))
+      ++ ([ "popen2" ] <* guard (cg /= Node && not isWindows))
       ++ [ -- Evaluator
        "evaluator004",
        -- Unfortunately the behaviour of Double is platform dependent so the

--- a/tests/allbackends/popen2/Test.idr
+++ b/tests/allbackends/popen2/Test.idr
@@ -1,0 +1,12 @@
+import System.File
+
+main : IO ()
+main = do
+    Right process <- popen2 "cat"
+        | Left err => printLn err
+    printLn $ process.pid > 0
+    _ <- fPutStrLn process.input "Hello, Idris!\n"
+    closeFile process.input
+    Right result <- fRead process.output
+        | Left err => printLn err
+    putStr result

--- a/tests/allbackends/popen2/expected
+++ b/tests/allbackends/popen2/expected
@@ -1,0 +1,3 @@
+True
+Hello, Idris!
+

--- a/tests/allbackends/popen2/run
+++ b/tests/allbackends/popen2/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --exec main Test.idr


### PR DESCRIPTION
# Description

Adds a `popen2` function to `System.File.Process` which allows Idris to run subprocesses with access to both the input and output file streams.  It currently doesn't support windows, but updates are welcome if it's possible and somebody knows how to do it (and can verify that it works). This feature was requested by @jfdm in #2935, and I think @ohad was asking about it last year.

With this change you can do:
```idris
import System.File

main : IO ()
main = do
    Right (inFile, outFile) <- popen2 "idris2"
        | Left err => printLn err
    _ <- fPutStrLn outFile ":h\n"
    closeFile outFile
    Right result <- fRead inFile
        | Left err => printLn err
    putStrLn result
    putStrLn "done"
```

But I'd recommend writing be done on a separate thread from reading to avoid deadlocking if the subprocess is waiting for a reader while we're waiting to write.

Let me know if any changes are needed.

## Should this change go in the CHANGELOG?

Yes, I added a note to the CHANGELOG.
