### PR TITLE
[ test ] Remove unnecessary messages from stderr

### DIFF
--- a/tests/node/node004/run
+++ b/tests/node/node004/run
@@ -1,5 +1,5 @@
 . ../../testutils.sh
 
-rm test.buf
+[ -e test.buf ] && rm test.buf
 
 run --cg node Buffer.idr

--- a/tests/node/node017/run
+++ b/tests/node/node017/run
@@ -1,6 +1,6 @@
 . ../../testutils.sh
 
-rm -rf testdir
+[ -e testdir ] && rm -rf testdir
 
 run --cg node dir.idr | filter_test_dir
 cat testdir/test.txt

--- a/tests/node/node017/run
+++ b/tests/node/node017/run
@@ -1,6 +1,6 @@
 . ../../testutils.sh
 
-[ -e testdir ] && rm -rf testdir
+rm -rf testdir
 
 run --cg node dir.idr | filter_test_dir
 cat testdir/test.txt

--- a/tests/node/node018/run
+++ b/tests/node/node018/run
@@ -1,5 +1,5 @@
 . ../../testutils.sh
 
-rm testout.txt
+[ -e testout.txt ] && rm testout.txt
 
 run --cg node File.idr


### PR DESCRIPTION
This prevents "rm: cannot remove ...: No such file or directory" errors
by only running rm when the file is actually present. Another potential
solution would be to keep using rm every time, but reroute 2>/dev/null
so that the failure message doesn't get displayed to the user.# Description

This prevents `rm: cannot remove ...: No such file or directory` errors
by only running `rm` when the file is actually present. Other potential
solutions would to keep using `rm` every time, but using the `-f` flag to
prevent it from printing out the error message or rerouting `2>/dev/null` so
that the message doesn't get displayed to the user.

I think that the run scripts should be altered to also delete these files after
running the test, so they don't clutter the `git status` (or at least the files
should be added to a `.gitignore`), but I'm not sure whether that would be
desired (in this case, `node/node017` should also be modified). If it is
desired, please let me know if I should update this PR or open a new issue/PR
about it.


## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

I feel like this is minor enough that it doesn't warrant changes to either, even
though it technically is a user-facing change if they're the ones manually
running compiler tests. If you still wish for it to be present just let me know.
