### PR TITLE
[ fix ] Prevent relative path traversal in elaborator scripts

### DIFF
--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -129,6 +129,7 @@ elabScript rig fc nest env script@(NDCon nfc nm t ar args) exp
         pathDoesNotEscape _     []           = True
         pathDoesNotEscape Z     (".."::rest) = False
         pathDoesNotEscape (S n) (".."::rest) = pathDoesNotEscape n rest
+        pathDoesNotEscape n     ("." ::rest) = pathDoesNotEscape n rest
         pathDoesNotEscape n     (_   ::rest) = pathDoesNotEscape (S n) rest
 
     elabCon : Defs -> String -> List (Closure vars) -> Core (NF vars)

--- a/tests/idris2/reflection/reflection024/src/LessSimpleRW.idr
+++ b/tests/idris2/reflection/reflection024/src/LessSimpleRW.idr
@@ -35,3 +35,8 @@ failing "path must not escape the directory"
 
   -- Check a slightly more complicated case of escaping
   %runElab readAndLog "nonExistentOriginally/../../whatever"
+
+failing "path must not escape the directory"
+
+  -- Check that '.' does not allow escaping
+  %runElab readAndLog "./../whatever"


### PR DESCRIPTION
# Description

Compile-time file operations introduced in #3099 attempt to check file paths and prevent exiting the directory specified by `LookupDir`. This safeguard, however, can be easily fooled by the use of `./` as part of the path. For instance, the following call would result in the creation or  modification of a file outside the project directory:

```idris
%runElab writeFile ProjectDir "./../outerFile" "uh oh"
```

This occurs because the introduced function `pathDoesNotEscape` performs the check by tracking how deep the provided relative path goes down in the directory tree, making sure it doesn't go up more than it goes down. It, however, treats "." like a regular directory, allowing the user to increase the depth perceived by the function "for free". This PR adds special handling of the "." directory in the path to prevent escaping via this mechanism.