### PR TITLE
Revert "Treat unit types as erased in constructors" (#3002)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,10 +44,6 @@
 * `getChar` is now supported on Node.js and `putChar` is supported on both JavaScript backends.
 * Integer-indexed arrays are now supported.
 
-#### Optimizations
-
-* Unit types can now be erased by the optimiser in data types.
-
 ### Compiler changes
 
 * If `IAlternative` expression with `FirstSuccess` rule fails to typecheck,

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -29,7 +29,7 @@ import public Libraries.Utils.Binary
 ||| version number if you're changing the version more than once in the same day.
 export
 ttcVersion : Int
-ttcVersion = 20230705 * 100 + 0
+ttcVersion = 20230331 * 100 + 0
 
 export
 checkTTCVersion : String -> Int -> Int -> Core ()

--- a/src/TTImp/Elab/Utils.idr
+++ b/src/TTImp/Elab/Utils.idr
@@ -1,7 +1,6 @@
 module TTImp.Elab.Utils
 
 import Core.Case.CaseTree
-import Core.CompileExpr
 import Core.Context
 import Core.Core
 import Core.Env
@@ -33,23 +32,6 @@ detagSafe defs (NTCon _ n _ _ args)
         = elem i ns || notErased (i + 1) ns rest
 detagSafe defs _ = pure False
 
-||| Check if the name at the head of a given Term is a unit type.
-||| This does not evaluate the term, so can return false negatives,
-||| if the unit type is not in the Term directly.
-export
-isUnitType :
-    {auto _ : Ref Ctxt Defs} ->
-    Term vs ->
-    Core Bool
-isUnitType (Ref fc (TyCon {}) n) = do
-    defs <- get Ctxt
-    Just (TCon _ _ _ _ _ _ [con] _) <- lookupDefExact n $ gamma defs
-        | _ => pure False
-    hasFlag (virtualiseFC fc) con (ConType UNIT)
-isUnitType (App _ f _) = isUnitType f
-isUnitType (Bind fc x (Let {}) rhs) = isUnitType rhs
-isUnitType _ = pure False
-
 findErasedFrom : {auto c : Ref Ctxt Defs} ->
                  Defs -> Nat -> NF [] -> Core (List Nat, List Nat)
 findErasedFrom defs pos (NBind fc x (Pi _ c _ aty) scf)
@@ -60,9 +42,9 @@ findErasedFrom defs pos (NBind fc x (Pi _ c _ aty) scf)
          (erest, dtrest) <- findErasedFrom defs (1 + pos) sc
          let dt' = if !(detagSafe defs !(evalClosure defs aty))
                       then (pos :: dtrest) else dtrest
-         if isErased c || !(isUnitType !(quote defs [] aty))
-            then pure (pos :: erest, dt')
-            else pure (erest, dt')
+         pure $ if isErased c
+                   then (pos :: erest, dt')
+                   else (erest, dt')
 findErasedFrom defs pos tm = pure ([], [])
 
 -- Find the argument positions in the given type which are guaranteed to be


### PR DESCRIPTION
Reverts idris-lang/Idris2#3002 which currently breaks some packages on [pack-db](https://github.com/stefan-hoeck/idris2-pack-db), e.g. [TyRE](https://github.com/kasiamarek/tyre). Further discussion on the Discord in the `package-manager` channel, starting [here (n.b. requires Discord access)](https://discord.com/channels/827106007712661524/841274390481600562/1126865667233161268).