### PR TITLE
Update typedd.rst: Chapter 5: new imports for exercises in 5.3.4

### DIFF
--- a/docs/source/typedd/typedd.rst
+++ b/docs/source/typedd/typedd.rst
@@ -89,6 +89,9 @@ In ``ReadNum.idr``, since functions must now be ``covering`` by default, add
 a ``partial`` annotation to ``readNumbers_v2``. (This is the version of ``readNumbers``
 on page 135.)
 
+The file-handling functions for the exercises in section 5.3.4 are no longer in the
+Prelude.  Import `System.File.Handle` and `System.File.ReadWrite` to use them.
+
 Chapter 6
 ---------
 


### PR DESCRIPTION
The instructions for the exercises at the end of section 5.3.4 list several file-handling functions needed for the exercises.  They were in the Prelude, but now are in `System.File.Handle` and `System.File.ReadWrite`, and I added a note about that.  (`import System.File` would work for the exercise code, but the docs aren't there, so I didn't mention that.  I also didn't mention there a few other definitions, in other modules, that one needs to look up to understand the functions that the book lists.  I think that figuring out that one needs to find those additional docs is supposed to be part of the exercise.)

# Description


## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

