### PR TITLE
Improve `buildIdris` and expose the `idris2-api` via the Nix flake.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Next version]
 
+### Building/Packaging changes
+
+* The Nix flake's `buildIdris` function now returns a set with `executable` and
+  `library` attributes. These supersede the now-deprecated `build` and
+  `installLibrary` attributes. `executable` is the same as `build` and `library`
+  is a function that takes an argument determining whether the library should be
+  installed with sourcecode files or not; other than that, `library`
+  functionally replaces `installLibrary`.
+
+* The Nix flake now exposes the Idris2 API package as `idris2-api` and Idris2's
+  C support library as `support`.
+
 ### Language changes
 
 ### Compiler changes

--- a/flake.nix
+++ b/flake.nix
@@ -57,21 +57,21 @@
               make src/IdrisPaths.idr
             '';
           };
-        in rec {
+        in {
           checks = import ./nix/test.nix {
             inherit (pkgs) system stdenv runCommand lib;
             inherit nixpkgs flake-utils;
             idris = self;
           };
-          packages = {
+          packages = rec {
             support = idris2Support;
             idris2 = idris2Pkg;
             idris2-api = idris2ApiPkg.library { withSource = true; };
+            default = idris2;
           } // (import ./nix/text-editor.nix {
             inherit pkgs idris-emacs-src idris2Pkg;
           });
           inherit buildIdris;
-          defaultPackage = packages.idris2;
         };
     in lib.mkOvrOptsFlake
     (opts: flake-utils.lib.eachDefaultSystem (per-system opts) // sys-agnostic);

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,15 @@
             inherit idris2-version;
             idris2 = idris2Pkg;
           };
+          idris2ApiPkg = buildIdris {
+            src = ./.;
+            projectName = "idris2api";
+            idrisLibraries = [ ];
+            preBuild = ''
+              export IDRIS2_PREFIX=$out/lib
+              make src/IdrisPaths.idr
+            '';
+          };
         in rec {
           checks = import ./nix/test.nix {
             inherit (pkgs) system stdenv runCommand lib;
@@ -57,6 +66,7 @@
           packages = {
             support = idris2Support;
             idris2 = idris2Pkg;
+            idris2-api = idris2ApiPkg.library { withSource = true; };
           } // (import ./nix/text-editor.nix {
             inherit pkgs idris-emacs-src idris2Pkg;
           });

--- a/nix/buildIdris.nix
+++ b/nix/buildIdris.nix
@@ -6,7 +6,7 @@ let
   idrName = "idris2-${idris2-version}";
   libSuffix = "lib/${idrName}";
   lib-dirs =
-    lib.strings.concatMapStringsSep ":" (p: "${p}/${libSuffix}") idrisLibraries;
+    lib.strings.makeSearchPath libSuffix idrisLibraries;
   drvAttrs = builtins.removeAttrs attrs [ "idrisLibraries" ];
 in rec {
   executable = stdenv.mkDerivation (drvAttrs // {

--- a/nix/buildIdris.nix
+++ b/nix/buildIdris.nix
@@ -9,7 +9,7 @@ let
     lib.strings.concatMapStringsSep ":" (p: "${p}/${libSuffix}") idrisLibraries;
   drvAttrs = builtins.removeAttrs attrs [ "idrisLibraries" ];
 in rec {
-  build = stdenv.mkDerivation (drvAttrs // {
+  executable = stdenv.mkDerivation (drvAttrs // {
     name = projectName;
     src = src;
     nativeBuildInputs = [ idris2 ];
@@ -30,12 +30,18 @@ in rec {
       runHook postInstall
     '';
   });
-  installLibrary = build.overrideAttrs (_: {
-    buildPhase = "";
-    installPhase = ''
-      mkdir -p $out/${libSuffix}
-      export IDRIS2_PREFIX=$out/lib
-      idris2 --install ${ipkgName}
-    '';
-  });
+  library = { withSource ? false }:
+    let installCmd = if withSource then "--install-with-src" else "--install";
+    in executable.overrideAttrs (_: {
+      installPhase = ''
+        runHook preInstall
+        mkdir -p $out/${libSuffix}
+        export IDRIS2_PREFIX=$out/lib
+        idris2 ${installCmd} ${ipkgName}
+        runHook postInstall
+      '';
+    });
+  # deprecated aliases:
+  build = builtins.trace "Warning: 'build' is a deprecated alias for 'executable'." executable;
+  installLibrary = builtins.trace "Warning: 'installLibrary' is a deprecated alias for 'library { }'." (library { });
 }

--- a/nix/buildIdris.nix
+++ b/nix/buildIdris.nix
@@ -42,6 +42,6 @@ in rec {
       '';
     });
   # deprecated aliases:
-  build = builtins.trace "Warning: 'build' is a deprecated alias for 'executable'." executable;
-  installLibrary = builtins.trace "Warning: 'installLibrary' is a deprecated alias for 'library { }'." (library { });
+  build = lib.warn "build is a deprecated alias for 'executable'." executable;
+  installLibrary = lib.warn "installLibrary is a deprecated alias for 'library { }'." (library { });
 }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     "TEST_IDRIS2_SUPPORT_DIR=${supportLibrariesPath}"
   ];
 
