### PR TITLE
In "Updates Required", modify comments about stringToNatOrZ to reflect working cast

### DIFF
--- a/docs/source/typedd/typedd.rst
+++ b/docs/source/typedd/typedd.rst
@@ -77,13 +77,13 @@ For the reasons described above:
 Chapter 5
 ---------
 
-There is no longer a ``Cast`` instance from ``String`` to ``Nat``, because its
-behaviour of returing Z if the ``String`` wasn't numeric was thought to be
+Although there is a ``Cast`` instance from ``String`` to ``Nat``, its
+behaviour of returing Z if the ``String`` is not numeric is now thought to be
 confusing and potentially error prone. Instead, there is ``stringToNatOrZ`` in
 ``Data.String`` which at least has a clearer name. So:
 
-In ``Loops.idr`` and ``ReadNum.idr`` add ``import Data.String`` and change ``cast`` to
-``stringToNatOrZ``
+In ``Loops.idr`` and ``ReadNum.idr`` it's preferable to add ``import Data.String``
+and change ``cast`` to ``stringToNatOrZ``.
 
 In ``ReadNum.idr``, since functions must now be ``covering`` by default, add
 a ``partial`` annotation to ``readNumbers_v2``. (This is the version of ``readNumbers``


### PR DESCRIPTION
Re `cast` vs. `stringToNatOrZ` in the chapter 5 tip:

`cast` from `String` to `Nat` *does* work in Idris 2, version 0.6.0-a75161cb2, so the first sentence is not currently correct.  There is no change needed to code in the book or the associated source file to make the code work correctly.

In the Discord documentation channel, z_snail suggested changing the text to merely recommend changing `cast` to `stringToNatOrZ`, without requiring it.   This PR proposes that change.  I tried to modify the text as little as possible, but I made some additional, strictly speaking unnecessary revisions where I thought they would make the wording clearer given the essential changes.  I added a missing period as well.

An alternative is to simply delete the two paragraphs concerning `cast` and `stringToNatOrZ`, given that `cast` works.

(If the `cast` from `String` to `Nat` is destined to be removed, perhaps this PR should be ignored.)



# Description


## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

