### PR TITLE
[ fix ] Pin chez v9.5.8a in windows CI

### DIFF
--- a/.github/workflows/ci-idris2.yml
+++ b/.github/workflows/ci-idris2.yml
@@ -209,7 +209,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Get Chez Scheme
         run: |
-          git clone --depth 1 https://github.com/cisco/ChezScheme
+          git clone --depth 1 --branch v9.5.8a https://github.com/cisco/ChezScheme
           c:\msys64\usr\bin\bash -l -c "pacman -S --noconfirm tar make mingw-w64-x86_64-gcc"
           echo "PWD=$(c:\msys64\usr\bin\cygpath -u $(pwd))" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Configure and Build Chez Scheme
@@ -422,7 +422,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Get Chez Scheme
         run: |
-          git clone --depth 1 https://github.com/cisco/ChezScheme
+          git clone --depth 1 --branch v9.5.8a https://github.com/cisco/ChezScheme
           c:\msys64\usr\bin\bash -l -c "pacman -S --noconfirm tar make mingw-w64-x86_64-gcc"
           echo "PWD=$(c:\msys64\usr\bin\cygpath -u $(pwd))" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Configure and Build Chez Scheme


### PR DESCRIPTION
To try to stabilize the windows CI, this PR pins the windows chez to the latest release (9.5.8a) instead of pulling the latest dev version. This appears to fix the issue with the `chez/futures001` test.
