### PR TITLE
Separate support derivation (and small related tweaks to the Makefile)

### DIFF
--- a/bootstrap-stage1-chez.sh
+++ b/bootstrap-stage1-chez.sh
@@ -25,7 +25,7 @@ mkdir -p ../build/exec/idris2_app
 # but with the SCHEME var that we already know at this time
 # baked into it.
 echo '#!/bin/sh' >../build/exec/idris2
-echo "SCHEME=${SCHEME}" >>../build/exec/idris2
+echo "SCHEME=\"${SCHEME}\"" >>../build/exec/idris2
 cat ../bootstrap/idris2-boot.sh >>../build/exec/idris2
 chmod +x ../build/exec/idris2
 

--- a/bootstrap-stage1-chez.sh
+++ b/bootstrap-stage1-chez.sh
@@ -20,5 +20,14 @@ ${SCHEME} --script ../bootstrap/compile.ss
 # Put the result in the usual place where the target goes
 mkdir -p ../build/exec
 mkdir -p ../build/exec/idris2_app
-install ../bootstrap/idris2-boot.sh ../build/exec/idris2
+
+# we "install" bootstrap/idris2-boot.sh as build/exec/idris2
+# but with the SCHEME var that we already know at this time
+# baked into it.
+echo '#!/bin/sh' >../build/exec/idris2
+echo "SCHEME=${SCHEME}" >>../build/exec/idris2
+cat ../bootstrap/idris2-boot.sh >>../build/exec/idris2
+chmod +x ../build/exec/idris2
+
 install idris2_app/* ../build/exec/idris2_app
+echo 'bootstrap stage 1 complete'

--- a/bootstrap-stage2.sh
+++ b/bootstrap-stage2.sh
@@ -8,16 +8,18 @@ IDRIS2_CG="${IDRIS2_CG-"chez"}"
 
 # BOOTSTRAP_PREFIX must be the "clean" build root, without cygpath -m
 # Otherwise, we get 'git: Bad address'
-echo "$BOOTSTRAP_PREFIX"
-DYLIB_PATH="$BOOTSTRAP_PREFIX/lib"
+echo "bootstrapping in: $BOOTSTRAP_PREFIX"
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-"${BOOTSTRAP_PREFIX}/lib"}"
+export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH:-"${BOOTSTRAP_PREFIX}/lib"}"
+export IDRIS2_DATA="${IDRIS2_DATA:-"${BOOTSTRAP_PREFIX}/support"}"
 
-$MAKE bootstrap-libs IDRIS2_CG="$IDRIS2_CG" LD_LIBRARY_PATH="$DYLIB_PATH" \
+$MAKE bootstrap-libs IDRIS2_CG="$IDRIS2_CG" \
     PREFIX="$BOOTSTRAP_PREFIX" SCHEME="$SCHEME"
-$MAKE bootstrap-install IDRIS2_CG="$IDRIS2_CG" LD_LIBRARY_PATH="$DYLIB_PATH" \
+$MAKE bootstrap-install IDRIS2_CG="$IDRIS2_CG" \
     PREFIX="$BOOTSTRAP_PREFIX" SCHEME="$SCHEME"
 
 # Now rebuild everything properly
 $MAKE clean-libs IDRIS2_BOOT="$BOOTSTRAP_PREFIX/bin/idris2"
 $MAKE all IDRIS2_BOOT="$BOOTSTRAP_PREFIX/bin/idris2" IDRIS2_CG="$IDRIS2_CG" \
-    LD_LIBRARY_PATH="$DYLIB_PATH" \
     SCHEME="$SCHEME"
+echo 'bootstrap stage 2 complete'

--- a/flake.nix
+++ b/flake.nix
@@ -32,13 +32,16 @@
             pkgs.chez
           else
             pkgs.chez-racket; # TODO: Should this always be the default?
+          idris2Support = pkgs.callPackage ./nix/support.nix { inherit idris2-version; };
           idris2Bootstrap = pkgs.callPackage ./nix/package.nix {
             inherit idris2-version chez;
             idris2Bootstrap = null;
+            support = idris2Support;
             srcRev = self.shortRev or "dirty";
           };
           idris2Pkg = pkgs.callPackage ./nix/package.nix {
             inherit idris2-version chez idris2Bootstrap;
+            support = idris2Support;
             srcRev = self.shortRev or "dirty";
           };
           buildIdris = pkgs.callPackage ./nix/buildIdris.nix {
@@ -52,6 +55,7 @@
             idris = self;
           };
           packages = {
+            support = idris2Support;
             idris2 = idris2Pkg;
           } // (import ./nix/text-editor.nix {
             inherit pkgs idris-emacs-src idris2Pkg;

--- a/nix/support.nix
+++ b/nix/support.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, gmp, idris2-version }:
+stdenv.mkDerivation rec {
+  pname = "libidris2_support";
+  version = idris2-version;
+
+  src = ../.;
+
+  strictDeps = true;
+  buildInputs = [ gmp ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+  ] ++ lib.optional stdenv.isDarwin "OS=";
+
+  buildFlags = [ "support" ];
+
+  installTargets = "install-support";
+
+  postInstall = ''
+    mv $out/idris2-${version}/lib $out/lib
+    mv $out/idris2-${version}/support $out/share
+    rmdir $out/idris2-${version}
+  '';
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -10,7 +10,7 @@ retest:
 	./build/exec/runtests $(IDRIS2) $(INTERACTIVE) --timing --failure-file failures --threads $(threads) --only-file failures --only $(only) --except $(except)
 
 testbin:
-	${IDRIS2} --build tests.ipkg
+	$(IDRIS2) --build tests.ipkg
 
 clean:
 	$(RM) failures

--- a/tests/testutils.sh
+++ b/tests/testutils.sh
@@ -87,8 +87,10 @@ if [ -z "$PREFIX_CHANGED" ] && [ -n "$IDRIS2_PREFIX" ]; then
 
     # Set where to look to installed stuff
     export IDRIS2_PACKAGE_PATH="$OLD_PP$SEP$NEW_PP"
-    export IDRIS2_LIBS="$OLD_PP/libs$SEP$NEW_PP/libs"
-    export IDRIS2_DATA="$OLD_PP/support$SEP$NEW_PP/support"
+    # Use TEST_IDRIS2_LIBS and TEST_IDRIS2_DATA to pass locations for
+    # prebuilt libidris2_support and its DATA files.
+    export IDRIS2_LIBS="$OLD_PP/libs$SEP$NEW_PP/libs$SEP$TEST_IDRIS2_LIBS"
+    export IDRIS2_DATA="$OLD_PP/support$SEP$NEW_PP/support$SEP$TEST_IDRIS2_DATA"
 
     # Set where to install stuff
     export IDRIS2_PREFIX="$NEW_PREFIX"


### PR DESCRIPTION
# Description

I aimed to not make any drastic or unneeded changes with this PR. Hopefully others agree that the small Makefile changes are all net positive in any context even if they were motivated in this case by a Nix refactor.

I tried to tell the story with the commit messages, but to enumerate the changes briefly:
1. Instead of each of the two Chez bootstrap stages reading the `SCHEME` env var separately, take advantage of the fact that this variable is known in stage 1 and carry it forward to stage 2 automatically.
2. Export needed library paths at the top of bootstrap stage 2 instead of inlining the environment variables. This reduces repetition which is even more significant given that I added two additional variables (one of them, `DYLD_LIBRARY_PATH`, just for good measure).
3. Retain test isolation while still supporting flexibility with what support library to use by introducing optional overrides with `TEST_` prefixes for library paths.
4. Refactor Makefile slightly to specify the path for support files as a variable and at the same time build the support library based on a target that refers to the file name as is idiomatic to avoid rebuilding the support library if it is already there.
5. Tackle a TODO in the Nix configs to build the support library as its own derivation and then use that in the Idris 2 build process.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

