### PR TITLE
[ totality ] divergent function accepted as total

### DIFF
--- a/src/Core/Termination/SizeChange.idr
+++ b/src/Core/Termination/SizeChange.idr
@@ -214,6 +214,16 @@ prefixPath pred g = go g []
           else
             go f ((l, g) :: path)
 
+-- returns `Just a.path` iff there is no self-decreasing edge,
+-- i.e. there is no argument `n` with `index n a.change === (n, Smaller)`
+checkNonDesc : ArgChange -> Maybe Path
+checkNonDesc a = go Z a.change
+  where
+    go : Nat -> Change -> Maybe Path
+    go _ [] = Just a.path
+    go n (Just (k, Smaller) :: xs) = if n == k then Nothing else go (S n) xs
+    go n (_ :: xs) = go (S n) xs
+
 ||| Finding non-terminating loops
 findLoops : {auto c : Ref Ctxt Defs} -> SCSet ->
             Core (NameMap {- $ \ f => -} (Maybe (Path {- f f -} )))
@@ -223,16 +233,12 @@ findLoops s
          -- Hence the following filter:
          let loops = filterEndos (\a => composeChange a.change a.change == a.change) s
          log "totality.termination.calc" 7 $ "Loops: " ++ show loops
-         let terms = map (foldMap (\a => checkDesc Z a.change a.path)) loops
+         let terms = map (foldMap checkNonDesc) loops
          pure terms
     where
       filterEndos : (ArgChange -> Bool) -> SCSet -> NameMap (List ArgChange)
       filterEndos p = mapWithKey (\f, m => filter p (Data.SortedSet.toList (lookupSet f m)))
 
-      checkDesc : Nat -> Change -> Path -> Maybe Path
-      checkDesc _ [] p = Just p
-      checkDesc n (Just (k, Smaller) :: xs) p = if n == k then Nothing else checkDesc (S n) xs p
-      checkDesc n (_ :: xs) p = checkDesc (S n) xs p
 
 findNonTerminatingLoop : {auto c : Ref Ctxt Defs} -> SCSet -> Core (Maybe (Name, Path))
 findNonTerminatingLoop s

--- a/src/Core/Termination/SizeChange.idr
+++ b/src/Core/Termination/SizeChange.idr
@@ -12,6 +12,11 @@ import Libraries.Data.SortedSet
 
 %default covering
 
+-- Based on:
+-- The Size-Change Principle for Termination
+-- by Chin Soon Lee, Neil D. Jones, Amir M. Ben-Amram
+-- https://doi.org/10.1145/360204.360210
+
 ------------------------------------------------------------------------
 -- Basic types
 

--- a/src/Core/Termination/SizeChange.idr
+++ b/src/Core/Termination/SizeChange.idr
@@ -218,16 +218,16 @@ findLoops s
          -- Hence the following filter:
          let loops = filterEndos (\a => composeChange a.change a.change == a.change) s
          log "totality.termination.calc" 7 $ "Loops: " ++ show loops
-         let terms = map (foldMap (\a => checkDesc a.change a.path)) loops
+         let terms = map (foldMap (\a => checkDesc Z a.change a.path)) loops
          pure terms
     where
       filterEndos : (ArgChange -> Bool) -> SCSet -> NameMap (List ArgChange)
       filterEndos p = mapWithKey (\f, m => filter p (Data.SortedSet.toList (lookupSet f m)))
 
-      checkDesc : Change -> Path -> Maybe Path
-      checkDesc [] p = Just p
-      checkDesc (Just (_, Smaller) :: _) p = Nothing
-      checkDesc (_ :: xs) p = checkDesc xs p
+      checkDesc : Nat -> Change -> Path -> Maybe Path
+      checkDesc _ [] p = Just p
+      checkDesc n (Just (k, Smaller) :: xs) p = if n == k then Nothing else checkDesc (S n) xs p
+      checkDesc n (_ :: xs) p = checkDesc (S n) xs p
 
 findNonTerminatingLoop : {auto c : Ref Ctxt Defs} -> SCSet -> Core (Maybe (Name, Path))
 findNonTerminatingLoop s

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -231,7 +231,7 @@ idrisTestsTotality = MkTestPool "Totality checking" [] Nothing
        "total001", "total002", "total003", "total004", "total005",
        "total006", "total007", "total008", "total009", "total010",
        "total011", "total012", "total013", "total014", "total015",
-       "total016", "total017", "total018"
+       "total016", "total017", "total018", "total019"
       ]
 
 -- This will only work with an Idris compiled via Chez or Racket, but at

--- a/tests/idris2/total019/Check.idr
+++ b/tests/idris2/total019/Check.idr
@@ -1,0 +1,5 @@
+%default total
+
+foo : List Char -> List Char -> ()
+foo (c :: cs) _ = foo (c :: cs) cs
+foo _ _ = ()

--- a/tests/idris2/total019/expected
+++ b/tests/idris2/total019/expected
@@ -1,0 +1,9 @@
+1/1: Building Check (Check.idr)
+Error: foo is not total, possibly not terminating due to recursive path Main.foo
+
+Check:3:1--3:35
+ 1 | %default total
+ 2 | 
+ 3 | foo : List Char -> List Char -> ()
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+

--- a/tests/idris2/total019/run
+++ b/tests/idris2/total019/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --no-banner --check Check.idr


### PR DESCRIPTION
The following function is accepted by Idris as total, but it diverges if the first argument is non-empty:
```idris
total
foo : List Char -> List Char -> ()
foo (c :: cs) _ = foo (c :: cs) cs
foo _ _ = ()
```
(This is a reduction of an issue reported by Monadic Cat on Discord.)

The size change info for the function is:
```
Size change: Main.foo: [Just (0, Same), Just (0, Smaller)]
```
The totality checker is correctly assessing that the second argument is a smaller copy of the first, but I believe we need an argument to be smaller than itself. That is the number in the tuple needs to be the same as the index in the array. 

I updated the code based on this assumption, and it resolved this issue and still passes all of the existing test cases.
