### PR TITLE
[cleanup] Makefile boot-prefix cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ TEST_PREFIX ?= ${IDRIS2_CURDIR}/build/env
 TEST_IDRIS2_SUPPORT_DIR ?= ${TEST_PREFIX}/${NAME_VERSION}
 
 # Library and data paths for bootstrap-test
-IDRIS2_BOOT_PREFIX := ${IDRIS2_CURDIR}/bootstrap-build
+export IDRIS2_BOOT_PREFIX := ${IDRIS2_CURDIR}/bootstrap-build
 
 # These are the library path in the build dir to be used during build
 IDRIS2_LIBRARIES = prelude base linear network contrib test
@@ -265,8 +265,8 @@ bootstrap: support
 	sed 's/libidris2_support.so/${IDRIS2_SUPPORT}/g; s|__PREFIX__|${IDRIS2_BOOT_PREFIX}|g' \
 		bootstrap/idris2_app/idris2.ss \
 		> "${IDRIS2_BOOT_PREFIX}/idris2_app/idris2-boot.ss"
-	IDRIS2_BOOT_PREFIX="${IDRIS2_BOOT_PREFIX}" $(SHELL) ./bootstrap-stage1-chez.sh
-	IDRIS2_CG="chez" IDRIS2_BOOT_PREFIX="${IDRIS2_BOOT_PREFIX}" $(SHELL) ./bootstrap-stage2.sh
+	$(SHELL) ./bootstrap-stage1-chez.sh
+	IDRIS2_CG="chez" $(SHELL) ./bootstrap-stage2.sh
 
 # Bootstrapping using racket
 bootstrap-racket: support
@@ -275,8 +275,8 @@ bootstrap-racket: support
 	sed 's|__PREFIX__|${IDRIS2_BOOT_PREFIX}|g' \
 		bootstrap/idris2_app/idris2.rkt \
 		> "${IDRIS2_BOOT_PREFIX}/idris2_app/idris2-boot.rkt"
-	IDRIS2_BOOT_PREFIX="${IDRIS2_BOOT_PREFIX}" $(SHELL) ./bootstrap-stage1-racket.sh
-	IDRIS2_CG="racket" IDRIS2_BOOT_PREFIX="${IDRIS2_BOOT_PREFIX}" $(SHELL) ./bootstrap-stage2.sh
+	$(SHELL) ./bootstrap-stage1-racket.sh
+	IDRIS2_CG="racket" $(SHELL) ./bootstrap-stage2.sh
 
 bootstrap-test:
 	$(MAKE) test INTERACTIVE='' IDRIS2_PREFIX=${IDRIS2_BOOT_PREFIX}

--- a/Makefile
+++ b/Makefile
@@ -260,23 +260,23 @@ install-libdocs: libdocs
 bootstrap: support
 	@if [ "$$(echo '(threaded?)' | $(SCHEME) --quiet)" = "#f" ] ; then \
 		echo "ERROR: Chez is missing threading support" ; exit 1 ; fi
-	mkdir -p bootstrap-build/idris2_app
-	cp ${IDRIS2_SUPPORT_DIR}/${IDRIS2_SUPPORT} bootstrap-build/idris2_app/
+	mkdir -p "${IDRIS2_BOOT_PREFIX}/idris2_app"
+	cp ${IDRIS2_SUPPORT_DIR}/${IDRIS2_SUPPORT} "${IDRIS2_BOOT_PREFIX}/idris2_app/"
 	sed 's/libidris2_support.so/${IDRIS2_SUPPORT}/g; s|__PREFIX__|${IDRIS2_BOOT_PREFIX}|g' \
 		bootstrap/idris2_app/idris2.ss \
-		> bootstrap-build/idris2_app/idris2-boot.ss
-	$(SHELL) ./bootstrap-stage1-chez.sh
-	IDRIS2_CG="chez" $(SHELL) ./bootstrap-stage2.sh
+		> "${IDRIS2_BOOT_PREFIX}/idris2_app/idris2-boot.ss"
+	IDRIS2_BOOT_PREFIX="${IDRIS2_BOOT_PREFIX}" $(SHELL) ./bootstrap-stage1-chez.sh
+	IDRIS2_CG="chez" IDRIS2_BOOT_PREFIX="${IDRIS2_BOOT_PREFIX}" $(SHELL) ./bootstrap-stage2.sh
 
 # Bootstrapping using racket
 bootstrap-racket: support
