### PR TITLE
[ doc ] document %cg pragma

### DIFF
--- a/docs/source/reference/pragmas.rst
+++ b/docs/source/reference/pragmas.rst
@@ -140,7 +140,16 @@ using ``--directive extraRuntime=mycode.ss`` on the command line for the chez ba
 
     %cg chez extraRuntime=mycode.ss
 
-See the code generator documentation for available directives.
+The ``%cg`` pragma is followed by the name of a codegen and a directive for that codegen, terminated by
+newline.  Directives from imported modules, including transitive imports, will aggregate. All of the
+directives given in the source are stored in the module, but only the directives for the current codegen
+are used at link time.
+
+How directives are treated in aggregate depends on the codegen and directive. For example, the
+``extraRuntime`` directive for the Chez codegen is deduplicated.  And the javascript backend gives
+the ``minimal`` directive priority over the ``compact`` directive if both are present.
+
+See the section for each codegen under :ref:`sect-execs` for available directives.
 
 Pragmas on declarations
 =======================

--- a/docs/source/reference/pragmas.rst
+++ b/docs/source/reference/pragmas.rst
@@ -130,6 +130,18 @@ Set the expression search timeout in milliseconds.  The default is 1000.
 Set the maximum number of stuck applications allowed while unifying a meta. The
 default value is 25.
 
+``%cg``
+--------------------
+
+Codegen directives can be included in source code with the ``%cg`` pragma. For example, instead of
+using ``--directive extraRuntime=mycode.ss`` on the command line for the chez backend, you can write:
+
+.. code-block:: idris
+
+    %cg chez extraRuntime=mycode.ss
+
+See the code generator documentation for available directives.
+
 Pragmas on declarations
 =======================
 


### PR DESCRIPTION
# Description

Add documentation for the `%cg` pragma. I missed this one when documenting the pragmas because it is hiding in the lexer.

