### PR TITLE
[ cleanup ] remove duplicate copy of header parsing

### DIFF
--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1930,31 +1930,24 @@ import_ fname indents
          pure (MkImport (boundToFC fname b) reexp ns nsAs)
 
 export
-prog : OriginDesc -> EmptyRule Module
-prog fname
+progHdr : OriginDesc -> EmptyRule Module
+progHdr fname
     = do b <- bounds (do doc    <- optDocumentation fname
                          nspace <- option (nsAsModuleIdent mainNS)
                                      (do decoratedKeyword fname "module"
                                          decorate fname Module $ mustWork moduleIdent)
                          imports <- block (import_ fname)
                          pure (doc, nspace, imports))
-         ds      <- block (topDecl fname)
-         (doc, nspace, imports) <- pure b.val
-         pure (MkModule (boundToFC fname b)
-                        nspace imports doc (collectDefs (concat ds)))
-
-export
-progHdr : OriginDesc -> EmptyRule Module
-progHdr fname
-    = do b <- bounds (do doc    <- optDocumentation fname
-                         nspace <- option (nsAsModuleIdent mainNS)
-                                     (do decoratedKeyword fname "module"
-                                         mustWork moduleIdent)
-                         imports <- block (import_ fname)
-                         pure (doc, nspace, imports))
          (doc, nspace, imports) <- pure b.val
          pure (MkModule (boundToFC fname b)
                         nspace imports doc [])
+
+export
+prog : OriginDesc -> EmptyRule Module
+prog fname
+    = do mod <- progHdr fname
+         ds <- block (topDecl fname)
+         pure $ { decls := collectDefs (concat ds)} mod
 
 parseMode : Rule REPLEval
 parseMode


### PR DESCRIPTION
This PR removes a duplicate copy of the header parser. (This was discussed in  #3068)

There are two copies of the parser code for the file header in `Parser.idr`.  One is in `progHdr`, which is used to parse the header for building the module tree and deciding whether to rebuild a file or not.  The other is in `prog` which is used to parse the entire `.idr` file.  Because there are two copies, they could accidentally diverge from each other.  This has already happened, but currently the only difference is a `Module` decoration.

Here I keep the copy in `progHdr`, adding the decoration, and have `prog` call `progHdr` and then add the declarations.
