### PR TITLE
[ doc ] Headings for envvars based on use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,6 +299,8 @@
 * Updates the docs for `envvars` to match the changes introduced in #2649.
 * Both `make install` and `idris2 --install...` now respect `DESTDIR` which
   can be set to install into a staging directory for distro packaging.
+* Updates the docs for `envvars` to categorise when environment variables are
+  used (runtime, build-time, or both).
 
 ## v0.6.0
 

--- a/docs/source/reference/envvars.rst
+++ b/docs/source/reference/envvars.rst
@@ -8,9 +8,21 @@ Idris 2 recognises a number of environment variables, to decide where to look
 for packages, external libraries, code generators, etc. It currently recognises,
 in approximately the order you're likely to need them:
 
-* ``EDITOR`` - Editor used in REPL ``:e`` command.
+Build-time
+----------
+
 * ``PREFIX`` - Default way to set the Idris2 installation prefix.
 * ``IDRIS2_PREFIX`` - Alternative way to set the Idris2 installation prefix.
+
+Runtime
+-------
+
+* ``EDITOR`` - Editor used in REPL ``:e`` command.
+
+Both
+----
+
+* ``IDRIS2_CG`` - Codegen backend.
 * ``IDRIS2_PATH`` - Directories where Idris2 looks for import files, in addition
   to the imports in packages
 * ``IDRIS2_PACKAGE_PATH`` - Directories where Idris2 looks for Idris 2 packages,
@@ -22,14 +34,11 @@ in approximately the order you're likely to need them:
   typically support code for code generators.
 * ``IDRIS2_LIBS`` - Directories where Idris2 looks for libraries (for code
   generation).
-* ``IDRIS2_CG`` - Codegen backend.
-* ``IDRIS2_INC_CGS`` - Code generators to use (comma separated) when compiling modules incrementally.
 * ``CHEZ`` - Chez backend: location of the ``chez`` executable.
 * ``RACKET`` - Racket backend: location of the ``racket`` executable.
 * ``RACKET_RACO`` - Racket backend: location of the ``raco`` executable.
-* ``GAMBIT_GSI`` - Gambit backend: location of the ``gsi`` executable.
-* ``GAMBIT_GSC`` - Gambit backend: location of the ``gsc`` executable.
-* ``GAMBIT_GSC_BACKEND`` - Gambit backend: arguments passed to ``gsc``.
+* ``IDRIS2_INC_CGS`` - Code generators to use (comma separated) when compiling
+  modules incrementally.
 * ``IDRIS2_CC`` - RefC backend: location of the C compiler executable.
 * ``IDRIS2_CFLAGS`` - RefC backend: C compiler flags.
 * ``IDRIS2_CPPFLAGS`` - RefC backend: C preprocessor flags.
@@ -43,4 +52,7 @@ in approximately the order you're likely to need them:
   codegens.
 * ``NO_COLOR`` - Instruct Idris not to print colour to stdout. Passing the
   --colour/--color option will supersede this environment variable.
+* ``GAMBIT_GSI`` - Gambit backend: location of the ``gsi`` executable.
+* ``GAMBIT_GSC`` - Gambit backend: location of the ``gsc`` executable.
+* ``GAMBIT_GSC_BACKEND`` - Gambit backend: arguments passed to ``gsc``.
 


### PR DESCRIPTION
# Description

Some envvars are only used at build-time, some only at runtime, and lots are used at both. This clearly cagetorises them accordingly in the docs. Having these headings was suggested [a long time ago](https://github.com/idris-lang/Idris2/pull/3024#issuecomment-1644572572) by dunham; I finally got around to doing it... (Side-note: the original discussion suggests that this indexing used to be in the Idris docs. However, I have been unable to find this and so have just gone based on testing and grep­-ing the makefile.)


## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

