### PR TITLE
Fix executable output of buildIdris nix helper

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -14,6 +14,13 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
   installed with sourcecode files or not; other than that, `library`
   functionally replaces `installLibrary`.
 
+* The Nix flake's `buildIdris` `executable` property (previously `build`) has
+  been fixed in a few ways. It used to output a non-executable file for NodeJS
+  builds (now the file has the executable bit set). It used to output the
+  default Idris2 wrapper for Scheme builds which relies on utilities not
+  guaranteed at runtime by the Nix derivation; now it rewraps the output to only
+  depend on the directory containing Idris2's runtime support library.
+
 * The Nix flake now exposes the Idris2 API package as `idris2-api` and Idris2's
   C support library as `support`.
 

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,7 @@
           buildIdris = pkgs.callPackage ./nix/buildIdris.nix {
             inherit idris2-version;
             idris2 = idris2Pkg;
+            support = idris2Support;
           };
           idris2ApiPkg = buildIdris {
             src = ./.;


### PR DESCRIPTION
# Description

The last Nix PR I merged got the `buildIdris` function working much better for library installation. This PR makes executable builds much more useful. Where before they copied every build artifact blindly, now build artifacts are treated differently depending on whether its an _app folder for a scheme build where we want to re-wrap the binary or the single file for a NodeJS build where we want to set the executable bit.

These changes have been tested with several downstream projects including the `idris2-lsp` flake addition that I have in-progress and one of my more substantial Idris2 CLI tools.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

