### PR TITLE
[ test ] fix clean_names function in testutils.sh

### DIFF
--- a/tests/codegen/builtin001/expected
+++ b/tests/codegen/builtin001/expected
@@ -1,3 +1,3 @@
 Dumping case trees to Main.cases
-Main.plus = [{arg:1}, {arg:1}]: (%case !{arg:1} [(%constcase 0 !{arg:1})] Just (%let {e:0} (-Integer [!{arg:1}, 1]) (+Integer [(Main.plus [!{e:0}, !{arg:1}]), 1])))
+Main.plus = [{arg:1}, {arg:2}]: (%case !{arg:1} [(%constcase 0 !{arg:2})] Just (%let {e:0} (-Integer [!{arg:1}, 1]) (+Integer [(Main.plus [!{e:0}, !{arg:2}]), 1])))
 Main.main = [{ext:0}]: (Main.plus [1, 2])

--- a/tests/idris2/basic/basic044/expected
+++ b/tests/idris2/basic/basic044/expected
@@ -24,8 +24,8 @@ LOG unify.equal:10: Skipped unification (equal already): Type and Type
 LOG unify.meta:5: Adding new meta ({P:cut:1}, (Term:1, Rig0))
 LOG unify.meta:5: Adding new meta ({P:vars:1}, (Term:2, Rig0))
 LOG unify.equal:10: Skipped unification (equal already): Type and Type
-LOG unify.meta:5: Adding new meta ({P:cut:1}, (Term:3, Rig0))
-LOG unify.meta:5: Adding new meta ({P:vars:1}, (Term:4, Rig0))
+LOG unify.meta:5: Adding new meta ({P:cut:2}, (Term:3, Rig0))
+LOG unify.meta:5: Adding new meta ({P:vars:2}, (Term:4, Rig0))
 LOG unify.equal:10: Skipped unification (equal already): Type and Type
 LOG unify.equal:10: Skipped unification (equal already): Type and Type
 LOG declare.data:1: Processing Term.Chk
@@ -33,13 +33,13 @@ LOG unify.equal:10: Skipped unification (equal already): Type and Type
 LOG unify.equal:10: Skipped unification (equal already): Type and Type
 LOG unify.equal:10: Skipped unification (equal already): Type and Type
 LOG unify.equal:10: Skipped unification (equal already): Type and Type
-LOG unify.meta:5: Adding new meta ({P:cut:2}, (Term:5, Rig0))
-LOG unify.meta:5: Adding new meta ({P:vars:2}, (Term:6, Rig0))
+LOG unify.meta:5: Adding new meta ({P:cut:3}, (Term:5, Rig0))
+LOG unify.meta:5: Adding new meta ({P:vars:3}, (Term:6, Rig0))
 LOG unify.equal:10: Skipped unification (equal already): Type and Type
 LOG unify.equal:10: Skipped unification (equal already): Type and Type
 LOG unify.equal:10: Skipped unification (equal already): Type and Type
-LOG unify.meta:5: Adding new meta ({P:cut:3}, (Term:7, Rig0))
-LOG unify.meta:5: Adding new meta ({P:vars:3}, (Term:8, Rig0))
+LOG unify.meta:5: Adding new meta ({P:cut:4}, (Term:7, Rig0))
+LOG unify.meta:5: Adding new meta ({P:vars:4}, (Term:8, Rig0))
 LOG unify.meta:5: Adding new meta ({P:n:1}, (Term:9, Rig0))
 LOG unify.equal:10: Skipped unification (equal already): Type and Type
 LOG unify.equal:10: Skipped unification (equal already): Type and Type
@@ -48,16 +48,16 @@ LOG unify.equal:10: Skipped unification (equal already): Type and Type
 LOG unify.equal:10: Skipped unification (equal already): Type and Type
 LOG unify.equal:10: Skipped unification (equal already): Type and Type
 LOG unify.equal:10: Skipped unification (equal already): Type and Type
-LOG unify.meta:5: Adding new meta ({P:vars:4}, (Term:10, Rig0))
-LOG unify.meta:5: Adding new meta ({P:cut:4}, (Term:11, Rig0))
+LOG unify.meta:5: Adding new meta ({P:vars:5}, (Term:10, Rig0))
+LOG unify.meta:5: Adding new meta ({P:cut:5}, (Term:11, Rig0))
 LOG unify.equal:10: Skipped unification (equal already): Type and Type
 LOG unify.equal:10: Skipped unification (equal already): Type and Type
