### PR TITLE
[ cleanup ] Do not wrap the `mainExpression` into `lazy` in ES backends

### DIFF
--- a/src/Compiler/ES/Codegen.idr
+++ b/src/Compiler/ES/Codegen.idr
@@ -749,14 +749,14 @@ def (MkFunction n as body) = do
   mde  <- mode <$> get ESs
   b    <- stmt Returns body >>= stmt
   let cmt = comment $ hsep (shown n :: toList ((":" <++>) <$> mty))
-  case args of
+  if null args && n /= mainExpr
     -- zero argument toplevel functions are converted to
-    -- lazily evaluated constants.
-    [] => pure $ printDoc mde $ vcat
+    -- lazily evaluated constants (except the main expression).
+    then pure $ printDoc mde $ vcat
           [ cmt
           , constant (var !(get NoMangleMap) ref)
                ("__lazy(" <+> function neutral [] b <+> ")") ]
-    _  => pure $ printDoc mde $ vcat
+    else pure $ printDoc mde $ vcat
           [ cmt
           , function (var !(get NoMangleMap) ref)
                (map (var !(get NoMangleMap)) args) b ]

--- a/tests/node/node028/HelloWorld.idr
+++ b/tests/node/node028/HelloWorld.idr
@@ -1,0 +1,4 @@
+module HelloWorld
+
+main : IO ()
+main = putStrLn "Hello, world!"

--- a/tests/node/node028/LazyIsStillThere.idr
+++ b/tests/node/node028/LazyIsStillThere.idr
@@ -1,0 +1,7 @@
+module LazyIsStillThere
+
+topLevelConst : Nat
+topLevelConst = 16 + 8
+
+main : IO ()
+main = putStrLn "Top-level constant: \{show topLevelConst}"

--- a/tests/node/node028/expected
+++ b/tests/node/node028/expected
@@ -1,0 +1,15 @@
+# Top-level constants are lazily evaluated and strongly memoised.
+# This is implemented by wrapping them to the function called `__lazy`.
+# The only top-level function that should not be treated so is the expression for `main : IO ()`.
+# In this test we check this.
+--------------
+# Running an example without any top-level constants...
+# We expect no usages of `__lazy` to be present, maybe only a definition.
+Hello, world!
+function __lazy(thunk) {
+--------------
+# Running an example with some top-level constant...
+# We expect `__lazy` to be used on the RHS for the top-level constant called `topLevelConst`.
+Top-level constant: 24
+function __lazy(thunk) {
+const LazyIsStillThere_topLevelConst = __lazy(function () {

--- a/tests/node/node028/run
+++ b/tests/node/node028/run
@@ -1,0 +1,20 @@
+. ../../testutils.sh
+
+echo '# Top-level constants are lazily evaluated and strongly memoised.'
+echo '# This is implemented by wrapping them to the function called `__lazy`.'
+echo '# The only top-level function that should not be treated so is the expression for `main : IO ()`.'
+echo '# In this test we check this.'
+
+echo '--------------'
+
+echo '# Running an example without any top-level constants...'
+echo '# We expect no usages of `__lazy` to be present, maybe only a definition.'
+run --cg node -o hw.js HelloWorld.idr
+grep '__lazy' build/exec/hw.js
+
+echo '--------------'
+
+echo '# Running an example with some top-level constant...'
+echo '# We expect `__lazy` to be used on the RHS for the top-level constant called `topLevelConst`.'
+run --cg node -o lsth.js LazyIsStillThere.idr
+grep '__lazy' build/exec/lsth.js


### PR DESCRIPTION
This seems to be unnecessary, and, as was discussed [in the Discord](https://discord.com/channels/827106007712661524/827109161857712128/1199083661769838685), is as safe as the original code. This allows the tree-shaked code to not to contain unneeded definition of `__lazy` when it is indeed is not needed.

I added a test that checks that `mainExpression` is indeed compiled without `__lazy`, and that `__lazy` indeed was inserted when it was inserted before this PR.