### PR TITLE
[ base ] Add `mapPropertyRelevant`, `tabulate` and `(++)` for `Vect`'s `All`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,7 +199,8 @@
 * Generalized `imapProperty` in `Data.List.Quantifiers.All.All`
   and `Data.Vect.Quantifiers.All.All`.
 
-* Add `zipPropertyWith`, `traverseProperty`, `traversePropertyRelevant` and `remember`
+* Add `zipPropertyWith`, `traverseProperty`, `traversePropertyRelevant`,
+  `mapPropertyRelevant`, `(++)`, `tabulate` and `remember`
   to `Data.Vect.Quantifiers.All.All`.
 
 * Add `anyToFin` to `Data.Vect.Quantifiers.Any`,

--- a/libs/base/Data/Vect/Quantifiers.idr
+++ b/libs/base/Data/Vect/Quantifiers.idr
@@ -126,6 +126,16 @@ namespace All
   mapProperty f [] = []
   mapProperty f (p::pl) = f p :: mapProperty f pl
 
+  ||| A variant of `mapProperty` that also allows accessing
+  ||| the values of `xs` that the corresponding `ps` prove `p` about.
+  export
+  mapPropertyRelevant : {xs : Vect n a} ->
+                        (f : (x : a) -> p x -> q x) ->
+                        (ps : All p xs) ->
+                        All q xs
+  mapPropertyRelevant f [] = []
+  mapPropertyRelevant f (p :: ps) = f _ p :: mapPropertyRelevant f ps
+
   public export
   imapProperty : {0 a : Type}
               -> {0 p,q : a -> Type}
@@ -194,6 +204,19 @@ namespace All
                              f (All q xs)
   traversePropertyRelevant f [] = pure []
   traversePropertyRelevant f (x :: xs) = [| f _ x :: traversePropertyRelevant f xs |]
+
+  public export
+  tabulate : {n : _} ->
+             {0 xs : Vect n _} ->
+             (f : (ix : Fin n) -> p (ix `index` xs)) ->
+             All p {n} xs
+  tabulate {xs = []} f = []
+  tabulate {xs = _ :: _} f = f FZ :: tabulate (\ix => f (FS ix))
+
+  public export
+  (++) : (axs : All p xs) -> (ays : All p ys) -> All p (xs ++ ys)
+  [] ++ ays = ays
+  (ax :: axs) ++ ays = ax :: (axs ++ ays)
 
   export
   All (Show . p) xs => Show (All p xs) where


### PR DESCRIPTION
# Description

Adding some more functions that are useful in practice and might be not exactly trivial to implement (like `tabulate`'s erased `xs` but unerased `n` to allow for pattern-matching on the shape of `xs`).

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

