### PR TITLE
[ elab ] Support more applicative traversals of `TTImp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,9 @@
 * Adds bindings for IEEE floating point constants NaN and (+/-) Inf, as well as
   machine epsilon and unit roundoff. Speeds vary depending on backend.
 
+* A more generalised way of applicative mapping of `TTImp` expression was added,
+  called `mapATTImp`; the original `mapMTTimp` was implemented through the new one.
+
 #### System
 
 * Changes `getNProcessors` to return the number of online processors rather than

--- a/tests/idris2/reflection/reflection025/expected
+++ b/tests/idris2/reflection/reflection025/expected
@@ -43,7 +43,7 @@ LOG elab:0: current fn: [< CurrFn.f]
 LOG elab:0: current fn: [< CurrFn.f']
 LOG elab:0: current fn: [< CurrFn.f'']
 LOG elab:0: current fn: [< CurrFn.f''', CurrFn.case block in "f'''"]
-LOG elab:0: current fn: [< CurrFn.n, CurrFn.4808:2662:f]
+LOG elab:0: current fn: [< CurrFn.n, CurrFn.<nums>:<nums>:f]
 LOG elab:0: current fn: [< CurrFn.w, CurrFn.with block in "w"]
 LOG elab:0: current fn: [< CurrFn.w, CurrFn.with block in "w"]
 ------------
@@ -53,7 +53,7 @@ LOG elab:0: === current fn: [< RefDefsDeep.f] ===
 LOG elab:0: === current fn: [< RefDefsDeep.f'] ===
 LOG elab:0: === current fn: [< RefDefsDeep.f''] ===
 LOG elab:0: === current fn: [< RefDefsDeep.f''', RefDefsDeep.case block in "f'''"] ===
-LOG elab:0: === current fn: [< RefDefsDeep.n, RefDefsDeep.4822:2927:f] ===
+LOG elab:0: === current fn: [< RefDefsDeep.n, RefDefsDeep.<nums>:<nums>:f] ===
 LOG elab:0: === current fn: [< RefDefsDeep.w, RefDefsDeep.with block in "w"] ===
 LOG elab:0: === current fn: [< RefDefsDeep.w, RefDefsDeep.with block in "w"] ===
 LOG elab:0: Names `RefDefsDeep.f` refers to:
@@ -174,7 +174,7 @@ LOG elab:0:   - Prelude.Basics.True
 LOG elab:0:   - Prelude.Basics.False
 LOG elab:0:   - Builtin.assert_total
 LOG elab:0:   - Builtin.MkUnit
-LOG elab:0:   - RefDefsDeep.4822:2927:f
+LOG elab:0:   - RefDefsDeep.<nums>:<nums>:f
 LOG elab:0:   - RefDefsDeep.case block in "n,f"
 LOG elab:0: 
 LOG elab:0: Names `RefDefsDeep.w` refers to:

--- a/tests/idris2/reflection/reflection025/expected
+++ b/tests/idris2/reflection/reflection025/expected
@@ -43,7 +43,7 @@ LOG elab:0: current fn: [< CurrFn.f]
 LOG elab:0: current fn: [< CurrFn.f']
 LOG elab:0: current fn: [< CurrFn.f'']
 LOG elab:0: current fn: [< CurrFn.f''', CurrFn.case block in "f'''"]
-LOG elab:0: current fn: [< CurrFn.n, CurrFn.4800:2662:f]
+LOG elab:0: current fn: [< CurrFn.n, CurrFn.4808:2662:f]
 LOG elab:0: current fn: [< CurrFn.w, CurrFn.with block in "w"]
 LOG elab:0: current fn: [< CurrFn.w, CurrFn.with block in "w"]
 ------------
@@ -53,7 +53,7 @@ LOG elab:0: === current fn: [< RefDefsDeep.f] ===
 LOG elab:0: === current fn: [< RefDefsDeep.f'] ===
 LOG elab:0: === current fn: [< RefDefsDeep.f''] ===
 LOG elab:0: === current fn: [< RefDefsDeep.f''', RefDefsDeep.case block in "f'''"] ===
-LOG elab:0: === current fn: [< RefDefsDeep.n, RefDefsDeep.4814:2927:f] ===
+LOG elab:0: === current fn: [< RefDefsDeep.n, RefDefsDeep.4822:2927:f] ===
 LOG elab:0: === current fn: [< RefDefsDeep.w, RefDefsDeep.with block in "w"] ===
 LOG elab:0: === current fn: [< RefDefsDeep.w, RefDefsDeep.with block in "w"] ===
 LOG elab:0: Names `RefDefsDeep.f` refers to:
@@ -174,7 +174,7 @@ LOG elab:0:   - Prelude.Basics.True
 LOG elab:0:   - Prelude.Basics.False
 LOG elab:0:   - Builtin.assert_total
 LOG elab:0:   - Builtin.MkUnit
-LOG elab:0:   - RefDefsDeep.4814:2927:f
+LOG elab:0:   - RefDefsDeep.4822:2927:f
 LOG elab:0:   - RefDefsDeep.case block in "n,f"
 LOG elab:0: 
 LOG elab:0: Names `RefDefsDeep.w` refers to:

--- a/tests/idris2/reflection/reflection025/run
+++ b/tests/idris2/reflection/reflection025/run
@@ -1,5 +1,6 @@
 . ../../../testutils.sh
 
+{
 check RefDefs.idr
 echo ------------
 check CurrFn.idr
@@ -7,3 +8,4 @@ echo ------------
 check RefDefsDeep.idr
 echo ------------
 check InspectRec.idr
+} | sed -e 's/\.[0-9]*:[0-9]*:/.<nums>:<nums>:/'


### PR DESCRIPTION
# Description

I propose to allow a bit more applicable, applicative mapping of `TTImp`s, which generalises existing `mapMTTImp` way.

Proposed way allows you to do, for example, the following. Since traversal goes bottom up, from leaves up to the root, there might be not enough information of whether some transformation should be done, or not. Consider you want some transformation happen, but want to cancel it if some condition happens. You may need an original value at this point. The proposed addition of `mapMMTTImp` (along with existing `mapMTTImp`) allows this:

```idris
record WithOrig a where
  constructor W
  orig : a
  main : Lazy a

Functor WithOrig where
  map f = {orig $= f, main $= f}

Applicative WithOrig where
  pure x = W x x
  W fo fm <*> W xo xm = W (fo xo) (fm xm)

whateverTransformation : TTImp -> TTImp

condTrans : WithOrig TTImp -> WithOrig TTImp
condTrans wo = if cond wo.orig then wo else {main $= whateverTransformation} wo
```

Running `mapMMTTImp condTrans expr`, you have both original **sub**expression and the transformed one inside the `condTrans` function, allowing you to control precisely whether or not any particular change should be done.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

