### PR TITLE
[ fix #2967 ] Fix issue parsing __LOC__ arguments 

### DIFF
--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -220,7 +220,6 @@ mutual
     <|> lazy fname indents
     <|> if_ fname indents
     <|> with_ fname indents
-    <|> debugString fname
     <|> do b <- bounds (MkPair <$> simpleExpr fname indents <*> many (argExpr q fname indents))
            (f, args) <- pure b.val
            pure (applyExpImp (start b) (end b) f (concat args))
@@ -530,6 +529,7 @@ mutual
           pure $ case projs of
             [] => root
             _  => PPostfixApp (boundToFC fname b) root projs
+    <|> debugString fname
     <|> do b <- bounds (forget <$> some (bounds postfixProj))
            pure $ let projs = map (\ proj => (boundToFC fname proj, proj.val)) b.val in
                   PPostfixAppPartial (boundToFC fname b) projs

--- a/tests/idris2/basic069/DebugInfo.idr
+++ b/tests/idris2/basic069/DebugInfo.idr
@@ -17,3 +17,5 @@ main = do
 
            __LOC__}
       """
+
+  putStrLn __FILE__

--- a/tests/idris2/basic069/expected
+++ b/tests/idris2/basic069/expected
@@ -3,3 +3,4 @@ file: DebugInfo
 line: 7
 col:      24
 loc further down the file: File DebugInfo, line 17, characters 11-18
+DebugInfo


### PR DESCRIPTION
Fixes issue #2967.  DebugInfo strings like `__LOC__` and `__FILE__` would cause a parse error if they were an argument to an application.   I moved the `debugString fname` from `appExpr` to `simpleExpr` and updated the test case `basic069` to also include the case below.

Previously, this code:
```idris
main : IO ()
main = putStrLn __LOC__
```
reported an error:
```
1/1: Building src.Loc (src/Loc.idr)
Error: Couldn't parse declaration.

src.Loc:2:1--2:5
 1 | main : IO ()
 2 | main = putStrLn __LOC__
     ^^^^
```
and now that code is accepted by the compiler.
