### PR TITLE
Update docs copyright notice from 2020 to 2023

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ import sphinx_rtd_theme
 
 # General information about the project.
 project = 'Idris2'
-copyright = '2020, The Idris Community'
+copyright = '2023, The Idris Community'
 author = 'The Idris Community'
 
 # The short X.Y version.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ import sphinx_rtd_theme
 
 # General information about the project.
 project = 'Idris2'
-copyright = '2023, The Idris Community'
+copyright = '2020-2023, The Idris Community'
 author = 'The Idris Community'
 
 # The short X.Y version.


### PR DESCRIPTION
# Description

The pages at https://idris2.readthedocs.io/ show "© Copyright 2020, The Idris Community". This actually made me think that the project is dead. It turns out that the year is hardcoded in a file and should be updated.
