### PR TITLE
[ elab ] Implement abilities for recursion check in elab scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@
 * Elaborator scripts were made to be able to access project files,
   allowing the support for type providers and similar stuff.
 * Elaborator scripts were made to be able to inspect which definitions are
-  referred to by another definitions.
+  referred to by another definitions, and in which function currently elaborator is.
+  These features together give an ability to inspect whether particular expressions
+  are recursive (including mutual recursion).
 
 ### REPL changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 * Default implicits are supported for named implementations.
 * Elaborator scripts were made to be able to access project files,
   allowing the support for type providers and similar stuff.
+* Elaborator scripts were made to be able to inspect which definitions are
+  referred to by another definitions.
 
 ### REPL changes
 

--- a/libs/base/Language/Reflection.idr
+++ b/libs/base/Language/Reflection.idr
@@ -87,6 +87,8 @@ data Elab : Type -> Type where
      GetLocalType : Name -> Elab TTImp
      -- Get the constructors of a data type. The name must be fully resolved.
      GetCons : Name -> Elab (List Name)
+     -- Get all function definition names referred in a definition. The name must be fully resolved.
+     GetReferredFns : Name -> Elab (List Name)
      -- Check a group of top level declarations
      Declare : List Decl -> Elab ()
 
@@ -181,6 +183,9 @@ interface Monad m => Elaboration m where
   ||| Get the constructors of a fully qualified data type name
   getCons : Name -> m (List Name)
 
+  ||| Get all the name of function definitions that a given definition refers to (transitively)
+  getReferredFns : Name -> m (List Name)
+
   ||| Make some top level declarations
   declare : List Decl -> m ()
 
@@ -227,6 +232,7 @@ Elaboration Elab where
   getInfo        = GetInfo
   getLocalType   = GetLocalType
   getCons        = GetCons
+  getReferredFns = GetReferredFns
   declare        = Declare
   readFile       = ReadFile
   writeFile      = WriteFile
@@ -251,6 +257,7 @@ Elaboration m => MonadTrans t => Monad (t m) => Elaboration (t m) where
   getInfo             = lift . getInfo
   getLocalType        = lift . getLocalType
   getCons             = lift . getCons
+  getReferredFns      = lift . getReferredFns
   declare             = lift . declare
   readFile            = lift .: readFile
   writeFile d         = lift .: writeFile d

--- a/libs/base/Language/Reflection.idr
+++ b/libs/base/Language/Reflection.idr
@@ -89,6 +89,8 @@ data Elab : Type -> Type where
      GetCons : Name -> Elab (List Name)
      -- Get all function definition names referred in a definition. The name must be fully resolved.
      GetReferredFns : Name -> Elab (List Name)
+     -- Get the name of the current and outer functions, if it is applicable
+     GetCurrentFn : Elab (SnocList Name)
      -- Check a group of top level declarations
      Declare : List Decl -> Elab ()
 
@@ -186,6 +188,9 @@ interface Monad m => Elaboration m where
   ||| Get all the name of function definitions that a given definition refers to (transitively)
   getReferredFns : Name -> m (List Name)
 
+  ||| Get the name of the current and outer functions, if we are in a function
+  getCurrentFn : m (SnocList Name)
+
   ||| Make some top level declarations
   declare : List Decl -> m ()
 
@@ -233,6 +238,7 @@ Elaboration Elab where
   getLocalType   = GetLocalType
   getCons        = GetCons
   getReferredFns = GetReferredFns
+  getCurrentFn   = GetCurrentFn
   declare        = Declare
   readFile       = ReadFile
   writeFile      = WriteFile
@@ -258,6 +264,7 @@ Elaboration m => MonadTrans t => Monad (t m) => Elaboration (t m) where
   getLocalType        = lift . getLocalType
   getCons             = lift . getCons
   getReferredFns      = lift . getReferredFns
+  getCurrentFn        = lift getCurrentFn
   declare             = lift . declare
   readFile            = lift .: readFile
   writeFile d         = lift .: writeFile d

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -299,6 +299,9 @@ elabScript rig fc nest env script@(NDCon nfc nm t ar args) exp
                  | Nothing => failWith defs $ show dn ++ " is not a definition"
              ns <- deepRefersTo def
              scriptRet ns
