### PR TITLE
[ ffi ] Fix missing structure declarations in scheme ffi

### DIFF
--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -365,7 +365,7 @@ mkStruct (CFStruct n flds)
     showFld : (String, CFType) -> Core Builder
     showFld (n, ty) = pure $ "[" ++ fromString n ++ " " ++ !(cftySpec emptyFC ty) ++ "]"
 mkStruct (CFIORes t) = mkStruct t
-mkStruct (CFFun a b) = do ignore (mkStruct a); mkStruct b
+mkStruct (CFFun a b) = do [| mkStruct a ++ mkStruct b |]
 mkStruct _ = pure ""
 
 schFgnDef : {auto c : Ref Ctxt Defs} ->

--- a/src/Compiler/Scheme/Gambit.idr
+++ b/src/Compiler/Scheme/Gambit.idr
@@ -328,7 +328,7 @@ mkStruct (CFStruct n flds)
     showFld : (String, CFType) -> Core Builder
     showFld (n, ty) = pure $ "(" ++ fromString n ++ " " ++ !(cftySpec emptyFC ty) ++ ")"
 mkStruct (CFIORes t) = mkStruct t
-mkStruct (CFFun a b) = do ignore (mkStruct a); mkStruct b
+mkStruct (CFFun a b) = [| mkStruct a ++ mkStruct b |]
 mkStruct _ = pure ""
 
 schFgnDef : {auto c : Ref Ctxt Defs} ->

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -311,7 +311,7 @@ mkStruct (CFStruct n flds)
     showFld : (String, CFType) -> Core Builder
     showFld (n, ty) = pure $ "[" ++ fromString n ++ " " ++ !(cftySpec emptyFC ty) ++ "]"
 mkStruct (CFIORes t) = mkStruct t
-mkStruct (CFFun a b) = do ignore (mkStruct a); mkStruct b
+mkStruct (CFFun a b) = [| mkStruct a ++ mkStruct b |]
 mkStruct _ = pure ""
 
 schFgnDef : {auto f : Ref Done (List String) } ->

--- a/tests/allschemes/ffi001/Struct.idr
+++ b/tests/allschemes/ffi001/Struct.idr
@@ -1,0 +1,13 @@
+import System.FFI
+
+PtrAST : Type
+PtrAST = Struct "AST" [("value", AnyPtr)]
+
+%foreign "C:freeAST,foo"
+prim_freeAST : (PtrAST -> Int) -> PrimIO ()
+
+freeAST : HasIO io => (PtrAST -> Int) -> io ()
+freeAST ast = primIO $ prim_freeAST ast
+
+main : IO ()
+main = freeAST (\x => 1)

--- a/tests/allschemes/ffi001/run
+++ b/tests/allschemes/ffi001/run
@@ -1,0 +1,4 @@
+. ../../testutils.sh
+
+# Previously reported: unrecognized foreign-callable argument ftype name AST
+idris2 -c Struct.idr -o out </dev/null


### PR DESCRIPTION
When a FFI call contains a function type as argument whose domain is a `Struct` the definition for the struct type is not emitted by codegen, causing an error at compile time.  This issue was reported and diagnosed by slayerofthebad on discord. It occurs in chez, racket, and gambit.

The root cause was that the `Builder` returned by `mkStruct a` was being dropped. It represents the string for the structure definition, and needed to be concatenated with the one for the domain before returning. (These expressions end up at the top level.)

Before the change, the test case would fail to compile with:
```
Exception: unrecognized foreign-callable argument ftype name AST at line 616, char 162 of /Users/dunham/build/i2/Idris2/build/exec/out_app/out.ss
```
And after the change it compiles.

I tested the gambit case manually, I don't think CI covers it.
