### PR TITLE
[ ci ] Run a brew update during ci

### DIFF
--- a/.github/workflows/ci-idris2-and-libs.yml
+++ b/.github/workflows/ci-idris2-and-libs.yml
@@ -174,6 +174,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install build dependencies
         run: |
+          brew update
           brew install chezscheme
           brew install coreutils
           echo "$HOME/.idris2/bin" >> "$GITHUB_PATH"
@@ -330,6 +331,7 @@ jobs:
           path: ~/.idris2/
       - name: Install build dependencies
         run: |
+          brew update
           brew install chezscheme
           brew install coreutils
           echo "$HOME/.idris2/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
PR #3122 failed during build because `macos-bootstrap-chez` used chez scheme 9.6.4 and `macos-self-host-chez` used 9.6.2, which is incompatible. It looks like chez was updated in homebrew last week and `macos-self-host-chez` got a machine with an older homebrew install.

I'm proposing we address the issue by doing a `brew update` before installing chez scheme.  This is consistent with the `apt-get update` being run on the linux side, but homebrew is more aggressive about updating dependencies.

Between the two jobs, this ends up adding about 10 minutes to the mac build path, because homebrew insists on upgrading a bunch of packages, but mac still finished slightly before windows, so it may not effect overall time. 

