### PR TITLE
[ base ] Add a bridge between `MonadState` and `Ref`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,9 @@
 
 * Implements `Ord` for `Count` from `Language.Reflection`.
 
+* Implements `MonadState` for `Data.Ref` with a named implementation requiring
+  a particular reference.
+
 #### System
 
 * Changes `getNProcessors` to return the number of online processors rather than

--- a/libs/base/Data/Ref.idr
+++ b/libs/base/Data/Ref.idr
@@ -2,6 +2,7 @@ module Data.Ref
 
 import public Data.IORef
 import public Control.Monad.ST
+import Control.Monad.State.Interface
 
 %default total
 
@@ -22,3 +23,13 @@ Ref (ST s) (STRef s) where
   newRef = newSTRef
   readRef = readSTRef
   writeRef = writeSTRef
+
+namespace MonadState
+
+  export
+  ForRef : Ref m r => Monad m => r a -> MonadState a m
+  ForRef ref = MS where
+    %inline
+    [MS] MonadState a m where
+      get = readRef ref
+      put = writeRef ref

--- a/tests/base/data_ref_monadstate/RefMonadState.idr
+++ b/tests/base/data_ref_monadstate/RefMonadState.idr
@@ -1,0 +1,20 @@
+module RefMonadState
+
+import Control.Monad.State.Interface
+
+import Data.Ref
+
+%default total
+
+fancy : MonadState Nat m => HasIO m => m String
+fancy = do
+  n <- get
+  putStrLn "current n: \{show n}"
+  put $ 20 + n
+  pure "`\{show n}`"
+
+main : IO ()
+main = do
+  ref <- newRef 18
+  for_ [1..4] $ const $ fancy @{ForRef ref}
+  putStrLn "resulting value: \{show !(readRef ref)}"

--- a/tests/base/data_ref_monadstate/a-test.ipkg
+++ b/tests/base/data_ref_monadstate/a-test.ipkg
@@ -1,0 +1,1 @@
+package a-test

--- a/tests/base/data_ref_monadstate/expected
+++ b/tests/base/data_ref_monadstate/expected
@@ -1,0 +1,5 @@
+current n: 18
+current n: 38
+current n: 58
+current n: 78
+resulting value: 98

--- a/tests/base/data_ref_monadstate/run
+++ b/tests/base/data_ref_monadstate/run
@@ -1,0 +1,3 @@
+. ../../testutils.sh
+
+run RefMonadState.idr


### PR DESCRIPTION
# Description

Allows to use some existing code with `MonadState` requirement in a `Ref`-based environment, and anyway have the common code for both of the worlds, when applicable.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

