### PR TITLE
[fix] Package Search Paths

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -28,6 +28,14 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 
 ### Compiler changes
 
+* The compiler now differentiates between "package search path" and "package
+  directories." Previously both were combined (as seen in the `idris2 --paths`
+  output for "Package Directories"). Now entries in the search path will be
+  printed under an "Package Search Paths" entry and package directories will
+  continue to be printed under "Package Directories." The `IDRIS2_PACKAGE_PATH`
+  environment variable adds to the "Package Search Paths." Functionally this is
+  not a breaking change.
+
 #### RefC Backend
 
 * Fix invalid memory read onf strSubStr.

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -2131,6 +2131,10 @@ addPackageDir: {auto c : Ref Ctxt Defs} -> String -> Core ()
 addPackageDir dir = update Ctxt { options->dirs->package_dirs $= ((::) dir) . filter (/= dir) }
 
 export
+addPackageSearchPath: {auto c : Ref Ctxt Defs} -> String -> Core ()
+addPackageSearchPath dir = update Ctxt { options->dirs->package_search_paths $= ((::) dir) . filter (/= dir) }
+
+export
 addDataDir : {auto c : Ref Ctxt Defs} -> String -> Core ()
 addDataDir dir = update Ctxt { options->dirs->data_dirs $= (++ [dir]) }
 

--- a/src/Core/Options.idr
+++ b/src/Core/Options.idr
@@ -24,7 +24,8 @@ record Dirs where
   output_dir : Maybe String -- output directory, relative to working directory
   prefix_dir : String -- installation prefix, for finding data files (e.g. run time support)
   extra_dirs : List String -- places to look for import files
-  package_dirs : List String -- places to look for packages
+  package_search_paths : List String -- paths at which to look for packages
+  package_dirs : List String -- places where specific needed packages at required versions are located
   lib_dirs : List String -- places to look for libraries (for code generation)
   data_dirs : List String -- places to look for data file
 
@@ -38,7 +39,7 @@ outputDirWithDefault d = fromMaybe (build_dir d </> "exec") (output_dir d)
 
 public export
 toString : Dirs -> String
-toString d@(MkDirs wdir sdir bdir ldir odir dfix edirs pdirs ldirs ddirs) = """
+toString d@(MkDirs wdir sdir bdir ldir odir dfix edirs ppaths pdirs ldirs ddirs) = """
   + Working Directory      :: \{ show wdir }
   + Source Directory       :: \{ show sdir }
   + Build Directory        :: \{ show bdir }
@@ -46,6 +47,7 @@ toString d@(MkDirs wdir sdir bdir ldir odir dfix edirs pdirs ldirs ddirs) = """
   + Output Directory       :: \{ show $ outputDirWithDefault d }
   + Installation Prefix    :: \{ show dfix }
   + Extra Directories      :: \{ show edirs }
+  + Package Search Paths   :: \{ show ppaths }
   + Package Directories    :: \{ show pdirs }
   + CG Library Directories :: \{ show ldirs }
   + Data Directories       :: \{ show ddirs }
@@ -214,7 +216,7 @@ getCG o cg = lookup (toLower cg) (availableCGs o)
 
 defaultDirs : Dirs
 defaultDirs = MkDirs "." Nothing "build" "depends" Nothing
-                     "/usr/local" ["."] [] [] []
+                     "/usr/local" ["."] [] [] [] []
 
 defaultPPrint : PPrinter
 defaultPPrint = MkPPOpts False False True False

--- a/src/Idris/Driver.idr
+++ b/src/Idris/Driver.idr
@@ -62,7 +62,7 @@ updateEnv
          blibs <- coreLift $ idrisGetEnv "IDRIS2_LIBS"
          whenJust blibs $ traverseList1_ addLibDir . splitPaths
          pdirs <- coreLift $ idrisGetEnv "IDRIS2_PACKAGE_PATH"
-         whenJust pdirs $ traverseList1_ addPackageDir . splitPaths
+         whenJust pdirs $ traverseList1_ addPackageSearchPath . splitPaths
          cg <- coreLift $ idrisGetEnv "IDRIS2_CG"
          whenJust cg $ \ e => case getCG (options defs) e of
            Just cg => setCG cg
@@ -76,6 +76,9 @@ updateEnv
          -- for the tests means they test the local version not the installed
          -- version
          defs <- get Ctxt
+         -- add global package path to the package search paths (after those
+         -- added by the user with IDRIS2_PACKAGE_PATH)
+         addPackageSearchPath !pkgGlobalDirectory
          -- These might fail while bootstrapping
          catch (addPkgDir "prelude" anyBounds) (const (pure ()))
          catch (addPkgDir "base" anyBounds) (const (pure ()))

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -1080,7 +1080,7 @@ process (ImportPackage package) = do
   defs <- get Ctxt
   searchDirs <- extraSearchDirectories
   let Just packageDir = find
-        (\d => isInfixOf package (fromMaybe d (fileName d)))
+        (\d => isInfixOf package (fromMaybe d $ fileName =<< parent d))
         searchDirs
     | _ => pure (REPLError "Package not found in the known search directories")
   let packageDirPath = parse packageDir

--- a/tests/testutils.sh
+++ b/tests/testutils.sh
@@ -95,7 +95,7 @@ if [ -z "$PREFIX_CHANGED" ] && [ -n "$IDRIS2_PREFIX" ]; then
     export IDRIS2_PACKAGE_PATH="$OLD_PP$SEP$NEW_PP"
     # Use TEST_IDRIS2_LIBS and TEST_IDRIS2_DATA to pass locations for
     # prebuilt libidris2_support and its DATA files.
-    export IDRIS2_LIBS="$OLD_PP/libs$SEP$NEW_PP/libs$SEP$TEST_IDRIS2_LIBS"
+    export IDRIS2_LIBS="$OLD_PP/lib$SEP$NEW_PP/lib$SEP$TEST_IDRIS2_LIBS"
     export IDRIS2_DATA="$OLD_PP/support$SEP$NEW_PP/support$SEP$TEST_IDRIS2_DATA"
 
     # Set where to install stuff


### PR DESCRIPTION
# Description

For a number of versions now it has been the case that two different concepts share the same name in the Idris2 build process:
1. Locations where packages are searched for (e.g. `~/.idris2/idris2-0.7.0`)
2. Directories containing packages at the required versions for the current build (e.g. `~/.idris2/idris2-0.7.0/base-0.7.0`)

The build context has stored both of these things as `package_dirs` until now. This mixed-use can be quite confusing. If you print `idris2 --paths`, you will see a mix of `(1)` and `(2)` in the output for "Package Directories." Despite this output, the two really are used differently. Adding a path to `IDRIS2_PACKAGE_PATH` will add it to that shared list, but it will only work (i.e. a package will only be discoverable due to the additional path) if you are specifying a path of type `(1)`, not type `(2)`.

This PR breaks the two concepts out. directories containing packages at resolved versions are still stored as `package_dirs` but directories within which packages should be searched for are stored as `package_search_paths`. They have their own line items in the output of `idris2 --paths`. `IDRIS2_PACKAGE_PATH` only affects `package_search_paths`.

This PR also takes the previously implicit "global" package search path and explicitly stores it in the `package_search_paths`. This is a small code cleanup, but it has the added benefit that the global search path is printed by `idris2 --paths` rather than being a hidden implementation detail.

The last thing this PR does is fix a bug already present in Idris2 that stopped the REPL `:package "<name>"` command from working. It must have stopped working way back when package ttc files started getting stored under a versioned subfolder because the fix was to pop the top directory off of the path when attempting to load a whole package at the REPL.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

