### PR TITLE
[ re #3171 ] Correct mistakenly forgotten to be updated changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 * `Data.List.Lazy` was moved from `contrib` to `base`.
 
+* Added an `Interpolation` implementation for primitive decimal numeric types and `Nat`.
+
 #### Contrib
 
 * `Data.List.Lazy` was moved from `contrib` to `base`.
@@ -269,8 +271,6 @@
 
 * `Ref` interface from `Data.Ref` inherits `Monad` and was extended by a function
   for value modification implemented through reading and writing by default.
-
-* Added an `Interpolation` implementation for primitive decimal numeric types and `Nat`.
 
 #### System
 


### PR DESCRIPTION
Unfortunately, I wasn't fast enough to notice this, and this is an examplary case for future (and the only reason why I do this as a separate PR, not as a part of some future bigger one): after an addition to the PR template which mentions the appropriate changelog update, lots of PRs indeed update it, but they update the place relevant to the point of PR creation, which not has changed after the recent release. A lot of PRs need updates in precisely this part.
