### PR TITLE
[ codegen ] get rid of trivial let statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,8 @@
   `TTImp.ProcessDef.genRunTime`. This allows us to track when incomplete `case`
   blocks get the runtime error added.
 
+* Constant folding of trivial let statements.
+
 ### Library changes
 
 #### Prelude

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -310,7 +310,7 @@ chezTests = MkTestPool "Chez backend" [] (Just Chez)
     , "futures001"
     , "bitops"
     , "casts"
-    , "constfold"
+    , "constfold", "constfold2"
     , "memo"
     , "newints"
     , "integers"

--- a/tests/chez/constfold2/Check.idr
+++ b/tests/chez/constfold2/Check.idr
@@ -1,0 +1,19 @@
+import Data.List
+import Data.String
+import System.File
+
+path : String
+path = "build/exec/fold_app/fold.ss"
+
+mainLine : String -> Bool
+mainLine str =
+  ("(define Main-main" `isPrefixOf` str) &&
+  not ("Main-manyToSmall" `isInfixOf` str)
+
+main : IO ()
+main = do
+  Right str <- readFile path
+    | Left err => putStrLn "Error when reading \{path}"
+  case any mainLine (lines str) of
+    True  => putStrLn "Constant expression correctly folded"
+    False => putStrLn "Failed to fold constant expression"

--- a/tests/chez/constfold2/Fold.idr
+++ b/tests/chez/constfold2/Fold.idr
@@ -1,0 +1,27 @@
+import Data.Nat
+
+%default total
+
+record Small where
+  constructor S
+  value : Nat
+  {auto 0 prf : LTE value 20}
+
+Show Small where show = show . value
+
+record Smaller where
+  constructor XS
+  value : Nat
+  {auto 0 prf : LTE value 10}
+
+-- This is the identity function
+toSmall : Smaller -> Small
+toSmall (XS v @{prf}) = S v @{transitive prf %search}
+
+-- This is again the identity function
+manyToSmall : List Smaller -> List Small
+manyToSmall [] = []
+manyToSmall (x::xs) = toSmall x :: manyToSmall xs
+
+main : IO ()
+main = printLn $ manyToSmall [XS 1, XS 2, XS 3]

--- a/tests/chez/constfold2/expected
+++ b/tests/chez/constfold2/expected
@@ -1,0 +1,3 @@
+1/1: Building Check (Check.idr)
+Main> Constant expression correctly folded
+Main> Bye for now!

--- a/tests/chez/constfold2/input
+++ b/tests/chez/constfold2/input
@@ -1,0 +1,2 @@
+:exec main
+:q

--- a/tests/chez/constfold2/run
+++ b/tests/chez/constfold2/run
@@ -1,0 +1,5 @@
+rm -rf build
+
+$1 --no-banner --no-color --quiet -o fold Fold.idr
+$1 --no-banner --no-color --console-width 0 Check.idr < input
+


### PR DESCRIPTION
# Description

Idris sometimes introduces trivial and unnecessary let expressions which prevent the identity optimizer from performing its task. Consider the following example:

```idris
module Id

import Data.Nat

%default total

record Small where
  constructor S
  value : Nat
  {auto 0 prf : LTE value 20}

Show Small where show = show . value

record Smaller where
  constructor XS
  value : Nat
  {auto 0 prf : LTE value 10}

-- This is the identity function
toSmall : Smaller -> Small
toSmall (XS v @{prf}) = S v @{transitive prf %search}

-- This is again the identity function
manyToSmall : List Smaller -> List Small
manyToSmall [] = []
manyToSmall (x::xs) = toSmall x :: manyToSmall xs

main : IO ()
main = printLn $ manyToSmall [XS 1, XS 2, XS 3]
```

`toSmall` is the identity function as is `manyToSmall`. However, as can be seen in the generated JS code, `toSmall` is not optimized away due to a trivial `const` statement.

```javascript
/* Id.toSmall : Smaller -> Small */
function Id_toSmall($0) {
 const $1 = $0;
 return $1;
}

/* Id.manyToSmall : List Smaller -> List Small */
function Id_manyToSmall($0) {
 switch($0.h) {
  case 0: /* nil */ return {h: 0};
  case undefined: /* cons */ return {a1: Id_toSmall($0.a1), a2: Id_manyToSmall($0.a2)};
 }
}
```
Luckily, it is straight forward to get rid of these as part of constant folding, and this is the content of this PR.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

