### PR TITLE
[new] add autocompletion scripts to Nix output

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, chez, clang, gmp, fetchFromGitHub, makeWrapper, support, idris2Version
+{ stdenv, lib, chez, clang, gmp, fetchFromGitHub, makeWrapper, installShellFiles, support, idris2Version
 , srcRev, gambit, nodejs, zsh, idris2Bootstrap ? null }:
 
 # Uses scheme to bootstrap the build of idris2
@@ -14,9 +14,9 @@ stdenv.mkDerivation rec {
   src = ../.;
 
   strictDeps = true;
-  nativeBuildInputs = [ makeWrapper clang chez ]
+  nativeBuildInputs = [ makeWrapper installShellFiles clang chez ]
     ++ lib.optional stdenv.isDarwin [ zsh ]
-    ++ lib.optional (! bootstrap) [ idris2Bootstrap ];
+    ++ lib.optional (!bootstrap) [ idris2Bootstrap ];
   buildInputs = [ chez gmp support ];
 
   prePatch = ''
@@ -82,5 +82,9 @@ stdenv.mkDerivation rec {
       --suffix IDRIS2_PACKAGE_PATH ':' "${globalLibrariesPath}" \
       --suffix LD_LIBRARY_PATH ':' "${supportLibrariesPath}" \
       --suffix DYLD_LIBRARY_PATH ':' "${supportLibrariesPath}" \
+
+    installShellCompletion --cmd idris2 \
+      --bash <($out/bin/idris2 --bash-completion-script idris2) \
+      --zsh <($out/bin/idris2 --zsh-completion-script idris2) \
   '';
 }


### PR DESCRIPTION
# Description

Nix offers a standard way to expose auto-completion scripts in derivation outputs. Since Idris has auto-completion scripts for bash/zsh, install those into the output.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