+    elabCon defs "GetCurrentFn" []
+        = do defs <- get Ctxt
+             scriptRet defs.defsStack
     elabCon defs "Declare" [d]
         = do d' <- evalClosure defs d
              decls <- reify defs d'

--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -978,7 +978,8 @@ processDef : {vars : _} ->
              List ElabOpt -> NestedNames vars -> Env Term vars -> FC ->
              Name -> List ImpClause -> Core ()
 processDef opts nest env fc n_in cs_in
-    = do n <- inCurrentNS n_in
+  = do n <- inCurrentNS n_in
+       withDefStacked n $ do
          defs <- get Ctxt
          Just gdef <- lookupOrAddAlias opts nest env fc n cs_in
            | Nothing => noDeclaration fc n

--- a/tests/idris2/reflection/reflection025/CurrFn.idr
+++ b/tests/idris2/reflection/reflection025/CurrFn.idr
@@ -1,0 +1,37 @@
+module CurrFn
+
+import Language.Reflection
+
+%default total
+
+%language ElabReflection
+
+logCurrFn : Elab ()
+logCurrFn = logMsg "elab" 0 "current fn: \{show !getCurrentFn}"
+
+%runElab logCurrFn
+
+f : Nat -> Nat
+f x = case %runElab logCurrFn of () => x + 4
+
+f' : Nat -> Nat
+f' x = x + case %runElab logCurrFn of () => 4
+
+f'' : Nat -> Nat
+f'' Z     = 4
+f'' (S x) = f $ case %runElab logCurrFn of () => x
+
+f''' : Nat -> Nat
+f''' x = case x of
+           Z   => 4
+           S x => f $ case %runElab logCurrFn of () => x
+
+n : Nat -> Nat
+n x = x + f x where
+  f : Nat -> Nat
+  f x = case %runElab logCurrFn of () => x + 4
+
+w : Nat -> Nat
+w x with (x + 5)
+  _ | Z   = x + case %runElab logCurrFn of () => 4
+  _ | S n = f $ case %runElab logCurrFn of () => n

--- a/tests/idris2/reflection/reflection025/InspectRec.idr
+++ b/tests/idris2/reflection/reflection025/InspectRec.idr
@@ -1,0 +1,61 @@
+module InspectRec
+
+import Control.Monad.Writer
+
+import Language.Reflection
+
+%default total
+
+%language ElabReflection
+
+isFunc : NameInfo -> Bool
+isFunc $ MkNameInfo Func = True
+isFunc _                 = False
+
+inspectRec : Elaboration m => (desc : String) -> a -> m a
+inspectRec desc val = do
+  expr <- quote val
+  fns <- getCurrentFn
+  let _ : Monoid Bool := Any
+  rec <- execWriterT $ flip mapMTTImp expr $ \case
+           e@(IVar fc nm) => do
+             is <- getInfo nm
+             let is = fst <$> filter (isFunc . snd) is
+             refs <- map join $ for is $ \n => (n::) <$> getReferredFns n
+             tell $ any (\fn => any (==fn) refs) fns
+             pure e
+           e => pure e
+  logMsg "elab" 0 "case \{desc}: \{the String $ if rec then "recursive" else "non-recursive"}"
+  pure val
+
+----------------------------------------------
+
+dec : Nat -> Nat
+dec Z     = %runElab inspectRec "zero case" 0
+dec (S n) = %runElab inspectRec "non-zero case" n
+
+----------------------------------------------
+
+simpleRec : Nat -> Nat
+simpleRec Z     = %runElab inspectRec "base case" 10
+simpleRec (S n) = %runElab inspectRec "next cast" $ simpleRec n
+
+----------------------------------------------
+
+mutualRec1 : Nat -> Nat
+mutualRec2 : Nat -> Nat
+
+mutualRec1 Z     = %runElab inspectRec "mutual rec 1, base" 11
+mutualRec1 (S n) = %runElab inspectRec "mutual rec 1, next" $ mutualRec2 n
+
+mutualRec2 Z     = %runElab inspectRec "mutual rec 2, base" 12
+mutualRec2 (S n) = %runElab inspectRec "mutual rec 2, next" $ mutualRec1 n
+
+----------------------------------------------
+
+nestedMutRec1 : Nat -> Nat
+nestedMutRec1 Z     = %runElab inspectRec "nestedMut rec 1, base" 11
+nestedMutRec1 (S n) = %runElab inspectRec "nestedMut rec 1, next" $ nestedMutRec2 n where
+  nestedMutRec2 : Nat -> Nat
+  nestedMutRec2 Z     = %runElab inspectRec "nestedMut rec 2, base" 12
+  nestedMutRec2 (S n) = %runElab inspectRec "nestedMut rec 2, next" $ nestedMutRec1 n

