### PR TITLE
[fix] ambiguity error with Uninhabited interface implementations.

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -83,8 +83,7 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
   implemented through the newly added one. The similar alternative for `mapMTTImp`
   is added too.
 
-* Removed need for the runtime value of the implicit argument in `succNotLTEpred`,
-  and added its result as an `Uninhabited` instance.
+* Removed need for the runtime value of the implicit argument in `succNotLTEpred`.
 
 #### Contrib
 

--- a/libs/base/Data/Nat.idr
+++ b/libs/base/Data/Nat.idr
@@ -182,10 +182,6 @@ export
 succNotLTEpred : Not $ LTE (S x) x
 succNotLTEpred {x = (S right)} (LTESucc y) = succNotLTEpred y
 
-export
-Uninhabited (LTE (S x) x) where
-  uninhabited = succNotLTEpred
-
 public export
 isLTE : (m, n : Nat) -> Dec (LTE m n)
 isLTE Z n = Yes LTEZero

--- a/tests/base/data_nat/Properties.idr
+++ b/tests/base/data_nat/Properties.idr
@@ -1,0 +1,8 @@
+import Data.Nat
+
+lteZeroSuccAbsurd : LTE (S Z) Z -> Void
+lteZeroSuccAbsurd y = absurd y
+
+lteSuccAbsurd : LTE (S x) x -> Void
+lteSuccAbsurd y = succNotLTEpred y
+

--- a/tests/base/data_nat/expected
+++ b/tests/base/data_nat/expected
@@ -1,0 +1,1 @@
+1/1: Building Properties (Properties.idr)

--- a/tests/base/data_nat/run
+++ b/tests/base/data_nat/run
@@ -1,0 +1,3 @@
+. ../../testutils.sh
+
+check Properties.idr


### PR DESCRIPTION
closes https://github.com/idris-lang/Idris2/issues/3230

# Description
This PR reverts the addition of a new Uninhabited implementation found in https://github.com/idris-lang/Idris2/pull/3225.

That addition looked good at face value, but with small Nats it causes ambiguity with another pre-existing implementation of the same interface. I think the most reasonable solution is to remove the new interface implementation because it is in essence already a named implementation of Uninhabited (`absurd x` can be spelled `succNotLTEpred x`).

I've added a test that failed with the following ambiguity prior to reverting the interface imoplementation:
```
Error: While processing right hand side of lteZeroSuccAbsurd. Multiple solutions found in search of:
    Uninhabited (LTE 1 0)

Properties:4:23--4:31
 1 | import Data.Nat
 2 | 
 3 | lteZeroSuccAbsurd : LTE (S Z) Z -> Void
 4 | lteZeroSuccAbsurd y = absurd y
                           ^^^^^^^^

Possible correct results:
    Uninhabited implementation at Data.Nat:96:1--98:33
    Uninhabited implementation at Data.Nat:185:1--187:31
```

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

