### PR TITLE
[ derive ] Small improvements in `Deriving.Common`

### DIFF
--- a/libs/base/Deriving/Common.idr
+++ b/libs/base/Deriving/Common.idr
@@ -18,7 +18,7 @@ data IsFreeOf : (x : Name) -> (ty : TTImp) -> Type where
   TrustMeFO : IsFreeOf a x
 
 ||| We may need to manufacture proofs and so we provide the `assert` escape hatch.
-export
+export -- %unsafe -- uncomment as soon as 0.7.0 is released
 assert_IsFreeOf : IsFreeOf x ty
 assert_IsFreeOf = TrustMeFO
 
@@ -165,7 +165,7 @@ data HasImplementation : (intf : a -> Type) -> TTImp -> Type where
   TrustMeHI : HasImplementation intf t
 
 ||| We may need to manufacture proofs and so we provide the `assert` escape hatch.
-export
+export -- %unsafe -- uncomment as soon as 0.7.0 is released
 assert_hasImplementation : HasImplementation intf t
 assert_hasImplementation = TrustMeHI
 

--- a/tests/base/deriving_traversable/expected
+++ b/tests/base/deriving_traversable/expected
@@ -65,7 +65,7 @@ LOG derive.traversable.clauses:1:
   traverseIVect : {0 m : _} -> {0 a, b : Type} -> {0 f : Type -> Type} -> Applicative f => (a -> f b) -> IVect {n = m} a -> f (IVect {n = m} b)
   traverseIVect f (MkIVect x2) = MkIVect <$> (traverse f x2)
 LOG derive.traversable.clauses:1: 
-  traverseEqMap : {0 key, eq : _} -> {0 a, b : Type} -> {0 f : Type -> Type} -> Applicative f => (a -> f b) -> EqMap key {{conArg:13919} = eq} a -> f (EqMap key {{conArg:13919} = eq} b)
+  traverseEqMap : {0 key, eq : _} -> {0 a, b : Type} -> {0 f : Type -> Type} -> Applicative f => (a -> f b) -> EqMap key {{conArg:13933} = eq} a -> f (EqMap key {{conArg:13933} = eq} b)
   traverseEqMap f (MkEqMap x3) = MkEqMap <$> (traverse (traverse f) x3)
 LOG derive.traversable.clauses:1: 
   traverseTree : {0 l : _} -> {0 a, b : Type} -> {0 f : Type -> Type} -> Applicative f => (a -> f b) -> Tree l a -> f (Tree l b)


### PR DESCRIPTION
# Description

Two things are done:
- unsafe operations were commented to be marked as `%unsafe` as soon as released compiler supports them, and
- errors of the `isType` function were made to point to the expression that caused the failure, if there is one.