-	mkdir -p bootstrap-build/idris2_app
-	cp ${IDRIS2_SUPPORT_DIR}/${IDRIS2_SUPPORT} bootstrap-build/idris2_app/
+	mkdir -p "${IDRIS2_BOOT_PREFIX}/idris2_app"
+	cp ${IDRIS2_SUPPORT_DIR}/${IDRIS2_SUPPORT} "${IDRIS2_BOOT_PREFIX}/idris2_app/"
 	sed 's|__PREFIX__|${IDRIS2_BOOT_PREFIX}|g' \
 		bootstrap/idris2_app/idris2.rkt \
-		> bootstrap-build/idris2_app/idris2-boot.rkt
-	$(SHELL) ./bootstrap-stage1-racket.sh
-	IDRIS2_CG="racket" $(SHELL) ./bootstrap-stage2.sh
+		> "${IDRIS2_BOOT_PREFIX}/idris2_app/idris2-boot.rkt"
+	IDRIS2_BOOT_PREFIX="${IDRIS2_BOOT_PREFIX}" $(SHELL) ./bootstrap-stage1-racket.sh
+	IDRIS2_CG="racket" IDRIS2_BOOT_PREFIX="${IDRIS2_BOOT_PREFIX}" $(SHELL) ./bootstrap-stage2.sh
 
 bootstrap-test:
 	$(MAKE) test INTERACTIVE='' IDRIS2_PREFIX=${IDRIS2_BOOT_PREFIX}

--- a/bootstrap-stage1-chez.sh
+++ b/bootstrap-stage1-chez.sh
@@ -9,12 +9,12 @@ if [ -z "$SCHEME" ] || [ -z "$IDRIS2_VERSION" ]; then
     fi
     exit 1
 fi
-echo "Bootstrapping SCHEME=$SCHEME IDRIS2_VERSION=$IDRIS2_VERSION"
+echo "[bootstrap] Bootstrapping SCHEME=$SCHEME IDRIS2_VERSION=$IDRIS2_VERSION"
 
 # Compile the bootstrap scheme
 # TODO: Move boot-build to Makefile in bootstrap/Makefile
 cd "${IDRIS2_BOOT_PREFIX}"
-echo "Building idris2-boot from idris2-boot.ss"
+echo "[bootstrap] Building idris2-boot from idris2-boot.ss"
 ${SCHEME} --script ../bootstrap/compile.ss
 
 # Put the result in the usual place where the target goes
