### PR TITLE
Remove nat magic

### DIFF
--- a/libs/prelude/Prelude/Types.idr
+++ b/libs/prelude/Prelude/Types.idr
@@ -39,7 +39,7 @@ nonNegativeIntegerToNat :
 nonNegativeIntegerToNat 0 = Z
 nonNegativeIntegerToNat x =
     let -- x >= 0 and x != 0
-        -- so x >= 0 so x - 1 >= 0
+        -- so x > 0 so x - 1 >= 0
         prf = believe_me Refl
      in S $ nonNegativeIntegerToNat {prf}
           $ assert_smaller x $ x - 1


### PR DESCRIPTION
# Description

Remove compiler magic around `Nat`.

This uses `%transform` rules, which are currently fragile (see #3183) so it doesn't work currently.
Once that issue is fixed, then this should work well.

## Should this change go in the CHANGELOG?

Yes, I will do this later

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated `CHANGELOG.md` (and potentially also
      `CONTRIBUTORS.md`).

