### PR TITLE
[ base ] Add `anyToFin` converting a Vect's `Any` to its index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,9 @@
 
 * Add `zipPropertyWith` to `Data.Vect.Quantifiers.All.All`.
 
+* Add `anyToFin` to `Data.Vect.Quantifiers.Any`,
+  converting the `Any` witness to the index into the corresponding element.
+
 * Implemented `Ord` for `Language.Reflection.TT.Name`, `Language.Reflection.TT.Namespace`
   and `Language.Reflection.TT.UserName`.
 

--- a/libs/base/Data/Vect/Quantifiers.idr
+++ b/libs/base/Data/Vect/Quantifiers.idr
@@ -61,6 +61,12 @@ namespace Any
   toExists (Here prf)  = Evidence _ prf
   toExists (There prf) = toExists prf
 
+  ||| Get the bounded numeric position of the element satisfying the predicate
+  public export
+  anyToFin : {0 xs : Vect n a} -> Any p xs -> Fin n
+  anyToFin (Here _) = FZ
+  anyToFin (There later) = FS (anyToFin later)
+
 namespace All
   ||| A proof that all elements of a vector satisfy a property. It is a list of
   ||| proofs, corresponding element-wise to the `Vect`.

--- a/libs/base/Data/Vect/Quantifiers.idr
+++ b/libs/base/Data/Vect/Quantifiers.idr
@@ -67,6 +67,14 @@ namespace Any
   anyToFin (Here _) = FZ
   anyToFin (There later) = FS (anyToFin later)
 
+  ||| `anyToFin`'s return type satisfies the predicate
+  export
+  anyToFinCorrect : {0 xs : Vect n a} ->
+                    (witness : Any p xs) ->
+                    p (anyToFin witness `index` xs)
+  anyToFinCorrect (Here prf) = prf
+  anyToFinCorrect (There later) = anyToFinCorrect later
+
 namespace All
   ||| A proof that all elements of a vector satisfy a property. It is a list of
   ||| proofs, corresponding element-wise to the `Vect`.


### PR DESCRIPTION
# Description

This generalizes `Data.Vect.Elem.elemToFin`.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

