### PR TITLE
[ papers ] Port the first part of "Deferring the details [...]" by Liam O'Connor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,8 +185,8 @@
   J. Garret Morris, and Aaron Stump.
   [https://doi.org/10.1145/3571196](https://doi.org/10.1145/3571196)
 
-* Ports "Deferring the Details and Deriving Programs" by Liam O'Connor as
-  `Data.ProofDelay` and `Language.Trip`
+* Ports the first half of "Deferring the Details and Deriving Programs" by Liam
+  O'Connor as `Data.ProofDelay`.
   [https://doi.org/10.1145/3331554.3342605](https://doi.org/10.1145/3331554.3342605)
   [http://liamoc.net/images/deferring.pdf](http://liamoc.net/images/deferring.pdf)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,9 +180,10 @@
 #### Papers
 
 * In `Control.DivideAndConquer`: a port of the paper
-  `A Type-Based Approach to Divide-And-Conquer Recursion in Coq`
+  "A Type-Based Approach to Divide-And-Conquer Recursion in Coq"
   by Pedro Abreu, Benjamin Delaware, Alex Hubers, Christa Jenkins,
-  J. Garret Morris, and Aaron Stump
+  J. Garret Morris, and Aaron Stump.
+  [https://doi.org/10.1145/3571196](https://doi.org/10.1145/3571196)
 
 ### Other Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,7 +186,7 @@
   [https://doi.org/10.1145/3571196](https://doi.org/10.1145/3571196)
 
 * Ports "Deferring the Details and Deriving Programs" by Liam O'Connor as
-  TODO
+  `Data.ProofDelay` and `Language.Trip`
   [https://doi.org/10.1145/3331554.3342605](https://doi.org/10.1145/3331554.3342605)
   [http://liamoc.net/images/deferring.pdf](http://liamoc.net/images/deferring.pdf)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,11 @@
   J. Garret Morris, and Aaron Stump.
   [https://doi.org/10.1145/3571196](https://doi.org/10.1145/3571196)
 
+* Ports "Deferring the Details and Deriving Programs" by Liam O'Connor as
+  TODO
+  [https://doi.org/10.1145/3331554.3342605](https://doi.org/10.1145/3331554.3342605)
+  [http://liamoc.net/images/deferring.pdf](http://liamoc.net/images/deferring.pdf)
+
 ### Other Changes
 
 * The `data` subfolder of an installed or local dependency package is now automatically

--- a/libs/base/Data/List/Quantifiers.idr
+++ b/libs/base/Data/List/Quantifiers.idr
@@ -166,6 +166,20 @@ namespace All
   HList : List Type -> Type
   HList = All id
 
+  export
+  splitAt : (xs : List a) -> All p (xs ++ ys) -> (All p xs, All p ys)
+  splitAt [] pxs = ([], pxs)
+  splitAt (_ :: xs) (px :: pxs) = mapFst (px ::) (splitAt xs pxs)
+
+  export
+  take : (xs : List a) -> All p (xs ++ ys) -> All p xs
+  take xs pxs = fst (splitAt xs pxs)
+
+  export
+  drop : (xs : List a) -> All p (xs ++ ys) -> All p ys
+  drop xs pxs = snd (splitAt xs pxs)
+
+
 ------------------------------------------------------------------------
 -- Relationship between all and any
 

--- a/libs/papers/Control/DivideAndConquer.idr
+++ b/libs/papers/Control/DivideAndConquer.idr
@@ -2,6 +2,7 @@
 ||| A Type-Based Approach to Divide-And-Conquer Recursion in Coq
 ||| by Pedro Abreu, Benjamin Delaware, Alex Hubers, Christa Jenkins,
 ||| J. Garret Morris, and Aaron Stump
+||| https://doi.org/10.1145/3571196
 |||
 ||| The original paper relies on Coq's impredicative Set axiom,
 ||| something we don't have access to in Idris 2. We can however

--- a/libs/papers/Data/ProofDelay.idr
+++ b/libs/papers/Data/ProofDelay.idr
@@ -145,15 +145,25 @@ example2 =
                       (branch 4 leaf leaf)
                       (branch 10 leaf leaf))
 
+      -- we _could_ construct the proofs by hand, but Idris can just also find
+      -- them (as long as we tell it which proof to find)
       proofs : HList ?
-      proofs =  LTESucc (LTESucc LTEZero)
-             :: LTESucc (LTESucc LTEZero)
-             :: LTESucc (LTESucc (LTESucc LTEZero))
-             :: LTESucc (LTESucc (LTESucc (LTESucc LTEZero)))
-             :: LTESucc (LTESucc (LTESucc (LTESucc (LTESucc LTEZero))))
-             :: LTESucc (LTESucc (LTESucc (LTESucc (LTESucc (LTESucc
-                        (LTESucc (LTESucc (LTESucc (LTESucc LTEZero)))))))))
+      proofs =  the ( 2 `LTE`  2) %search
+             :: the ( 2 `LTE`  3) %search
+             :: the ( 3 `LTE`  4) %search
+             :: the ( 4 `LTE`  5) %search
+             :: the ( 5 `LTE` 10) %search
+             :: the (10 `LTE` 10) %search
              :: []
+      {- proofs =  LTESucc (LTESucc LTEZero)
+       -        :: LTESucc (LTESucc LTEZero)
+       -        :: LTESucc (LTESucc (LTESucc LTEZero))
+       -        :: LTESucc (LTESucc (LTESucc (LTESucc LTEZero)))
+       -        :: LTESucc (LTESucc (LTESucc (LTESucc (LTESucc LTEZero))))
+       -        :: LTESucc (LTESucc (LTESucc (LTESucc (LTESucc (LTESucc
+       -                   (LTESucc (LTESucc (LTESucc (LTESucc LTEZero)))))))))
+       -        :: []
+       -}
 
   in structure.prove proofs
 

--- a/libs/papers/Data/ProofDelay.idr
+++ b/libs/papers/Data/ProofDelay.idr
@@ -4,6 +4,8 @@
 ||| https://doi.org/10.1145/3331554.3342605
 module Data.ProofDelay
 
+import Data.Nat
+
 %default total
 
 namespace HList
@@ -48,8 +50,8 @@ pure x = Prf [] (const x)
 
 ||| Delay the full computation of `x` until `later`.
 public export
-later : (tx : _) -> PDelay tx
-later tx = Prf (tx :: []) (\(x :: []) => x)
+later : {tx : _} -> PDelay tx
+later = Prf (tx :: []) (\(x :: []) => x)
 
 -- pronounced "apply"
 ||| We can compose `PDelay` computations.
@@ -57,4 +59,56 @@ public export
 (<*>) : PDelay (a -> b) -> PDelay a -> PDelay b
 (Prf goals1 prove1) <*> (Prf goals2 prove2) =
   Prf (goals1 ++ goals2) (\hl => prove1 (takeH hl) (prove2 (dropH hl)))
+
+
+------------------------------------------------------------------------
+-- Example uses
+
+||| An ordered list type.
+|||
+||| [27](https://dl.acm.org/doi/10.1145/2503778.2503786)
+public export
+data OList : (m, n : Nat) -> Type where
+  Nil  : (m `LTE` n) -> OList m n
+  Cons : (x : Nat) -> (m `LTE` x) -> OList x n -> OList m n
+
+||| A binary search tree carrying proofs of the ordering in the leaves.
+|||
+||| [31](https://dl.acm.org/doi/10.1145/2628136.2628163)
+public export
+data BST : (m, n : Nat) -> Type where
+  Leaf : (m `LTE` n) -> BST m n
+  Branch : (x : Nat) -> (l : BST m x) -> (r : BST x n) -> BST m n
+
+||| OList `Nil`, but delaying the proof obligation.
+public export
+nil : {m, n : Nat} -> PDelay (OList m n)
+nil = [| Nil later |]
+
+||| OList `Cons`, but delaying the proof obligations.
+public export
+cons : {m, n : Nat} -> (x : Nat) -> PDelay (OList x n) -> PDelay (OList m n)
+cons x xs =
+  let cx : ?  -- Idris can figure out the type
+      cx = Cons x
+  in [| cx later xs |]
+
+||| Extracting an actual `OList` from the delayed version requires providing the
+||| unergonomic proofs.
+public export
+example : OList 1 5
+example =
+  let structure : ?
+      structure = 1 `cons` (2 `cons` (3 `cons` (4 `cons` (5 `cons` nil))))
+
+      proofs : HList ?
+      proofs =  (LTESucc LTEZero)
+             :: (LTESucc LTEZero)
+             :: (LTESucc (LTESucc LTEZero))
+             :: (LTESucc (LTESucc (LTESucc LTEZero)))
+             :: (LTESucc (LTESucc (LTESucc (LTESucc LTEZero))))
+             :: (LTESucc (LTESucc (LTESucc (LTESucc (LTESucc LTEZero)))))
+             :: []
+
+  in structure.prove proofs
 

--- a/libs/papers/Data/ProofDelay.idr
+++ b/libs/papers/Data/ProofDelay.idr
@@ -114,3 +114,46 @@ example =
 
   in structure.prove proofs
 
+-- BST
+
+||| BST `Leaf`, but delaying the proof obligation.
+public export
+leaf : {m, n : Nat} -> PDelay (BST m n)
+leaf = [| Leaf later |]
+
+||| BST `Branch`, but delaying the proof obligations.
+public export
+branch :  {m, n : Nat}
+       -> (x : Nat)
+       -> (l : PDelay (BST m x))
+       -> (r : PDelay (BST x n))
+       -> PDelay (BST m n)
+branch x l r =
+  let bx : ?
+      bx = Branch x
+  in [| bx l r |]
+
+||| Once again, extracting the actual `BST` requires providing the uninteresting
+||| proofs.
+public export
+example2 : BST 2 10
+example2 =
+  let structure : ?
+      structure = branch 3
+                    (branch 2 leaf leaf)
+                    (branch 5
+                      (branch 4 leaf leaf)
+                      (branch 10 leaf leaf))
+
+      proofs : HList ?
+      proofs =  LTESucc (LTESucc LTEZero)
+             :: LTESucc (LTESucc LTEZero)
+             :: LTESucc (LTESucc (LTESucc LTEZero))
+             :: LTESucc (LTESucc (LTESucc (LTESucc LTEZero)))
+             :: LTESucc (LTESucc (LTESucc (LTESucc (LTESucc LTEZero))))
+             :: LTESucc (LTESucc (LTESucc (LTESucc (LTESucc (LTESucc
+                        (LTESucc (LTESucc (LTESucc (LTESucc LTEZero)))))))))
+             :: []
+
+  in structure.prove proofs
+

--- a/libs/papers/Data/ProofDelay.idr
+++ b/libs/papers/Data/ProofDelay.idr
@@ -1,0 +1,60 @@
+||| The contents of this module are based on the paper
+||| Deferring the Details and Deriving Programs
+||| by Liam O'Connor
+||| https://doi.org/10.1145/3331554.3342605
+module Data.ProofDelay
+
+%default total
+
+namespace HList
+  ||| Heterogeneous list indexed by list of types of every element.
+  |||
+  ||| [21](https://doi.org/10.1145/1017472.1017488)
+  public export
+  data HList : List Type -> Type where
+    Nil  : HList []
+    (::) : {0 s : _} -> {0 ss : _} -> s -> HList ss -> HList (s :: ss)
+
+  ||| Similar to `take` for normal lists, except for the index.
+  public export
+  takeH : {ss : _} -> HList (ss ++ ts) -> HList ss
+  takeH {ss = []} ys = []
+  takeH {ss = (s :: ss)} (x :: xs) = x :: takeH xs
+
+  ||| Similar to `drop` for normal lists, except for the index.
+  public export
+  dropH : {ss : _} -> HList (ss ++ ts) -> HList ts
+  dropH {ss = []} ys = ys
+  dropH {ss = (s :: ss)} (x :: xs) = dropH xs
+
+
+||| A type `x` which can only be computed once some, delayed, proof obligations
+||| have been fulfilled.
+public export
+record PDelay (x : Type) where
+  constructor Prf
+
+  ||| List of propositions we need to prove.
+  goals : List Type
+
+  ||| Given the proofs required (i.e. the goals), actually compute the value x.
+  prove : HList goals -> x
+
+
+||| A value which can immediately be constructed (i.e. no delayed proofs).
+public export
+pure : tx -> PDelay tx
+pure x = Prf [] (const x)
+
+||| Delay the full computation of `x` until `later`.
+public export
+later : (tx : _) -> PDelay tx
+later tx = Prf (tx :: []) (\(x :: []) => x)
+
+-- pronounced "apply"
+||| We can compose `PDelay` computations.
+public export
+(<*>) : PDelay (a -> b) -> PDelay a -> PDelay b
+(Prf goals1 prove1) <*> (Prf goals2 prove2) =
+  Prf (goals1 ++ goals2) (\hl => prove1 (takeH hl) (prove2 (dropH hl)))
+

--- a/libs/papers/Data/ProofDelay.idr
+++ b/libs/papers/Data/ProofDelay.idr
@@ -80,6 +80,8 @@ data BST : (m, n : Nat) -> Type where
   Leaf : (m `LTE` n) -> BST m n
   Branch : (x : Nat) -> (l : BST m x) -> (r : BST x n) -> BST m n
 
+-- OList
+
 ||| OList `Nil`, but delaying the proof obligation.
 public export
 nil : {m, n : Nat} -> PDelay (OList m n)
@@ -102,12 +104,12 @@ example =
       structure = 1 `cons` (2 `cons` (3 `cons` (4 `cons` (5 `cons` nil))))
 
       proofs : HList ?
-      proofs =  (LTESucc LTEZero)
-             :: (LTESucc LTEZero)
-             :: (LTESucc (LTESucc LTEZero))
-             :: (LTESucc (LTESucc (LTESucc LTEZero)))
-             :: (LTESucc (LTESucc (LTESucc (LTESucc LTEZero))))
-             :: (LTESucc (LTESucc (LTESucc (LTESucc (LTESucc LTEZero)))))
+      proofs =  LTESucc LTEZero
+             :: LTESucc LTEZero
+             :: LTESucc (LTESucc LTEZero)
+             :: LTESucc (LTESucc (LTESucc LTEZero))
+             :: LTESucc (LTESucc (LTESucc (LTESucc LTEZero)))
+             :: LTESucc (LTESucc (LTESucc (LTESucc (LTESucc LTEZero))))
              :: []
 
   in structure.prove proofs

--- a/libs/papers/Language/Trip.idr
+++ b/libs/papers/Language/Trip.idr
@@ -1,8 +1,0 @@
-||| The contents of this module are based on the paper
-||| Deferring the Details and Deriving Programs
-||| by Liam O'Connor
-||| https://doi.org/10.1145/3331554.3342605
-module Language.Trip
-
-import Data.ProofDelay
-

--- a/libs/papers/Language/Trip.idr
+++ b/libs/papers/Language/Trip.idr
@@ -1,0 +1,8 @@
+||| The contents of this module are based on the paper
+||| Deferring the Details and Deriving Programs
+||| by Liam O'Connor
+||| https://doi.org/10.1145/3331554.3342605
+module Language.Trip
+
+import Data.ProofDelay
+

--- a/libs/papers/papers.ipkg
+++ b/libs/papers/papers.ipkg
@@ -26,6 +26,8 @@ modules = Control.DivideAndConquer,
 
           Data.OpenUnion,
 
+          Data.ProofDelay,
+
           Data.Recursion.Free,
 
           Data.Tree.Perfect,
@@ -45,6 +47,8 @@ modules = Control.DivideAndConquer,
           Language.IntrinsicTyping.STLCR,
 
           Language.Tagless,
+
+          Language.Trip,
 
           Language.TypeTheory,
 

--- a/libs/papers/papers.ipkg
+++ b/libs/papers/papers.ipkg
@@ -48,8 +48,6 @@ modules = Control.DivideAndConquer,
 
           Language.Tagless,
 
-          Language.Trip,
-
           Language.TypeTheory,
 
           Search.Auto,


### PR DESCRIPTION
# Description

This ports the proof delay part of the paper as `papers/Data/ProofDelay.idr`.

I did start an implementation of Trip, but it's quite a bit more work than I anticipated, so I'm putting that on ice for now. If anyone else thinks it would be fun to do, by all means go for it!  : )

## Should this change go in the CHANGELOG?

- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

