### PR TITLE
[ ci ] Update deploy-action in ci-idris2-and-libs.yml

### DIFF
--- a/.github/workflows/ci-idris2-and-libs.yml
+++ b/.github/workflows/ci-idris2-and-libs.yml
@@ -762,7 +762,7 @@ jobs:
           cd -
           cp -r www/html/* .github/scripts/html/
       - name: Deploy HTML
-        uses: JamesIves/github-pages-deploy-action@4.1.3
+        uses: JamesIves/github-pages-deploy-action@4.4.3
         if: ${{ success() && env.IDRIS2_DEPLOY }}
 
         with:

--- a/.github/workflows/ci-idris2-and-libs.yml
+++ b/.github/workflows/ci-idris2-and-libs.yml
@@ -762,7 +762,7 @@ jobs:
           cd -
           cp -r www/html/* .github/scripts/html/
       - name: Deploy HTML
-        uses: JamesIves/github-pages-deploy-action@4.4.3
+        uses: JamesIves/github-pages-deploy-action@v4.4.3
         if: ${{ success() && env.IDRIS2_DEPLOY }}
 
         with:


### PR DESCRIPTION
Previous version of JamesIves/github-pages-deploy-action uses [deprecated GH Actions functionality](https://github.com/idris-lang/Idris2/actions/runs/6612307397/job/17958920185#step:15:61). It'll break eventually, better safe than sorry.