-LOG unify.meta:5: Adding new meta ({P:cut:5}, (Term:12, Rig0))
-LOG unify.meta:5: Adding new meta ({P:vars:5}, (Term:13, Rig0))
+LOG unify.meta:5: Adding new meta ({P:cut:6}, (Term:12, Rig0))
+LOG unify.meta:5: Adding new meta ({P:vars:6}, (Term:13, Rig0))
 LOG unify.equal:10: Skipped unification (equal already): Type and Type
 LOG unify.equal:10: Skipped unification (equal already): Type and Type
 LOG unify.equal:10: Skipped unification (equal already): Type and Type
-LOG unify.meta:5: Adding new meta ({P:vars:6}, (Term:14, Rig0))
+LOG unify.meta:5: Adding new meta ({P:vars:7}, (Term:14, Rig0))
 LOG unify.equal:10: Skipped unification (equal already): Type and Type
 LOG unify.equal:10: Skipped unification (equal already): Type and Type
 LOG unify.equal:10: Skipped unification (equal already): Type and Type
@@ -96,13 +96,13 @@ LOG declare.def:3: Initially missing in Term.NF:
 Term> Bye for now!
 1/1: Building Vec (Vec.idr)
 LOG declare.type:1: Processing Vec.Vec
-LOG declare.def:2: Case tree for Vec.Vec: [0] ({arg:1} : (Data.Fin.Fin {arg:2}[1])) -> {arg:2}[1]
+LOG declare.def:2: Case tree for Vec.Vec: [0] ({arg:1} : (Data.Fin.Fin {arg:2}[1])) -> {arg:3}[1]
 LOG declare.type:1: Processing Vec.Nil
-LOG declare.def:2: Case tree for Vec.Nil: [0] (Prelude.Uninhabited.absurd {arg:2}[0] (Data.Fin.Fin Prelude.Types.Z) Data.Fin.Uninhabited implementation at Data.Fin:1)
+LOG declare.def:2: Case tree for Vec.Nil: [0] (Prelude.Uninhabited.absurd {arg:3}[0] (Data.Fin.Fin Prelude.Types.Z) Data.Fin.Uninhabited implementation at Data.Fin:1)
 LOG declare.type:1: Processing Vec.(::)
