### PR TITLE
[RefC] [Test] Valgrind support & Fix invalid memory read of strSubstr

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -34,8 +34,6 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 
 * Fix memory leaks of IORef. Now that IORef holds values by itself,
   global_IORefStorage is no longer needed.
-  In addition, atomic operation is now supported. However, it has not been
-  well tested yet.
 
 #### NodeJS Backend
 

--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -33,7 +33,7 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 * Fix invalid memory read onf strSubStr.
 
 * Fix memory leaks of IORef. Now that IORef holds values by itself,
-  global_IORefStorage is no longer needed.
+  global_IORef_Storage is no longer needed.
 
 #### NodeJS Backend
 

--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -28,6 +28,15 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 
 ### Compiler changes
 
+#### RefC Backend
+
+* Fix invalid memory read onf strSubStr.
+
+* Fix memory leaks of IORef. Now that IORef holds values by itself,
+  global_IORefStorage is no longer needed.
+  In addition, atomic operation is now supported. However, it has not been
+  well tested yet.
+
 #### NodeJS Backend
 
 * The NodeJS executable output to `build/exec/` now has its executable bit set.

--- a/src/Compiler/RefC/RefC.idr
+++ b/src/Compiler/RefC/RefC.idr
@@ -974,10 +974,6 @@ header = do
       #include <runtime.h>
       /* \{ generatedString "RefC" } */
 