@@ -30,4 +30,4 @@ cat ../bootstrap/idris2-boot.sh >>../build/exec/idris2
 chmod +x ../build/exec/idris2
 
 install idris2_app/* ../build/exec/idris2_app
-echo 'bootstrap stage 1 complete'
+echo '[bootstrap] bootstrap stage 1 complete'

--- a/bootstrap-stage1-chez.sh
+++ b/bootstrap-stage1-chez.sh
@@ -13,7 +13,7 @@ echo "Bootstrapping SCHEME=$SCHEME IDRIS2_VERSION=$IDRIS2_VERSION"
 
 # Compile the bootstrap scheme
 # TODO: Move boot-build to Makefile in bootstrap/Makefile
-cd bootstrap-build
+cd "${IDRIS2_BOOT_PREFIX}"
 echo "Building idris2-boot from idris2-boot.ss"
 ${SCHEME} --script ../bootstrap/compile.ss
 

--- a/bootstrap-stage1-racket.sh
+++ b/bootstrap-stage1-racket.sh
@@ -6,11 +6,11 @@ if [ -z "$IDRIS2_VERSION" ]; then
     echo "Required IDRIS2_VERSION env is not set."
     exit 1
 fi
-echo "Bootstrapping IDRIS2_VERSION=$IDRIS2_VERSION"
+echo "[bootstrap] Bootstrapping IDRIS2_VERSION=$IDRIS2_VERSION"
 
 # Compile the bootstrap scheme
 cd "${IDRIS2_BOOT_PREFIX}"
-echo "Building idris2-boot from idris2-boot.rkt"
+echo "[bootstrap] Building idris2-boot from idris2-boot.rkt"
 raco exe idris2_app/idris2-boot.rkt
 
 # Put the result in the usual place where the target goes
@@ -18,3 +18,4 @@ mkdir -p ../build/exec
 mkdir -p ../build/exec/idris2_app
 install ../bootstrap/idris2-rktboot.sh ../build/exec/idris2
 install idris2_app/* ../build/exec/idris2_app
+echo '[bootstrap] bootstrap stage 1 complete'

--- a/bootstrap-stage1-racket.sh
+++ b/bootstrap-stage1-racket.sh
@@ -9,7 +9,7 @@ fi
 echo "Bootstrapping IDRIS2_VERSION=$IDRIS2_VERSION"
 
 # Compile the bootstrap scheme
-cd bootstrap-build
+cd "${IDRIS2_BOOT_PREFIX}"
 echo "Building idris2-boot from idris2-boot.rkt"
 raco exe idris2_app/idris2-boot.rkt
 

--- a/bootstrap-stage2.sh
+++ b/bootstrap-stage2.sh
@@ -6,7 +6,7 @@ IDRIS2_CG="${IDRIS2_CG-"chez"}"
 
 # IDRIS2_BOOT_PREFIX must be the "clean" build root, without cygpath -m
 # Otherwise, we get 'git: Bad address'
-echo "bootstrapping in: $IDRIS2_BOOT_PREFIX"
+echo "[bootstrap] bootstrapping in: $IDRIS2_BOOT_PREFIX"
 export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-"${IDRIS2_BOOT_PREFIX}/lib"}"
 export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH:-"${IDRIS2_BOOT_PREFIX}/lib"}"
 export IDRIS2_DATA="${IDRIS2_DATA:-"${IDRIS2_BOOT_PREFIX}/support"}"
@@ -17,7 +17,8 @@ $MAKE bootstrap-install IDRIS2_CG="$IDRIS2_CG" \
     PREFIX="$IDRIS2_BOOT_PREFIX" SCHEME="$SCHEME"
 
 # Now rebuild everything properly
+echo '[bootstrap] cleaning and rebuilding...'
 $MAKE clean-libs IDRIS2_BOOT="$IDRIS2_BOOT_PREFIX/bin/idris2"
 $MAKE all IDRIS2_BOOT="$IDRIS2_BOOT_PREFIX/bin/idris2" IDRIS2_CG="$IDRIS2_CG" \
     SCHEME="$SCHEME"
-echo 'bootstrap stage 2 complete'
+echo '[bootstrap] stage 2 complete'

--- a/bootstrap-stage2.sh
+++ b/bootstrap-stage2.sh
@@ -2,24 +2,22 @@
 
 set -e # exit on any error
 
-BOOTSTRAP_PREFIX=$PWD/bootstrap-build
-
 IDRIS2_CG="${IDRIS2_CG-"chez"}"
 
-# BOOTSTRAP_PREFIX must be the "clean" build root, without cygpath -m
+# IDRIS2_BOOT_PREFIX must be the "clean" build root, without cygpath -m
 # Otherwise, we get 'git: Bad address'
-echo "bootstrapping in: $BOOTSTRAP_PREFIX"
-export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-"${BOOTSTRAP_PREFIX}/lib"}"
-export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH:-"${BOOTSTRAP_PREFIX}/lib"}"
-export IDRIS2_DATA="${IDRIS2_DATA:-"${BOOTSTRAP_PREFIX}/support"}"
+echo "bootstrapping in: $IDRIS2_BOOT_PREFIX"
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-"${IDRIS2_BOOT_PREFIX}/lib"}"
+export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH:-"${IDRIS2_BOOT_PREFIX}/lib"}"
+export IDRIS2_DATA="${IDRIS2_DATA:-"${IDRIS2_BOOT_PREFIX}/support"}"
 
 $MAKE bootstrap-libs IDRIS2_CG="$IDRIS2_CG" \
-    PREFIX="$BOOTSTRAP_PREFIX" SCHEME="$SCHEME"
+    PREFIX="$IDRIS2_BOOT_PREFIX" SCHEME="$SCHEME"
 $MAKE bootstrap-install IDRIS2_CG="$IDRIS2_CG" \
-    PREFIX="$BOOTSTRAP_PREFIX" SCHEME="$SCHEME"
+    PREFIX="$IDRIS2_BOOT_PREFIX" SCHEME="$SCHEME"
 
 # Now rebuild everything properly
-$MAKE clean-libs IDRIS2_BOOT="$BOOTSTRAP_PREFIX/bin/idris2"
-$MAKE all IDRIS2_BOOT="$BOOTSTRAP_PREFIX/bin/idris2" IDRIS2_CG="$IDRIS2_CG" \
+$MAKE clean-libs IDRIS2_BOOT="$IDRIS2_BOOT_PREFIX/bin/idris2"
+$MAKE all IDRIS2_BOOT="$IDRIS2_BOOT_PREFIX/bin/idris2" IDRIS2_CG="$IDRIS2_CG" \
     SCHEME="$SCHEME"
 echo 'bootstrap stage 2 complete'

--- a/bootstrap-stage2.sh
+++ b/bootstrap-stage2.sh
@@ -7,9 +7,10 @@ IDRIS2_CG="${IDRIS2_CG-"chez"}"
 # IDRIS2_BOOT_PREFIX must be the "clean" build root, without cygpath -m
 # Otherwise, we get 'git: Bad address'
 echo "[bootstrap] bootstrapping in: $IDRIS2_BOOT_PREFIX"
-export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-"${IDRIS2_BOOT_PREFIX}/lib"}"
-export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH:-"${IDRIS2_BOOT_PREFIX}/lib"}"
-export IDRIS2_DATA="${IDRIS2_DATA:-"${IDRIS2_BOOT_PREFIX}/support"}"
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-"${IDRIS2_BOOT_PREFIX}/idris2-0.7.0/lib"}"
+export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH:-"${IDRIS2_BOOT_PREFIX}/idris2-0.7.0/lib"}"
+export PATH="${PATH:-"${IDRIS2_BOOT_PREFIX}/idris2-0.7.0/lib"}"
+export IDRIS2_DATA="${IDRIS2_DATA:-"${IDRIS2_BOOT_PREFIX}/idris2-0.7.0/support"}"
 
 $MAKE bootstrap-libs IDRIS2_CG="$IDRIS2_CG" \
     PREFIX="$IDRIS2_BOOT_PREFIX" SCHEME="$SCHEME"
@@ -19,6 +20,8 @@ $MAKE bootstrap-install IDRIS2_CG="$IDRIS2_CG" \
 # Now rebuild everything properly
 echo '[bootstrap] cleaning and rebuilding...'
 $MAKE clean-libs IDRIS2_BOOT="$IDRIS2_BOOT_PREFIX/bin/idris2"
+echo "triage -- $(ls ${IDRIS2_BOOT_PREFIX})"
+echo "triage -- $(ls ${IDRIS2_BOOT_PREFIX}/idris2-*/lib)"
 $MAKE all IDRIS2_BOOT="$IDRIS2_BOOT_PREFIX/bin/idris2" IDRIS2_CG="$IDRIS2_CG" \
     SCHEME="$SCHEME"
 echo '[bootstrap] stage 2 complete'


### PR DESCRIPTION
# Description

This PR does two things:
1. Anywhere that `bootstrap-build` was hard-coded, I've swapped in `${IDRIS2_BOOT_PREFIX}` to avoid unnecessary risk of breakage in the future.
2. I've replaced bootstrap-stage2 `${BOOTSTRAP_PREFIX}` with `${IDRIS2_BOOT_PREFIX}` as well; this was just another name for the same thing.

This was a fairly straight forward refactor; no intentions of making things behave differently or wiring things up in a different manner (aside from reducing the locations where bootstrap build prefixes needed to be defined).

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

