### PR TITLE
Add Monad instance for Prelude.id

### DIFF
--- a/libs/base/Control/Monad/Identity.idr
+++ b/libs/base/Control/Monad/Identity.idr
@@ -4,6 +4,19 @@ import Data.Bits
 
 %default total
 
+public export
+Functor Prelude.id where
+    map f x = f x
+
+public export
+Applicative Prelude.id where
+    pure x = x
+    f <*> x = f x
+
+public export
+Monad Prelude.id where
+    x >>= f = f x
+
 ||| The identity monad. This monad provides no abilities other than pure
 ||| computation.
 public export


### PR DESCRIPTION
While `Identity` is better for most cases, you can occasionally get away with `id` instead. This has the benefit of not needing to wrap/unwrap your result.