### PR TITLE
[ re #2944, fix ] Make `popen2` be able to not to leak system resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,10 @@
 * `Ref` interface from `Data.Ref` inherits `Monad` and was extended by a function
   for value modification implemented through reading and writing by default.
 
+* A function `popen2Wait` was added to wait for the process started with `popen2`
+  function and clean up all system resources (to not to leave zombie processes in
+  particular).
+
 #### System
 
 * Changes `getNProcessors` to return the number of online processors rather than

--- a/support/c/idris_file.h
+++ b/support/c/idris_file.h
@@ -3,9 +3,11 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 
 #ifdef _WIN32
 #include <io.h>
+#include <processthreadsapi.h>
 #endif
 
 FILE *idris2_openFile(char *name, char *mode);
@@ -59,6 +61,11 @@ FILE *idris2_stderr();
 struct child_process;
 
 struct child_process *idris2_popen2(char *cmd);
+
 int idris2_popen2ChildPid(struct child_process *ptr);
+void *idris2_popen2ChildHandler(struct child_process *ptr);
 FILE *idris2_popen2FileIn(struct child_process *ptr);
 FILE *idris2_popen2FileOut(struct child_process *ptr);
+
+int idris2_popen2WaitByHandler(void *hProcess);
+int idris2_popen2WaitByPid(pid_t pid);

--- a/tests/allbackends/popen2/Test.idr
+++ b/tests/allbackends/popen2/Test.idr
@@ -2,11 +2,16 @@ import System.File
 
 main : IO ()
 main = do
+    putStrLn "main thread: before all"
     Right process <- popen2 "cat"
         | Left err => printLn err
     printLn $ process.pid > 0
     _ <- fPutStrLn process.input "Hello, Idris!\n"
+    putStrLn "main thread: before closing subinput"
     closeFile process.input
+    putStrLn "main thread: before reading suboutput"
     Right result <- fRead process.output
         | Left err => printLn err
+    putStrLn "main thread: before printing suboutput"
     putStr result
+    putStrLn "main thread: after all"

--- a/tests/allbackends/popen2/Test.idr
+++ b/tests/allbackends/popen2/Test.idr
@@ -1,9 +1,9 @@
 import System.File
 
-main : IO ()
-main = do
+runPopen2 : (cmd : String) -> IO ()
+runPopen2 cmd = do
     putStrLn "main thread: before all"
-    Right process <- popen2 "cat"
+    Right process <- popen2 cmd
         | Left err => printLn err
     printLn $ process.pid > 0
     _ <- fPutStrLn process.input "Hello, Idris!\n"
@@ -14,4 +14,16 @@ main = do
         | Left err => printLn err
     putStrLn "main thread: before printing suboutput"
     putStr result
+    putStrLn "main thread: before waiting subprocess"
+    exitCode <- popen2Wait process
+    putStrLn "subprocess exit code: \{show exitCode}"
     putStrLn "main thread: after all"
+
+main : IO ()
+main = runPopen2 "cat"
+
+main2 : IO ()
+main2 = runPopen2 "cat && exit 4"
+
+main3 : IO ()
+main3 = runPopen2 "cat && echo \"Two  spaces\" && exit 4"

--- a/tests/allbackends/popen2/expected
+++ b/tests/allbackends/popen2/expected
@@ -1,3 +1,8 @@
+main thread: before all
 True
+main thread: before closing subinput
+main thread: before reading suboutput
+main thread: before printing suboutput
 Hello, Idris!
 
+main thread: after all

--- a/tests/allbackends/popen2/expected
+++ b/tests/allbackends/popen2/expected
@@ -5,4 +5,29 @@ main thread: before reading suboutput
 main thread: before printing suboutput
 Hello, Idris!
 
+main thread: before waiting subprocess
+subprocess exit code: 0
+main thread: after all
+------
+main thread: before all
+True
+main thread: before closing subinput
+main thread: before reading suboutput
+main thread: before printing suboutput
+Hello, Idris!
+
+main thread: before waiting subprocess
+subprocess exit code: 4
+main thread: after all
+------
+main thread: before all
+True
+main thread: before closing subinput
+main thread: before reading suboutput
+main thread: before printing suboutput
+Hello, Idris!
+
+Two  spaces
+main thread: before waiting subprocess
+subprocess exit code: 4
 main thread: after all

--- a/tests/allbackends/popen2/run
+++ b/tests/allbackends/popen2/run
@@ -1,3 +1,8 @@
 . ../../testutils.sh
 
 run Test.idr
+echo "------"
+idris2 --exec main2 Test.idr
+echo "------"
+idris2 --exec main3 Test.idr | sed 's/^"//' | sed 's/" *$//'
+# filtering above is to level differences in quotes echoing by Windows and the rest


### PR DESCRIPTION
# Description

Current implementation of `popen2` function introduces in #2944 has slightly different behaviour for POSIX and Windows systems, and, more importantly, it leaves zombie processes on POSIX systems, which, when being run regularly, leads to exhaustiveness of PIDs in a system.

Anyway, leaky and unstable behaviour is not to nice, so I propose the simplest solution I came with. I suggest to make behaviour similar in POSIX and WIndows AND requiring a cleanup call `popen2Wait`. Roughtly speaking, this is not a much stretch, because for usual `popen` we already have a pair function `pclose` with the similar meaning. We can't have direct "closing" analogue for `popen2`, because moment and order of closing of the file handlers depends on a particular use (unlike `popen`), so, full cleanup has to be in a series of closings of file handlers and then calling to the newly added function `popen2Wait`.

Behaviour of the existing (leaky) Idris code that currently uses existing `popen2` function remains unchanged with this PR (being run on POSIX systems). So this PR shouldn't break anything.

Alternative solution of the leaking problem was considered (and even mosly implemented in a separate branch). I produces fully detached process which does not produce a zombie in the end, disallowing, however, to get the exit code of this process (at least, easily). But this solution (suddenly) happened to be much more complicated, and, after several attempts to design nicely, I realised that this alternative solution should contain the solution from this PR, so we should first do this before thinking whether we need an ability of detached processes or not.

Pinging @dunhamsteve and @mattpolzin as the original's PR author and main reviewer.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

