### PR TITLE
[ fix ] Disable top-level constants optimisation during incremental compilation

### DIFF
--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -658,7 +658,7 @@ incCompile c s sourceFile
                version <- coreLift $ chezVersion chez
                fgndefs <- traverse (getFgnCall version) ndefs
                (sortedDefs, constants) <- sortDefs ndefs
-               compdefs <- traverse (getScheme constants (chezExtPrim constants) chezString) sortedDefs
+               compdefs <- traverse (getScheme empty (chezExtPrim empty) chezString) sortedDefs
                let code = concat $ map snd fgndefs ++ compdefs
                Right () <- coreLift $ writeFile ssFile $ build code
                   | Left err => throw (FileErr ssFile err)


### PR DESCRIPTION
# Description

Since incremental compilation currently has no way to know about constants in other modules, this commit sets the list of constants to `empty` (as is done in the `ChezSep` backend) which allows successful compilation.

# Background

The optimisation for non-recursive top-level constants introduced in #2817 accidentally breaks incremental compilation when an optimised top-level constant is referenced in another module (noticeable in larger, non-trivial programs, e.g. when building Idris itself in incremental mode).

The resulting error message (during execution) can look like this:

```
Exception: variable PrimIO-unsafePerformIO is not bound
```

The above error is caused due to the order of the different `(load "xyz.so")` statements. But even when correcting the `(load)` order by hand, the following error occurrs:

```
Exception: attempt to apply non-procedure #(1)
```
This one is caused by the top-level constant being a value instead of a zero-argument function. The referencing module only knows about its own constants and therefore treats the constant in the other module as zero-argument function instead of a constant value.

Making top-level constants work together with incremental compilation would require to do both the following:
1. sorting the `(load)` statements, if this is even possible (might there be circular dependencies?)
2. somehow passing along the info which top-level names in other modules are values (instead of zero-arg functions) to the individual module during compilation

I believe this fix is fine, considering the incrementally compiled code is expected to be slower during runtime anyways.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

