### PR TITLE
[ test ] fix pkgs test failures

### DIFF
--- a/tests/idris2/pkg/pkg016/bar.ipkg
+++ b/tests/idris2/pkg/pkg016/bar.ipkg
@@ -1,4 +1,4 @@
-package bar
+package two
 sourcedir = "bar"
 modules = Bar
-depends = foo
+depends = one

--- a/tests/idris2/pkg/pkg016/baz.ipkg
+++ b/tests/idris2/pkg/pkg016/baz.ipkg
@@ -1,4 +1,4 @@
-package baz
+package three
 sourcedir = "baz"
 modules = Baz
-depends = bar
+depends = two

--- a/tests/idris2/pkg/pkg016/foo.ipkg
+++ b/tests/idris2/pkg/pkg016/foo.ipkg
@@ -1,3 +1,3 @@
-package foo
+package one
 sourcedir = "foo"
 modules = Foo

--- a/tests/idris2/pkg/pkg016/run
+++ b/tests/idris2/pkg/pkg016/run
@@ -7,6 +7,6 @@ idris2 --build test.ipkg
 
 build/exec/test
 
-rm -r "${IDRIS2_PREFIX}"/idris2-*/foo-0
-rm -r "${IDRIS2_PREFIX}"/idris2-*/bar-0
-rm -r "${IDRIS2_PREFIX}"/idris2-*/baz-0
+rm -r "${IDRIS2_PREFIX}"/idris2-*/one-0
+rm -r "${IDRIS2_PREFIX}"/idris2-*/two-0
+rm -r "${IDRIS2_PREFIX}"/idris2-*/three-0

--- a/tests/idris2/pkg/pkg016/test.ipkg
+++ b/tests/idris2/pkg/pkg016/test.ipkg
@@ -1,6 +1,6 @@
 package test
 sourcedir = "src"
 modules = Test
-depends = baz
+depends = three
 main = Test
 executable = test


### PR DESCRIPTION
The tests `pkg006` and `pkg015` are randomly failing. It looks like this is happening because `pkg016` is installing (and later removing) packages named `foo`, `bar`, and `baz`. These packages are seen by the other tests if they happen to run at the same time. This PR mitigates the issue by renaming the packages in the `pkg016` test.

This should fix #3084 (the issue was also noted in #3081).
