### PR TITLE
[ impl ] Support `default` implicits in named implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * New `fromTTImp`, `fromName`, and `fromDecls` names for custom `TTImp`,
   `Name`, and `Decls` literals.
 * Call to `%macro`-functions do not require the `ElabReflection` extension.
+* Default implicits are supported for named implementations.
 
 ### REPL changes
 

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -447,7 +447,7 @@ mutual
                     PDecl' nm
        PImplementation : FC ->
                          Visibility -> List PFnOpt -> Pass ->
-                         (implicits : List (FC, RigCount, Name, PTerm' nm)) ->
+                         (implicits : List (FC, RigCount, Name, PiInfo (PTerm' nm), PTerm' nm)) ->
                          (constraints : List (Maybe Name, PTerm' nm)) ->
                          Name ->
                          (params : List (PTerm' nm)) ->

--- a/src/Idris/Syntax/Traversals.idr
+++ b/src/Idris/Syntax/Traversals.idr
@@ -327,11 +327,11 @@ mapPTermM f = goPTerm where
       (::) . (\ c => (a, b, c)) <$> goPTerm t
                                 <*> go3TupledPTerms ts
 
-    goImplicits : List (x, y, z, PTerm' nm) ->
-                      Core (List (x, y, z, PTerm' nm))
+    goImplicits : List (x, y, z, PiInfo (PTerm' nm), PTerm' nm) ->
+                      Core (List (x, y, z, PiInfo (PTerm' nm), PTerm' nm))
     goImplicits [] = pure []
-    goImplicits ((a, b, c, t) :: ts) =
-      ((::) . (a,b,c,)) <$> goPTerm t
+    goImplicits ((a, b, c, p, t) :: ts) =
+      ((::) . (a,b,c,)) <$> ((,) <$> goPiInfo p <*> goPTerm t)
                         <*> goImplicits ts
 
     go4TupledPTerms : List (x, y, PiInfo (PTerm' nm), PTerm' nm) ->
@@ -576,9 +576,9 @@ mapPTerm f = goPTerm where
     go3TupledPTerms [] = []
     go3TupledPTerms ((a, b, t) :: ts) = (a, b, goPTerm t) :: go3TupledPTerms ts
 
-    goImplicits : List (x, y, z, PTerm' nm) -> List (x, y, z, PTerm' nm)
+    goImplicits : List (x, y, z, PiInfo (PTerm' nm), PTerm' nm) -> List (x, y, z, PiInfo (PTerm' nm), PTerm' nm)
     goImplicits [] = []
-    goImplicits ((a, b, c, t) :: ts) = (a,b,c, goPTerm t) :: goImplicits ts
+    goImplicits ((a, b, c, p, t) :: ts) = (a,b,c, goPiInfo p, goPTerm t) :: goImplicits ts
 
     go4TupledPTerms : List (x, y, PiInfo (PTerm' nm), PTerm' nm) ->
                       List (x, y, PiInfo (PTerm' nm), PTerm' nm)

--- a/tests/idris2/interface/interface030/DefaultImplicitsInImpls.idr
+++ b/tests/idris2/interface/interface030/DefaultImplicitsInImpls.idr
@@ -1,0 +1,20 @@
+module DefaultImplicitsInImpls
+
+import Data.Vect
+
+%default total
+
+[TunableImpl] {default False fancy : Bool} -> Show Nat where
+  show x = if fancy then "!!! hohoho !!!" else "no fancy"
+
+X0 : String
+X0 = show @{TunableImpl} 5
+
+x0Corr : X0 === "no fancy"
+x0Corr = Refl
+
+X1 : String
+X1 = show @{TunableImpl {fancy=True}} 5
+
+x1Corr : X1 === "!!! hohoho !!!"
+x1Corr = Refl

--- a/tests/idris2/interface/interface030/expected
+++ b/tests/idris2/interface/interface030/expected
@@ -1,0 +1,1 @@
+1/1: Building DefaultImplicitsInImpls (DefaultImplicitsInImpls.idr)

--- a/tests/idris2/interface/interface030/run
+++ b/tests/idris2/interface/interface030/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check DefaultImplicitsInImpls.idr


### PR DESCRIPTION
# Description

There is no principle why named implementation cannot have a `default` implicit argument. You always could model it with

```idris
%hint
NamedImpl : {default V tuning : _} -> Interface ...
NamedImpl = N where
  [N] Interface ... where
    ...
```

but why not to support it directly? This PR enables the code from above be written as

```idris
[NamedImpl] {default V tuning : _} -> Interface ... where
  ...
```
i.e. to write default implicit arguments exactly where usual implicit arguments are written in implementations.

P.S. And now I understand why Edwin complains about the way how the interfaces and implementations are elaborated: sometimes code looks horrifying.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

