### PR TITLE
Add documentation for Not.

### DIFF
--- a/libs/prelude/Prelude/Basics.idr
+++ b/libs/prelude/Prelude/Basics.idr
@@ -6,6 +6,10 @@ import Prelude.Ops
 
 %default total
 
+
+||| `Not x` is an alias for `x -> Void`, indicating that any term of type `x`
+||| leads to a contradiction. It can be used in conjunction with `void` or
+||| `absurd`.
 public export
 Not : Type -> Type
 Not x = x -> Void


### PR DESCRIPTION
# Description
Add documentation for Not.  Based on a suggestion by Andre in discord.

## Should this change go in the CHANGELOG?
Yes, I think so.

- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

