### PR TITLE
Hopefully final refactor of `buildIdris` for some time

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -21,7 +21,7 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
   guaranteed at runtime by the Nix derivation; now it rewraps the output to only
   depend on the directory containing Idris2's runtime support library.
 
-* The Nix flake now exposes the Idris2 API package as `idris2-api` and Idris2's
+* The Nix flake now exposes the Idris2 API package as `idris2Api` and Idris2's
   C support library as `support`.
 
 ### Language changes

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -33,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671864851,
-        "narHash": "sha256-Z3L5MSWOyTdVTIVBrLEh2HwgDYGcqf1gnGYFx+7gb/k=",
+        "lastModified": 1705877117,
+        "narHash": "sha256-7LRSFcFDlb3MSt5KKBZlPNjvYVcGzQ8Si2IVqvmK4is=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "27392c3cb3ddc39123426aa88fe186aa0ea1c253",
+        "rev": "35d61a923bbb0cd44d49115a6efc82032c39cfac",
         "type": "github"
       },
       "original": {
@@ -51,6 +54,21 @@
         "flake-utils": "flake-utils",
         "idris-emacs-src": "idris-emacs-src",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
 
   outputs = { self, nixpkgs, flake-utils, idris-emacs-src }:
     let
-      idris2-version = "0.7.0";
+      idris2Version = "0.7.0";
       lib = import ./nix/lib.nix;
       sys-agnostic = rec {
         templates.pkg = {
@@ -22,7 +22,7 @@
           description = "A custom Idris 2 package with dependencies";
         };
         defaultTemplate = templates.pkg;
-        version = idris2-version;
+        version = idris2Version;
       };
       per-system = { config ? { }, overlays ? [ ] }:
         system:
@@ -32,26 +32,27 @@
             pkgs.chez
           else
             pkgs.chez-racket; # TODO: Should this always be the default?
-          idris2Support = pkgs.callPackage ./nix/support.nix { inherit idris2-version; };
+          idris2Support = pkgs.callPackage ./nix/support.nix { inherit idris2Version; };
           idris2Bootstrap = pkgs.callPackage ./nix/package.nix {
-            inherit idris2-version chez;
+            inherit idris2Version chez;
             idris2Bootstrap = null;
             support = idris2Support;
             srcRev = self.shortRev or "dirty";
           };
           idris2Pkg = pkgs.callPackage ./nix/package.nix {
-            inherit idris2-version chez idris2Bootstrap;
+            inherit idris2Version chez idris2Bootstrap;
             support = idris2Support;
             srcRev = self.shortRev or "dirty";
           };
           buildIdris = pkgs.callPackage ./nix/buildIdris.nix {
-            inherit idris2-version;
+            inherit idris2Version;
             idris2 = idris2Pkg;
             support = idris2Support;
           };
           idris2ApiPkg = buildIdris {
             src = ./.;
-            projectName = "idris2api";
+            ipkgName = "idris2api";
+            version = idris2Version;
             idrisLibraries = [ ];
             preBuild = ''
               export IDRIS2_PREFIX=$out/lib
@@ -67,7 +68,7 @@
           packages = rec {
             support = idris2Support;
             idris2 = idris2Pkg;
-            idris2-api = idris2ApiPkg.library { withSource = true; };
+            idris2Api = idris2ApiPkg.library { withSource = true; };
             default = idris2;
           } // (import ./nix/text-editor.nix {
             inherit pkgs idris-emacs-src idris2Pkg;

--- a/nix/buildIdris.nix
+++ b/nix/buildIdris.nix
@@ -1,61 +1,87 @@
-{ stdenv, lib, idris2-version, idris2, support, makeWrapper }:
-{ src, projectName, idrisLibraries, ... }@attrs:
+{ stdenv, lib, idris2Version, idris2, support, makeWrapper }:
+# Usage: let
+#          pkg = idris2Pkg.buildIdris {
+#            src = ...;
+#            ipkgName = "my-pkg";
+#            idrisLibraries = [ ];
+#          };
+#        in {
+#          lib = pkg.library { withSource = true; };
+#          bin = pkg.executable;
+#        }
+#
+{ src
+, ipkgName
+, version ? "unversioned"
+, idrisLibraries
+, ... }@attrs:
 
 let
-  ipkgName = projectName + ".ipkg";
-  idrName = "idris2-${idris2-version}";
+  ipkgFileName = ipkgName + ".ipkg";
+  idrName = "idris2-${idris2Version}";
   libSuffix = "lib/${idrName}";
-  lib-dirs =
+  libDirs =
     lib.strings.makeSearchPath libSuffix idrisLibraries;
-  drvAttrs = builtins.removeAttrs attrs [ "idrisLibraries" ];
-in rec {
-  executable = stdenv.mkDerivation (drvAttrs // {
-    name = projectName;
+  drvAttrs = builtins.removeAttrs attrs [
+    "ipkgName"
+    "idrisLibraries"
+  ];
+
+  sharedAttrs = drvAttrs // {
+    pname = ipkgName;
+    inherit version;
     src = src;
-    buildInputs = idrisLibraries ++ attrs.buildInputs or [];
     nativeBuildInputs = [ idris2 makeWrapper ] ++ attrs.nativeBuildInputs or [];
-    configurePhase = ''
-      runHook preConfigure
-      export IDRIS2_PACKAGE_PATH=${lib-dirs}
-      runHook postConfigure
-    '';
+    buildInputs = idrisLibraries ++ attrs.buildInputs or [];
+
+    IDRIS2_PACKAGE_PATH = libDirs;
+
     buildPhase = ''
       runHook preBuild
-      idris2 --build ${ipkgName}
+      idris2 --build ${ipkgFileName}
       runHook postBuild
     '';
-    installPhase = ''
-      runHook preInstall
-      mkdir -p $out/bin
-      scheme_app="$(find ./build/exec -name '*_app')"
-      if [ "$scheme_app" = ''' ]; then
-        mv -- build/exec/* $out/bin/
-        chmod +x $out/bin/*
-      else
-        cd build/exec/*_app
-        rm -f ./libidris2_support.so
-        for file in *.so; do
-          bin_name="''${file%.so}"
-          mv -- "$file" "$out/bin/$bin_name"
-          wrapProgram "$out/bin/$bin_name" \
-            --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ support ]} \
-            --prefix DYLD_LIBRARY_PATH : ${lib.makeLibraryPath [ support ]}
-        done
-      fi
-      runHook postInstall
-    '';
-  });
-  library = { withSource ? false }:
-    let installCmd = if withSource then "--install-with-src" else "--install";
-    in executable.overrideAttrs (_: {
-      installPhase = ''
+  };
+
+in rec {
+  executable = stdenv.mkDerivation (sharedAttrs //
+    { installPhase = ''
         runHook preInstall
-        mkdir -p $out/${libSuffix}
-        export IDRIS2_PREFIX=$out/lib
-        idris2 ${installCmd} ${ipkgName}
+        mkdir -p $out/bin
+        scheme_app="$(find ./build/exec -name '*_app')"
+        if [ "$scheme_app" = ''' ]; then
+          mv -- build/exec/* $out/bin/
+          chmod +x $out/bin/*
+          # ^ remove after Idris2 0.8.0 is released. will be superfluous:
+          # https://github.com/idris-lang/Idris2/pull/3189
+        else
+          cd build/exec/*_app
+          rm -f ./libidris2_support.so
+          for file in *.so; do
+            bin_name="''${file%.so}"
+            mv -- "$file" "$out/bin/$bin_name"
+            wrapProgram "$out/bin/$bin_name" \
+              --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ support ]} \
+              --prefix DYLD_LIBRARY_PATH : ${lib.makeLibraryPath [ support ]}
+          done
+        fi
         runHook postInstall
       '';
-    });
+    }
+  );
+
+  library = { withSource ? false }:
+    let installCmd = if withSource then "--install-with-src" else "--install";
+    in stdenv.mkDerivation (sharedAttrs //
+      { installPhase = ''
+          runHook preInstall
+          mkdir -p $out/${libSuffix}
+          export IDRIS2_PREFIX=$out/lib
+          idris2 ${installCmd} ${ipkgFileName}
+          runHook postInstall
+        '';
+      }
+    );
   # deprecated aliases:
   build = lib.warn "build is a deprecated alias for 'executable'." executable;
   installLibrary = lib.warn "installLibrary is a deprecated alias for 'library { }'." (library { });

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, chez, clang, gmp, fetchFromGitHub, makeWrapper, support, idris2-version
+{ stdenv, lib, chez, clang, gmp, fetchFromGitHub, makeWrapper, support, idris2Version
 , srcRev, gambit, nodejs, zsh, idris2Bootstrap ? null }:
 
 # Uses scheme to bootstrap the build of idris2
@@ -9,7 +9,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "idris2";
-  version = idris2-version;
+  version = idris2Version;
 
   src = ../.;
 

--- a/nix/support.nix
+++ b/nix/support.nix
@@ -1,7 +1,7 @@
-{ stdenv, lib, gmp, idris2-version }:
+{ stdenv, lib, gmp, idris2Version }:
 stdenv.mkDerivation rec {
   pname = "libidris2_support";
-  version = idris2-version;
+  version = idris2Version;
 
   src = ../.;
 

--- a/nix/templates/pkg/flake.nix
+++ b/nix/templates/pkg/flake.nix
@@ -15,7 +15,7 @@
         idrisPkgs = idris.packages.${system};
         buildIdris = idris.buildIdris.${system};
         pkgs = buildIdris {
-          projectName = "mypkg";
+          ipkgName = "mypkg";
           src = ./.;
           idrisLibraries = [ ];
         };

--- a/nix/templates/pkgWithDeps/flake.nix
+++ b/nix/templates/pkgWithDeps/flake.nix
@@ -22,7 +22,7 @@
         idrisPkgs = idris.packages.${system};
         buildIdris = idris.buildIdris.${system};
         pkgs = buildIdris {
-          projectName = "pkgWithDeps";
+          ipkgName = "pkgWithDeps";
           src = ./.;
           idrisLibraries = [ my-pkg ];
         };


### PR DESCRIPTION
The changes look more drastic than they are. The meat and potatoes of `buildIdris` are not changing, just some naming, some code organization (implementation details), and relatively small details of the output (like `name` being versioned now).

- align buildIdris function with direction of nixpkgs version.
- rename `idris2-api` flake output to `idris2Api` to follow nixpkgs.
- rename `projectName` buildIdris argument to `ipkgName` to better self-document its purpose.
- tangentially, update naming of local variables to follow nixpkgs.
- use pname/version instead of name for buildIdris derivations.

------

This is next on my list before considering merging:
- [x] Test this end-to-end by rebuilding the LSP server.