### PR TITLE
[ fix ] Improve error messages at end of if statements

### DIFF
--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -820,7 +820,7 @@ mutual
                            commitKeyword fname indents "else"
                            e <- typeExpr pdef fname indents
                            pure (x, t, e))
-           atEnd indents
+           mustWork $ atEnd indents
            (x, t, e) <- pure b.val
            pure (PIfThenElse (boundToFC fname b) x t e)
 

--- a/tests/idris2/perror016/ParseIf4.idr
+++ b/tests/idris2/perror016/ParseIf4.idr
@@ -1,0 +1,10 @@
+import System.File
+foo : File -> IO ()
+foo file = do
+    stuff <- fgetLine file
+    case stuff of
+      (Left err) => printLn err
+      (Right content) => if content == ""
+                            then println "Empty"
+                            else blah <- doSomething
+                                 putStrLn content

--- a/tests/idris2/perror016/expected
+++ b/tests/idris2/perror016/expected
@@ -26,3 +26,15 @@ ParseIf3:3:26--3:30
  3 | test a = (if a < 0 the 0 else 5)
                               ^^^^
 
+1/1: Building ParseIf4 (ParseIf4.idr)
+Error: Couldn't parse any alternatives:
+1: Not the end of a block entry.
+
+ParseIf4:9:39--9:41
+ 5 |     case stuff of
+ 6 |       (Left err) => printLn err
+ 7 |       (Right content) => if content == ""
+ 8 |                             then println "Empty"
+ 9 |                             else blah <- doSomething
+                                           ^^
+... (2 others)

--- a/tests/idris2/perror016/run
+++ b/tests/idris2/perror016/run
@@ -3,3 +3,4 @@ rm -rf build
 $1 --no-color --console-width 0 --check ParseIf.idr || true
 $1 --no-color --console-width 0 --check ParseIf2.idr || true
 $1 --no-color --console-width 0 --check ParseIf3.idr || true
+$1 --no-color --console-width 0 --check ParseIf4.idr || true


### PR DESCRIPTION
A discord user reported a confusing error message pointing at `=>` and saying `=>` was expected. The error was a missing `do` which caused `atEnd` to fail further down the AST.  I put a `mustWork` on the `atEnd` to surface that error and point at a more appropriate location.

Test case:
```idris
import System.File
foo : File -> IO ()
foo file = do
    stuff <- fgetLine file
    case stuff of
      (Left err) => printLn err
      (Right content) => if content == ""
                            then println "Empty"
                            else blah <- doSomething
                                 putStrLn content
```
Previous error message:
```
1/1: Building Foo (Foo.idr)
Error: Expected '=>' or 'impossible'.

Foo:7:23--7:25
 3 | foo file = do
 4 |     stuff <- fgetLine file
 5 |     case stuff of
 6 |       (Left err) => printLn err
 7 |       (Right content) => if content == ""
                           ^^
```
New error message:

```
1/1: Building ParseIf4 (ParseIf4.idr)
Error: Couldn't parse any alternatives:
1: Not the end of a block entry.

ParseIf4:9:39--9:41
 5 |     case stuff of
 6 |       (Left err) => printLn err
 7 |       (Right content) => if content == ""
 8 |                             then println "Empty"
 9 |                             else blah <- doSomething
                                           ^^
```