### PR TITLE
[ deriving ] Try to reduce a type before searching it's showable

### DIFF
--- a/libs/base/Deriving/Show.idr
+++ b/libs/base/Deriving/Show.idr
@@ -245,6 +245,8 @@ namespace Show
                   let MW = rig
                     | _ => throwError (NotAnUnconstrainedValue rig)
 
+                  -- try to reduce the type before analysis
+                  ty <- try (check {expected=Type} ty >>= \x => quote x) (pure ty)
                   res <- withError (WhenCheckingArg (mapTTImp cleanup ty)) $ do
                            typeView f (paraz <>> []) ty
                   pure $ Just (showPrecFun fc mutualWith res v)

--- a/tests/base/deriving_show/DeriveShow.idr
+++ b/tests/base/deriving_show/DeriveShow.idr
@@ -192,3 +192,17 @@ namespace EqMap
 
   eqMap : (eq : Eq key) => Show key => Show val => Show (EqMap key @{eq} val)
   eqMap = %runElab derive
+
+namespace Reducible
+
+  Y : Bool -> Type
+  Y True  = Bool
+  Y False = Nat
+
+  data X : Type where
+    X0 : X
+    X1 : Bool -> X
+    X2 : Y True -> Y False -> X
+
+  x : Show X
+  x = %runElab derive

--- a/tests/base/deriving_show/expected
+++ b/tests/base/deriving_show/expected
@@ -83,6 +83,11 @@ LOG derive.show.assumption:10: I am assuming that the parameter val can be shown
 LOG derive.show.clauses:1: 
   showPrecEqMap : {0 key : _} -> Show key => {0 eq, val : _} -> Show val => Prec -> EqMap key {{conArg:5125} = eq} val -> String
   showPrecEqMap d (MkEqMap x0) = showCon d "MkEqMap" (showArg x0)
+LOG derive.show.clauses:1: 
+  showPrecX : Prec -> X -> String
+  showPrecX d X0 = "X0"
+  showPrecX d (X1 x0) = showCon d "X1" (showArg x0)
+  showPrecX d (X2 x0 x1) = showCon d "X2" (concat ((showArg x0) :: ((showArg x1) :: Nil)))
 DeriveShow> "Lam (Call Add ((::) (Var Nothing) ((::) (Var (Just ())) Nil)))"
 DeriveShow> 
 Bye for now!


### PR DESCRIPTION
# Description

Sometimes data type definitions contain type aliases, including non-trivial ones. The current derivation mechanism tries to count them as proper types without an attempt to treat them. The example of such a type can be found in the added test case.

What I suggest is to try to reduce a type before analysis using quotation. Since, we do not restore the whole context of a type expression being reduced, we only `try` it and fallback to the original behaviour if we didn't manage.

Notice that this mechanism cannot be applied directly to `Type -> Type` derivations like `Functor`, since in this case we *have to* restore the context, at least the parameter type has to be there. I do this type of stuff in some of my elaboration scripts, but this change is far beyond a simple fix, which this PR pretends to be.