--- a/tests/idris2/reflection/reflection025/RefDefs.idr
+++ b/tests/idris2/reflection/reflection025/RefDefs.idr
@@ -1,0 +1,43 @@
+module RefDefs
+
+import Language.Reflection
+
+%default total
+
+%language ElabReflection
+
+simple : Nat -> Nat
+simple x = x + 5
+
+simpleRec : Nat -> Nat
+simpleRec Z = 4
+simpleRec (S n) = S $ simpleRec n
+
+mutRec1 : Nat -> Nat
+mutRec2 : Nat -> Nat
+
+mutRec1 Z = Z
+mutRec1 (S n) = mutRec2 n
+
+mutRec2 Z = Z
+mutRec2 (S n) = mutRec1 n
+
+printRefDefs : Name -> Elab ()
+printRefDefs name = do
+  [(name, _)] <- getInfo name
+    | [] => fail "definition \{show name} is not found"
+    | ns@(_::_) => fail "name \{show name} is ambiguous: \{show $ fst <$> ns}"
+  names <- getReferredFns name
+  logMsg "elab" 0 "Names `\{show name}` refers to:"
+  for_ names $ logMsg "elab" 0 . ("  - " ++) . show
+  logMsg "elab" 0 ""
+
+%runElab
+  traverse_ printRefDefs
+    [ `{RefDefs.simple}
+    , `{RefDefs.simpleRec}
+    , `{RefDefs.mutRec1}
+    , `{Prelude.Bool}
+    , `{Prelude.Nat}
+    , `{Language.Reflection.TTImp.TTImp}
+    ]

--- a/tests/idris2/reflection/reflection025/RefDefs.idr
+++ b/tests/idris2/reflection/reflection025/RefDefs.idr
@@ -22,6 +22,7 @@ mutRec1 (S n) = mutRec2 n
 mutRec2 Z = Z
 mutRec2 (S n) = mutRec1 n
 
+export
 printRefDefs : Name -> Elab ()
 printRefDefs name = do
   [(name, _)] <- getInfo name

