### PR TITLE
Use `do` notation in `some`

### DIFF
--- a/libs/contrib/Data/String/Parser.idr
+++ b/libs/contrib/Data/String/Parser.idr
@@ -208,7 +208,9 @@ mutual
     export
     covering
     some : Monad m => ParseT m a -> ParseT m (List a)
-    some p = [| p :: many p |]
+    some p = do r <- p
+                rs <- many p
+                pure $ r :: rs
 
     ||| Always succeeds, will accumulate the results of `p` in a list until it fails.
     export


### PR DESCRIPTION
# Description

This fixes #2099, which causes an infinite loop upon using the `some` function. These would be equivalent if the function was total, but it isn't.

## Should this change go in the CHANGELOG?

I don't think so, but I'm not sure.

