### PR TITLE
implement DESTDIR support for distros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,8 @@
 * Fixes an error in the `Makefile` where setting `IDRIS2_PREFIX` caused
   bootstrapping to fail.
 * Updates the docs for `envvars` to match the changes introduced in #2649.
+* Both `make install` and `idris2 --install...` now respect `DESTDIR` which
+  can be set to install into a staging directory for distro packaging.
 
 ## v0.6.0
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -30,6 +30,7 @@ Hiroki Hattori
 Ilya Rezvov
 Jan de Muijnck-Hughes
 Jeetu
+Jens Petersen
 Joey Eremondi
 Johann Rudloff
 Kamil Shakirov

--- a/Makefile
+++ b/Makefile
@@ -192,13 +192,13 @@ install-with-src-api: src/IdrisPaths.idr
 	${IDRIS2_BOOT} --install-with-src ${IDRIS2_LIB_IPKG}
 
 install-idris2:
-	mkdir -p ${PREFIX}/bin/
-	install ${TARGET} ${PREFIX}/bin
+	mkdir -p ${DESTDIR}${PREFIX}/bin/
+	install ${TARGET} ${DESTDIR}${PREFIX}/bin
 ifeq ($(OS), windows)
-	-install ${TARGET}.cmd ${PREFIX}/bin
+	-install ${TARGET}.cmd ${DESTDIR}${PREFIX}/bin
 endif