-      /* a global storage for IO References */
-      IORef_Storage * global_IORef_Storage;
-
-
       """
     let headerFiles = Libraries.Data.SortedSet.toList !(get HeaderFiles)
     let headerLines = map (\h => "#include <" ++ h ++ ">\n") headerFiles
@@ -998,7 +994,6 @@ footer = do
                         "idris2_setArgs(argc, argv);"
                         ""
           }
-          global_IORef_Storage = NULL;
           Value *mainExprVal = __mainExpression_0();
           trampoline(mainExprVal);
           return 0; // bye bye

--- a/support/refc/_datatypes.h
+++ b/support/refc/_datatypes.h
@@ -7,10 +7,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if !defined(__STDC_NO_ATOMICS__)
-#include <stdatomic.h>
-#endif
-
 #include "buffer.h"
 
 #define NO_TAG 0
@@ -140,11 +136,7 @@ typedef struct {
 
 typedef struct {
   Value_header header;
-#if !defined(__STDC_NO_ATOMICS__) && ATOMIC_POINTER_LOCK_FREE
-  Value *_Atomic v;
-#else
   Value *v;
-#endif
 } Value_IORef;
 
 typedef struct {

--- a/support/refc/_datatypes.h
+++ b/support/refc/_datatypes.h
@@ -7,6 +7,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if !defined(__STDC_NO_ATOMICS__)
+#include <stdatomic.h>
+#endif
+
 #include "buffer.h"
 
 #define NO_TAG 0
@@ -136,7 +140,11 @@ typedef struct {
 
 typedef struct {
   Value_header header;
-  int32_t index;
+#if !defined(__STDC_NO_ATOMICS__) && ATOMIC_POINTER_LOCK_FREE
+  Value *_Atomic v;
+#else
+  Value *v;
+#endif
 } Value_IORef;
 
 typedef struct {
@@ -172,12 +180,5 @@ typedef struct {
 } Value_Condition;
 
 typedef struct {
-  Value **refs;
-  int filled;
-  int total;
-} IORef_Storage;
-
-typedef struct {
   Value_header header;
-  IORef_Storage *listIORefs;
 } Value_World;

--- a/support/refc/cBackend.h
+++ b/support/refc/cBackend.h
@@ -16,5 +16,3 @@
 #include "runtime.h"
 #include "stringOps.h"
 #include "threads.h"
-
-extern IORef_Storage *global_IORef_Storage;

--- a/support/refc/memoryManagement.c
+++ b/support/refc/memoryManagement.c
@@ -1,5 +1,8 @@
 #include "refc_util.h"
 #include "runtime.h"
+#if !defined(__STDC_NO_ATOMICS__)
+#include <stdatomic.h>
+#endif
 
 Value *newValue(size_t size) {
   Value *retVal = (Value *)malloc(size);
@@ -259,7 +262,11 @@ void removeReference(Value *elem) {
       break;
     }
     case IOREF_TAG:
-      /* nothing to delete, added for sake of completeness */
+#if !defined(__STDC_NO_ATOMICS__) && ATOMIC_POINTER_LOCK_FREE
+  removeReference(atomic_load(&((Value_IORef*)elem)->v));
+#else
+  removeReference((Value_IORef*)elem)->v);
+#endif
       break;
 
     case BUFFER_TAG: {

--- a/support/refc/memoryManagement.c
+++ b/support/refc/memoryManagement.c
@@ -1,8 +1,5 @@
 #include "refc_util.h"
 #include "runtime.h"
-#if !defined(__STDC_NO_ATOMICS__)
-#include <stdatomic.h>
-#endif
 
 Value *newValue(size_t size) {
   Value *retVal = (Value *)malloc(size);
@@ -262,11 +259,7 @@ void removeReference(Value *elem) {
       break;
     }
     case IOREF_TAG:
-#if !defined(__STDC_NO_ATOMICS__) && ATOMIC_POINTER_LOCK_FREE
-  removeReference(atomic_load(&((Value_IORef*)elem)->v));
-#else
-  removeReference((Value_IORef*)elem)->v);
-#endif
+      removeReference(((Value_IORef *)elem)->v);
       break;
 
     case BUFFER_TAG: {

--- a/support/refc/prim.c
+++ b/support/refc/prim.c
@@ -2,57 +2,34 @@
 #include "refc_util.h"
 #include <string.h>
 #include <unistd.h>
-
-// This is NOT THREAD SAFE in the current implementation
-
-IORef_Storage *newIORef_Storage(int capacity) {
-  IORef_Storage *retVal = (IORef_Storage *)malloc(sizeof(IORef_Storage));
-  IDRIS2_REFC_VERIFY(retVal, "malloc failed");
-  retVal->filled = 0;
-  retVal->total = capacity;
-  retVal->refs = (Value **)malloc(sizeof(Value *) * retVal->total);
-  return retVal;
-}
-
-void doubleIORef_Storage(IORef_Storage *ior) {
-  Value **values = (Value **)malloc(sizeof(Value *) * ior->total * 2);
-  IDRIS2_REFC_VERIFY(values, "malloc failed");
-  ior->total *= 2;
-  for (int i = 0; i < ior->filled; i++) {
-    values[i] = ior->refs[i];
-  }
-  free(ior->refs);
-  ior->refs = values;
-}
+#if !defined(__STDC_NO_ATOMICS__)
+#include <stdatomic.h>
+#endif
 
 Value *idris2_Data_IORef_prim__newIORef(Value *erased, Value *input_value,
                                         Value *_world) {
-  // if no ioRef Storag exist, start with one
-  if (!global_IORef_Storage) {
-    global_IORef_Storage = newIORef_Storage(128);
-  }
-  // expand size of needed
-  if (global_IORef_Storage->filled >= global_IORef_Storage->total) {
-    doubleIORef_Storage(global_IORef_Storage);
-  }
-
-  // store value
   Value_IORef *ioRef = IDRIS2_NEW_VALUE(Value_IORef);
   ioRef->header.tag = IOREF_TAG;
-  ioRef->index = global_IORef_Storage->filled;
-  global_IORef_Storage->refs[global_IORef_Storage->filled] =
-      newReference(input_value);
-  global_IORef_Storage->filled++;
-
+#if !defined(__STDC_NO_ATOMICS__) && ATOMIC_POINTER_LOCK_FREE
+  atomic_store(&ioRef->v, newReference(input_value));
+#else
+  ioRef->v = newReference(input_value);
+#endif
   return (Value *)ioRef;
 }
 
-Value *idris2_Data_IORef_prim__writeIORef(Value *erased, Value *_index,
+Value *idris2_Data_IORef_prim__writeIORef(Value *erased, Value *_ioref,
                                           Value *new_value, Value *_world) {
-  Value_IORef *index = (Value_IORef *)_index;
-  removeReference(global_IORef_Storage->refs[index->index]);
-  global_IORef_Storage->refs[index->index] = newReference(new_value);
-  return newReference(_index);
+  Value_IORef *ioref = (Value_IORef *)_ioref;
+  newReference(new_value);
+#if !defined(__STDC_NO_ATOMICS__) && ATOMIC_POINTER_LOCK_FREE
+  Value *old = atomic_exchange(&ioref->v, new_value);
+#else
+  Value *old = ioref->v;
+  ioref->v = new_value;
+#endif
+  removeReference(old);
+  return NULL;
 }
 
 // -----------------------------------

--- a/support/refc/prim.c
+++ b/support/refc/prim.c
@@ -2,19 +2,12 @@
 #include "refc_util.h"
 #include <string.h>
 #include <unistd.h>
-#if !defined(__STDC_NO_ATOMICS__)
-#include <stdatomic.h>
-#endif
 
 Value *idris2_Data_IORef_prim__newIORef(Value *erased, Value *input_value,
                                         Value *_world) {
   Value_IORef *ioRef = IDRIS2_NEW_VALUE(Value_IORef);
   ioRef->header.tag = IOREF_TAG;
-#if !defined(__STDC_NO_ATOMICS__) && ATOMIC_POINTER_LOCK_FREE
-  atomic_store(&ioRef->v, newReference(input_value));
-#else
   ioRef->v = newReference(input_value);
-#endif
   return (Value *)ioRef;
 }
 
@@ -22,12 +15,8 @@ Value *idris2_Data_IORef_prim__writeIORef(Value *erased, Value *_ioref,
                                           Value *new_value, Value *_world) {
   Value_IORef *ioref = (Value_IORef *)_ioref;
   newReference(new_value);
-#if !defined(__STDC_NO_ATOMICS__) && ATOMIC_POINTER_LOCK_FREE
-  Value *old = atomic_exchange(&ioref->v, new_value);
-#else
   Value *old = ioref->v;
   ioref->v = new_value;
-#endif
   removeReference(old);
   return NULL;
 }

--- a/support/refc/prim.h
+++ b/support/refc/prim.h
@@ -1,20 +1,12 @@
 #pragma once
 
 #include "cBackend.h"
-#if !defined(__STDC_NO_ATOMICS__)
-#include <stdatomic.h>
-#endif
 
 // IORef
 
 Value *idris2_Data_IORef_prim__newIORef(Value *, Value *, Value *);
-#if !defined(__STDC_NO_ATOMICS__) && ATOMIC_POINTER_LOCK_FREE
 #define idris2_Data_IORef_prim__readIORef(erased, ioref, world)                \
-  (newReference(atomic_load(&((Value_IORef *)ioref)->v)))
-#else
-#define idris2_Data_IORef_prim__readIORef(erased, ioref, world)                \
-  (newReference(((Value_IORef *)iroef)->v)))
-#endif
+  (newReference(((Value_IORef *)ioref)->v))
 
 Value *idris2_Data_IORef_prim__writeIORef(Value *, Value *, Value *, Value *);
 

--- a/support/refc/prim.h
+++ b/support/refc/prim.h
@@ -1,12 +1,20 @@
 #pragma once
 
 #include "cBackend.h"
+#if !defined(__STDC_NO_ATOMICS__)
+#include <stdatomic.h>
+#endif
 
 // IORef
 
 Value *idris2_Data_IORef_prim__newIORef(Value *, Value *, Value *);
-#define idris2_Data_IORef_prim__readIORef(erased, ix, world)                   \
-  (newReference(global_IORef_Storage->refs[((Value_IORef *)ix)->index]))
+#if !defined(__STDC_NO_ATOMICS__) && ATOMIC_POINTER_LOCK_FREE
+#define idris2_Data_IORef_prim__readIORef(erased, ioref, world)                \
+  (newReference(atomic_load(&((Value_IORef *)ioref)->v)))
+#else
+#define idris2_Data_IORef_prim__readIORef(erased, ioref, world)                \
+  (newReference(((Value_IORef *)iroef)->v)))
+#endif
 
 Value *idris2_Data_IORef_prim__writeIORef(Value *, Value *, Value *, Value *);
 

--- a/support/refc/stringOps.c
+++ b/support/refc/stringOps.c
@@ -74,11 +74,17 @@ Value *strAppend(Value *a, Value *b) {
 Value *strSubstr(Value *start, Value *len, Value *s) {
   char *input = ((Value_String *)s)->str;
   int offset = extractInt(start);
-  int l = extractInt(len);
+  if (offset < 0)
+    offset = 0;
 
-  int tailLen = strlen(input);
-  if (tailLen < offset + l) {
-    l = tailLen - offset;
+  int l = extractInt(len);
+  if (l < 0)
+    l = 0;
+
+  int tailLen = strlen(input) - offset;
+
+  if (tailLen < l) {
+    l = tailLen;
   }
 
   Value_String *retVal = makeEmptyString(l + 1);

--- a/support/refc/stringOps.c
+++ b/support/refc/stringOps.c
@@ -73,16 +73,10 @@ Value *strAppend(Value *a, Value *b) {
 
 Value *strSubstr(Value *start, Value *len, Value *s) {
   char *input = ((Value_String *)s)->str;
-  int offset = extractInt(start);
-  if (offset < 0)
-    offset = 0;
-
+  int offset = extractInt(start); /* start and len is Nat. */
   int l = extractInt(len);
-  if (l < 0)
-    l = 0;
 
   int tailLen = strlen(input) - offset;
-
   if (tailLen < l) {
     l = tailLen;
   }

--- a/support/refc/stringOps.c
+++ b/support/refc/stringOps.c
@@ -77,8 +77,8 @@ Value *strSubstr(Value *start, Value *len, Value *s) {
   int l = extractInt(len);
 
   int tailLen = strlen(input);
-  if (tailLen < l) {
-    l = tailLen;
+  if (tailLen < offset + l) {
+    l = tailLen - offset;
   }
 
   Value_String *retVal = makeEmptyString(l + 1);

--- a/tests/refc/args/run
+++ b/tests/refc/args/run
@@ -1,5 +1,5 @@
 . ../../testutils.sh
 
-idris2 --cg refc -o refc_args TestArgs.idr > /dev/null
-./build/exec/refc_args a b
+idris2 --cg refc -o refc_args TestArgs.idr
+$VALGRIND ./build/exec/refc_args a b
 ./build/exec/refc_args c

--- a/tests/refc/buffer/run
+++ b/tests/refc/buffer/run
@@ -1,7 +1,7 @@
 . ../../testutils.sh
 
-idris2 --cg refc -o refc_buffer TestBuffer.idr > /dev/null
-./build/exec/refc_buffer
+idris2 --cg refc -o refc_buffer TestBuffer.idr
+$VALGRIND ./build/exec/refc_buffer
 base64 -i testWrite.buf
 
 rm testWrite.buf

--- a/tests/refc/ccompilerArgs/run
+++ b/tests/refc/ccompilerArgs/run
@@ -26,6 +26,6 @@ export LDLIBS="-lexternalc"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:./library/"
 export DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH:./library/"
 
-idris2 --cg refc -o cffi Main.idr > /dev/null
+idris2 --cg refc -o cffi Main.idr
 
-./build/exec/cffi
+$VALGRIND ./build/exec/cffi

--- a/tests/refc/doubles/run
+++ b/tests/refc/doubles/run
@@ -1,4 +1,4 @@
 . ../../testutils.sh
 
-idris2 --cg refc -o refc_doubles TestDoubles.idr > /dev/null
-./build/exec/refc_doubles
+idris2 --cg refc -o refc_doubles TestDoubles.idr
+$VALGRIND ./build/exec/refc_doubles

--- a/tests/refc/garbageCollect/run
+++ b/tests/refc/garbageCollect/run
@@ -1,5 +1,5 @@
 . ../../testutils.sh
 
-idris2 --cg refc -o testGC TestGarbageCollect.idr > /dev/null
+idris2 --cg refc -o testGC TestGarbageCollect.idr
 
-./build/exec/testGC
+$VALGRIND ./build/exec/testGC

--- a/tests/refc/integers/run
+++ b/tests/refc/integers/run
@@ -1,4 +1,4 @@
 . ../../testutils.sh
 
-idris2 --cg refc -o refc_integers TestIntegers.idr > /dev/null
-./build/exec/refc_integers
+idris2 --cg refc -o refc_integers TestIntegers.idr
+$VALGRIND ./build/exec/refc_integers

--- a/tests/refc/issue1778/run
+++ b/tests/refc/issue1778/run
@@ -1,4 +1,4 @@
 . ../../testutils.sh
 
-idris2 --cg refc -o reverse Reverse.idr > /dev/null
-./build/exec/reverse
+idris2 --cg refc -o reverse Reverse.idr
+$VALGRIND ./build/exec/reverse

--- a/tests/refc/issue2424/run
+++ b/tests/refc/issue2424/run
@@ -1,5 +1,4 @@
 . ../../testutils.sh
 
-idris2 --cg refc -o test ControlAppMonadTest.idr > /dev/null
-
-./build/exec/test
+idris2 --cg refc -o test ControlAppMonadTest.idr
+$VALGRIND ./build/exec/test

--- a/tests/refc/issue2452/run
+++ b/tests/refc/issue2452/run
@@ -1,4 +1,4 @@
 . ../../testutils.sh
 
-idris2 --cg refc -o bits_case BitsCase.idr > /dev/null
-./build/exec/bits_case
+idris2 --cg refc -o bits_case BitsCase.idr
+$VALGRIND ./build/exec/bits_case

--- a/tests/refc/prims/run
+++ b/tests/refc/prims/run
@@ -1,4 +1,4 @@
 . ../../testutils.sh
 
-idris2 --cg refc -o test Test.idr > /dev/null
-./build/exec/test
+idris2 --cg refc -o test Test.idr
+$VALGRIND ./build/exec/test

--- a/tests/refc/refc001/run
+++ b/tests/refc/refc001/run
@@ -1,4 +1,4 @@
 . ../../testutils.sh
 
-idris2 --cg refc -o refc001 Tail.idr > /dev/null
-./build/exec/refc001
+idris2 --cg refc -o refc001 Tail.idr
+$VALGRIND ./build/exec/refc001

--- a/tests/refc/refc002/run
+++ b/tests/refc/refc002/run
@@ -1,4 +1,4 @@
 . ../../testutils.sh
 
-idris2 --cg refc -o refc002 RecordProjection.idr > /dev/null
-./build/exec/refc002
+idris2 --cg refc -o refc002 RecordProjection.idr
+$VALGRIND ./build/exec/refc002

--- a/tests/refc/refc003/run
+++ b/tests/refc/refc003/run
@@ -1,4 +1,4 @@
 . ../../testutils.sh
 
-idris2 --cg refc -o refc003 Issue1191.idr > /dev/null
-./build/exec/refc003
+idris2 --cg refc -o refc003 Issue1191.idr
+$VALGRIND ./build/exec/refc003

--- a/tests/refc/reg001/run
+++ b/tests/refc/reg001/run
@@ -1,5 +1,4 @@
 . ../../testutils.sh
 
 idris2 --cg refc Issue1843.idr -o test
-
-./build/exec/test
+$VALGRIND ./build/exec/test

--- a/tests/refc/strings/TestStrings.idr
+++ b/tests/refc/strings/TestStrings.idr
@@ -34,7 +34,11 @@ main = do
     putStrLn $ "\{show $ length overtake0} : \{overtake0}"
     let overtake1 = substr 1 2 ""
     putStrLn $ "\{show $ length overtake1} : \{overtake1}"
-
+    putStrLn $ substr (-10) (1) helloWorld
+    putStrLn $ substr 2 (-2) helloWorld
+    putStrLn $ substr (-5) (-2) helloWorld
+    putStrLn $ substr 1000000 1 helloWorld
+    putStrLn $ substr 5 100000 helloWorld
 
     putStrLn $ show $ assert_total $ strIndex helloWorld 1
 

--- a/tests/refc/strings/TestStrings.idr
+++ b/tests/refc/strings/TestStrings.idr
@@ -29,8 +29,13 @@ main = do
     putStrLn $ reverse helloWorld
     putStrLn $ reverse ""
     putStrLn $ substr 1 2 helloWorld
-    putStrLn $ substr 10 10 helloWorld
-    putStrLn $ substr 1 2 ""
+
+    let overtake0 = substr 10 10 helloWorld
+    putStrLn $ "\{show $ length overtake0} : \{overtake0}"
+    let overtake1 = substr 1 2 ""
+    putStrLn $ "\{show $ length overtake1} : \{overtake1}"
+
+
     putStrLn $ show $ assert_total $ strIndex helloWorld 1
 
     putStrLn $ strCons 'a' "bc"

--- a/tests/refc/strings/expected
+++ b/tests/refc/strings/expected
@@ -4,8 +4,8 @@ Hello, world
 dlrow ,olleH
 
 el
-ld
-
+2 : ld
+0 : 
 'e'
 abc
 a

--- a/tests/refc/strings/expected
+++ b/tests/refc/strings/expected
@@ -6,6 +6,11 @@ dlrow ,olleH
 el
 2 : ld
 0 : 
+H
+
+
+
+, world
 'e'
 abc
 a

--- a/tests/refc/strings/run
+++ b/tests/refc/strings/run
@@ -1,4 +1,4 @@
 . ../../testutils.sh
 
-idris2 --cg refc -p contrib -o refc_strings TestStrings.idr > /dev/null
-./build/exec/refc_strings
+idris2 --cg refc -p contrib -o refc_strings TestStrings.idr
+$VALGRIND ./build/exec/refc_strings

--- a/tests/testutils.sh
+++ b/tests/testutils.sh
@@ -11,7 +11,7 @@ idris2="$1"
 rm -rf build
 rm -rf prefix
 
-if [ "$(echo "$idris2" | grep refc)" ]; then
+if echo "$idris2" | grep -q refc; then
     if type valgrind >/dev/null 2>&1; then
         VALGRIND="valgrind --leak-check=full -s --log-file=output.valgrind.refc.log"
     else

--- a/tests/testutils.sh
+++ b/tests/testutils.sh
@@ -11,7 +11,7 @@ idris2="$1"
 rm -rf build
 rm -rf prefix
 
-if [ "`echo $idris2 | grep refc`" ]; then
+if [ "$(echo "$idris2" | grep refc)" ]; then
     if type valgrind >/dev/null 2>&1; then
         VALGRIND="valgrind --leak-check=full -s --log-file=output.valgrind.refc.log"
     else

--- a/tests/testutils.sh
+++ b/tests/testutils.sh
@@ -11,6 +11,14 @@ idris2="$1"
 rm -rf build
 rm -rf prefix
 
+if [ "`echo $idris2 | grep refc`" ]; then
+    if type valgrind >/dev/null 2>&1; then
+        VALGRIND="valgrind --leak-check=full -s --log-file=output.valgrind.refc.log"
+    else
+        unset VALGRIND
+    fi;
+fi;
+
 idris2() {
     $idris2 --no-banner --console-width 0 --no-color "$@"
 }
@@ -20,6 +28,7 @@ check() {
 }
 
 run() {
+    echo $idris2
     idris2 --exec main "$@"
 }
 

--- a/tests/testutils.sh
+++ b/tests/testutils.sh
@@ -13,7 +13,7 @@ rm -rf prefix
 
 if echo "$idris2" | grep -q refc; then
     if type valgrind >/dev/null 2>&1; then
-        VALGRIND="valgrind --leak-check=full -s --log-file=output.valgrind.refc.log"
+        export VALGRIND="valgrind --leak-check=full -s --log-file=output.valgrind.refc.log"
     else
         unset VALGRIND
     fi

--- a/tests/testutils.sh
+++ b/tests/testutils.sh
@@ -28,7 +28,6 @@ check() {
 }
 
 run() {
-    echo $idris2
     idris2 --exec main "$@"
 }
 

--- a/tests/testutils.sh
+++ b/tests/testutils.sh
@@ -11,12 +11,10 @@ idris2="$1"
 rm -rf build
 rm -rf prefix
 
-if echo "$idris2" | grep -q refc; then
-    if type valgrind >/dev/null 2>&1; then
-        export VALGRIND="valgrind --leak-check=full -s --log-file=output.valgrind.refc.log"
-    else
-        unset VALGRIND
-    fi
+if type valgrind >/dev/null 2>&1; then
+    export VALGRIND="valgrind --leak-check=full -s --log-file=output.valgrind.refc.log"
+else
+    unset VALGRIND
 fi
 
 idris2() {

--- a/tests/testutils.sh
+++ b/tests/testutils.sh
@@ -16,8 +16,8 @@ if [ "$(echo "$idris2" | grep refc)" ]; then
         VALGRIND="valgrind --leak-check=full -s --log-file=output.valgrind.refc.log"
     else
         unset VALGRIND
-    fi;
-fi;
+    fi
+fi
 
 idris2() {
     $idris2 --no-banner --console-width 0 --no-color "$@"


### PR DESCRIPTION
# Description

* Bug fix
    - Invalid memory read of strSubStr. (String overrun)
    - Memory leaks of IORef.
* Perform memory leak analysis, if valgrind is installed.(Only for RefC)
* Keeping error messages at compile time of tests in the output to make debug easy.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

