### PR TITLE
[ fix ] Use freshly built `libidris2_support` in compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,12 +59,13 @@ export SCHEME
 
 .PHONY: all idris2-exec libdocs testenv testenv-clean support clean-support clean FORCE
 
-all: support ${TARGET} libs
+all: ${TARGET} libs
 
 idris2-exec: ${TARGET}
 
-${TARGET}: src/IdrisPaths.idr
+${TARGET}: support src/IdrisPaths.idr
 	${IDRIS2_BOOT} --build ${IDRIS2_APP_IPKG}
+	cp ${IDRIS2_CURDIR}/support/c/${IDRIS2_SUPPORT} ${TARGETDIR}/${NAME}_app/${IDRIS2_SUPPORT}
 
 # We use FORCE to always rebuild IdrisPath so that the git SHA1 info is always up to date
 src/IdrisPaths.idr: FORCE


### PR DESCRIPTION
Currently, when the compiler executable is built, `libidris2_support.so` from the previous compiler version is shipped with the new one. This makes it impossible to add new foreign functions to the compiler without an intermediate step adding new functions to `libidris2_support.so`  but not using them yet. Additionally, it makes it impossible for commits that use new foreign functions to pass CI, because the compiler is first built with the last release version, which does not contain the new foreign functions in its support files.

This PR addresses the issue by replacing the `libidris2_support.so` file with a freshly built one.