### PR TITLE
Fix static JS code: open process mode in support_system_file_popen

### DIFF
--- a/support/js/support_system_file.js
+++ b/support/js/support_system_file.js
@@ -132,7 +132,8 @@ function support_system_file_popen (cmd, m) {
     case "r":
       io_setting = ['ignore', write_fd, 2]
       break
-    case "w", "a":
+    case "w": 
+    case "a":
       io_setting = [write_fd, 'ignore', 2]
       break
     default:


### PR DESCRIPTION
In JS switch cases with shared code should look like this:
```js
switch(smth) {
  case 'w':
  case 'a':
     // shared code
     break;
}
```
In case of original code, first case always ignored:
```js
switch(smth) {
  case 'w', 'a':   // Case 'w' always ignored
     // 'a'-only code
     break;
}
```

# Description

## Should this change go in the CHANGELOG?

No, because currently NodeJS backend supports only 'r' mode, so this switch-case ignored anyway