-LOG declare.def:2: Case tree for Vec.(::): case {arg:2}[4] : (Data.Fin.Fin (Prelude.Types.S {arg:2}[0])) of
- { Data.Fin.FZ {e:0} => [0] {arg:2}[3]
- | Data.Fin.FS {e:1} {e:2} => [1] ({arg:2}[5] {e:2}[1])
+LOG declare.def:2: Case tree for Vec.(::): case {arg:4}[4] : (Data.Fin.Fin (Prelude.Types.S {arg:3}[0])) of
+ { Data.Fin.FZ {e:0} => [0] {arg:5}[3]
+ | Data.Fin.FS {e:1} {e:2} => [1] ({arg:6}[5] {e:2}[1])
  }
 LOG declare.type:1: Processing Vec.test
 LOG elab.ambiguous:5: Ambiguous elaboration at Vec:1:
@@ -115,8 +115,8 @@ LOG elab.ambiguous:5: Ambiguous elaboration (kept 3 out of 3 candidates) (not de
 (($resolved5 Nil) ((:: ((:: (fromInteger 0)) Nil)) Nil))
 Target type : ({arg:1} : (Data.Fin.Fin (Prelude.Types.S (Prelude.Types.S Prelude.Types.Z)))) -> (Prelude.Basics.List Prelude.Types.Nat)
 LOG elab.ambiguous:5: Ambiguous elaboration (kept 2 out of 2 candidates) (not delayed) at Vec:3:
-$resolved3
 $resolved6
+$resolved7
 Target type : ?Vec.{a:4574}_[]
 LOG elab.ambiguous:5: Ambiguous elaboration (kept 3 out of 3 candidates) (not delayed) at Vec:4:
 (($resolved3 ((:: (fromInteger 0)) Nil)) Nil)
@@ -133,16 +133,16 @@ LOG elab.ambiguous:5: Ambiguous elaboration at Vec:6:
   ($resolved2 0)
 With default. Target type : ?Vec.{a:4579}_[]
 LOG elab.ambiguous:5: Ambiguous elaboration (kept 2 out of 2 candidates) (not delayed) at Vec:7:
-$resolved3
 $resolved6
+$resolved7
 Target type : (Vec.Vec ?Vec.{a:4579}_[] ?Vec.{n:4578}_[])
 LOG elab.ambiguous:5: Ambiguous elaboration at Vec:6:
   ($resolved1 0)
   ($resolved2 0)
 With default. Target type : ?Vec.{a:4578}_[]
 LOG elab.ambiguous:5: Ambiguous elaboration (kept 2 out of 2 candidates) (not delayed) at Vec:8:
-$resolved3
 $resolved6
+$resolved7
 Target type : (Vec.Vec ?Vec.{a:4577}_[] ?Vec.{n:4576}_[])
 LOG elab.ambiguous:5: Ambiguous elaboration (kept 1 out of 3 candidates) (delayed) at Vec:5:
 (($resolved4 (fromInteger 0)) Nil)
@@ -152,7 +152,7 @@ LOG elab.ambiguous:5: Ambiguous elaboration at Vec:6:
   ($resolved2 0)
 With default. Target type : Prelude.Types.Nat
 LOG elab.ambiguous:5: Ambiguous elaboration (kept 1 out of 2 candidates) (delayed) at Vec:3:
-$resolved6
+$resolved7
 Target type : (Prelude.Basics.List Prelude.Types.Nat)
 LOG declare.def:2: Case tree for Vec.test: [0] (Vec.(::) (Prelude.Types.S Prelude.Types.Z) (Prelude.Basics.List Prelude.Types.Nat) (Prelude.Basics.Nil Prelude.Types.Nat) (Vec.(::) Prelude.Types.Z (Prelude.Basics.List Prelude.Types.Nat) (Prelude.Basics.(::) Prelude.Types.Nat Prelude.Types.Z (Prelude.Basics.Nil Prelude.Types.Nat)) (Vec.Nil (Prelude.Basics.List Prelude.Types.Nat))))
 Vec> Bye for now!

--- a/tests/idris2/evaluator/spec001/expected
+++ b/tests/idris2/evaluator/spec001/expected
@@ -17,28 +17,28 @@ function Main_main($0) {
 }
 1/1: Building Desc (Desc.idr)
 LOG specialise.declare:5: Specialising Desc.fold ($resolved2) -> _PE.PE_fold_3a845f1ca594c582 by (0, Dynamic), (1, Static (Desc.Sum Desc.Stop (Desc.Prod Desc.Rec Desc.Rec))), (2, Dynamic)
-LOG specialise:3: Specialised type _PE.PE_fold_3a845f1ca594c582: {0 a : Type} -> ({arg:1} : ({arg:1} : (Desc.Meaning (Desc.Sum Desc.Stop (Desc.Prod Desc.Rec Desc.Rec)) a[0])) -> a[1]) -> ({arg:2} : (Desc.Mu (Desc.Sum Desc.Stop (Desc.Prod Desc.Rec Desc.Rec)))) -> a[2]
+LOG specialise:3: Specialised type _PE.PE_fold_3a845f1ca594c582: {0 a : Type} -> ({arg:1} : ({arg:2} : (Desc.Meaning (Desc.Sum Desc.Stop (Desc.Prod Desc.Rec Desc.Rec)) a[0])) -> a[1]) -> ({arg:3} : (Desc.Mu (Desc.Sum Desc.Stop (Desc.Prod Desc.Rec Desc.Rec)))) -> a[2]
 LOG specialise:5: Attempting to specialise:
 ((((Desc.fold [a = a]) [d = d]) alg) ((Desc.MkMu [d = d]) t)) = (alg (((((Desc.fmap [b = a]) [a = ?a]) d) ((Builtin.assert_total [a = ?a]) (((Desc.fold [a = a]) [d = d]) alg))) t))
 LOG specialise:5: New patterns for _PE.PE_fold_3a845f1ca594c582:
 (((_PE.PE_fold_3a845f1ca594c582 [a = a]) alg) ((Desc.MkMu [d = ((Desc.Sum Desc.Stop) ((Desc.Prod Desc.Rec) Desc.Rec))]) t)) = (alg (((((Desc.fmap [b = a]) [a = ?]) ((Desc.Sum Desc.Stop) ((Desc.Prod Desc.Rec) Desc.Rec))) ((Builtin.assert_total [a = ?]) (((Desc.fold [a = a]) [d = ((Desc.Sum Desc.Stop) ((Desc.Prod Desc.Rec) Desc.Rec))]) alg))) t))
 LOG specialise:5: Already specialised _PE.PE_fold_3a845f1ca594c582
 LOG specialise:5: Already specialised _PE.PE_fold_3a845f1ca594c582
-LOG specialise:5: New RHS: (alg[0] (Prelude.Types.bimap (Builtin.Pair a[1] a[1]) (Builtin.Pair (Desc.Mu (Desc.Sum Desc.Stop (Desc.Prod Desc.Rec Desc.Rec))) (Desc.Mu (Desc.Sum Desc.Stop (Desc.Prod Desc.Rec Desc.Rec)))) Builtin.Unit Builtin.Unit (Prelude.Basics.id Builtin.Unit) \({arg:3} : (Builtin.Pair (Desc.Mu (Desc.Sum Desc.Stop (Desc.Prod Desc.Rec Desc.Rec))) (Desc.Mu (Desc.Sum Desc.Stop (Desc.Prod Desc.Rec Desc.Rec))))) => (Prelude.Types.bimap a[2] (Desc.Mu (Desc.Sum Desc.Stop (Desc.Prod Desc.Rec Desc.Rec))) a[2] (Desc.Mu (Desc.Sum Desc.Stop (Desc.Prod Desc.Rec Desc.Rec))) (_PE.PE_fold_3a845f1ca594c582 a[2] alg[1]) (_PE.PE_fold_3a845f1ca594c582 a[2] alg[1]) {arg:3}[0]) t[2]))
+LOG specialise:5: New RHS: (alg[0] (Prelude.Types.bimap (Builtin.Pair a[1] a[1]) (Builtin.Pair (Desc.Mu (Desc.Sum Desc.Stop (Desc.Prod Desc.Rec Desc.Rec))) (Desc.Mu (Desc.Sum Desc.Stop (Desc.Prod Desc.Rec Desc.Rec)))) Builtin.Unit Builtin.Unit (Prelude.Basics.id Builtin.Unit) \({arg:4} : (Builtin.Pair (Desc.Mu (Desc.Sum Desc.Stop (Desc.Prod Desc.Rec Desc.Rec))) (Desc.Mu (Desc.Sum Desc.Stop (Desc.Prod Desc.Rec Desc.Rec))))) => (Prelude.Types.bimap a[2] (Desc.Mu (Desc.Sum Desc.Stop (Desc.Prod Desc.Rec Desc.Rec))) a[2] (Desc.Mu (Desc.Sum Desc.Stop (Desc.Prod Desc.Rec Desc.Rec))) (_PE.PE_fold_3a845f1ca594c582 a[2] alg[1]) (_PE.PE_fold_3a845f1ca594c582 a[2] alg[1]) {arg:4}[0]) t[2]))
 LOG specialise:5: Already specialised _PE.PE_fold_3a845f1ca594c582
 1/1: Building Desc2 (Desc2.idr)
-LOG specialise.declare:5: Specialising Main.fold ($resolved3) -> _PE.PE_fold_8abb50b713fe8e5e by (0, Static Prelude.Types.Nat), (1, Static Prelude.Basics.List), (2, Static (Prelude.Interfaces.MkFunctor Prelude.Basics.List \{0 b : Type} => \{0 a : Type} => \(func : ({arg:4} : a[0]) -> b[2]) => \({arg:4} : (Prelude.Basics.List a[1])) => (Prelude.Types.List.mapImpl b[3] a[2] func[1] {arg:4}[0]))), (3, Dynamic)
-LOG specialise:3: Specialised type _PE.PE_fold_8abb50b713fe8e5e: ({arg:5} : ({arg:5} : (Prelude.Basics.List Prelude.Types.Nat)) -> Prelude.Types.Nat) -> ({arg:5} : (Main.Mu Prelude.Basics.List)) -> Prelude.Types.Nat
+LOG specialise.declare:5: Specialising Main.fold ($resolved3) -> _PE.PE_fold_8abb50b713fe8e5e by (0, Static Prelude.Types.Nat), (1, Static Prelude.Basics.List), (2, Static (Prelude.Interfaces.MkFunctor Prelude.Basics.List \{0 b : Type} => \{0 a : Type} => \(func : ({arg:5} : a[0]) -> b[2]) => \({arg:6} : (Prelude.Basics.List a[1])) => (Prelude.Types.List.mapImpl b[3] a[2] func[1] {arg:6}[0]))), (3, Dynamic)
+LOG specialise:3: Specialised type _PE.PE_fold_8abb50b713fe8e5e: ({arg:7} : ({arg:8} : (Prelude.Basics.List Prelude.Types.Nat)) -> Prelude.Types.Nat) -> ({arg:9} : (Main.Mu Prelude.Basics.List)) -> Prelude.Types.Nat
 LOG specialise:5: Attempting to specialise:
 (((((Main.fold [a = a]) [f = f]) [fun = fun]) alg) ((Main.MkMu [f = f]) t)) = (alg ((((((Prelude.Interfaces.(<$>) [b = a]) [a = (Main.Mu f)]) [f = f]) [{conArg:1} = fun]) ((((Main.fold [a = a]) [f = f]) [fun = fun]) alg)) t))
 LOG specialise:5: New patterns for _PE.PE_fold_8abb50b713fe8e5e:
-((_PE.PE_fold_8abb50b713fe8e5e alg) ((Main.MkMu [f = Prelude.Basics.List]) t)) = (alg ((((((Prelude.Interfaces.(<$>) [b = Prelude.Types.Nat]) [a = (Main.Mu Prelude.Basics.List)]) [f = Prelude.Basics.List]) [{conArg:1} = ((Prelude.Interfaces.MkFunctor [f = Prelude.Basics.List]) (%lam Rig0 Implicit (Just b) %type (%lam Rig0 Implicit (Just a) %type (%lam RigW Explicit (Just func) (%pi RigW Explicit (Just {arg:4}) a b) (%lam RigW Explicit (Just {arg:4}) (Prelude.Basics.List a) ((((Prelude.Types.List.mapImpl [b = b]) [a = a]) func) {arg:4}))))))]) ((((Main.fold [a = Prelude.Types.Nat]) [f = Prelude.Basics.List]) [fun = ((Prelude.Interfaces.MkFunctor [f = Prelude.Basics.List]) (%lam Rig0 Implicit (Just b) %type (%lam Rig0 Implicit (Just a) %type (%lam RigW Explicit (Just func) (%pi RigW Explicit (Just {arg:4}) a b) (%lam RigW Explicit (Just {arg:4}) (Prelude.Basics.List a) ((((Prelude.Types.List.mapImpl [b = b]) [a = a]) func) {arg:4}))))))]) alg)) t))
-LOG specialise.declare:5: Specialising Main.fold ($resolved3) -> _PE.PE_fold_a727631bc09e3761 by (0, Static Prelude.Types.Nat), (1, Static Prelude.Basics.List), (2, Static (Prelude.Interfaces.MkFunctor Prelude.Basics.List \{0 b : Type} => \{0 a : Type} => \(func : ({arg:4} : a[0]) -> b[2]) => \({arg:4} : (Prelude.Basics.List a[1])) => (Prelude.Types.List.mapAppend a[2] b[3] (Prelude.Basics.Lin b[3]) func[1] {arg:4}[0]))), (3, Dynamic)
-LOG specialise:3: Specialised type _PE.PE_fold_a727631bc09e3761: ({arg:5} : ({arg:5} : (Prelude.Basics.List Prelude.Types.Nat)) -> Prelude.Types.Nat) -> ({arg:5} : (Main.Mu Prelude.Basics.List)) -> Prelude.Types.Nat
+((_PE.PE_fold_8abb50b713fe8e5e alg) ((Main.MkMu [f = Prelude.Basics.List]) t)) = (alg ((((((Prelude.Interfaces.(<$>) [b = Prelude.Types.Nat]) [a = (Main.Mu Prelude.Basics.List)]) [f = Prelude.Basics.List]) [{conArg:1} = ((Prelude.Interfaces.MkFunctor [f = Prelude.Basics.List]) (%lam Rig0 Implicit (Just b) %type (%lam Rig0 Implicit (Just a) %type (%lam RigW Explicit (Just func) (%pi RigW Explicit (Just {arg:5}) a b) (%lam RigW Explicit (Just {arg:6}) (Prelude.Basics.List a) ((((Prelude.Types.List.mapImpl [b = b]) [a = a]) func) {arg:6}))))))]) ((((Main.fold [a = Prelude.Types.Nat]) [f = Prelude.Basics.List]) [fun = ((Prelude.Interfaces.MkFunctor [f = Prelude.Basics.List]) (%lam Rig0 Implicit (Just b) %type (%lam Rig0 Implicit (Just a) %type (%lam RigW Explicit (Just func) (%pi RigW Explicit (Just {arg:5}) a b) (%lam RigW Explicit (Just {arg:6}) (Prelude.Basics.List a) ((((Prelude.Types.List.mapImpl [b = b]) [a = a]) func) {arg:6}))))))]) alg)) t))
+LOG specialise.declare:5: Specialising Main.fold ($resolved3) -> _PE.PE_fold_a727631bc09e3761 by (0, Static Prelude.Types.Nat), (1, Static Prelude.Basics.List), (2, Static (Prelude.Interfaces.MkFunctor Prelude.Basics.List \{0 b : Type} => \{0 a : Type} => \(func : ({arg:5} : a[0]) -> b[2]) => \({arg:6} : (Prelude.Basics.List a[1])) => (Prelude.Types.List.mapAppend a[2] b[3] (Prelude.Basics.Lin b[3]) func[1] {arg:6}[0]))), (3, Dynamic)
+LOG specialise:3: Specialised type _PE.PE_fold_a727631bc09e3761: ({arg:7} : ({arg:8} : (Prelude.Basics.List Prelude.Types.Nat)) -> Prelude.Types.Nat) -> ({arg:9} : (Main.Mu Prelude.Basics.List)) -> Prelude.Types.Nat
 LOG specialise:5: Attempting to specialise:
 (((((Main.fold [a = a]) [f = f]) [fun = fun]) alg) ((Main.MkMu [f = f]) t)) = (alg ((((((Prelude.Interfaces.(<$>) [b = a]) [a = (Main.Mu f)]) [f = f]) [{conArg:1} = fun]) ((((Main.fold [a = a]) [f = f]) [fun = fun]) alg)) t))
 LOG specialise:5: New patterns for _PE.PE_fold_a727631bc09e3761:
-((_PE.PE_fold_a727631bc09e3761 alg) ((Main.MkMu [f = Prelude.Basics.List]) t)) = (alg ((((((Prelude.Interfaces.(<$>) [b = Prelude.Types.Nat]) [a = (Main.Mu Prelude.Basics.List)]) [f = Prelude.Basics.List]) [{conArg:1} = ((Prelude.Interfaces.MkFunctor [f = Prelude.Basics.List]) (%lam Rig0 Implicit (Just b) %type (%lam Rig0 Implicit (Just a) %type (%lam RigW Explicit (Just func) (%pi RigW Explicit (Just {arg:4}) a b) (%lam RigW Explicit (Just {arg:4}) (Prelude.Basics.List a) (((((Prelude.Types.List.mapAppend [a = a]) [b = b]) (Prelude.Basics.Lin [a = b])) func) {arg:4}))))))]) ((((Main.fold [a = Prelude.Types.Nat]) [f = Prelude.Basics.List]) [fun = ((Prelude.Interfaces.MkFunctor [f = Prelude.Basics.List]) (%lam Rig0 Implicit (Just b) %type (%lam Rig0 Implicit (Just a) %type (%lam RigW Explicit (Just func) (%pi RigW Explicit (Just {arg:4}) a b) (%lam RigW Explicit (Just {arg:4}) (Prelude.Basics.List a) (((((Prelude.Types.List.mapAppend [a = a]) [b = b]) (Prelude.Basics.Lin [a = b])) func) {arg:4}))))))]) alg)) t))
+((_PE.PE_fold_a727631bc09e3761 alg) ((Main.MkMu [f = Prelude.Basics.List]) t)) = (alg ((((((Prelude.Interfaces.(<$>) [b = Prelude.Types.Nat]) [a = (Main.Mu Prelude.Basics.List)]) [f = Prelude.Basics.List]) [{conArg:1} = ((Prelude.Interfaces.MkFunctor [f = Prelude.Basics.List]) (%lam Rig0 Implicit (Just b) %type (%lam Rig0 Implicit (Just a) %type (%lam RigW Explicit (Just func) (%pi RigW Explicit (Just {arg:5}) a b) (%lam RigW Explicit (Just {arg:6}) (Prelude.Basics.List a) (((((Prelude.Types.List.mapAppend [a = a]) [b = b]) (Prelude.Basics.Lin [a = b])) func) {arg:6}))))))]) ((((Main.fold [a = Prelude.Types.Nat]) [f = Prelude.Basics.List]) [fun = ((Prelude.Interfaces.MkFunctor [f = Prelude.Basics.List]) (%lam Rig0 Implicit (Just b) %type (%lam Rig0 Implicit (Just a) %type (%lam RigW Explicit (Just func) (%pi RigW Explicit (Just {arg:5}) a b) (%lam RigW Explicit (Just {arg:6}) (Prelude.Basics.List a) (((((Prelude.Types.List.mapAppend [a = a]) [b = b]) (Prelude.Basics.Lin [a = b])) func) {arg:6}))))))]) alg)) t))
 LOG specialise:5: Already specialised _PE.PE_fold_a727631bc09e3761
 LOG specialise:5: New RHS: (alg[0] (Prelude.Types.List.mapAppend (Main.Mu Prelude.Basics.List) Prelude.Types.Nat (Prelude.Basics.Lin Prelude.Types.Nat) (_PE.PE_fold_a727631bc09e3761 alg[0]) t[1]))
 LOG specialise:5: Already specialised _PE.PE_fold_a727631bc09e3761
@@ -48,7 +48,7 @@ LOG specialise:5: New RHS: (alg[0] (Prelude.Types.List.mapAppend (Main.Mu Prelud
 LOG specialise:5: Already specialised _PE.PE_fold_8abb50b713fe8e5e
 1/1: Building Identity (Identity.idr)
 LOG specialise.declare:5: Specialising Main.identity ($resolved1) -> _PE.PE_identity_3c7f5598e5c9b732 by (0, Static Prelude.Types.Nat), (1, Dynamic)
-LOG specialise:3: Specialised type _PE.PE_identity_3c7f5598e5c9b732: ({arg:6} : (Prelude.Basics.List Prelude.Types.Nat)) -> (Prelude.Basics.List Prelude.Types.Nat)
+LOG specialise:3: Specialised type _PE.PE_identity_3c7f5598e5c9b732: ({arg:10} : (Prelude.Basics.List Prelude.Types.Nat)) -> (Prelude.Basics.List Prelude.Types.Nat)
 LOG specialise:5: Attempting to specialise:
 ((Main.identity [a = a]) (Prelude.Basics.Nil [a = a])) = (Prelude.Basics.Nil [a = a])
 ((Main.identity [a = a]) (((Prelude.Basics.(::) [a = a]) x) xs)) = (((Prelude.Basics.(::) [a = a]) x) ((Main.identity [a = a]) xs))
@@ -60,26 +60,26 @@ LOG specialise:5: Already specialised _PE.PE_identity_3c7f5598e5c9b732
 LOG specialise:5: New RHS: (Prelude.Basics.(::) Prelude.Types.Nat x[1] (_PE.PE_identity_3c7f5598e5c9b732 xs[0]))
 LOG specialise:5: Already specialised _PE.PE_identity_3c7f5598e5c9b732
 LOG compiler.identity:5: found identity flag for: _PE.PE_identity_3c7f5598e5c9b732, 0
-	old def: Just [{arg:3}]: (%case !{arg:3} [(%concase [nil] Prelude.Basics.Nil Just 0 [] (%con [nil] Prelude.Basics.Nil Just 0 [])), (%concase [cons] Prelude.Basics.(::) Just 1 [{e:2}, {e:3}] (%con [cons] Prelude.Basics.(::) Just 1 [!{e:2}, (_PE.PE_identity_3c7f5598e5c9b732 [!{e:3}])]))] Nothing)
-LOG compiler.identity:5: 	new def: [{arg:3}]: !{arg:3}
+	old def: Just [{arg:11}]: (%case !{arg:11} [(%concase [nil] Prelude.Basics.Nil Just 0 [] (%con [nil] Prelude.Basics.Nil Just 0 [])), (%concase [cons] Prelude.Basics.(::) Just 1 [{e:2}, {e:3}] (%con [cons] Prelude.Basics.(::) Just 1 [!{e:2}, (_PE.PE_identity_3c7f5598e5c9b732 [!{e:3}])]))] Nothing)
+LOG compiler.identity:5: 	new def: [{arg:11}]: !{arg:11}
 LOG compiler.identity:5: found identity flag for: Main.identity, 0
-	old def: Just [{arg:3}]: (%case !{arg:3} [(%concase [nil] Prelude.Basics.Nil Just 0 [] (%con [nil] Prelude.Basics.Nil Just 0 [])), (%concase [cons] Prelude.Basics.(::) Just 1 [{e:2}, {e:3}] (%con [cons] Prelude.Basics.(::) Just 1 [!{e:2}, (Main.identity [!{e:3}])]))] Nothing)
-LOG compiler.identity:5: 	new def: [{arg:3}]: !{arg:3}
+	old def: Just [{arg:12}]: (%case !{arg:12} [(%concase [nil] Prelude.Basics.Nil Just 0 [] (%con [nil] Prelude.Basics.Nil Just 0 [])), (%concase [cons] Prelude.Basics.(::) Just 1 [{e:2}, {e:3}] (%con [cons] Prelude.Basics.(::) Just 1 [!{e:2}, (Main.identity [!{e:3}])]))] Nothing)
+LOG compiler.identity:5: 	new def: [{arg:12}]: !{arg:12}
 LOG compiler.identity:5: found identity flag for: _PE.PE_identity_3c7f5598e5c9b732, 0
-	old def: Just [{arg:3}]: !{arg:3}
-LOG compiler.identity:5: 	new def: [{arg:3}]: !{arg:3}
+	old def: Just [{arg:11}]: !{arg:11}
+LOG compiler.identity:5: 	new def: [{arg:11}]: !{arg:11}
 LOG compiler.identity:5: found identity flag for: Main.identity, 0
-	old def: Just [{arg:3}]: !{arg:3}
-LOG compiler.identity:5: 	new def: [{arg:3}]: !{arg:3}
+	old def: Just [{arg:12}]: !{arg:12}
+LOG compiler.identity:5: 	new def: [{arg:12}]: !{arg:12}
 LOG compiler.identity:5: found identity flag for: Main.test, 0
-	old def: Just [{arg:3}]: !{arg:3}
-LOG compiler.identity:5: 	new def: [{arg:3}]: !{arg:3}
+	old def: Just [{arg:11}]: !{arg:11}
+LOG compiler.identity:5: 	new def: [{arg:11}]: !{arg:11}
 LOG compiler.identity:5: found identity flag for: _PE.PE_identity_3c7f5598e5c9b732, 0
-	old def: Just [{arg:3}]: !{arg:3}
-LOG compiler.identity:5: 	new def: [{arg:3}]: !{arg:3}
+	old def: Just [{arg:11}]: !{arg:11}
+LOG compiler.identity:5: 	new def: [{arg:11}]: !{arg:11}
 LOG compiler.identity:5: found identity flag for: Main.identity, 0
-	old def: Just [{arg:3}]: !{arg:3}
-LOG compiler.identity:5: 	new def: [{arg:3}]: !{arg:3}
+	old def: Just [{arg:12}]: !{arg:12}
+LOG compiler.identity:5: 	new def: [{arg:12}]: !{arg:12}
 LOG compiler.identity:5: found identity flag for: Main.test, 0
-	old def: Just [{arg:3}]: !{arg:3}
-LOG compiler.identity:5: 	new def: [{arg:3}]: !{arg:3}
+	old def: Just [{arg:11}]: !{arg:11}
+LOG compiler.identity:5: 	new def: [{arg:11}]: !{arg:11}

--- a/tests/testutils.sh
+++ b/tests/testutils.sh
@@ -57,7 +57,7 @@ _awk_clean_name='
     while (match($0, /(P:[A-z]+:|arg:|conArg:|ttc[\\\/][0-9]+|[$]resolved)[0-9]+|[A-z.]+:[0-9]+:[0-9]+--[0-9]+:[0-9]+|[A-z]+[.][0-9]+:[0-9]+/)) {
         rs = RSTART
         rl = RLENGTH
-        m = substr($0, rs, rl - 1)
+        m = substr($0, rs, rl)
         pfx = "XXX"
         if (match(m,/^(\$resolved|arg:|conArg:|ttc[\\\/]|P:[A-z]+:|[A-z.]+:|[A-z]+[.])/)) { pfx = substr(m, RSTART, RLENGTH) }
         if (!(m in mapping)) {


### PR DESCRIPTION
This PR fixes an off by one error in `clean_names` awk script in `testutils.sh`.  The last digit of a name was ignored, causing some names to be merged that shouldn't be.  The issue was noted by @buzden here: https://github.com/idris-lang/Idris2/pull/3156#issuecomment-1983175868 
