### PR TITLE
[ error ] Improve error messages when reading ipkg files

### DIFF
--- a/tests/idris2/pkg/pkg018/bad.ipkg
+++ b/tests/idris2/pkg/pkg018/bad.ipkg
@@ -1,0 +1,2 @@
+package bad
+depend = contrib

--- a/tests/idris2/pkg/pkg018/bad2.ipkg
+++ b/tests/idris2/pkg/pkg018/bad2.ipkg
@@ -1,0 +1,2 @@
+package bad
+sourcedir = src

--- a/tests/idris2/pkg/pkg018/expected
+++ b/tests/idris2/pkg/pkg018/expected
@@ -1,0 +1,14 @@
+Uncaught error: Error: Unrecognised property "depend".
+
+"bad.ipkg":2:1--2:7
+ 1 | package bad
+ 2 | depend = contrib
+     ^^^^^^
+
+Uncaught error: Error: Expected string.
+
+"bad2.ipkg":2:13--2:16
+ 1 | package bad
+ 2 | sourcedir = src
+                 ^^^
+

--- a/tests/idris2/pkg/pkg018/run
+++ b/tests/idris2/pkg/pkg018/run
@@ -1,0 +1,4 @@
+. ../../../testutils.sh
+
+idris2 --build bad.ipkg
+idris2 --build bad2.ipkg


### PR DESCRIPTION
The parser for `.ipkg` files reports any error as "Expected end of input". The root cause was a "many" and an "alt" that eat the error messages. Here I've added `mustWork` where appropriate, a better error message for when it hits an unknown keyword, and added the original source to the error message.

Previously:
```
Uncaught error: Parse errors ([("bad.ipkg":3:1--3:7, "Expected end of input.")])
```
Now it says:
```
Uncaught error: Error: Unrecognised property "depend".

"bad.ipkg":3:1--3:7
 1 | package idris2app
 2 |
 3 | depend = network
     ^^^^^^
```
The other test case reports this instead of "Expected end of input":
```
Uncaught error: Error: Expected string.

"bad2.ipkg":2:13--2:16
 1 | package bad
 2 | sourcedir = src
                 ^^^
```


### Should this change go in the CHANGELOG?

Probably not significant enough to warrant a change log entry. 
