### PR TITLE
[ test ] Fix package tests hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ idris2docs_venv
 /ipkg/build
 
 /tests/**/build
+/tests/**/prefix
 /tests/**/output*
 /tests/**/*.so
 /tests/**/*.dylib

--- a/tests/idris2/basic/basic071/run
+++ b/tests/idris2/basic/basic071/run
@@ -1,5 +1,6 @@
-rm -rf build
-$1 --no-color --console-width 0 --no-banner --check B.idr
+. ../../../testutils.sh
+
+check B.idr
 
 # Set very close time for A and B TTC files
 touch A.idr
@@ -13,4 +14,4 @@ sync build/ttc/*/B.tt*
 
 echo "-- this should be the last line of output --"
 
-$1 --no-color --console-width 0 --no-banner --check B.idr
+check B.idr

--- a/tests/idris2/basic/case001/run
+++ b/tests/idris2/basic/case001/run
@@ -1,4 +1,4 @@
-rm -rf build
+. ../../../testutils.sh
 
-$1 --no-color --console-width 0 --no-banner --codegen chez InlineCase.idr -o inline-case
+idris2 --codegen chez InlineCase.idr -o inline-case
 grep "define InlineCase-product" build/exec/inline-case_app/inline-case.ss

--- a/tests/idris2/basic/case002/run
+++ b/tests/idris2/basic/case002/run
@@ -1,3 +1,3 @@
-rm -rf build
+. ../../../testutils.sh
 
-$1 --no-color --console-width 0 --no-banner --check WhereData.idr
+check WhereData.idr

--- a/tests/idris2/basic/literals001/run
+++ b/tests/idris2/basic/literals001/run
@@ -1,3 +1,3 @@
-rm -rf build
+. ../../../testutils.sh
 
-$1 --no-color --console-width 0 --no-banner -c Test.idr
+check Test.idr

--- a/tests/idris2/literate/literate018/run
+++ b/tests/idris2/literate/literate018/run
@@ -1,3 +1,3 @@
-rm -rf build
+. ../../../testutils.sh
 
-$1  --no-color --console-width 0 --no-banner --check Test.lidr.md
+check Test.lidr.md

--- a/tests/idris2/pkg/pkg010/run
+++ b/tests/idris2/pkg/pkg010/run
@@ -1,6 +1,5 @@
 . ../../../testutils.sh
 
-export IDRIS2_PACKAGE_PATH=$IDRIS2_PREFIX/$NAME_VERSION
 export IDRIS2_PREFIX=$test_dir/currently/nonexistent/dir/
 
 export IDRIS2_INC_CGS=

--- a/tests/idris2/pkg/pkg016/run
+++ b/tests/idris2/pkg/pkg016/run
@@ -6,7 +6,3 @@ idris2 --install baz.ipkg > /dev/null
 idris2 --build test.ipkg
 
 build/exec/test
-
-rm -r "${IDRIS2_PREFIX}"/idris2-*/foo-0
-rm -r "${IDRIS2_PREFIX}"/idris2-*/bar-0
-rm -r "${IDRIS2_PREFIX}"/idris2-*/baz-0

--- a/tests/idris2/total/total021/run
+++ b/tests/idris2/total/total021/run
@@ -1,6 +1,5 @@
-rm -rf build
+. ../../../testutils.sh
 
-$1 --no-color --console-width 0 --no-banner --check Issue-3030.idr
-$1 --no-color --console-width 0 --no-banner --check Issue-3030b.idr
-$1 --no-color --console-width 0 --no-banner --check Issue-524.idr
-
+check Issue-3030.idr
+check Issue-3030b.idr
+check Issue-524.idr

--- a/tests/testutils.sh
+++ b/tests/testutils.sh
@@ -9,6 +9,7 @@ idris2="$1"
 # Delete build files between runs to prevent unexpected differences.
 # As this is at the top-level, this is run when this script is imported.
 rm -rf build
+rm -rf prefix
 
 idris2() {
     $idris2 --no-banner --console-width 0 --no-color "$@"
@@ -32,8 +33,30 @@ sed_literal() {
 # Folder containing the currently running test
 if [ "$OS" = "windows" ]; then
     test_dir="$(cygpath -m "$(pwd)")"
+    SEP=";"
 else
     test_dir="$(pwd)"
+    SEP=":"
+fi
+
+# Set variables for hygiene testing
+if [ -z "$PREFIX_CHANGED" ] && [ -n "$IDRIS2_PREFIX" ]; then
+    OLD_PREFIX="$IDRIS2_PREFIX"
+    NEW_PREFIX="$test_dir/prefix"
+
+    OLD_PP="$OLD_PREFIX/$NAME_VERSION"
+    NEW_PP="$NEW_PREFIX/$NAME_VERSION"
+
+    # Set where to look to installed stuff
+    export IDRIS2_PACKAGE_PATH="$OLD_PP$SEP$NEW_PP"
+    export IDRIS2_LIBS="$OLD_PP/libs$SEP$NEW_PP/libs"
+    export IDRIS2_DATA="$OLD_PP/support$SEP$NEW_PP/support"
+
+    # Set where to install stuff
+    export IDRIS2_PREFIX="$NEW_PREFIX"
+
+    # Save from re-sourcing this file several times
+    export PREFIX_CHANGED=1
 fi
 
 # Remove test directory from output


### PR DESCRIPTION
I decided to be constructive in critics of #3085. This is an alternative, a more universal fix for the package tests hygiene problem. Fixes #3084, closes #3085. I also cleaned up old or became incorrect hygiene workarounds in existing tests.

Also, some tests' `run` scripts were changed due to the new style (I suppose, they were forgotten to be changed). To ease the review, I did it in a separate commit.