### PR TITLE
[ fix ] Make `traverse` and friends lazy for `LazyList`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,10 @@
   about the modulo operator's upper bound, which can be useful when working with
   indices (for example).
 
+* Existing specialised variants of functions from the `Traversable` for `LazyList`
+  were made to be indeed lazy by the effect, but their requirements were strengthened
+  from `Applicative` to `Monad`.
+
 #### Papers
 
 * In `Control.DivideAndConquer`: a port of the paper

--- a/libs/contrib/Data/List/Lazy.idr
+++ b/libs/contrib/Data/List/Lazy.idr
@@ -124,16 +124,16 @@ Monad LazyList where
 -- The result of a traversal will be a non-lazy list in general
 -- (you can't delay the "effect" of an applicative functor).
 public export
-traverse : Applicative f => (a -> f b) -> LazyList a -> f (List b)
+traverse : Monad f => (a -> f b) -> LazyList a -> f (List b)
 traverse g [] = pure []
-traverse g (x :: xs) = [| g x :: traverse g xs |]
+traverse g (x::xs) = pure $ !(g x) :: !(traverse g xs)
 
 public export %inline
-for : Applicative f => LazyList a -> (a -> f b) -> f (List b)
+for : Monad f => LazyList a -> (a -> f b) -> f (List b)
 for = flip traverse
 
 public export %inline
-sequence : Applicative f => LazyList (f a) -> f (List a)
+sequence : Monad f => LazyList (f a) -> f (List a)
 sequence = traverse id
 
 -- Traverse a lazy list with lazy effect lazily

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -125,7 +125,7 @@ idrisTests = MkTestPool "Misc" [] Nothing
        "import001", "import002", "import003", "import004", "import005", "import006",
        "import007", "import008", "import009",
        -- Implicit laziness, lazy evaluation
-       "lazy001", "lazy002", "lazy003",
+       "lazy001", "lazy002", "lazy003", "lazy004",
        -- Namespace blocks
        "namespace001", "namespace002", "namespace003", "namespace004", "namespace005",
        -- Parameters blocks

--- a/tests/idris2/misc/lazy004/LazyFor.idr
+++ b/tests/idris2/misc/lazy004/LazyFor.idr
@@ -1,0 +1,26 @@
+import Data.List.Lazy
+
+import Debug.Trace
+
+%default total
+
+xs : LazyList Nat
+xs = iterateN 5 (traceValBy (("xs: " ++) . show) . S) Z
+
+ys : Maybe (List Nat)
+ys = for xs $ \n => if n >= 3 then Nothing else Just (10 * n)
+
+xs' : LazyList Nat
+xs' = iterateN 5 (traceValBy (("xs': " ++) . show) . S) Z
+
+for' : Monad f => LazyList a -> (a -> f b) -> f $ List b
+for' [] _ = pure []
+for' (x::xs) g = pure $ !(g x) :: !(for' xs g)
+
+ys' : Maybe (List Nat)
+ys' = for' xs' $ \n => if n >= 3 then Nothing else Just (10 * n)
+
+main : IO ()
+main = do
+  putStrLn $ show ys
+  putStrLn $ show ys'

--- a/tests/idris2/misc/lazy004/expected
+++ b/tests/idris2/misc/lazy004/expected
@@ -1,0 +1,11 @@
+1/1: Building LazyFor (LazyFor.idr)
+Main> xs: 1
+xs: 2
+xs: 3
+Nothing
+Main> xs': 1
+xs': 2
+xs': 3
+Nothing
+Main> 
+Bye for now!

--- a/tests/idris2/misc/lazy004/input
+++ b/tests/idris2/misc/lazy004/input
@@ -1,0 +1,2 @@
+:exec putStrLn $ show ys
+:exec putStrLn $ show ys'

--- a/tests/idris2/misc/lazy004/run
+++ b/tests/idris2/misc/lazy004/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+idris2 -p contrib LazyFor.idr < input


### PR DESCRIPTION
# Description

This change is like #2412, but for old long-existing functions. Since `Applicative` interface is inherently not lazy, the current implementation was not lazy by the effect, even if the underlying monad's effect could be short-cutting. One can see an example in the added test.

Since, `LazyList` is still `Foldable`, old behaviour is reachable by converting the `LazyList` to `List`.

It may seem that this change relies on some exploiting of the breakage of monadic laws, but it is fundamental for an eager language since monad interface is inherently lazy anyway.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