--- a/tests/idris2/reflection/reflection025/RefDefsDeep.idr
+++ b/tests/idris2/reflection/reflection025/RefDefsDeep.idr
@@ -1,0 +1,51 @@
+module RefDefsDeep
+
+import Language.Reflection
+
+import RefDefs
+
+%default total
+
+%language ElabReflection
+
+logCurrFn : Elab ()
+logCurrFn = do
+  currFn <- getCurrentFn
+  logMsg "elab" 0 "=== current fn: \{show currFn} ==="
+
+%runElab logCurrFn
+
+f : Nat -> Nat
+f x = case %runElab logCurrFn of () => x + 4
+
+f' : Nat -> Nat
+f' x = x + case %runElab logCurrFn of () => 4
+
+f'' : Nat -> Nat
+f'' Z     = 4
+f'' (S x) = f $ case %runElab logCurrFn of () => x
+
+f''' : Nat -> Nat
+f''' x = case x of
+           Z   => 4
+           S x => f $ case %runElab logCurrFn of () => x
+
+n : Nat -> Nat
+n x = x + f x where
+  f : Nat -> Nat
+  f x = case %runElab logCurrFn of () => x + 4
+
+w : Nat -> Nat
+w x with (x + 5)
+  _ | Z   = x + case %runElab logCurrFn of () => 4
+  _ | S n = f $ case %runElab logCurrFn of () => n
+
+%runElab
+  traverse_ printRefDefs
+    [ `{f}
+    , `{f'}
+    , `{f''}
+    , `{f'''}
+    , `{n}
+    , `{w}
+    ]

--- a/tests/idris2/reflection/reflection025/expected
+++ b/tests/idris2/reflection/reflection025/expected
@@ -1,0 +1,38 @@
+1/1: Building RefDefs (RefDefs.idr)
+LOG elab:0: Names `RefDefs.simple` refers to:
+LOG elab:0:   - prim__sub_Integer
+LOG elab:0:   - prim__lte_Integer
+LOG elab:0:   - Prelude.Types.case block in "integerToNat"
+LOG elab:0:   - Prelude.Types.fromInteger
+LOG elab:0:   - Prelude.Types.Num implementation at Prelude.Types:66:1--71:33
+LOG elab:0:   - Prelude.Types.+
+LOG elab:0:   - Prelude.Types.*
+LOG elab:0:   - Prelude.Types.plus
+LOG elab:0:   - Prelude.Types.mult
+LOG elab:0:   - Prelude.Types.integerToNat
+LOG elab:0:   - Prelude.Types.Z
+LOG elab:0:   - Prelude.Types.S
+LOG elab:0:   - Prelude.Types.Nat
+LOG elab:0:   - Prelude.Num.MkNum
+LOG elab:0:   - Prelude.Num.(+)
+LOG elab:0:   - Prelude.Basics.intToBool
+LOG elab:0:   - Prelude.Basics.True
+LOG elab:0:   - Prelude.Basics.False
+LOG elab:0:   - Builtin.assert_total
+LOG elab:0: 
+LOG elab:0: Names `RefDefs.simpleRec` refers to:
+LOG elab:0:   - Prelude.Types.Z
+LOG elab:0:   - Prelude.Types.S
+LOG elab:0:   - RefDefs.simpleRec
+LOG elab:0: 
+LOG elab:0: Names `RefDefs.mutRec1` refers to:
+LOG elab:0:   - Prelude.Types.Z
+LOG elab:0:   - RefDefs.mutRec1
+LOG elab:0:   - RefDefs.mutRec2
+LOG elab:0: 
+LOG elab:0: Names `Prelude.Basics.Bool` refers to:
+LOG elab:0: 
+LOG elab:0: Names `Prelude.Types.Nat` refers to:
+LOG elab:0: 
+LOG elab:0: Names `Language.Reflection.TTImp.TTImp` refers to:
+LOG elab:0: 

--- a/tests/idris2/reflection/reflection025/expected
+++ b/tests/idris2/reflection/reflection025/expected
@@ -36,3 +36,185 @@ LOG elab:0: Names `Prelude.Types.Nat` refers to:
 LOG elab:0: 
 LOG elab:0: Names `Language.Reflection.TTImp.TTImp` refers to:
 LOG elab:0: 
+------------
+1/1: Building CurrFn (CurrFn.idr)
+LOG elab:0: current fn: [< ]
+LOG elab:0: current fn: [< CurrFn.f]
+LOG elab:0: current fn: [< CurrFn.f']
+LOG elab:0: current fn: [< CurrFn.f'']
+LOG elab:0: current fn: [< CurrFn.f''', CurrFn.case block in "f'''"]
+LOG elab:0: current fn: [< CurrFn.n, CurrFn.4799:2662:f]
+LOG elab:0: current fn: [< CurrFn.w, CurrFn.with block in "w"]
+LOG elab:0: current fn: [< CurrFn.w, CurrFn.with block in "w"]
+------------
+2/2: Building RefDefsDeep (RefDefsDeep.idr)
+LOG elab:0: === current fn: [< ] ===
+LOG elab:0: === current fn: [< RefDefsDeep.f] ===
+LOG elab:0: === current fn: [< RefDefsDeep.f'] ===
+LOG elab:0: === current fn: [< RefDefsDeep.f''] ===
+LOG elab:0: === current fn: [< RefDefsDeep.f''', RefDefsDeep.case block in "f'''"] ===
+LOG elab:0: === current fn: [< RefDefsDeep.n, RefDefsDeep.4813:2927:f] ===
+LOG elab:0: === current fn: [< RefDefsDeep.w, RefDefsDeep.with block in "w"] ===
+LOG elab:0: === current fn: [< RefDefsDeep.w, RefDefsDeep.with block in "w"] ===
+LOG elab:0: Names `RefDefsDeep.f` refers to:
+LOG elab:0:   - prim__sub_Integer
+LOG elab:0:   - prim__lte_Integer
+LOG elab:0:   - Prelude.Types.case block in "integerToNat"
+LOG elab:0:   - Prelude.Types.fromInteger
+LOG elab:0:   - Prelude.Types.Num implementation at Prelude.Types:66:1--71:33
+LOG elab:0:   - Prelude.Types.+
+LOG elab:0:   - Prelude.Types.*
+LOG elab:0:   - Prelude.Types.plus
+LOG elab:0:   - Prelude.Types.mult
+LOG elab:0:   - Prelude.Types.integerToNat
+LOG elab:0:   - Prelude.Types.Z
+LOG elab:0:   - Prelude.Types.S
+LOG elab:0:   - Prelude.Types.Nat
+LOG elab:0:   - Prelude.Num.MkNum
+LOG elab:0:   - Prelude.Num.(+)
+LOG elab:0:   - Prelude.Basics.intToBool
+LOG elab:0:   - Prelude.Basics.True
+LOG elab:0:   - Prelude.Basics.False
+LOG elab:0:   - Builtin.assert_total
+LOG elab:0:   - Builtin.MkUnit
+LOG elab:0:   - RefDefsDeep.case block in "f"
+LOG elab:0: 
+LOG elab:0: Names `RefDefsDeep.f'` refers to:
+LOG elab:0:   - prim__sub_Integer
+LOG elab:0:   - prim__lte_Integer
+LOG elab:0:   - Prelude.Types.case block in "integerToNat"
+LOG elab:0:   - Prelude.Types.fromInteger
+LOG elab:0:   - Prelude.Types.Num implementation at Prelude.Types:66:1--71:33
+LOG elab:0:   - Prelude.Types.+
+LOG elab:0:   - Prelude.Types.*
+LOG elab:0:   - Prelude.Types.plus
+LOG elab:0:   - Prelude.Types.mult
+LOG elab:0:   - Prelude.Types.integerToNat
+LOG elab:0:   - Prelude.Types.Z
+LOG elab:0:   - Prelude.Types.S
+LOG elab:0:   - Prelude.Types.Nat
+LOG elab:0:   - Prelude.Num.MkNum
+LOG elab:0:   - Prelude.Num.(+)
+LOG elab:0:   - Prelude.Basics.intToBool
+LOG elab:0:   - Prelude.Basics.True
+LOG elab:0:   - Prelude.Basics.False
+LOG elab:0:   - Builtin.assert_total
+LOG elab:0:   - Builtin.MkUnit
+LOG elab:0:   - RefDefsDeep.case block in "f'"
+LOG elab:0: 
+LOG elab:0: Names `RefDefsDeep.f''` refers to:
+LOG elab:0:   - prim__sub_Integer
+LOG elab:0:   - prim__lte_Integer
+LOG elab:0:   - Prelude.Types.case block in "integerToNat"
+LOG elab:0:   - Prelude.Types.fromInteger
+LOG elab:0:   - Prelude.Types.Num implementation at Prelude.Types:66:1--71:33
+LOG elab:0:   - Prelude.Types.+
+LOG elab:0:   - Prelude.Types.*
+LOG elab:0:   - Prelude.Types.plus
+LOG elab:0:   - Prelude.Types.mult
+LOG elab:0:   - Prelude.Types.integerToNat
+LOG elab:0:   - Prelude.Types.Z
+LOG elab:0:   - Prelude.Types.S
+LOG elab:0:   - Prelude.Types.Nat
+LOG elab:0:   - Prelude.Num.MkNum
+LOG elab:0:   - Prelude.Num.(+)
+LOG elab:0:   - Prelude.Basics.intToBool
+LOG elab:0:   - Prelude.Basics.True
+LOG elab:0:   - Prelude.Basics.False
+LOG elab:0:   - Builtin.assert_total
+LOG elab:0:   - Builtin.MkUnit
+LOG elab:0:   - RefDefsDeep.f
+LOG elab:0:   - RefDefsDeep.case block in "f"
+LOG elab:0:   - RefDefsDeep.case block in "f''"
+LOG elab:0: 
+LOG elab:0: Names `RefDefsDeep.f'''` refers to:
+LOG elab:0:   - prim__sub_Integer
+LOG elab:0:   - prim__lte_Integer
+LOG elab:0:   - Prelude.Types.case block in "integerToNat"
+LOG elab:0:   - Prelude.Types.fromInteger
+LOG elab:0:   - Prelude.Types.Num implementation at Prelude.Types:66:1--71:33
+LOG elab:0:   - Prelude.Types.+
+LOG elab:0:   - Prelude.Types.*
+LOG elab:0:   - Prelude.Types.plus
+LOG elab:0:   - Prelude.Types.mult
+LOG elab:0:   - Prelude.Types.integerToNat
+LOG elab:0:   - Prelude.Types.Z
+LOG elab:0:   - Prelude.Types.S
+LOG elab:0:   - Prelude.Types.Nat
+LOG elab:0:   - Prelude.Num.MkNum
+LOG elab:0:   - Prelude.Num.(+)
+LOG elab:0:   - Prelude.Basics.intToBool
+LOG elab:0:   - Prelude.Basics.True
+LOG elab:0:   - Prelude.Basics.False
+LOG elab:0:   - Builtin.assert_total
+LOG elab:0:   - Builtin.MkUnit
+LOG elab:0:   - RefDefsDeep.f
+LOG elab:0:   - RefDefsDeep.case block in "f"
+LOG elab:0:   - RefDefsDeep.case block in "f'''"
+LOG elab:0:   - RefDefsDeep.case block in "case block in f'''"
+LOG elab:0: 
+LOG elab:0: Names `RefDefsDeep.n` refers to:
+LOG elab:0:   - prim__sub_Integer
+LOG elab:0:   - prim__lte_Integer
+LOG elab:0:   - Prelude.Types.case block in "integerToNat"
+LOG elab:0:   - Prelude.Types.fromInteger
+LOG elab:0:   - Prelude.Types.Num implementation at Prelude.Types:66:1--71:33
+LOG elab:0:   - Prelude.Types.+
+LOG elab:0:   - Prelude.Types.*
+LOG elab:0:   - Prelude.Types.plus
+LOG elab:0:   - Prelude.Types.mult
+LOG elab:0:   - Prelude.Types.integerToNat
+LOG elab:0:   - Prelude.Types.Z
+LOG elab:0:   - Prelude.Types.S
+LOG elab:0:   - Prelude.Types.Nat
+LOG elab:0:   - Prelude.Num.MkNum
+LOG elab:0:   - Prelude.Num.(+)
+LOG elab:0:   - Prelude.Basics.intToBool
+LOG elab:0:   - Prelude.Basics.True
+LOG elab:0:   - Prelude.Basics.False
+LOG elab:0:   - Builtin.assert_total
+LOG elab:0:   - Builtin.MkUnit
+LOG elab:0:   - RefDefsDeep.4813:2927:f
+LOG elab:0:   - RefDefsDeep.case block in "n,f"
+LOG elab:0: 
+LOG elab:0: Names `RefDefsDeep.w` refers to:
+LOG elab:0:   - prim__sub_Integer
+LOG elab:0:   - prim__lte_Integer
+LOG elab:0:   - Prelude.Types.case block in "integerToNat"
+LOG elab:0:   - Prelude.Types.fromInteger
+LOG elab:0:   - Prelude.Types.Num implementation at Prelude.Types:66:1--71:33
+LOG elab:0:   - Prelude.Types.+
+LOG elab:0:   - Prelude.Types.*
+LOG elab:0:   - Prelude.Types.plus
+LOG elab:0:   - Prelude.Types.mult
+LOG elab:0:   - Prelude.Types.integerToNat
+LOG elab:0:   - Prelude.Types.Z
+LOG elab:0:   - Prelude.Types.S
+LOG elab:0:   - Prelude.Types.Nat
+LOG elab:0:   - Prelude.Num.MkNum
+LOG elab:0:   - Prelude.Num.(+)
+LOG elab:0:   - Prelude.Basics.intToBool
+LOG elab:0:   - Prelude.Basics.True
+LOG elab:0:   - Prelude.Basics.False
+LOG elab:0:   - Builtin.assert_total
+LOG elab:0:   - Builtin.MkUnit
+LOG elab:0:   - RefDefsDeep.f
+LOG elab:0:   - RefDefsDeep.case block in "f"
+LOG elab:0:   - RefDefsDeep.with block in "w"
+LOG elab:0:   - RefDefsDeep.case block in "with block in w"
+LOG elab:0:   - RefDefsDeep.case block in "with block in w"
+LOG elab:0: 
+------------
+1/1: Building InspectRec (InspectRec.idr)
+LOG elab:0: case zero case: non-recursive
+LOG elab:0: case non-zero case: non-recursive
+LOG elab:0: case base case: non-recursive
+LOG elab:0: case next cast: recursive
+LOG elab:0: case mutual rec 1, base: non-recursive
+LOG elab:0: case mutual rec 1, next: non-recursive
+LOG elab:0: case mutual rec 2, base: non-recursive
+LOG elab:0: case mutual rec 2, next: recursive
+LOG elab:0: case nestedMut rec 1, base: non-recursive
+LOG elab:0: case nestedMut rec 2, base: non-recursive
+LOG elab:0: case nestedMut rec 2, next: recursive
+LOG elab:0: case nestedMut rec 1, next: recursive

--- a/tests/idris2/reflection/reflection025/run
+++ b/tests/idris2/reflection/reflection025/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check RefDefs.idr

--- a/tests/idris2/reflection/reflection025/run
+++ b/tests/idris2/reflection/reflection025/run
@@ -1,3 +1,9 @@
 . ../../../testutils.sh
 
 check RefDefs.idr
+echo ------------
+check CurrFn.idr
+echo ------------
+check RefDefsDeep.idr
+echo ------------
+check InspectRec.idr

--- a/tests/idris2/reflection/reflection025/test.ipkg
+++ b/tests/idris2/reflection/reflection025/test.ipkg
@@ -1,0 +1,1 @@
+package a-test


### PR DESCRIPTION
# Description

I wanted to be able to implement recursion-aware DSLs using elaborator scripts and macroses for a very long time. Very nice example for this would be a `MonadRec` interface, which allows to define stack-safe monads. Problem of this interface is that instead of nicely supported `>>=`, it uses its own function, which is really painful to be used by a human. So, I wanted to adapt a DSL which encodes nice `do`-syntax with appropriate functions from the `MonadRec` interface. The same goes for `Arrow`s too, BTW, and I believe, in more cases.

My initial idea was to define a script which takes the whole declaration, say

```idris
%runElab AsMonadRec `[
  f : Monad m => ... -> m a
  f ... = do
    someCode ...
    x <- someRecursiveCall <$> f ...
    ...
]
```

Then, I realised that this badly works for mutual recursion. And anyway, this is much more complicated to write and to maintain, since, actually, this script just gets a syntax of the whole definition in all glory of the language, and needs to work with it non-locally. I decided this to be a bad way.

Then I thought, that if in an elaboration script I would know what function I'm currently in, I could detect recustive calls. Well, this, actually, is not enough, since we can have mutual recursion and we don't have an ability to inspect body of an arbitrary function in elaboration script, and addition of this would be a too much a change. But, if we could inspect all definitions references in a definition, we could solve the task of recursiveness calculation fully, incluiding mutual recursion, and stay still on a local context of a particular function call or expression.

So, what I propose it to add a couple of operations to elab scripts, that allow to inspect references of definitions from definitions, and to allow to inspect what function we currently are in. This features together allow to inspect recursiveness, and the principle is shown in the added test (the last module in the `run` script, previous ones are technical tests).

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).
