### PR TITLE
[ error ] Fix error message for %defaulthint on a local function

### DIFF
--- a/src/TTImp/ProcessFnOpt.idr
+++ b/src/TTImp/ProcessFnOpt.idr
@@ -49,7 +49,9 @@ processFnOpt fc _ ndef (Hint d)
          addLocalHint ndef
 processFnOpt fc True ndef (GlobalHint a)
     = addGlobalHint ndef a
-processFnOpt fc _ ndef (GlobalHint a)
+processFnOpt fc _ ndef (GlobalHint True)
+    = throw (GenericMsg fc "%defaulthint is not valid in local definitions")
+processFnOpt fc _ ndef (GlobalHint False)
     = throw (GenericMsg fc "%globalhint is not valid in local definitions")
 processFnOpt fc _ ndef ExternFn
     = setFlag fc ndef Inline -- if externally defined, inline when compiling


### PR DESCRIPTION
# Description

If `%deaulthint` is used in a local definition, Idris complains "%globalhint is not valid in local definitions`.  This PR changes it to say "%defaulthint is not valid in local definitions" in that case.

```idris
foo : Nat -> Nat
foo x = x
    where
        %defaulthint
        bar : Show String
```
gives the error message:
```
Error: While processing right hand side of foo. %globalhint is not valid in local definitions
```
With the fix, it now says:
```
Error: While processing right hand side of foo. %defaulthint is not valid in local definitions
```
