### PR TITLE
[ re #3067, readme ] Fix the build badge in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Idris 2
 =======
 
 [![Documentation Status](https://readthedocs.org/projects/idris2/badge/?version=latest)](https://idris2.readthedocs.io/en/latest/?badge=latest)
-[![Build Status](https://github.com/idris-lang/Idris2/actions/workflows/ci-idris2.yml/badge.svg)](https://github.com/idris-lang/Idris2/actions/workflows/ci-idris2.yml)
+[![Build Status](https://github.com/idris-lang/Idris2/actions/workflows/ci-idris2-and-libs.yml/badge.svg?branch=main)](https://github.com/idris-lang/Idris2/actions/workflows/ci-idris2-and-libs.yml?query=branch%3Amain)
 
 [Idris 2](https://idris-lang.org/) is a purely functional programming language
 with first class types.


### PR DESCRIPTION
Workflow was renamed, while the badge was forgotten about.
