### PR TITLE
[ fix #3103, #3104 ] Disable broken tests

### DIFF
--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -160,6 +160,7 @@ refcTests = testsInDir "refc" "Reference counting C backend" {codegen = Just C}
 
 racketTests : IO TestPool
 racketTests = testsInDir "racket" "Racket backend" {codegen = Just Racket}
+  { pred = not . (`elem` ["conditions006", "conditions007"]) }
 
 nodeTests : IO TestPool
 nodeTests = testsInDir "node" "Node backend" {codegen = Just Node}

--- a/tests/racket/conditions006/Main.idr
+++ b/tests/racket/conditions006/Main.idr
@@ -1,3 +1,7 @@
+-- Disabled for now: no working
+-- conditionWaitTimeout
+-- for racket
+
 -- Idris2
 
 import System
@@ -16,4 +20,3 @@ main =
      sleep 2
      putStrLn "Sorry I'm late child!"
      threadWait t
-

--- a/tests/racket/conditions007/Main.idr
+++ b/tests/racket/conditions007/Main.idr
@@ -1,3 +1,7 @@
+-- Disabled for now: no working
+-- conditionWaitTimeout
+-- for racket
+
 -- Idris2
 
 import System
@@ -31,6 +35,5 @@ main =
 
        sleep m
        putStrLn "Sorry I'm late children! Weren't there more of you?..."
-       for impatients $ \t => threadWait t
+       for_ impatients $ \t => threadWait t
        sleep 1
-


### PR DESCRIPTION
Racket does not have FFI bindings for these primitives.