-	mkdir -p ${PREFIX}/bin/${NAME}_app
-	install ${TARGETDIR}/${NAME}_app/* ${PREFIX}/bin/${NAME}_app
+	mkdir -p ${DESTDIR}${PREFIX}/bin/${NAME}_app
+	install ${TARGETDIR}/${NAME}_app/* ${DESTDIR}${PREFIX}/bin/${NAME}_app
 
 install-support:
 	@${MAKE} -C support install
@@ -222,19 +222,19 @@ install-with-src-libs:
 	${MAKE} -C libs/linear install-with-src  IDRIS2=${TARGET} IDRIS2_PATH=${IDRIS2_BOOT_PATH} IDRIS2_INC_CGS=${IDRIS2_CG}
 
 install-libdocs: libdocs
-	mkdir -p ${PREFIX}/${NAME_VERSION}/docs/prelude
-	mkdir -p ${PREFIX}/${NAME_VERSION}/docs/base
-	mkdir -p ${PREFIX}/${NAME_VERSION}/docs/contrib
-	mkdir -p ${PREFIX}/${NAME_VERSION}/docs/network
-	mkdir -p ${PREFIX}/${NAME_VERSION}/docs/test
-	mkdir -p ${PREFIX}/${NAME_VERSION}/docs/linear
-	cp -r libs/prelude/build/docs/* ${PREFIX}/${NAME_VERSION}/docs/prelude
-	cp -r libs/base/build/docs/*    ${PREFIX}/${NAME_VERSION}/docs/base
-	cp -r libs/contrib/build/docs/* ${PREFIX}/${NAME_VERSION}/docs/contrib
-	cp -r libs/network/build/docs/* ${PREFIX}/${NAME_VERSION}/docs/network
-	cp -r libs/test/build/docs/*    ${PREFIX}/${NAME_VERSION}/docs/test
-	cp -r libs/linear/build/docs/*  ${PREFIX}/${NAME_VERSION}/docs/linear
-	install -m 644 support/docs/*   ${PREFIX}/${NAME_VERSION}/docs
+	mkdir -p ${DESTDIR}${PREFIX}/${NAME_VERSION}/docs/prelude
+	mkdir -p ${DESTDIR}${PREFIX}/${NAME_VERSION}/docs/base
+	mkdir -p ${DESTDIR}${PREFIX}/${NAME_VERSION}/docs/contrib
+	mkdir -p ${DESTDIR}${PREFIX}/${NAME_VERSION}/docs/network
+	mkdir -p ${DESTDIR}${PREFIX}/${NAME_VERSION}/docs/test
+	mkdir -p ${DESTDIR}${PREFIX}/${NAME_VERSION}/docs/linear
+	cp -r libs/prelude/build/docs/* ${DESTDIR}${PREFIX}/${NAME_VERSION}/docs/prelude
+	cp -r libs/base/build/docs/*    ${DESTDIR}${PREFIX}/${NAME_VERSION}/docs/base
+	cp -r libs/contrib/build/docs/* ${DESTDIR}${PREFIX}/${NAME_VERSION}/docs/contrib
+	cp -r libs/network/build/docs/* ${DESTDIR}${PREFIX}/${NAME_VERSION}/docs/network
+	cp -r libs/test/build/docs/*    ${DESTDIR}${PREFIX}/${NAME_VERSION}/docs/test
+	cp -r libs/linear/build/docs/*  ${DESTDIR}${PREFIX}/${NAME_VERSION}/docs/linear
+	install -m 644 support/docs/*   ${DESTDIR}${PREFIX}/${NAME_VERSION}/docs
 
 
 .PHONY: bootstrap bootstrap-build bootstrap-racket bootstrap-racket-build bootstrap-test bootstrap-clean

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -595,9 +595,11 @@ install pkg opts installSrc -- not used but might be in the future
     = do defs <- get Ctxt
          build <- ttcBuildDirectory
          let lib = installDir pkg
-         libTargetDir <- libInstallDirectory lib
-         ttcTargetDir <- ttcInstallDirectory lib
-         srcTargetDir <- srcInstallDirectory lib
+         mdestdir <- coreLift $ getEnv "DESTDIR"
+         let destdir = fromMaybe "" mdestdir
+         libTargetDir <- (destdir ++) <$> libInstallDirectory lib
+         ttcTargetDir <- (destdir ++) <$> ttcInstallDirectory lib
+         srcTargetDir <- (destdir ++) <$> srcInstallDirectory lib
 
          let src = source_dir (dirs (options defs))
          runScript (preinstall pkg)

--- a/support/Makefile
+++ b/support/Makefile
@@ -31,20 +31,20 @@ clean-chez:
 install: install-docs install-racket install-gambit install-js install-c install-refc install-chez
 
 install-docs:
-	mkdir -p ${PREFIX}/${NAME_VERSION}/support/docs
-	install -m 644 docs/*.css ${PREFIX}/${NAME_VERSION}/support/docs
+	mkdir -p ${DESTDIR}${PREFIX}/${NAME_VERSION}/support/docs
+	install -m 644 docs/*.css ${DESTDIR}${PREFIX}/${NAME_VERSION}/support/docs
 
 install-racket:
-	mkdir -p ${PREFIX}/${NAME_VERSION}/support/racket
-	install -m 644 racket/* ${PREFIX}/${NAME_VERSION}/support/racket
+	mkdir -p ${DESTDIR}${PREFIX}/${NAME_VERSION}/support/racket
+	install -m 644 racket/* ${DESTDIR}${PREFIX}/${NAME_VERSION}/support/racket
 
 install-gambit:
-	mkdir -p ${PREFIX}/${NAME_VERSION}/support/gambit
-	install -m 644 gambit/* ${PREFIX}/${NAME_VERSION}/support/gambit
+	mkdir -p ${DESTDIR}${PREFIX}/${NAME_VERSION}/support/gambit
+	install -m 644 gambit/* ${DESTDIR}${PREFIX}/${NAME_VERSION}/support/gambit
 
 install-js:
-	mkdir -p ${PREFIX}/${NAME_VERSION}/support/js
-	install -m 644 js/* ${PREFIX}/${NAME_VERSION}/support/js
+	mkdir -p ${DESTDIR}${PREFIX}/${NAME_VERSION}/support/js
+	install -m 644 js/* ${DESTDIR}${PREFIX}/${NAME_VERSION}/support/js
 
 install-c:
 	@${MAKE} -C c install

--- a/support/c/Makefile
+++ b/support/c/Makefile
@@ -51,8 +51,8 @@ cleandep: clean
 
 .PHONY: install
 install: build
-	mkdir -p ${PREFIX}/idris2-${IDRIS2_VERSION}/lib
-	mkdir -p ${PREFIX}/idris2-${IDRIS2_VERSION}/support/c
-	install -m 755 $(DYLIBTARGET) ${PREFIX}/idris2-${IDRIS2_VERSION}/lib
-	install -m 644 $(LIBTARGET)   ${PREFIX}/idris2-${IDRIS2_VERSION}/lib
-	install -m 644 *.h            ${PREFIX}/idris2-${IDRIS2_VERSION}/support/c
+	mkdir -p ${DESTDIR}${PREFIX}/idris2-${IDRIS2_VERSION}/lib
+	mkdir -p ${DESTDIR}${PREFIX}/idris2-${IDRIS2_VERSION}/support/c
+	install -m 755 $(DYLIBTARGET) ${DESTDIR}${PREFIX}/idris2-${IDRIS2_VERSION}/lib
+	install -m 644 $(LIBTARGET)   ${DESTDIR}${PREFIX}/idris2-${IDRIS2_VERSION}/lib
+	install -m 644 *.h            ${DESTDIR}${PREFIX}/idris2-${IDRIS2_VERSION}/support/c

--- a/support/chez/Makefile
+++ b/support/chez/Makefile
@@ -10,8 +10,8 @@ clean:
 build: support-sep.ss
 
 install: build
-	mkdir -p ${PREFIX}/idris2-${IDRIS2_VERSION}/support/chez
-	install -m 644 *.ss ${PREFIX}/idris2-${IDRIS2_VERSION}/support/chez
+	mkdir -p ${DESTDIR}${PREFIX}/idris2-${IDRIS2_VERSION}/support/chez
+	install -m 644 *.ss ${DESTDIR}${PREFIX}/idris2-${IDRIS2_VERSION}/support/chez
 
 support-sep.ss: support.ss
 	# start library header

--- a/support/refc/Makefile
+++ b/support/refc/Makefile
@@ -42,5 +42,5 @@ cleandep: clean
 
 .PHONY: install
 install: build
-	mkdir -p ${PREFIX}/idris2-${IDRIS2_VERSION}/support/refc
-	install -m 644 $(LIBTARGET) *.h ${PREFIX}/idris2-${IDRIS2_VERSION}/support/refc
+	mkdir -p ${DESTDIR}${PREFIX}/idris2-${IDRIS2_VERSION}/support/refc
+	install -m 644 $(LIBTARGET) *.h ${DESTDIR}${PREFIX}/idris2-${IDRIS2_VERSION}/support/refc


### PR DESCRIPTION
# Description
Prefix `${PREFIX}` with `${DESTDIR}` allowing installation into a staging directory for packaging Idris2.

Also take DESTDIR into account with `idris2 --install` etc.

## Should this change go in the CHANGELOG?

- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

I tested this a little on Fedora Linux.

When DESTDIR is not set, installation should behave exactly as now.