### PR TITLE
[ breaking ] Make laziness + codata reserved prims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,11 @@
 
 * Constant folding of trivial let statements and `believe_me`.
 
+* Made `Lazy`, `Inf`, `Delay`, and `Force` reserved compiler primitives, rather
+  than being magic string identifiers. This may mean that certain namespaces and
+  libraries need renaming (see, for example, the `Prelude.Interfaces` change
+  below).
+
 ### Library changes
 
 #### Prelude
@@ -99,6 +104,9 @@
 * Added an `Interpolation` implementation for `Void`.
 
 * Added `Compose` instances for `Bifunctor`, `Bifoldable` and `Bitraversable`.
+
+* Renamed the `Lazy` namespace in `Interfaces` to `ILazy` due to `Lazy` now
+  being a reserved compiler primitive.
 
 #### Base
 

--- a/libs/prelude/Prelude/Interfaces.idr
+++ b/libs/prelude/Prelude/Interfaces.idr
@@ -449,13 +449,13 @@ public export
 [MonoidApplicative] Applicative f => Monoid a => Monoid (f a) using SemigroupApplicative where
   neutral = pure neutral
 
-namespace Lazy
+namespace ILazy
   public export
   [SemigroupAlternative] Alternative f => Semigroup (Lazy (f a)) where
     x <+> y = force x <|> y
 
   public export
-  [MonoidAlternative] Alternative f => Monoid (Lazy (f a)) using Lazy.SemigroupAlternative where
+  [MonoidAlternative] Alternative f => Monoid (Lazy (f a)) using ILazy.SemigroupAlternative where
     neutral = delay empty
 
 public export
@@ -488,7 +488,7 @@ public export
 ||| Note: In Haskell, `choice` is called `asum`.
 %inline public export
 choice : Alternative f => Foldable t => t (Lazy (f a)) -> f a
-choice = force . concat @{Lazy.MonoidAlternative}
+choice = force . concat @{ILazy.MonoidAlternative}
 
 ||| A fused version of `choice` and `map`.
 %inline public export

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -942,16 +942,16 @@ mutual
 
   lazy : OriginDesc -> IndentInfo -> Rule PTerm
   lazy fname indents
-      = do tm <- bounds (decorate fname Typ (exactIdent "Lazy")
+      = do tm <- bounds (decorate fname Typ (lazyPrim "Lazy")
                          *> simpleExpr fname indents)
            pure (PDelayed (boundToFC fname tm) LLazy tm.val)
-    <|> do tm <- bounds (decorate fname Typ (exactIdent "Inf")
+    <|> do tm <- bounds (decorate fname Typ (lazyPrim "Inf")
                          *> simpleExpr fname indents)
            pure (PDelayed (boundToFC fname tm) LInf tm.val)
-    <|> do tm <- bounds (decorate fname Data (exactIdent "Delay")
+    <|> do tm <- bounds (decorate fname Data (lazyPrim "Delay")
                          *> simpleExpr fname indents)
            pure (PDelay (boundToFC fname tm) tm.val)
-    <|> do tm <- bounds (decorate fname Data (exactIdent "Force")
+    <|> do tm <- bounds (decorate fname Data (lazyPrim "Force")
                          *> simpleExpr fname indents)
            pure (PForce (boundToFC fname tm) tm.val)
 

--- a/src/Parser/Lexer/Source.idr
+++ b/src/Parser/Lexer/Source.idr
@@ -65,6 +65,7 @@ data Token
   | CGDirective String
   | EndInput
   | Keyword String
+  | LazyPrim String
   | Pragma String
   | MagicDebugInfo DebugInfo
   | Unrecognised String
@@ -104,6 +105,7 @@ Show Token where
   show (CGDirective x) = "CGDirective " ++ x
   show EndInput = "end of input"
   show (Keyword x) = x
+  show (LazyPrim x) = x
   show (Pragma x) = "pragma " ++ x
   show (MagicDebugInfo di) = show di
   show (Unrecognised x) = "Unrecognised " ++ x
@@ -136,6 +138,7 @@ Pretty Void Token where
   pretty (CGDirective x) = pretty "CGDirective" <++> pretty x
   pretty EndInput = reflow "end of input"
   pretty (Keyword x) = pretty x
+  pretty (LazyPrim x) = pretty x
   pretty (Pragma x) = pretty "pragma" <++> pretty x
   pretty (MagicDebugInfo di) = pretty (show di)
   pretty (Unrecognised x) = pretty "Unrecognised" <++> pretty x
@@ -245,6 +248,10 @@ keywords = ["data", "module", "where", "let", "in", "do", "record",
             "public", "export", "private",
             "infixl", "infixr", "infix", "prefix",
             "total", "partial", "covering"]
+
+public export
+lazyPrims : List String
+lazyPrims = ["Lazy", "Inf", "Force", "Delay"]
 
 public export
 debugInfo : List (String, DebugInfo)
@@ -388,7 +395,8 @@ mutual
     where
       parseIdent : String -> Token
       parseIdent x = if x `elem` keywords then Keyword x
-                     else Ident x
+                     else if x `elem` lazyPrims then LazyPrim x
+                          else Ident x
 
       parseNamespace : String -> Token
       parseNamespace ns = case mkNamespacedIdent ns of

--- a/src/Parser/Rule/Source.idr
+++ b/src/Parser/Rule/Source.idr
@@ -242,6 +242,14 @@ keyword req
                  _ => Nothing
 
 export
+lazyPrim : String -> Rule ()
+lazyPrim req
+    = terminal ("Unexpected laziness primitive '" ++ req ++ "'") $
+               \case
+                  LazyPrim s => guard (s == req)
+                  _ => Nothing
+
+export
 exactIdent : String -> Rule ()
 exactIdent req
     = terminal ("Expected " ++ req) $

--- a/src/TTImp/Parser.idr
+++ b/src/TTImp/Parser.idr
@@ -438,22 +438,22 @@ mutual
   lazy : OriginDesc -> IndentInfo -> Rule RawImp
   lazy fname indents
       = do start <- location
-           exactIdent "Lazy"
+           lazyPrim "Lazy"
            tm <- simpleExpr fname indents
            end <- location
            pure (IDelayed (MkFC fname start end) LLazy tm)
     <|> do start <- location
-           exactIdent "Inf"
+           lazyPrim "Inf"
            tm <- simpleExpr fname indents
            end <- location
            pure (IDelayed (MkFC fname start end) LInf tm)
     <|> do start <- location
-           exactIdent "Delay"
+           lazyPrim "Delay"
            tm <- simpleExpr fname indents
            end <- location
            pure (IDelay (MkFC fname start end) tm)
     <|> do start <- location
-           exactIdent "Force"
+           lazyPrim "Force"
            tm <- simpleExpr fname indents
            end <- location
            pure (IForce (MkFC fname start end) tm)


### PR DESCRIPTION
# Description

Changes `Lazy`, `Inf`, `Delay`, and `Force` to be reserved primitives instead of magic `exactIdent` strings.

This is moved from PR #2987 , which added `:doc` REPL interaction for these. This change is A) separate, and B) more controversial, since it potentially requires refactoring of libraries and tools outwith the Idris2 upstream.

Closes #2599 .

## Should this change go in the CHANGELOG?

- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

