### PR TITLE
[new] Nix dev shell to the flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,9 @@
             inherit pkgs idris-emacs-src idris2Pkg;
           });
           inherit buildIdris;
+          devShells.default = pkgs.mkShell {
+            packages = idris2Pkg.buildInputs;
+          };
         };
     in lib.mkOvrOptsFlake
     (opts: flake-utils.lib.eachDefaultSystem (per-system opts) // sys-agnostic);


### PR DESCRIPTION
# Description

This allows you to `make` Idris2 from a dev shell (`nix develop`).

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

