### PR TITLE
[ base ] Add `Data.Vect.Quantifiers.All.remember`, the inverse to `forget`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,7 +184,7 @@
 * Generalized `imapProperty` in `Data.List.Quantifiers.All.All`
   and `Data.Vect.Quantifiers.All.All`.
 
-* Add `zipPropertyWith` to `Data.Vect.Quantifiers.All.All`.
+* Add `zipPropertyWith` and `remember` to `Data.Vect.Quantifiers.All.All`.
 
 * Add `anyToFin` to `Data.Vect.Quantifiers.Any`,
   converting the `Any` witness to the index into the corresponding element.

--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -49,6 +49,11 @@ Biinjective Vect.(::) where
 -- Indexing into vectors
 --------------------------------------------------------------------------------
 
+export
+invertVectZ : (xs : Vect Z a) -> xs === []
+invertVectZ [] = Refl
+
+
 ||| All but the first element of the vector
 |||
 ||| ```idris example
@@ -66,6 +71,10 @@ tail (_::xs) = xs
 public export
 head : Vect (S len) elem -> elem
 head (x::_) = x
+
+export
+invertVectS : (xs : Vect (S n) a) -> xs === head xs :: tail xs
+invertVectS (_ :: _) = Refl
 
 ||| The last element of the vector
 |||

--- a/libs/base/Data/Vect/Quantifiers.idr
+++ b/libs/base/Data/Vect/Quantifiers.idr
@@ -136,10 +136,24 @@ namespace All
   imapProperty _ _              []      = []
   imapProperty i f @{ix :: ixs} (x::xs) = f @{ix} x :: imapProperty i f @{ixs} xs
 
+  ||| If `All` witnesses a property that does not depend on the vector `xs`
+  ||| it's indexed by, then it is really a `Vect`.
   public export
   forget : All (const p) {n} xs -> Vect n p
   forget []      = []
   forget (x::xs) = x :: forget xs
+
+  ||| Any `Vect` can be lifted to become an `All`
+  ||| witnessing the presence of elements of the `Vect`'s type.
+  public export
+  remember : (xs : Vect n ty) -> All (const ty) xs
+  remember [] = []
+  remember (x :: xs) = x :: remember xs
+
+  export
+  forgetRememberId : (xs : Vect n ty) -> forget (remember xs) = xs
+  forgetRememberId [] = Refl
+  forgetRememberId (x :: xs) = cong (x ::) (forgetRememberId xs)
 
   export
   zipPropertyWith : (f : {0 x : a} -> p x -> q x -> r x) ->

--- a/libs/base/Data/Vect/Quantifiers.idr
+++ b/libs/base/Data/Vect/Quantifiers.idr
@@ -155,6 +155,17 @@ namespace All
   forgetRememberId [] = Refl
   forgetRememberId (x :: xs) = cong (x ::) (forgetRememberId xs)
 
+  public export
+  castAllConst : {0 xs, ys : Vect n a} -> All (const ty) xs -> All (const ty) ys
+  castAllConst [] = rewrite invertVectZ ys in []
+  castAllConst (x :: xs) = rewrite invertVectS ys in x :: castAllConst xs
+
+  export
+  rememberForgetId : (vs : All (const ty) xs) ->
+    castAllConst (remember (forget vs)) === vs
+  rememberForgetId [] = Refl
+  rememberForgetId (x :: xs) = cong (x ::) (rememberForgetId xs)
+
   export
   zipPropertyWith : (f : {0 x : a} -> p x -> q x -> r x) ->
                     All p xs -> All q xs -> All r xs
@@ -232,4 +243,3 @@ namespace All
   drop' 0 ys = rewrite minusZeroRight k in ys
   drop' (S k) [] = []
   drop' (S k) (y :: ys) = drop' k ys
-


### PR DESCRIPTION
# Description

This seems to come in useful, and since the implementation might be non-obvious (as been discussed in Discord), it's probably worth having the function in the library.

Note that proving `rememberForgetId` (that is, the identity in the other direction of `remember . forget`) is more complicated, since it only holds modulo the `xs` that the `All` is indexed by, and I'm not sure we want to go that route, especially given that there currently seems to be no machinery for doing `All (const p) xs -> All (const p) ys` (although I'd be happy to add that if you think it might be worth it!)

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

