### PR TITLE
Add a new CHANGELOG_NEXT.md file and update documentation around CHANGELOG entries.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,6 @@
 
 <!-- Please delete this section if it doesn't apply -->
 - [ ] If this is a fix, user-facing change, a compiler change, or a new paper
-      implementation, I have updated `CHANGELOG.md` (and potentially also
+      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
       `CONTRIBUTORS.md`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,7 @@
+
+This CHANGELOG describes the history of already-released versions. Please see [CHANGELOG_NEXT](./CHANGELOG_NEXT.md) for changes merged into the main branch but not yet released.
+
 # Changelog
-
-## [Next version]
-
-### Language changes
-
-### Compiler changes
-
-### Library changes
-
-#### Prelude
-
-#### Base
-
-* `Data.List.Lazy` was moved from `contrib` to `base`.
-
-* Added an `Interpolation` implementation for primitive decimal numeric types and `Nat`.
-
-#### Contrib
-
-* `Data.List.Lazy` was moved from `contrib` to `base`.
 
 ## v0.7.0
 

--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -1,0 +1,25 @@
+
+This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELOG](./CHANGELOG.md) for changes to all previously released versions of Idris2. All new PRs should target this file (`CHANGELOG_NEXT`).
+
+# Changelog
+
+## [Next version]
+
+### Language changes
+
+### Compiler changes
+
+### Library changes
+
+#### Prelude
+
+#### Base
+
+* `Data.List.Lazy` was moved from `contrib` to `base`.
+
+* Added an `Interpolation` implementation for primitive decimal numeric types and `Nat`.
+
+#### Contrib
+
+* `Data.List.Lazy` was moved from `contrib` to `base`.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ we haven't been too prescriptive about this. If you're editing a source file,
 try to be consistent with the existing style choices made by previous authors.
 We may need to be more formal about this in future!
 
-Please remember to update `CHANGELOG.md`, and if it's your first contribution
+Please remember to update `CHANGELOG_NEXT.md`, and if it's your first contribution
 you can add yourself to `CONTRIBUTORS`.
 
 In all cases, a pull request must have a short description (one sentence is

--- a/Release/CHECKLIST
+++ b/Release/CHECKLIST
@@ -10,7 +10,7 @@
 [x] Change version number in tests pkg010 and pkg017  (TODO: make this step unnecessary!)
     N.B. There are 2 instances of these: tests/idris2/ and tests/idris2/pkg/
 [x] Make sure INSTALL.md gives the correct minimum Idris version
-[x] Update CHANGELOG.md to refer to the "Next version" changes as the new
+[x] Move CHANGELOG_NEXT.md entries into CHANGELOG.md under a heading for the upcoming release version. Reset CHANGELOG_NEXT.md.
     release version, leaving the next "Next version" blank.
 [x] Update bootstrap chez and racket (built with new version)
     [x] Compile Idris2 with the appropriate CG


### PR DESCRIPTION
# Description

We have a small problem that when releasing a new version, all existing PRs with entries in the CHANGELOG need to be updated so they do not mistakenly add entries to the already-released version. This PR adopts a strategy that was [suggested twice](https://github.com/idris-lang/Idris2/pull/3178) (as in use by other projects). It won't always make post-release management of open PRs effortless, but it should make it so that we have no risk of accidentally modifying the CHANGELOG for an already-released version.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).
