### PR TITLE
docs: typo in list difference documentation

### DIFF
--- a/libs/base/Data/List.idr
+++ b/libs/base/Data/List.idr
@@ -279,7 +279,7 @@ infix 7 \\
 |||
 ||| In the following example, the result is `[2, 4]`.
 ||| ```idris example
-||| [1, 2, 3, 4] // [1, 3]
+||| [1, 2, 3, 4] \\ [1, 3]
 ||| ```
 |||
 public export


### PR DESCRIPTION
# Description

https://github.com/idris-lang/Idris2/blob/6729fa8c89792c8d75b58daa86ad2e70c438120f/libs/base/Data/List.idr#L273-L287

A trivial typo fix for `\\` in `Data.List` where the example had a typo showing it as `//`

## Should this change go in the CHANGELOG?

I guess probably not.