### PR TITLE
Support "make -j"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,6 +301,7 @@
   can be set to install into a staging directory for distro packaging.
 * Updates the docs for `envvars` to categorise when environment variables are
   used (runtime, build-time, or both).
+* Fixed build failure occuring when `make -j` is in effect.
 
 ## v0.6.0
 

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,9 @@ export SCHEME
 
 .PHONY: all idris2-exec libdocs testenv testenv-clean support clean-support clean FORCE
 
-all: ${TARGET} libs
+all:
+	${MAKE} ${TARGET}
+	${MAKE} libs
 
 idris2-exec: ${TARGET}
 

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ contrib: base
 test-lib: contrib
 	${MAKE} -C libs/test IDRIS2=${TARGET} IDRIS2_INC_CGS=${IDRIS2_CG} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 
-linear: prelude
+linear: prelude base
 	${MAKE} -C libs/linear IDRIS2=${TARGET} IDRIS2_INC_CGS=${IDRIS2_CG} IDRIS2_PATH=${IDRIS2_BOOT_PATH}
 
 papers: contrib linear


### PR DESCRIPTION
# Description

There are two cases where `make -j` fails: `make bootstrap -j` and `make all -j`. I fixed them both in two separate commits. 

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).