### PR TITLE
[ parser ] Fix issues parsing %logging followed by named impls - fix #3097

### DIFF
--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -970,9 +970,6 @@ mutual
            uds' <- traverse (desugarDecl ps) uds
            update Syn { usingImpl := oldu }
            pure (concat uds')
-  desugarDecl ps (PReflect fc tm)
-      = throw (GenericMsg fc "Reflection not implemented yet")
---       pure [IReflect fc !(desugar AnyExpr ps tm)]
   desugarDecl ps (PInterface fc vis cons_in tn doc params det conname body)
       = do addDocString tn doc
            let paramNames = map fst params

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1848,6 +1848,8 @@ topDecl fname indents
          pure [d]
   <|> do ds <- claims fname indents
          pure (forget ds)
+  <|> do d <- directiveDecl fname indents
+         pure [d]
   <|> do d <- implDecl fname indents
          pure [d]
   <|> do d <- definition fname indents
@@ -1872,8 +1874,6 @@ topDecl fname indents
   <|> do d <- runElabDecl fname indents
          pure [d]
   <|> do d <- transformDecl fname indents
-         pure [d]
-  <|> do d <- directiveDecl fname indents
          pure [d]
   <|> do dstr <- bounds (terminal "Expected CG directive"
                           (\case

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1828,13 +1828,9 @@ fixDecl fname indents
 
 directiveDecl : OriginDesc -> IndentInfo -> Rule PDecl
 directiveDecl fname indents
-    = do b <- bounds ((do d <- directive fname indents
-                          pure (\fc : FC => PDirective fc d))
-                     <|>
-                      (do decoratedPragma fname "runElab"
-                          tm <- expr pdef fname indents
-                          atEnd indents
-                          pure (\fc : FC => PReflect fc tm)))
+    = do b <- bounds (do d <- directive fname indents
+                         pure (\fc : FC => PDirective fc d))
+
          pure (b.val (boundToFC fname b))
 
 -- Declared at the top

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1828,10 +1828,8 @@ fixDecl fname indents
 
 directiveDecl : OriginDesc -> IndentInfo -> Rule PDecl
 directiveDecl fname indents
-    = do b <- bounds (do d <- directive fname indents
-                         pure (\fc : FC => PDirective fc d))
-
-         pure (b.val (boundToFC fname b))
+    = do b <- bounds (directive fname indents)
+         pure (PDirective (boundToFC fname b) b.val)
 
 -- Declared at the top
 -- topDecl : OriginDesc -> IndentInfo -> Rule (List PDecl)

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -434,7 +434,6 @@ mutual
                      List (PDecl' nm) -> PDecl' nm
        PUsing : FC -> List (Maybe Name, PTerm' nm) ->
                 List (PDecl' nm) -> PDecl' nm
-       PReflect : FC -> PTerm' nm -> PDecl' nm
        PInterface : FC ->
                     Visibility ->
                     (constraints : List (Maybe Name, PTerm' nm)) ->
@@ -482,7 +481,6 @@ mutual
   getPDeclLoc (PData fc _ _ _ _) = fc
   getPDeclLoc (PParameters fc _ _) = fc
   getPDeclLoc (PUsing fc _ _) = fc
-  getPDeclLoc (PReflect fc _) = fc
   getPDeclLoc (PInterface fc _ _ _ _ _ _ _ _) = fc
   getPDeclLoc (PImplementation fc _ _ _ _ _ _ _ _ _ _) = fc
   getPDeclLoc (PRecord fc _ _ _ _) = fc
@@ -1055,7 +1053,6 @@ Show PDecl where
   show (PData{}) = "PData"
   show (PParameters{}) = "PParameters"
   show (PUsing{}) = "PUsing"
-  show (PReflect{}) = "PReflect"
   show (PInterface{}) = "PInterface"
   show (PImplementation{}) = "PImplementation"
   show (PRecord{}) = "PRecord"

--- a/src/Idris/Syntax/Traversals.idr
+++ b/src/Idris/Syntax/Traversals.idr
@@ -240,7 +240,6 @@ mapPTermM f = goPTerm where
     goPDecl (PUsing fc mnts ps) =
       PUsing fc <$> goPairedPTerms mnts
                 <*> goPDecls ps
-    goPDecl (PReflect fc t) = PReflect fc <$> goPTerm t
     goPDecl (PInterface fc v mnts n doc nrts ns mn ps) =
       PInterface fc v <$> goPairedPTerms mnts
                       <*> pure n
@@ -523,7 +522,6 @@ mapPTerm f = goPTerm where
       = PParameters fc (go4TupledPTerms nts) (goPDecl <$> ps)
     goPDecl (PUsing fc mnts ps)
       = PUsing fc (goPairedPTerms mnts) (goPDecl <$> ps)
-    goPDecl (PReflect fc t) = PReflect fc $ goPTerm t
     goPDecl (PInterface fc v mnts n doc nrts ns mn ps)
       = PInterface fc v (goPairedPTerms mnts) n doc (go3TupledPTerms nrts) ns mn (goPDecl <$> ps)
     goPDecl (PImplementation fc v opts p is cs n ts mn ns mps)

--- a/tests/idris2/error/perror030/LoggingParse.idr
+++ b/tests/idris2/error/perror030/LoggingParse.idr
@@ -1,0 +1,7 @@
+import Data.Vect
+
+%logging "elab" 1
+
+[Named] {n : Nat} -> Show (Vect n a) where
+  show x = "whatever"
+

--- a/tests/idris2/error/perror030/expected
+++ b/tests/idris2/error/perror030/expected
@@ -1,0 +1,1 @@
+1/1: Building LoggingParse (LoggingParse.idr)

--- a/tests/idris2/error/perror030/run
+++ b/tests/idris2/error/perror030/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check LoggingParse.idr 


### PR DESCRIPTION
In issue #3097, a `%logging` pragma followed by a named implementation will produce an odd parse error.  The root cause for this is a second, inline parser for `%logging` inside `simplerExpr` that is being hit while `implDecl` attempts to parse the `%logging` line.  I addressed the issue by moving the `directiveDecl` parser before the `impDecl` parser in the alt.

But this change broke `%runElab` statements. It turns out that there is an old parser for `%runElab` inside `directiveDecl` that was no longer being used because `runElabDecl` occurred first.  It parsed `%runElab` to `PReflect`, which desugars to a "Reflection not implemented yet" error. So I removed that.

Since `PReflect` is not used (the real parser for `%runElab` produces a `PRunElabDecl`), I also removed `PReflect`.

Previously:
```idris
import Data.Vect
%logging "elab" 100
[Named] {n : Nat} -> Show (Vect n a) where
  show x = "whatever"
```
produced this error:
```
Error: Expected '}'.

BugImplImplLogging:5:12--5:13
 1 | import Data.Vect
 2 | 
 3 | %logging "elab" 100
 4 | 
 5 | [Named] {n : Nat} -> Show (Vect n a) where
                ^
```
And now it compiles without error.
