### PR TITLE
[ gambit ] fix pack / unpack segfault with gambit scheme

### DIFF
--- a/support/gambit/support.scm
+++ b/support/gambit/support.scm
@@ -2,10 +2,10 @@
 ;; https://github.com/gambit/gambit/blob/master/gsc/_t-x86.scm#L1106 #L1160
 (define (blodwen-os)
   (cond
-    [(memq (cadr (system-type)) '(apple)) "darwin"]
-    [(memq (caddr (system-type)) '(linux-gnu)) "unix"]
-    [(memq (caddr (system-type)) '(mingw32 mingw64)) "windows"]
-    [else "unknown"]))
+    ((memq (cadr (system-type)) '(apple)) "darwin")
+    ((memq (caddr (system-type)) '(linux-gnu)) "unix")
+    ((memq (caddr (system-type)) '(mingw32 mingw64)) "windows")
+    (else "unknown")))
 
 ;; TODO Convert to macro
 (define (blodwen-read-args desc)
@@ -16,7 +16,7 @@
 
 (define blodwen-lazy
   (lambda (f)
-    (let ([evaluated #f] [res void])
+    (let ((evaluated #f) (res void))
       (lambda ()
         (if (not evaluated)
             (begin (set! evaluated #t)
@@ -132,20 +132,12 @@
 (define-macro (cast-string-int x)
   `(exact-truncate (cast-string-double ,x)))
 
-(define (from-idris-list xs)
-  (if (= (vector-ref xs 0) 0)
-    '()
-    (cons (vector-ref xs 1) (from-idris-list (vector-ref xs 2)))))
-
 (define-macro (string-pack xs)
-  `(apply string (from-idris-list ,xs)))
-(define (to-idris-list-rev acc xs)
-  (if (null? xs)
-    acc
-    (to-idris-list-rev (vector 1 (car xs) acc) (cdr xs))))
-(define (string-unpack s) (to-idris-list-rev (vector 0) (reverse (string->list s))))
+  `(apply string ,xs))
+
+(define (string-unpack s) (string->list s))
 (define-macro (string-concat xs)
-  `(apply string-append (from-idris-list ,xs)))
+  `(apply string-append ,xs))
 
 (define-macro (string-cons x y)
   `(string-append (string ,x) ,y))


### PR DESCRIPTION
This PR fixes a segfault involving `unpack` in gambit and syntax errors in `support.scm` when using the latest gambit. 

The following code segfaults when compiled with the gambit backend:
```idris
main : IO ()
main = printLn "hello, world"
```
The root cause was that `pack` / `unpack` expect a different list representation than Idris currently uses. I suspect it was written before Idris mapped lists to native scheme lists. 

I also discovered that gambit 4.9.5 reports syntax errors for `support.scm`. It doesn't like the use of `[]` instead of `()`.  Gambit 4.9.3 on a different platform is happy with the brackets. I couldn't track down when this changed, but did find that R7RS reserves `[]` and `{}` for future use.

I've addressed both of these issues in this PR.  The code has been tested locally with:
```idris
main : IO ()
main = printLn $ fastConcat [ "Hello, ", "world"]
```
which exercises `pack`, `unpack`, and `fastConcat`.

Other issues remain - the FFI doesn't support passing `Buffer` and a lot of the `blodwen-` functions are missing (including buffer and threading functions). I briefly investigated, but decided to punt.
