### PR TITLE
Make NodeJS backend's output file executable

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -21,6 +21,12 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 
 ### Compiler changes
 
+#### NodeJS Backend
+
+* The NodeJS executable output to `build/exec/` now has its executable bit set.
+  That file already had a NodeJS shebang at the top, so now it is fully ready to
+  go after compilation.
+
 ### Library changes
 
 #### Prelude

--- a/tests/node/executable/TestExecutable.idr
+++ b/tests/node/executable/TestExecutable.idr
@@ -1,0 +1,6 @@
+module TestExecutable
+
+import System
+
+main : IO ()
+main = putStrLn "Hi there!"

--- a/tests/node/executable/expected
+++ b/tests/node/executable/expected
@@ -1,0 +1,2 @@
+Hi there!
+Hi there!

--- a/tests/node/executable/run
+++ b/tests/node/executable/run
@@ -2,8 +2,18 @@
 
 idris2 --cg node -o node_executable TestExecutable.idr > /dev/null
 
-# node still executes it
+# node still executes it:
 node ./build/exec/node_executable
 
-# can be executed on its own due to shebang and executable bit
-./build/exec/node_executable
+# it can be executed on its own due to shebang and executable bit:
+# (/usr/bin/env as used in shebang is problematic in edge cases
+#  but still generally a good bet; we will make sure the test works
+#  even when /usr/bin/env cannot be used)
+fallback () {
+  nodejs="$(command -v node)"
+  # cross-platform supported sed-ing (unlike with in-place option)
+  cp ./build/exec/node_executable ./build/exec/node_executable_src
+  sed "s#/usr/bin/env node#$nodejs#" ./build/exec/node_executable_src > ./build/exec/node_executable
+  ./build/exec/node_executable
+}
+./build/exec/node_executable || fallback

--- a/tests/node/executable/run
+++ b/tests/node/executable/run
@@ -1,0 +1,9 @@
+. ../../testutils.sh
+
+idris2 --cg node -o node_executable TestExecutable.idr > /dev/null
+
+# node still executes it
+node ./build/exec/node_executable
+
+# can be executed on its own due to shebang and executable bit
+./build/exec/node_executable


### PR DESCRIPTION
# Description
The output file from compiling with the NodeJS backend is now executable which complements the already existing shebang at the top of that file nicely.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

