### PR TITLE
Add library loading for Racket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@
 * Non-recursive top-level constants are compiled to eagerly evaluated
   constants in Chez Scheme.
 
+#### Racket
+
+* FFI declarations can now specify which `require` to perform, i.e. which
+  library to load before executing the FFI.
+  The syntax is `scheme,racket:my-function,my-library`.
+
 #### Node.js/Browser
 
 * Generated JavaScript files now include a shebang when using the Node.js backend

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -280,6 +280,9 @@ useCC appdir fc ccs args ret
            Just ("scheme,racket", [sfn]) =>
                do let body = schemeCall fc sfn (map fst args) ret
                   pure ("", body)
+           Just ("scheme,racket", [sfn, racketlib]) =>
+               do let body = schemeCall fc sfn (map fst args) ret
+                  pure (fromString $ "(require " ++ racketlib ++ ")", body)
            Just ("scheme", [sfn]) =>
                do let body = schemeCall fc sfn (map fst args) ret
                   pure ("", body)

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -338,6 +338,7 @@ racketTests = MkTestPool "Racket backend" [] (Just Racket)
     , "conditions005"
 --    , "conditions006"
 --    , "conditions007"
+    , "ffi001"
     ]
 
 nodeTests : TestPool

--- a/tests/racket/ffi001/RacketLib.idr
+++ b/tests/racket/ffi001/RacketLib.idr
@@ -1,0 +1,8 @@
+%foreign "scheme,racket:(lambda (x) (if (port-number? x) 1 0)),racket/tcp"
+isPortNumber : Int -> Bool
+
+main : IO ()
+main = do
+  putStrLn $ "0 is port: " ++ show (isPortNumber 0)
+  putStrLn $ "1 is port: " ++ show (isPortNumber 1)
+  putStrLn $ "2 is port: " ++ show (isPortNumber 2)

--- a/tests/racket/ffi001/expected
+++ b/tests/racket/ffi001/expected
@@ -1,0 +1,3 @@
+0 is port: False
+1 is port: True
+2 is port: True

--- a/tests/racket/ffi001/run
+++ b/tests/racket/ffi001/run
@@ -1,0 +1,1 @@
+$1 --no-banner --no-color --console-width 0 --cg racket RacketLib.idr --exec main


### PR DESCRIPTION
# Description
This adds an optional ",library" suffix to Racket FFI definitions. Replaces #3048.

Before this PR, FFI definitions that use bindings from parent scopes are always unreliable since a user can't know which libraries are `require`d as part of code generation:

https://github.com/idris-lang/Idris2/blob/86c53e6071ee83008dc77e4572e20be195d5b137/src/Compiler/Scheme/Racket.idr#L48-L56

Suppose a user's library Foo, which uses any of the functions `require`d there. If a future Idris version removed this code the Foo library would stop working.

To make this more robust, this PR gives users the *option* of specifying which Racket library they are defining FFI for. Now, the require is inserted when that code is generated, meaning that Foo would still work on this future hypothetical version of Idris that doesn't `require` the necessary library any more. Racket accepts multiple `require`s of the same library, so if Idris re-adds the `require` again, the library doesn't break.

## Should this change go in the CHANGELOG?
Yes, changelog entry added in separate commit.