### PR TITLE
Add support code for racket/tcp

### DIFF
--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -46,6 +46,8 @@ schHeader prof libs = fromString """
   #lang racket/base
   ;; \{ generatedString "Racket" }
   (require racket/async-channel)         ; for asynchronous channels
+  (require racket/tcp)                   ; for tcp
+  (require racket/port)                  ; for read-bytes-evt, necessary for tcp
   (require racket/future)                ; for parallelism/concurrency
   (require racket/math)                  ; for math ops
   (require racket/system)                ; for system

--- a/support/racket/support.rkt
+++ b/support/racket/support.rkt
@@ -328,6 +328,39 @@
       (blodwen-error-quit "Exception in mutexRelease: thread does not own mutex")
       (semaphore-post sema)))
 
+;; TCP
+
+(define (blodwen-tcp-listen port)
+  ;; return nil on exception, for example when port in use
+  (with-handlers ([exn:fail:network? (lambda (x) '())])
+    (tcp-listen port)
+  )
+)
+
+(define (blodwen-tcp-accept listener)
+  (let-values
+    ;; Racket doesn't allow treating the multiple returned
+    ;; values a pair to unpack later. So we make it a list.
+    ([(in-port out-port) (tcp-accept listener)]
+    )
+    (list in-port out-port)
+  )
+)
+
+(define (blodwen-tcp-connect hostname port)
+  ;; return nil on exception, for example when connection rejected
+  (with-handlers ([exn:fail:network? (lambda (x) '())])
+    (let-values
+      ([(in-port out-port) (tcp-connect hostname port)]
+      )
+      (list in-port out-port)
+    )
+  )
+)
+
+(define blodwen-input-port car)
+(define (blodwen-output-port list-elems) (car (cdr list-elems)))
+
 ;; Condition Variables
 ;; As per p.5 of the MS paper
 ;; https://www.microsoft.com/en-us/research/wp-content/uploads/2004/12/ImplementingCVs.pdf
@@ -547,6 +580,9 @@
 
 (define (blodwen-is-box obj)
   (if (box? obj) 1 0))
+
+(define (blodwen-is-eof obj)
+  (if (eof-object? obj) 1 0))
 
 (define (blodwen-make-symbol str)
   (string->symbol str))


### PR DESCRIPTION
Since the Racket TCP code uses multiple return values, it isn't easy to use from Idris without writing custom scheme code. But this custom code can't be added in a library since `directive extraRuntime=...` seems to only work for executables.

To avoid bloating contrib, I haven't added any code that actually uses this. But it would look like this:

```idris
module RacketTCP

import Data.Buffer as Buffer

export
data Listener: Type where [external]

export
data InputPort : Type where [external]

export
data OutputPort : Type where [external]

data PortPair : Type where [external]

export
data ReadSyncEvt : Type where [external]

export
data WriteSyncEvt : Type where [external]

data EOFOrBuffer : Type where [external]

data NilOrPortPair : Type where [external]

data NilOrListener : Type where [external]

public export
data EOF = MkEOF

public export
data Couldn'tConnect = MkCouldn'tConnect

%foreign "scheme,racket:blodwen-input-port"
prim__rfst : PortPair -> PrimIO InputPort

%foreign "scheme,racket:blodwen-output-port"
prim__rsnd : PortPair -> PrimIO OutputPort

rfst : HasIO io => PortPair -> io InputPort
rfst = primIO . prim__rfst

rsnd : HasIO io => PortPair -> io OutputPort
rsnd = primIO . prim__rsnd

%foreign "scheme,racket:blodwen-tcp-listen"
prim__tcpListen : Bits16 -> PrimIO NilOrListener

%foreign "scheme,racket:blodwen-is-eof"
prim__isEOF : EOFOrBuffer -> PrimIO Int

%foreign "scheme,racket:blodwen-is-nil"
prim__isNil : NilOrPortPair -> PrimIO Int

%foreign "scheme,racket:blodwen-is-nil"
prim__isNilListener : NilOrListener -> PrimIO Int

assertIsBuffer : EOFOrBuffer -> Buffer
assertIsBuffer = believe_me

assertIsPortPair : NilOrPortPair -> PortPair
assertIsPortPair = believe_me

assertIsListener : NilOrListener -> Listener
assertIsListener = believe_me

public export
data ErrListen = MkListenErr

export
tcpListen : HasIO io => Bits16 -> io (Either ErrListen Listener)
tcpListen port = do
  errOrListener <- primIO (prim__tcpListen port)
  nil <- primIO (prim__isNilListener errOrListener)
  if nil == 1
     then pure (Left MkListenErr)
     else pure (Right $ assertIsListener errOrListener)


%foreign "scheme,racket:blodwen-tcp-accept"
prim__tcpAccept : Listener -> PrimIO PortPair

portPairToIdrisPair : HasIO io => PortPair -> io (Pair InputPort OutputPort)
portPairToIdrisPair portPair = do
  inputPort <- rfst portPair
  outputPort <- rsnd portPair
  pure $ MkPair inputPort outputPort

export
tcpAccept : HasIO io => Listener -> io (Pair InputPort OutputPort)
tcpAccept listener = do
  portPairToIdrisPair =<< primIO (prim__tcpAccept listener)

%foreign "scheme,racket:blodwen-tcp-connect"
prim__tcpConnect : String -> Bits16 -> PrimIO NilOrPortPair

export
tcpConnect : HasIO io => String -> Bits16 -> io (Either Couldn'tConnect (Pair InputPort OutputPort))
tcpConnect hostname port = do
  nilOrPortPair <- primIO (prim__tcpConnect hostname port)
  nil <- primIO (prim__isNil nilOrPortPair)
  if nil == 1
     then pure (Left MkCouldn'tConnect)
     else Right <$> portPairToIdrisPair (assertIsPortPair nilOrPortPair)

%foreign "scheme,racket:read-bytes-evt"
prim__readBytesEvt : Bits16 -> InputPort -> PrimIO ReadSyncEvt

export
readBytesEvt : HasIO io => Bits16 -> InputPort -> io ReadSyncEvt
readBytesEvt count inPort = primIO $ prim__readBytesEvt count inPort

%foreign "scheme,racket:sync"
prim__readSync : ReadSyncEvt -> PrimIO EOFOrBuffer

%foreign "scheme,racket:sync"
prim__writeSync : WriteSyncEvt -> PrimIO Bits64

export
readSync : HasIO io => ReadSyncEvt -> io (Either EOF Buffer)
readSync readSyncEvt = do
  evt <- primIO (prim__readSync readSyncEvt)
  isEOF <- primIO (prim__isEOF evt)
  if isEOF == 1
     then pure (Left MkEOF)
     else pure (Right (assertIsBuffer evt))

export
writeSync : HasIO io => WriteSyncEvt -> io Bits64
writeSync = primIO . prim__writeSync

%foreign "scheme,racket:write-bytes-avail-evt"
prim__writeBytesAvailEvt : Buffer -> OutputPort -> PrimIO WriteSyncEvt

export
writeBytesAvailEvt : HasIO io => Buffer -> OutputPort -> io WriteSyncEvt
writeBytesAvailEvt buf port = primIO $ prim__writeBytesAvailEvt buf port

%foreign "scheme,racket:flush-output"
prim__flushOutput : OutputPort -> PrimIO Unit

export
flushOutput : HasIO io => OutputPort -> io Unit
flushOutput = primIO . prim__flushOutput
```

I haven't added a changelog entry since the support code doesn't seem to have a section there.

