### PR TITLE
Fix `buildIdris` on non-macos machines

### DIFF
--- a/nix/buildIdris.nix
+++ b/nix/buildIdris.nix
@@ -33,7 +33,7 @@ in rec {
         chmod +x $out/bin/*
       else
         cd build/exec/*_app
-        rm libidris2_support.so
+        rm -f ./libidris2_support.so
         for file in *.so; do
           bin_name="''${file%.so}"
           mv -- "$file" "$out/bin/$bin_name"

--- a/nix/buildIdris.nix
+++ b/nix/buildIdris.nix
@@ -33,6 +33,7 @@ in rec {
         chmod +x $out/bin/*
       else
         cd build/exec/*_app
+        rm libidris2_support.so
         for file in *.so; do
           bin_name="''${file%.so}"
           mv -- "$file" "$out/bin/$bin_name"


### PR DESCRIPTION
## Description

We build the support library as its own derivation for Nix builds so we do not want to copy it as part of the `buildIdris` install phase and we certainly don't want to wrap it as if it were an executable.


