### PR TITLE
Update typedd.rst: fixed typo in function name, added page ref

### DIFF
--- a/docs/source/typedd/typedd.rst
+++ b/docs/source/typedd/typedd.rst
@@ -86,7 +86,8 @@ In ``Loops.idr`` and ``ReadNum.idr`` add ``import Data.String`` and change ``cas
 ``stringToNatOrZ``
 
 In ``ReadNum.idr``, since functions must now be ``covering`` by default, add
-a ``partial`` annotation to ``readNumber_v2``.
+a ``partial`` annotation to ``readNumbers_v2``. (This is the version of ``readNumbers``
+on page 135.)
 
 Chapter 6
 ---------


### PR DESCRIPTION
readNumber_v2 should be readNumbers_v2.  I also added a remark pointing to the corresponding function definition in the book, for people who prefer to type  in the definitions themselves (like me) rather than using the source files in the repo.  Not sure if that addition is OK.  I can take it out if so.

There's another issue with the chapter 5 tips, but I'm not sure what the right fix is, so I'll submit an issue separately.

# Description

Fixed typo in function name in tip for chapter 5 of TDDI.  Also added remark pointing to the relevant page number of the function definition in the text, since it's slightly different from the one in the source file (although  the correspondence is easy to guess).

## Should this change go in the CHANGELOG?

No.


