### PR TITLE
Add `(++)` for `List` variation of `All`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 * Added an `Interpolation` implementation for primitive decimal numeric types and `Nat`.
 
+* Added append `(++)` for `List` version of `All`.
+
 #### Contrib
 
 * `Data.List.Lazy` was moved from `contrib` to `base`.

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -33,6 +33,7 @@ Ilya Rezvov
 Jan de Muijnck-Hughes
 Jeetu
 Jens Petersen
+Joel Berkeley
 Joey Eremondi
 Johann Rudloff
 Kamil Shakirov

--- a/libs/base/Data/List/Quantifiers.idr
+++ b/libs/base/Data/List/Quantifiers.idr
@@ -166,6 +166,12 @@ namespace All
   HList : List Type -> Type
   HList = All id
 
+  ||| Concatenate lists of proofs.
+  public export
+  (++) : All p xs -> All p ys -> All p (xs ++ ys)
+  [] ++ pys = pys
+  (px :: pxs) ++ pys = px :: (pxs ++ pys)
+
   export
   splitAt : (xs : List a) -> All p (xs ++ ys) -> (All p xs, All p ys)
   splitAt [] pxs = ([], pxs)

--- a/libs/base/Data/List/Quantifiers.idr
+++ b/libs/base/Data/List/Quantifiers.idr
@@ -170,7 +170,7 @@ namespace All
   public export
   (++) : All p xs -> All p ys -> All p (xs ++ ys)
   [] ++ pys = pys
-  (px :: pxs) ++ pys = px :: (pxs ++ pys)
+  (px :: pxs) ++ pys = px :: (Quantifiers.(++) pxs pys)
 
   export
   splitAt : (xs : List a) -> All p (xs ++ ys) -> (All p xs, All p ys)

--- a/libs/base/Data/List/Quantifiers.idr
+++ b/libs/base/Data/List/Quantifiers.idr
@@ -170,7 +170,7 @@ namespace All
   public export
   (++) : All p xs -> All p ys -> All p (xs ++ ys)
   [] ++ pys = pys
-  (px :: pxs) ++ pys = px :: (Quantifiers.(++) pxs pys)
+  (px :: pxs) ++ pys = px :: (pxs ++ pys)
 
   export
   splitAt : (xs : List a) -> All p (xs ++ ys) -> (All p xs, All p ys)

--- a/src/Libraries/Data/List/Quantifiers/Extra.idr
+++ b/src/Libraries/Data/List/Quantifiers/Extra.idr
@@ -14,6 +14,8 @@ lookup v (px :: pxs)
       No _ => lookup v pxs
       Yes Refl => Just px
 
+-- this function can be deleted once we release the next compiler version
+-- (after 0.7.0) as the function has been replicated in base
 export
 (++) : All p xs -> All p ys -> All p (xs ++ ys)
 [] ++ pys = pys

--- a/src/Libraries/Data/List/Quantifiers/Extra.idr
+++ b/src/Libraries/Data/List/Quantifiers/Extra.idr
@@ -14,8 +14,8 @@ lookup v (px :: pxs)
       No _ => lookup v pxs
       Yes Refl => Just px
 
--- TODO: delete this function once we release the next compiler version
--- (after 0.7.0) as it has been replicated in base's Data.List.Quantifiers
+-- TODO: delete this function after 0.7.1 is released
+-- as it now exists in base's Data.List.Quantifiers
 export
 (++) : All p xs -> All p ys -> All p (xs ++ ys)
 [] ++ pys = pys

--- a/src/Libraries/Data/List/Quantifiers/Extra.idr
+++ b/src/Libraries/Data/List/Quantifiers/Extra.idr
@@ -14,7 +14,7 @@ lookup v (px :: pxs)
       No _ => lookup v pxs
       Yes Refl => Just px
 
--- this function can be deleted once we release the next compiler version
+-- TODO delete this function once we release the next compiler version
 -- (after 0.7.0) as the function has been replicated in base
 export
 (++) : All p xs -> All p ys -> All p (xs ++ ys)

--- a/src/Libraries/Data/List/Quantifiers/Extra.idr
+++ b/src/Libraries/Data/List/Quantifiers/Extra.idr
@@ -19,7 +19,7 @@ lookup v (px :: pxs)
 export
 (++) : All p xs -> All p ys -> All p (xs ++ ys)
 [] ++ pys = pys
-(px :: pxs) ++ pys = px :: (pxs ++ pys)
+(px :: pxs) ++ pys = px :: (Extra.(++) pxs pys)
 
 export
 tabulate : ((x : a) -> p x) -> (xs : List a) -> All p xs

--- a/src/Libraries/Data/List/Quantifiers/Extra.idr
+++ b/src/Libraries/Data/List/Quantifiers/Extra.idr
@@ -15,7 +15,7 @@ lookup v (px :: pxs)
       Yes Refl => Just px
 
 -- TODO delete this function once we release the next compiler version
--- (after 0.7.0) as the function has been replicated in base
+-- (after 0.7.0) as it has been replicated in base's Data.List.Quantifiers
 export
 (++) : All p xs -> All p ys -> All p (xs ++ ys)
 [] ++ pys = pys

--- a/src/Libraries/Data/List/Quantifiers/Extra.idr
+++ b/src/Libraries/Data/List/Quantifiers/Extra.idr
@@ -14,7 +14,7 @@ lookup v (px :: pxs)
       No _ => lookup v pxs
       Yes Refl => Just px
 
--- TODO delete this function once we release the next compiler version
+-- TODO: delete this function once we release the next compiler version
 -- (after 0.7.0) as it has been replicated in base's Data.List.Quantifiers
 export
 (++) : All p xs -> All p ys -> All p (xs ++ ys)


### PR DESCRIPTION
# Description

This exists in `Data` for `SnocList` and `Vect` but not for `List` for some reason. I copied it verbatim from [src](https://github.com/idris-lang/Idris2/blob/2f2102c4134c8579a0406894b0beb563673255f0/src/Libraries/Data/List/Quantifiers/Extra.idr#L17-L20)

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

