### PR TITLE
[fix] macos-nix build: refc support files don't build under default environment anymore

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -19,9 +19,16 @@ stdenv.mkDerivation rec {
     ++ lib.optional (!bootstrap) [ idris2Bootstrap ];
   buildInputs = [ chez gmp support ];
 
+  # For bootstrap builds the Makefile will try to
+  # rebuild the support library if we don't patch
+  # bootstrap-install.
   prePatch = ''
     patchShebangs --build tests
-    sed 's/$(GIT_SHA1)/${srcRev}/' -i Makefile
+    substituteInPlace Makefile \
+      --replace-fail '$(GIT_SHA1)' '${srcRev}'
+  '' + lib.optionalString bootstrap ''
+    substituteInPlace Makefile \
+      --replace-fail 'bootstrap-install: install-idris2 install-support' 'bootstrap-install: install-idris2'
   '';
 
   makeFlags = [ "IDRIS2_SUPPORT_DIR=${supportLibrariesPath}" ]

--- a/nix/support.nix
+++ b/nix/support.nix
@@ -1,5 +1,8 @@
-{ stdenv, lib, gmp, idris2Version }:
-stdenv.mkDerivation rec {
+{ stdenv, lib, overrideSDK, gmp, idris2Version }:
+let
+  stdenv' = if stdenv.isDarwin then overrideSDK stdenv "11.0" else stdenv;
+in
+stdenv'.mkDerivation rec {
   pname = "libidris2_support";
   version = idris2Version;
 
@@ -10,7 +13,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "PREFIX=$(out)"
-  ] ++ lib.optional stdenv.isDarwin "OS=";
+  ] ++ lib.optional stdenv'.isDarwin "OS=";
 
   buildFlags = [ "support" ];
 


### PR DESCRIPTION
# Description

Recent changes to the Refc support files require a newer version of the macOS stdenv than Nixpkgs defaults to. This PR builds the Support derivation against the newer stdenv and patches a spot where the support derivation would have otherwise been rebuilt as part of the bootstrapping process.

This has no impact on non-nix builds for non-macos platforms.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

