### PR TITLE
[ fix ] Fix error handling in windows getTermLines

### DIFF
--- a/support/c/idris_term.c
+++ b/support/c/idris_term.c
@@ -16,14 +16,18 @@ void idris2_setupTerm() {
 
 int idris2_getTermCols() {
   CONSOLE_SCREEN_BUFFER_INFO csbi;
-  GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);
-  return (int)csbi.srWindow.Right - csbi.srWindow.Left + 1;
+  if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi)) {
+    return (int)csbi.srWindow.Right - csbi.srWindow.Left + 1;
+  }
+  return 0;
 }
 
 int idris2_getTermLines() {
   CONSOLE_SCREEN_BUFFER_INFO csbi;
-  GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);
-  return (int)csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
+  if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi)) {
+    return (int)csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
+  }
+  return 0;
 }
 
 #else


### PR DESCRIPTION
This PR fixes the failing windows CI test `scheme002` by checking the return value of `GetConsoleScreenBufferInfo`.  Windows was lacking error handling in the code for the getting the terminal size.  The fix is also included in #3027, so this PR be closed if that PR is merged.
