### PR TITLE
[ elab ] Support easy collection of information during `TTImp` traverse

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -68,6 +68,11 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
   with the exception of the latter dealing in `Bits8` which is more correct than
   `Int`.
 
+* Added an alternative `TTImp` traversal function `mapATTImp'` taking the original
+  `TTImp` at the input along with already traversed one. Existing `mapATTImp` is
+  implemented through the newly added one. The similar alternative for `mapMTTImp`
+  is added too.
+
 #### Contrib
 
 * `Data.List.Lazy` was moved from `contrib` to `base`.

--- a/tests/idris2/reflection/reflection027/TraverseWithConst.idr
+++ b/tests/idris2/reflection/reflection027/TraverseWithConst.idr
@@ -1,0 +1,29 @@
+module TraverseWithConst
+
+import Data.SortedSet
+import Data.SortedMap           -- workaround for issue #2439
+import Data.SortedMap.Dependent -- workaround for issue #2439
+
+import Control.Applicative.Const
+
+import Language.Reflection
+
+names : TTImp -> SortedSet Name
+names = runConst . mapATTImp' f where
+  f : TTImp -> Const (SortedSet Name) TTImp -> Const (SortedSet Name) TTImp
+  f (IVar _ n) = const $ MkConst $ SortedSet.singleton n
+  f _          = id
+
+%language ElabReflection
+
+logNames : TTImp -> Elab ()
+logNames expr = do
+  logSugaredTerm "elab.test" 0 "term being analysed" expr
+  logMsg "elab.test" 0 "- names: \{show $ SortedSet.toList $ names expr}"
+
+%runElab logNames `(f (a b) (c d))
+%runElab logNames `(Prelude.id $ Prelude.pure 5)
+%runElab logNames `(do
+                      x <- action1 a b
+                      y <- action2 b x
+                      pure (x, y))

--- a/tests/idris2/reflection/reflection027/expected
+++ b/tests/idris2/reflection/reflection027/expected
@@ -1,0 +1,7 @@
+1/1: Building TraverseWithConst (TraverseWithConst.idr)
+LOG elab.test:0: term being analysed: f (a b) (c d)
+LOG elab.test:0: - names: [a, b, c, d, f]
+LOG elab.test:0: term being analysed: id (pure (fromInteger 5))
+LOG elab.test:0: - names: [Prelude.id, Prelude.pure, fromInteger]
+LOG elab.test:0: term being analysed: action1 a b >>= (\x => action2 b x >>= (\y => pure _))
+LOG elab.test:0: - names: [Builtin.MkPair, Builtin.Pair, >>=, a, action1, action2, b, pure, x, y]

--- a/tests/idris2/reflection/reflection027/run
+++ b/tests/idris2/reflection/reflection027/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check TraverseWithConst.idr

--- a/tests/idris2/reflection/reflection027/test.ipkg
+++ b/tests/idris2/reflection/reflection027/test.ipkg
@@ -1,0 +1,1 @@
+package a-test


### PR DESCRIPTION
# Description

Current applicative traversals introduced at #3130 can be used for analysis of an expression, e.g. for collecting some data. But since currently the only way to analyse expression is to analyse the result of `pure`, used `Applicative` must contain at least on level of expressions, disallowing simple stuff like `Const` functor for applicative traversals for collecting the data.

But once we pass the original expression along with the current data to the user function, we gain the ability to traverse the data with simple applicatives, like `Const`. You can see an example of such collecting traversal in the newly added test.

This is a backward-compatible change in terms of main existing functions `mapATTImp` and `mapMTTImp`. However, intermediate functions for `mapM<WhateveElse>` changed their signatures to support using `mapATTImp'` internally.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

