### PR TITLE
[new] zsh completion script

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -167,10 +167,10 @@ You can also add it to your `.bashrc` file.
 From within ZSH, run the following commands:
 
 ```sh
-autoload -U +X compinit && compinit
-autoload -U +X bashcompinit && bashcompinit
-eval "$(idris2 --bash-completion-script idris2)"
+eval "$(idris2 --zsh-completion-script idris2)"
 ```
+
+ZSH auto-completion is implemented via `bashcompinit`.
 
 You can also add them to your `.zshrc` file.
 

--- a/src/Idris/CommandLine.idr
+++ b/src/Idris/CommandLine.idr
@@ -160,6 +160,8 @@ data CLOpt
   BashCompletion String String |
    ||| Generate bash completion script
   BashCompletionScript String |
+   ||| Generate zsh completion script
+  ZshCompletionScript String |
    ||| Turn on %default total globally
   Total |
    ||| Disable common subexpression elimination
@@ -370,7 +372,12 @@ options = [MkOpt ["--check", "-c"] [] [CheckOnly]
            MkOpt ["--bash-completion-script"]
                  [ Required "function name" ]
                  (\n => [BashCompletionScript n])
-                 (Just "Generate a bash script to activate autocompletion for Idris2")
+                 (Just "Generate a bash script to activate autocompletion for Idris2"),
+           -- zsh completion
+           MkOpt ["--zsh-completion-script"]
+                 [ Required "function name" ]
+                 (\n => [ZshCompletionScript n])
+                 (Just "Generate a zsh script (via bashcompinit) to activate autocompletion for Idris2")
            ]
 
 optShow : OptDesc -> (String, Maybe String)

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -248,8 +248,8 @@ opts x _ = pure $ if (x `elem` optionFlags)
                      else prefixOnly x optionFlags
 
 -- bash autocompletion script using the given function name
-completionScript : (fun : String) -> String
-completionScript fun = let fun' = "_" ++ fun in """
+bashCompletionScript : (fun : String) -> String
+bashCompletionScript fun = let fun' = "_" ++ fun in """
   \{ fun' }()
   {
     ED=$([ -z $2 ] && echo "--" || echo $2)
@@ -257,6 +257,13 @@ completionScript fun = let fun' = "_" ++ fun in """
   }
 
   complete -F \{ fun' } -o default idris2
+  """
+
+zshCompletionScript : (fun : String) -> String
+zshCompletionScript fun = """
+  autoload -U +X compinit && compinit
+  autoload -U +X bashcompinit && bashcompinit
+  \{ bashCompletionScript fun }
   """
 
 --------------------------------------------------------------------------------
@@ -428,7 +435,10 @@ preOptions (BashCompletion a b :: _)
          coreLift $ putStr $ unlines os
          pure False
 preOptions (BashCompletionScript fun :: _)
-    = do coreLift $ putStrLn $ completionScript fun
+    = do coreLift $ putStrLn $ bashCompletionScript fun
+         pure False
+preOptions (ZshCompletionScript fun :: _)
+    = do coreLift $ putStrLn $ zshCompletionScript fun
          pure False
 preOptions (Total :: opts)
     = do updateSession ({ totalReq := Total })


### PR DESCRIPTION
# Description
This is a pretty small benefit, but ever since I saw another project offer ZSH completion more directly by wrapping the init stuff up in the script I have wanted to add it everywhere.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

