### PR TITLE
[ codegen ] more flexible array implementation on JS backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Generated JavaScript files now include a shebang when using the Node.js backend
 * NodeJS now supports `popen`/`pclose` for the `Read` mode.
 * `getChar` is now supported on Node.js and `putChar` is supported on both JavaScript backends.
+* Integer-indexed arrays are now supported.
 
 ### Compiler changes
 

--- a/src/Compiler/ES/Codegen.idr
+++ b/src/Compiler/ES/Codegen.idr
@@ -557,9 +557,9 @@ jsPrim nm docs = case (dropAllNS nm, docs) of
   (UN (Basic "prim__newIORef"), [_,v,_]) => pure $ hcat ["({value:", v, "})"]
   (UN (Basic "prim__readIORef"), [_,r,_]) => pure $ hcat ["(", r, ".value)"]
   (UN (Basic "prim__writeIORef"), [_,r,v,_]) => pure $ hcat ["(", r, ".value=", v, ")"]
-  (UN (Basic "prim__newArray"), [_,s,v,_]) => pure $ hcat ["(Array(", s, ").fill(", v, "))"]
-  (UN (Basic "prim__arrayGet"), [_,x,p,_]) => pure $ hcat ["(", x, "[", p, "])"]
-  (UN (Basic "prim__arraySet"), [_,x,p,v,_]) => pure $ hcat ["(", x, "[", p, "]=", v, ")"]
+  (UN (Basic "prim__newArray"), [_,s,v,_]) => pure $ hcat ["(Array(", fromBigInt s, ").fill(", v, "))"]
+  (UN (Basic "prim__arrayGet"), [_,x,p,_]) => pure $ hcat ["(", x, "[", fromBigInt p, "])"]
+  (UN (Basic "prim__arraySet"), [_,x,p,v,_]) => pure $ hcat ["(", x, "[", fromBigInt p, "]=", v, ")"]
   (UN (Basic "void"), [_, _]) => pure . jsCrashExp $ jsStringDoc "Error: Executed 'void'"
   (UN (Basic "prim__void"), [_, _]) => pure . jsCrashExp $ jsStringDoc "Error: Executed 'void'"
   (UN (Basic "prim__codegen"), []) => do

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -363,6 +363,7 @@ nodeTests = MkTestPool "Node backend" [] (Just Node)
     , "fix1839"
     , "tailrec_libs"
     , "nomangle001", "nomangle002"
+    , "integer_array"
     ]
 
 vmcodeInterpTests : IO TestPool

--- a/tests/node/integer_array/array.idr
+++ b/tests/node/integer_array/array.idr
@@ -1,0 +1,48 @@
+import System
+
+import Data.Nat
+
+data ArrayData : Type -> Type where [external]
+
+-- We use `Integer` for indexing here instead of `Int` as in `Data.IOArray.Prims`
+%extern prim__newArray : forall a . Integer -> a -> PrimIO (ArrayData a)
+%extern prim__arrayGet : forall a . ArrayData a -> Integer -> PrimIO a
+%extern prim__arraySet : forall a . ArrayData a -> Integer -> a -> PrimIO ()
+
+record IOArray (n : Nat) a where
+  constructor MkIOArray
+  content : ArrayData a
+
+newArray : HasIO io => (n : Nat) -> a -> io (IOArray n a)
+newArray size v = pure (MkIOArray !(primIO (prim__newArray (cast size) v)))
+
+writeArray :
+     HasIO io
+  => IOArray n a
+  -> (m : Nat)
+  -> {auto 0 lt : LT m n}
+  -> a
+  -> io ()
+writeArray arr pos el = primIO (prim__arraySet (content arr) (cast pos) el)
+
+readArray :
+     HasIO io
+  => IOArray n a
+  -> (m : Nat)
+  -> {auto 0 lt : LT m n}
+  -> io a
+readArray arr pos = primIO (prim__arrayGet (content arr) (cast pos))
+
+toList : {n : _} -> HasIO io => IOArray n a -> io (List a)
+toList arr = iter n reflexive []
+where
+  iter : (m : Nat) -> (0 lte : LTE m n) -> List a -> io (List a)
+  iter 0     _ acc = pure acc
+  iter (S k) p acc = readArray arr k >>= \el => iter k (lteSuccLeft p) (el :: acc)
+
+main : IO ()
+main = do
+  x <- newArray 20 ""
+  writeArray x 11 "World"
+  writeArray x 10 "Hello"
+  printLn !(toList x)

--- a/tests/node/integer_array/expected
+++ b/tests/node/integer_array/expected
@@ -1,0 +1,3 @@
+1/1: Building array (array.idr)
+Main> ["", "", "", "", "", "", "", "", "", "", "Hello", "World", "", "", "", "", "", "", "", ""]
+Main> Bye for now!

--- a/tests/node/integer_array/input
+++ b/tests/node/integer_array/input
@@ -1,0 +1,2 @@
+:exec main
+:q

--- a/tests/node/integer_array/run
+++ b/tests/node/integer_array/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --cg node --no-banner array.idr < input


### PR DESCRIPTION
# Description

I'm working on a library for immutable and mutable (linear) arrays indexed by their size (using `Nat`). From a usability and theoretical correctness point of view it makes sense to use `Integer` for indexing (instead of the slower truncated `Int` being used in `Data.IOArray.Prim`) in the primitive calls and then `Nat` in the user-facing API. The scheme codegens are written in such a way that this is supported without modifications, because all integral primitives are `Integer`s at the backends anyway. The JS backends, however, use a different representation for `Integer` (`BigInt`) than for `Int` (`Number`).

This PR adjust the JS backends in such a way, that all integral types are supported for primitive indexing into arrays. This is a minimal adjustment that does not break any existing code as is verified by test `node/012`. An additional test case has been added, using `Integer` and `Nat` for indexing.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

