### PR TITLE
[ new ] add Data.List.grouped function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,8 @@
 
 * Adds updating functions to `SortedMap` and `SortedDMap`.
 
+* Adds `grouped` function to `Data.List` for splitting a list into equal-sized slices.
+
 #### System
 
 * Changes `getNProcessors` to return the number of online processors rather than

--- a/libs/base/Data/List.idr
+++ b/libs/base/Data/List.idr
@@ -925,6 +925,24 @@ public export
 groupAllWith : Ord b => (a -> b) -> List a -> List (List1 a)
 groupAllWith f = groupWith f . sortBy (comparing f)
 
+||| Partitions a list into fixed sized sublists.
+|||
+||| Note: The last list in the result might be shorter than the rest if
+|||       the input cannot evenly be split into groups of the same size.
+|||
+||| ```idris example
+||| grouped 3 [1..10] === [[1,2,3],[4,5,6],[7,8,9],[10]]
+||| ```
+public export
+grouped : (n : Nat) -> {auto 0 p : IsSucc n} -> List a -> List (List a)
+grouped _     []      = []
+grouped (S m) (x::xs) = go [<] [<x] m xs
+  where
+    go : SnocList (List a) -> SnocList a -> Nat -> List a -> List (List a)
+    go sxs sx c     []        = sxs <>> [sx <>> []]
+    go sxs sx 0     (x :: xs) = go (sxs :< (sx <>> [])) [<x] m xs
+    go sxs sx (S k) (x :: xs) = go sxs (sx :< x) k xs
+
 --------------------------------------------------------------------------------
 -- Properties
 --------------------------------------------------------------------------------


### PR DESCRIPTION
# Description
This adds a new function to `Data.List` for grouping a list into equal sized sub lists. For instance, `group 3 [1..10]` will return `[[1,2,3],[4,5,6],[7,8,9],[10]]`. I took the function's name from a similar function in Scala ([see here](https://www.scala-lang.org/api/current/scala/collection/immutable/List.html#grouped(size:Int):Iterator[C])).

The implementation is tail-recursive and runs in O(n).

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

