### PR TITLE
Remove shadowed names in documentation

### DIFF
--- a/docs/source/tutorial/typesfuns.rst
+++ b/docs/source/tutorial/typesfuns.rst
@@ -1350,7 +1350,7 @@ character:
 
     splitAt : Char -> String -> (String, String)
     splitAt c x = case break (== c) x of
-                      (x, y) => (x, strTail y)
+                      (l, r) => (l, strTail r)
 
 ``break`` is a library function which breaks a string into a pair of
 strings at the point where the given function returns true. We then


### PR DESCRIPTION
# Description

Hi, I'm learning Idris right now, and was going through the documentation. I noticed that one code example has `x` shadowed in the pattern matching of the `case` expression by the function parameter `x` of `splitAt`. I thought it would be clearer to use different names.

Let me know if this is correct (still learning Idris so perhaps I've made incorrect assumptions!)
