### PR TITLE
[ fix ] Exponentially reduce memory consumption for elab scripts running

### DIFF
--- a/libs/base/Language/Reflection.idr
+++ b/libs/base/Language/Reflection.idr
@@ -34,6 +34,8 @@ data LookupDir =
 export
 data Elab : Type -> Type where
      Pure : a -> Elab a
+     Map  : (a -> b) -> Elab a -> Elab b
+     Ap   : Elab (a -> b) -> Elab a -> Elab b
      Bind : Elab a -> (a -> Elab b) -> Elab b
      Fail : FC -> String -> Elab a
      Warn : FC -> String -> Elab ()
@@ -103,12 +105,12 @@ data Elab : Type -> Type where
 
 export
 Functor Elab where
-  map f e = Bind e $ Pure . f
+  map = Map
 
 export
 Applicative Elab where
   pure = Pure
-  f <*> a = Bind f (<$> a)
+  (<*>) = Ap
 
 export
 Alternative Elab where

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -159,6 +159,20 @@ elabScript rig fc nest env script@(NDCon nfc nm t ar args) exp
     elabCon defs "Pure" [_,val]
         = do empty <- clearDefs defs
              evalClosure empty val
+    elabCon defs "Map" [_,_,fm,act]
+        -- fm : A -> B
+        -- elab : A
+        = do act <- elabScript rig fc nest env !(evalClosure defs act) exp
+             act <- quote defs env act
+             fm <- evalClosure defs fm
+             applyToStack defs withHoles env fm [(getLoc act, toClosure withAll env act)]
+    elabCon defs "Ap" [_,_,actF,actX]
+        -- actF : Elab (A -> B)
+        -- actX : Elab A
+        = do actF <- elabScript rig fc nest env !(evalClosure defs actF) exp
+             actX <- elabScript rig fc nest env !(evalClosure defs actX) exp
+             actX <- quote defs env actX
+             applyToStack defs withHoles env actF [(getLoc actX, toClosure withAll env actX)]
     elabCon defs "Bind" [_,_,act,k]
         -- act : Elab A
         -- k : A -> Elab B

--- a/tests/idris2/reflection/reflection008/Interp.idr
+++ b/tests/idris2/reflection/reflection008/Interp.idr
@@ -61,3 +61,14 @@ testBlock = Op {a=Base Nat} {b=Base Nat} plus (Val 3) (Val 4)
 
 evalBlock : Nat
 evalBlock = eval [] testBlock
+
+namespace Hidden
+  export
+  unreducible : Nat -> Nat -> Nat
+  unreducible x y = y `minus` x
+
+testBlock' : Lang gam (Base Nat)
+testBlock' = Op {a=Base Nat} {b=Base Nat} unreducible (Val 3) (Val 4)
+
+evalBlock' : Nat
+evalBlock' = eval [] testBlock'

--- a/tests/idris2/reflection/reflection008/expected
+++ b/tests/idris2/reflection/reflection008/expected
@@ -3,5 +3,7 @@ Main> Main.evalAdd : Nat -> Nat -> Nat
 evalAdd x y = let add = \val, val => plus val val in add x y
 Main> Main.evalBlock : Nat
 evalBlock = plus 3 4
+Main> Main.evalBlock' : Nat
+evalBlock' = unreducible 3 4
 Main> 5
 Main> Bye for now!

--- a/tests/idris2/reflection/reflection008/input
+++ b/tests/idris2/reflection/reflection008/input
@@ -1,4 +1,5 @@
 :printdef evalAdd
 :printdef evalBlock
+:printdef evalBlock'
 evalAdd 2 3
 :q


### PR DESCRIPTION
It's been noticed for a long time that memory consumption of the compiler executing elaborator scripts somewhat exponential on the reached depth of monadic bindings in the `Elab` monad. At the same time, it's been noticed that code like `act1 *> act2 <* act3` uses much more memory comparing to the code `do {act1; r <- act2; act3; pure r}` when it is somewhere deep inside the script. My guess is that this is because of a closures preserving problem, similar to runtime problems of closure allocation.

Since both `map` and `<*>` were implemented through `Bind` in the `Elab` monad, I thought that running them in `Core` is much more efficient (because `Core` is effectively a glamourous `IO`, which is run optimised, with no cost for bindings). I tried this, but I didn't suspect how efficient this would be! My guess is that reduction of binds-depth severely reduces unneeded job of closures preserving in the evaluator.

Currently, one of my big elaborator scripts, which runs on the current `main` 3 hours 17 minutes taking 16.5 Gb of memory, runs just 2 hours 24 minutes using 10 Gb with this patch (both runs were on the same machine using the patched GC from Edwin). More impressively, another elaborator script that used more than **360 Gb** of memory unabling to finish due to out of memory error, successfully finishes using just **10 Gb** of memory with the change from this PR.

Those test are large and use a lot of dependencies, and it's really hard to make a small test out of them (and anyway, those cases run for several hours). I didn't manage to make a small test that exploits the problem being fixed.

In the implementation in managing newly added `Map` and `Ap` I used `applyToStack` function that is used in the management of the `Bind` constructor to apply arbitrary `NF` to an abribtrary closure. Unlike the `Bind` case, I used the weakest `EvalOpts` in order to not to reduce expressions too much (in fact, to preserve the status quo behaviour of produced expressions). I extended one exitsting test to make sure behaviour preserves in a different case too.