### PR TITLE
[ ttc ] Relax existing second-precision time requirements

### DIFF
--- a/src/Idris/ProcessIdr.idr
+++ b/src/Idris/ProcessIdr.idr
@@ -258,9 +258,9 @@ isTTCOutdated ttcFile sourceFiles
        srcTimes <- traverse modTime sourceFiles
        log "module.hash" 20 $
          unlines $
-           "Checking whether source code mod times are newer than \{show ttcTime}; src times:"
+           "Checking whether source code mod times are not older than \{show ttcTime}; src times:"
            :: zipWith (\ src, tm => "\{src} : \{show tm}") sourceFiles srcTimes
-       pure $ any (>= ttcTime) srcTimes
+       pure $ any (> ttcTime) srcTimes
 
 ||| If the source files hash hasn't changed
 export

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -43,6 +43,7 @@ idrisTestsBasic = MkTestPool "Fundamental language features" [] Nothing
        "basic056", "basic057", "basic058", "basic059", "basic060",
        "basic061", "basic062", "basic063", "basic064", "basic065",
        "basic066", "basic067", "basic068", "basic069", "basic070",
+       "basic071",
        "idiom001",
        "dotted001",
        "rewrite001",

--- a/tests/idris2/basic071/Simple.idr
+++ b/tests/idris2/basic071/Simple.idr
@@ -1,0 +1,6 @@
+module Simple
+
+%default total
+
+x : Nat
+x = 5

--- a/tests/idris2/basic071/expected
+++ b/tests/idris2/basic071/expected
@@ -1,0 +1,2 @@
+1/1: Building Simple (Simple.idr)
+-- this should be the last line of output --

--- a/tests/idris2/basic071/run
+++ b/tests/idris2/basic071/run
@@ -1,0 +1,10 @@
+rm -rf build
+
+$1 --no-color --console-width 0 --no-banner --check Simple.idr
+
+# Set the same time for the source file and TTC files
+touch *.idr build/ttc/*/*.tt*
+
+# No rebuild should happen
+echo "-- this should be the last line of output --"
+$1 --no-color --console-width 0 --no-banner --check Simple.idr


### PR DESCRIPTION
Currently source modification time must be strictly less than TTC file modification time. Since, time is measured in seconds, it can be read that source modification time must be at least one second less than the TTC file modification time. In some obscure situations this gives to extra rebuilds.

I propose to relax this requirement and allow source modification time to be in the same second as TTC file modification time. I couldn't imagine situation where this can break something comparing to the current behaviour. WDYT?

