### PR TITLE
[ fix ] Fix pattern match issue with function application in Refl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@
 
 * Fixed a bug that caused holes to appear unexpectedly during quotation of dependent pairs.
 
+* Fixed a bug that caused `f` to sometimes be replaced by `fx` after matching `fx = f x`.
+
 ### Library changes
 
 #### Prelude

--- a/src/Core/Case/CaseBuilder.idr
+++ b/src/Core/Case/CaseBuilder.idr
@@ -1089,7 +1089,7 @@ mutual
 
 export
 mkPat : {auto c : Ref Ctxt Defs} -> List Pat -> ClosedTerm -> ClosedTerm -> Core Pat
-mkPat args orig (Ref fc Bound n) = pure $ PLoc fc n
+mkPat [] orig (Ref fc Bound n) = pure $ PLoc fc n
 mkPat args orig (Ref fc (DataCon t a) n) = pure $ PCon fc n t a args
 mkPat args orig (Ref fc (TyCon t a) n) = pure $ PTyCon fc n a args
 mkPat args orig (Ref fc Func n)

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -70,7 +70,7 @@ idrisTestsTermination = MkTestPool "Termination checking" [] Nothing
 idrisTestsCasetree : TestPool
 idrisTestsCasetree = MkTestPool "Case tree building" [] Nothing
        -- Case tree building
-      ["casetree001", "casetree002", "casetree003"]
+      ["casetree001", "casetree002", "casetree003", "casetree004"]
 
 idrisTestsWarning : TestPool
 idrisTestsWarning = MkTestPool "Warnings" [] Nothing

--- a/tests/idris2/casetree004/LocalArgs.idr
+++ b/tests/idris2/casetree004/LocalArgs.idr
@@ -1,0 +1,11 @@
+import Data.Vect
+
+bar : (f : List a -> Nat) -> (xs : List a) -> Nat
+bar f xs = f xs
+
+-- Idris was putting fx@f for the first implicit (instead of fx@(f xs))
+foo : (f : List a -> Nat) -> (xs : List a) -> (0 _ : fx = f xs) -> Nat
+foo f xs Refl = bar f xs
+
+blah : (xs : List a) -> Vect (foo List.length xs Refl) ()
+blah xs = replicate (length xs) ()

--- a/tests/idris2/casetree004/expected
+++ b/tests/idris2/casetree004/expected
@@ -1,0 +1,1 @@
+1/1: Building LocalArgs (LocalArgs.idr)

--- a/tests/idris2/casetree004/run
+++ b/tests/idris2/casetree004/run
@@ -1,0 +1,3 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --no-banner LocalArgs.idr --check


### PR DESCRIPTION
# Description

In discord @ohad  reported a unification error where a function was being replaced by an application of the same function at type level.  A test case that demonstrates the issue is included below. The root cause was that when a `fx = f x` was matched, the implicit argument `fx` in the spine was turned into `fx@(f x)`.  When this was later processed in `mkPat` in `CaseBuilder.idr`, the spine was being collected, but inadvertently dropped, so the resulting pattern looked like `fx@f` and `fx` was later substituted for `f` in a function call (note that they have completely different types). 

The fix is to check for a non-empty spine and fallback to `PUnmatchable` if it's not empty.  This results in a pattern that is dotted and includes the arguments: `f@(.(f x))`.

Consider:

```idris
import Data.Vect

bar : (f : List a -> Nat) -> (xs : List a) -> Nat
bar f xs = f xs

foo : (f : List a -> Nat) -> (xs : List a) -> (0 _ : fx = f xs) -> Nat
foo f xs Refl = bar f xs

blah : (xs : List a) -> Vect (foo List.length xs Refl) ()
blah xs = replicate (length xs) ()
```

If we comment out `blah` to get it to compile and look at `:di foo` in the current version of Idris:
```
Main.foo
Arguments [{arg:0}, {arg:1}, {arg:2}, {arg:3}, {arg:4}]
Compile time tree: bar {arg:0} {arg:3}
Erasable args: [0, 1, 4]
Detaggable arg types: [4]
Inferrable args: [1]
Compiled: \ {arg:2}, {arg:3} => Main.bar {arg:2} {arg:3}
Refers to: Main.bar
Refers to (runtime): Main.bar
Flags: covering
Size change: Main.bar: [Just (1, Same), Just (2, Same), Just (3, Same)]
```
The compile time tree is passing `arg:0` to `bar`, which is the wrong type.  The compiled tree correctly passes `arg:2`.

Before this change, the code above failed to typecheck with:
```
1/1: Building LocalArgs (LocalArgs.idr)
Error: While processing right hand side of blah. When unifying:
    length xs xs
and:
    length xs

LocalArgs:11:11--11:35
 07 | foo : (f : List a -> Nat) -> (xs : List a) -> (0 _ : fx = f xs) -> Nat
 08 | foo f xs Refl = bar f xs
 09 | 
 10 | blah : (xs : List a) -> Vect (foo List.length xs Refl) ()
 11 | blah xs = replicate (length xs) ()
                ^^^^^^^^^^^^^^^^^^^^^^^^
```
After this change the file typechecks.


## Should this change go in the CHANGELOG?

- [X] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

