### PR TITLE
[ elab ] Let elab scripts access visibility modifiers

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -30,6 +30,9 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
   customise the syntax of operator to look more like a binder.
   See [#3113](https://github.com/idris-lang/Idris2/issues/3113).
 
+* Elaborator scripts were made to be able to access the visibility modifier of a
+  definition, via `getVis`.
+
 ### Backend changes
 
 #### RefC

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -31,6 +31,7 @@ Giuseppe Lomurno
 Guillaume Allais
 Hiroki Hattori
 Ilya Rezvov
+Jacob Walters
 Jan de Muijnck-Hughes
 Jeetu
 Jens Petersen

--- a/libs/base/Language/Reflection.idr
+++ b/libs/base/Language/Reflection.idr
@@ -85,6 +85,8 @@ data Elab : Type -> Type where
      GetType : Name -> Elab (List (Name, TTImp))
      -- Get the metadata associated with a name
      GetInfo : Name -> Elab (List (Name, NameInfo))
+     -- Get the visibility associated with a name
+     GetVis : Name -> Elab (List (Name, Visibility))
      -- Get the type of a local variable
      GetLocalType : Name -> Elab TTImp
      -- Get the constructors of a data type. The name must be fully resolved.
@@ -181,6 +183,9 @@ interface Monad m => Elaboration m where
   ||| Get the metadata associated with a name. Returns all matching names and their types
   getInfo : Name -> m (List (Name, NameInfo))
 
+  ||| Get the visibility associated with a name. Returns all matching names and their visibilities
+  getVis : Name -> m (List (Name, Visibility))
+
   ||| Get the type of a local variable
   getLocalType : Name -> m TTImp
 
@@ -237,6 +242,7 @@ Elaboration Elab where
   inCurrentNS    = InCurrentNS
   getType        = GetType
   getInfo        = GetInfo
+  getVis         = GetVis
   getLocalType   = GetLocalType
   getCons        = GetCons
   getReferredFns = GetReferredFns
@@ -263,6 +269,7 @@ Elaboration m => MonadTrans t => Monad (t m) => Elaboration (t m) where
   inCurrentNS         = lift . inCurrentNS
   getType             = lift . getType
   getInfo             = lift . getInfo
+  getVis              = lift . getVis
   getLocalType        = lift . getLocalType
   getCons             = lift . getCons
   getReferredFns      = lift . getReferredFns

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -18,6 +18,7 @@ import Idris.REPL.Opts
 import Idris.Syntax
 
 import Libraries.Data.NameMap
+import Libraries.Data.WithDefault
 import Libraries.Utils.Path
 
 import TTImp.Elab.Check
@@ -291,6 +292,10 @@ elabScript rig fc nest env script@(NDCon nfc nm t ar args) exp
         = do n' <- evalClosure defs n
              res <- lookupNameInfo !(reify defs n') (gamma defs)
              scriptRet res
+    elabCon defs "GetVis" [n]
+        = do dn <- reify defs !(evalClosure defs n)
+             ds <- lookupCtxtName dn (gamma defs)
+             scriptRet $ map (\(n,_,d) => (n, collapseDefault $ visibility d)) ds
     elabCon defs "GetLocalType" [n]
         = do n' <- evalClosure defs n
              n <- reify defs n'

--- a/tests/idris2/reflection/reflection028/GetVis.idr
+++ b/tests/idris2/reflection/reflection028/GetVis.idr
@@ -5,3 +5,12 @@ import Language.Reflection
 private fooPriv : Int
 export fooExp : Int
 public export fooPubExp : Int
+
+namespace A
+  private foo : Int
+
+namespace B
+  export foo : Int
+
+namespace C
+  public export foo : Int

--- a/tests/idris2/reflection/reflection028/GetVis.idr
+++ b/tests/idris2/reflection/reflection028/GetVis.idr
@@ -1,0 +1,7 @@
+module GetVis
+
+import Language.Reflection
+
+private fooPriv : Int
+export fooExp : Int
+public export fooPubExp : Int

--- a/tests/idris2/reflection/reflection028/expected
+++ b/tests/idris2/reflection/reflection028/expected
@@ -1,0 +1,5 @@
+1/1: Building GetVis (GetVis.idr)
+GetVis> GetVis> [(NS (MkNS ["GetVis"]) (UN (Basic "fooPriv")), Private)]
+GetVis> [(NS (MkNS ["GetVis"]) (UN (Basic "fooExp")), Export)]
+GetVis> [(NS (MkNS ["GetVis"]) (UN (Basic "fooPubExp")), Public)]
+GetVis> Bye for now!

--- a/tests/idris2/reflection/reflection028/expected
+++ b/tests/idris2/reflection/reflection028/expected
@@ -2,4 +2,5 @@
 GetVis> GetVis> [(NS (MkNS ["GetVis"]) (UN (Basic "fooPriv")), Private)]
 GetVis> [(NS (MkNS ["GetVis"]) (UN (Basic "fooExp")), Export)]
 GetVis> [(NS (MkNS ["GetVis"]) (UN (Basic "fooPubExp")), Public)]
+GetVis> [(NS (MkNS ["A", "GetVis"]) (UN (Basic "foo")), Private), (NS (MkNS ["B", "GetVis"]) (UN (Basic "foo")), Export), (NS (MkNS ["C", "GetVis"]) (UN (Basic "foo")), Public)]
 GetVis> Bye for now!

--- a/tests/idris2/reflection/reflection028/input
+++ b/tests/idris2/reflection/reflection028/input
@@ -2,4 +2,5 @@
 %runElab getVis `{fooPriv}
 %runElab getVis `{fooExp}
 %runElab getVis `{fooPubExp}
+%runElab getVis `{foo}
 :q

--- a/tests/idris2/reflection/reflection028/input
+++ b/tests/idris2/reflection/reflection028/input
@@ -1,0 +1,5 @@
+:let %language ElabReflection
+%runElab getVis `{fooPriv}
+%runElab getVis `{fooExp}
+%runElab getVis `{fooPubExp}
+:q

--- a/tests/idris2/reflection/reflection028/run
+++ b/tests/idris2/reflection/reflection028/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+idris2 GetVis.idr < input

--- a/tests/idris2/reflection/reflection028/test.ipkg
+++ b/tests/idris2/reflection/reflection028/test.ipkg
@@ -1,0 +1,1 @@
+package a-test


### PR DESCRIPTION
# Description
This is a small extension to the elaborator that allows an elab script to query the visibility of a declaration.

As a quick example, given the following file:
```idris
private foo : Bar
export baz : Quux
namespace A
  public export foo : Bar
```

We can get do the following in the REPL:
```idris
> :let %language ElabReflection
> %runElab getVis `{foo}
[(NS (MkNS ["A", "Main"]) (UN (Basic "foo")), Public),
 (NS (MkNS ["Main"]) (UN (Basic "foo")), Private)]
> %runElab getVis `{baz}
[(NS (MkNS ["Main"]) (UN (Basic "baz")), Export)]
```

The visibilities of all declarations matching the given `Name` are returned.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