-  installTargets = "install-idris2 install-libs";
+  installTargets = "install-idris2 install-with-src-libs";
   installFlags = [ "PREFIX=$(out)" ];
 
   # TODO: Move this into its own derivation, such that this can be changed

--- a/nix/templates/pkg/flake.nix
+++ b/nix/templates/pkg/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "My Idris 2 package";
+  description = "My Idris 2 program";
 
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.idris = {
@@ -21,7 +21,7 @@
         };
       in rec {
         packages = pkgs // idrisPkgs;
-        defaultPackage = pkgs.build;
+        defaultPackage = pkgs.executable;
         devShell = npkgs.mkShell {
           buildInputs = [ idrisPkgs.idris2 npkgs.rlwrap ];
           shellHook = ''

--- a/nix/templates/pkgWithDeps/flake.nix
+++ b/nix/templates/pkgWithDeps/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "My Idris 2 package";
+  description = "My Idris 2 program";
 
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.idris = {
@@ -7,6 +7,7 @@
     inputs.nixpkgs.follows = "nixpkgs";
     inputs.flake-utils.follows = "flake-utils";
   };
+  # some package this project depends on:
   inputs.pkg = {
     url = "github:idris-lang/pkg";
     inputs.flake-utils.follows = "flake-utils";
@@ -17,17 +18,17 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         npkgs = import nixpkgs { inherit system; };
-        my-pkg = pkg.packages.${system}.installLibrary;
+        my-pkg = pkg.packages.${system}.library { };
         idrisPkgs = idris.packages.${system};
         buildIdris = idris.buildIdris.${system};
         pkgs = buildIdris {
           projectName = "pkgWithDeps";
           src = ./.;
-          idrisLibraries = [ pkg ];
+          idrisLibraries = [ my-pkg ];
         };
       in rec {
         packages = pkgs // idrisPkgs;
-        defaultPackage = pkgs.build;
+        defaultPackage = pkgs.executable;
         devShell = npkgs.mkShell {
           buildInputs = [ idrisPkgs.idris2 npkgs.rlwrap ];
           shellHook = ''

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -16,12 +16,12 @@ let
       templateBuild = template.packages.${system}.${type};
     in templateBuild;
 
-  templateBuildDefault = createTemplate ./templates/pkg/flake.nix { } "build";
+  templateBuildDefault = createTemplate ./templates/pkg/flake.nix { } "executable";
   templateBuildDefaultLibrary =
-    createTemplate ./templates/pkg/flake.nix { } "installLibrary";
+    createTemplate ./templates/pkg/flake.nix { } "library" { };
   templateBuildWithDeps = createTemplate ./templates/pkgWithDeps/flake.nix {
     pkg = templateBuildDefaultLibrary;
-  } "build";
+  } "executable";
 
   testsTemplate = {
     checkFoo = ''

--- a/nix/test.nix
+++ b/nix/test.nix
@@ -38,5 +38,5 @@ let
 in withTests testsTemplate templateBuildDefault
 // withTests testsTemplateWithDeps templateBuildWithDeps // {
   idris2Tests =
-    idris.defaultPackage.${system}.overrideAttrs (a: { doCheck = true; });
+    idris.packages.${system}.default.overrideAttrs (a: { doCheck = true; });
 }


### PR DESCRIPTION
# Description

- Switch from deprecated `defaultPackage.${system}` to newer `package.${system}.default` flake structure.
- Rename `build` property of `buildIdris` result to `executable` (keep old property name around but deprecated).
- Rename `installLibrary` property of `buildIdris` result to `library` and turn it into a function that supports "install with source" (keep the old property name around but deprecated).
- Add the `idris2-api` package to the flake outputs.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

