### PR TITLE
[ fix ] codegen issue when using partial case statements in prelude.

### DIFF
--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -843,7 +843,7 @@ mkRunTime fc n
 
     mkCrash : {vars : _} -> String -> Term vars
     mkCrash msg
-       = apply fc (Ref fc Func (NS builtinNS (UN $ Basic "idris_crash")))
+       = apply fc (Ref fc Func (UN $ Basic "prim__crash"))
                [Erased fc Placeholder, PrimVal fc (Str msg)]
 
     matchAny : Term vars -> Term vars

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -89,7 +89,7 @@ idrisTestsError = MkTestPool "Error messages" [] Nothing
        "error011", "error012", "error013", "error014", "error015",
        "error016", "error017", "error018", "error019", "error020",
        "error021", "error022", "error023", "error024", "error025",
-       "error026",
+       "error026", "error027",
        -- Parse errors
        "perror001", "perror002", "perror003", "perror004", "perror005",
        "perror006", "perror007", "perror008", "perror009", "perror010",

--- a/tests/idris2/error027/Issue2950.idr
+++ b/tests/idris2/error027/Issue2950.idr
@@ -1,0 +1,2 @@
+main : IO ()
+main = printLn $ mod 10 0

--- a/tests/idris2/error027/expected
+++ b/tests/idris2/error027/expected
@@ -1,0 +1,1 @@
+ERROR: Unhandled input for Prelude.Num.case block in mod at Prelude.Num:94:3--96:44

--- a/tests/idris2/error027/run
+++ b/tests/idris2/error027/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --exec main Issue2950.idr


### PR DESCRIPTION
This pull request resolves #2950 and #2865 (which are the same issue).  There is a code generation problem in `Prelude.Num.mod` that causes it to pass an erased value to `idris_crash`.  

This error appears to happen because `Builtin` is not imported into `Prelude.Num` so `Builtin.idris_crash` is not in scope, but the code in `ProcessDef` is injecting a fallback case alt that references it.  I initially decided to detect this and report an error, but @Z-snails suggested we just call `prim__crash` directly. 

This problem affected all back-ends, but I'll discuss scheme below.

Previously the generated code looked like:
```scheme
(define PreludeC-45Num-u--mod_Integral_Int 
  (lambda (arg-0 arg-1) 
          (let ((sc0 (PreludeC-45EqOrd-u--C-61C-61_Eq_Int arg-1 (blodwen-toSignedInt 0 63)))) 
            (cond ((equal? sc0 0) (blodwen-euclidMod arg-0 arg-1)) 
                  (else ((Builtin-idris_crash 'erased) "Unhandled input for Prelude.Num.case block in mod at Prelude.Num:131:3--133:40"))))))
```
and, if you evaluated `mod 10 0` it would give the error:
```
Exception in string-append: erased is not a string
```

Now the generated scheme looks like
```scheme
(define PreludeC-45Num-u--mod_Integral_Int 
  (lambda (arg-0 arg-1) 
          (let ((sc0 (PreludeC-45EqOrd-u--C-61C-61_Eq_Int arg-1 (blodwen-toSignedInt 0 63)))) 
            (cond ((equal? sc0 0) (blodwen-euclidMod arg-0 arg-1)) 
                  (else (blodwen-error-quit (string-append "ERROR: " "Unhandled input for Prelude.Num.case block in mod at Prelude.Num:131:3--133:40")))))))
```
and the reported error is:
```
ERROR:  Unhandled input for Prelude.Num.case block in mod at Prelude.Num:131:3--133:40
```

