### PR TITLE
[ fix #3083 ] Fix record update with implicit args

### DIFF
--- a/src/TTImp/Elab/Record.idr
+++ b/src/TTImp/Elab/Record.idr
@@ -83,7 +83,7 @@ findFieldsAndTypeArgs defs con
              pure $ ((nameRoot x, imp, getRecordType [] nfty) :: rest, tyArgs)
     getExpNames (NTCon _ _ _ _ args)
         = do eargs <- traverse (evalClosure defs . snd) args
-             pure $ ([], foldl (\acc => \arg => 
+             pure $ ([], foldl (\acc => \arg =>
                 case arg of
                   NType _ n => n :: acc
                   _ => acc) [] eargs)

--- a/tests/idris2/data/record020/RecordImplicit.idr
+++ b/tests/idris2/data/record020/RecordImplicit.idr
@@ -1,0 +1,7 @@
+record WithShow (ty : Type) where
+  constructor MkWS
+  {auto hasShow : Show ty}
+  name : String
+
+foo : WithShow ty -> WithShow ty
+foo ws = { name := "meh" } ws

--- a/tests/idris2/data/record020/expected
+++ b/tests/idris2/data/record020/expected
@@ -1,0 +1,1 @@
+1/1: Building RecordImplicit (RecordImplicit.idr)

--- a/tests/idris2/data/record020/run
+++ b/tests/idris2/data/record020/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check RecordImplicit.idr


### PR DESCRIPTION
# Description

This PR fix #3083.
Now update of record leaves a hole only for implicit type variable.
Moreover, would it be correct to have a different behavior for auto arguments to make the following code correct?
```idris
record WithShow (ty : Type) where
  constructor MkWS
  {auto hasShow : Show ty}
  name : ty

foo : WithShow ty -> WithShow String
foo ws = { name := "meh" } ws
```