### PR TITLE
[ base ] Relevant and irrelevant traversals for `Data.Vect.Quantifiers.All`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,7 +188,8 @@
 * Generalized `imapProperty` in `Data.List.Quantifiers.All.All`
   and `Data.Vect.Quantifiers.All.All`.
 
-* Add `zipPropertyWith` and `remember` to `Data.Vect.Quantifiers.All.All`.
+* Add `zipPropertyWith`, `traverseProperty`, `traversePropertyRelevant` and `remember`
+  to `Data.Vect.Quantifiers.All.All`.
 
 * Add `anyToFin` to `Data.Vect.Quantifiers.Any`,
   converting the `Any` witness to the index into the corresponding element.

--- a/libs/base/Data/Vect/Quantifiers.idr
+++ b/libs/base/Data/Vect/Quantifiers.idr
@@ -173,6 +173,28 @@ namespace All
   zipPropertyWith f (px :: pxs) (qx :: qxs)
     = f px qx :: zipPropertyWith f pxs qxs
 
+  ||| A `Traversable`'s `traverse` for `All`,
+  ||| for traversals that don't care about the values of the associated `Vect`.
+  export
+  traverseProperty : Applicative f =>
+                     {0 xs : Vect n a} ->
+                     (forall x. p x -> f (q x)) ->
+                     All p xs ->
+                     f (All q xs)
+  traverseProperty f [] = pure []
+  traverseProperty f (x :: xs) = [| f x :: traverseProperty f xs |]
+
+  ||| A `Traversable`'s `traverse` for `All`,
+  ||| in case the elements of the `Vect` that the `All` is proving `p` about are also needed.
+  export
+  traversePropertyRelevant : Applicative f =>
+                             {xs : Vect n a} ->
+                             ((x : a) -> p x -> f (q x)) ->
+                             All p xs ->
+                             f (All q xs)
+  traversePropertyRelevant f [] = pure []
+  traversePropertyRelevant f (x :: xs) = [| f _ x :: traversePropertyRelevant f xs |]
+
   export
   All (Show . p) xs => Show (All p xs) where
     show pxs = "[" ++ show' "" pxs ++ "]"


### PR DESCRIPTION
# Description

Implement an analog of `Prelude.Traversable.traverse` for `All`s.

There are actually two traversals, one mirroring the current `mapProperty` and friends where the argument corresponding to the elements of `xs` in `All p xs` is irrelevant, and the other takes them as relevant, which seems to be useful in some real-world use cases. The first one results in a better code generation though, so having both looks like the most optimal decision.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

