### PR TITLE
[ re #3177 ] Separate the renaming from the rest

### DIFF
--- a/support/refc/casts.h
+++ b/support/refc/casts.h
@@ -74,7 +74,7 @@ Value *idris2_cast_Int32_to_string(Value *);
   (idris2_mkInt16((int16_t)idris2_vp_to_Int64(x)))
 #define idris2_cast_Int64_to_Int32(x)                                          \
   (idris2_mkInt32((int32_t)idris2_vp_to_Int64(x)))
-#define idris2_cast_Int64_to_Int64(x) (newReference(x))
+#define idris2_cast_Int64_to_Int64(x) (idris2_newReference(x))
 Value *idris2_cast_Int64_to_Integer(Value *);
 #define idris2_cast_Int64_to_Double(x)                                         \
   (idris2_mkDouble((double)idris2_vp_to_Int64(x)))

--- a/support/refc/memoryManagement.c
+++ b/support/refc/memoryManagement.c
@@ -1,7 +1,7 @@
 #include "refc_util.h"
 #include "runtime.h"
 
-Value *newValue(size_t size) {
+Value *idris2_newValue(size_t size) {
 #if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) /* C11 */
   Value *retVal = (Value *)aligned_alloc(
       sizeof(void *),
@@ -15,7 +15,7 @@ Value *newValue(size_t size) {
   return retVal;
 }
 
-Value_Arglist *newArglist(int missing, int total) {
+Value_Arglist *idris2_newArglist(int missing, int total) {
   Value_Arglist *retVal = IDRIS2_NEW_VALUE(Value_Arglist);
   retVal->header.tag = ARGLIST_TAG;
   retVal->total = total;
@@ -25,8 +25,8 @@ Value_Arglist *newArglist(int missing, int total) {
   return retVal;
 }
 
-Value_Constructor *newConstructor(int total, int tag) {
-  Value_Constructor *retVal = (Value_Constructor *)newValue(
+Value_Constructor *idris2_newConstructor(int total, int tag) {
+  Value_Constructor *retVal = (Value_Constructor *)idris2_newValue(
       sizeof(Value_Constructor) + sizeof(Value *) * total);
   retVal->header.tag = CONSTRUCTOR_TAG;
   retVal->total = total;
@@ -35,7 +35,7 @@ Value_Constructor *newConstructor(int total, int tag) {
   return retVal;
 }
 
-Value_Closure *makeClosureFromArglist(fun_ptr_t f, Value_Arglist *arglist) {
+Value_Closure *idris2_makeClosureFromArglist(fun_ptr_t f, Value_Arglist *arglist) {
   Value_Closure *retVal = IDRIS2_NEW_VALUE(Value_Closure);
   retVal->header.tag = CLOSURE_TAG;
   retVal->arglist = arglist; // (Value_Arglist *)newReference((Value*)arglist);
@@ -112,29 +112,29 @@ Value_String *idris2_mkString(char *s) {
   return retVal;
 }
 
-Value_Pointer *makePointer(void *ptr_Raw) {
+Value_Pointer *idris2_makePointer(void *ptr_Raw) {
   Value_Pointer *p = IDRIS2_NEW_VALUE(Value_Pointer);
   p->header.tag = POINTER_TAG;
   p->p = ptr_Raw;
   return p;
 }
 
-Value_GCPointer *makeGCPointer(void *ptr_Raw, Value_Closure *onCollectFct) {
+Value_GCPointer *idris2_makeGCPointer(void *ptr_Raw, Value_Closure *onCollectFct) {
   Value_GCPointer *p = IDRIS2_NEW_VALUE(Value_GCPointer);
   p->header.tag = GC_POINTER_TAG;
-  p->p = makePointer(ptr_Raw);
+  p->p = idris2_makePointer(ptr_Raw);
   p->onCollectFct = onCollectFct;
   return p;
 }
 
-Value_Buffer *makeBuffer(void *buf) {
+Value_Buffer *idris2_makeBuffer(void *buf) {
   Value_Buffer *b = IDRIS2_NEW_VALUE(Value_Buffer);
   b->header.tag = BUFFER_TAG;
   b->buffer = buf;
   return b;
 }
 
-Value_Array *makeArray(int length) {
+Value_Array *idris2_makeArray(int length) {
   Value_Array *a = IDRIS2_NEW_VALUE(Value_Array);
   a->header.tag = ARRAY_TAG;
   a->capacity = length;
@@ -143,7 +143,7 @@ Value_Array *makeArray(int length) {
   return a;
 }
 
-Value *newReference(Value *source) {
+Value *idris2_newReference(Value *source) {
   // note that we explicitly allow NULL as source (for erased arguments)
   if (source && !idris2_vp_is_unboxed(source)) {
     source->header.refCounter++;
@@ -151,7 +151,7 @@ Value *newReference(Value *source) {
   return source;
 }
 
-void removeReference(Value *elem) {
+void idris2_removeReference(Value *elem) {
   if (!elem || idris2_vp_is_unboxed(elem)) {
     return;
   }
@@ -184,19 +184,19 @@ void removeReference(Value *elem) {
     case CLOSURE_TAG: {
       Value_Closure *cl = (Value_Closure *)elem;
       Value_Arglist *al = cl->arglist;
-      removeReference((Value *)al);
+      idris2_removeReference((Value *)al);
       break;
     }
     case COMPLETE_CLOSURE_TAG: {
       Value_Closure *cl = (Value_Closure *)elem;
       Value_Arglist *al = cl->arglist;
-      removeReference((Value *)al);
+      idris2_removeReference((Value *)al);
       break;
     }
     case ARGLIST_TAG: {
       Value_Arglist *al = (Value_Arglist *)elem;
       for (int i = 0; i < al->filled; i++) {
-        removeReference(al->args[i]);
+        idris2_removeReference(al->args[i]);
       }
       free(al->args);
       break;
@@ -204,12 +204,12 @@ void removeReference(Value *elem) {
     case CONSTRUCTOR_TAG: {
       Value_Constructor *constr = (Value_Constructor *)elem;
       for (int i = 0; i < constr->total; i++) {
-        removeReference(constr->args[i]);
+        idris2_removeReference(constr->args[i]);
       }
       break;
     }
     case IOREF_TAG:
-      removeReference(((Value_IORef *)elem)->v);
+      idris2_removeReference(((Value_IORef *)elem)->v);
       break;
 
     case BUFFER_TAG: {
@@ -221,7 +221,7 @@ void removeReference(Value *elem) {
     case ARRAY_TAG: {
       Value_Array *a = (Value_Array *)elem;
       for (int i = 0; i < a->capacity; i++) {
-        removeReference(a->arr[i]);
+        idris2_removeReference(a->arr[i]);
       }
       free(a->arr);
       break;
@@ -234,9 +234,9 @@ void removeReference(Value *elem) {
       /* maybe here we need to invoke onCollectAny */
       Value_GCPointer *vPtr = (Value_GCPointer *)elem;
       Value *closure1 =
-          apply_closure((Value *)vPtr->onCollectFct, (Value *)vPtr->p);
-      apply_closure(closure1, NULL);
-      removeReference((Value *)vPtr->p);
+          idris2_apply_closure((Value *)vPtr->onCollectFct, (Value *)vPtr->p);
+      idris2_apply_closure(closure1, NULL);
+      idris2_removeReference((Value *)vPtr->p);
       break;
     }
 

--- a/support/refc/memoryManagement.c
+++ b/support/refc/memoryManagement.c
@@ -35,7 +35,8 @@ Value_Constructor *idris2_newConstructor(int total, int tag) {
   return retVal;
 }
 
-Value_Closure *idris2_makeClosureFromArglist(fun_ptr_t f, Value_Arglist *arglist) {
+Value_Closure *idris2_makeClosureFromArglist(fun_ptr_t f,
+                                             Value_Arglist *arglist) {
   Value_Closure *retVal = IDRIS2_NEW_VALUE(Value_Closure);
   retVal->header.tag = CLOSURE_TAG;
   retVal->arglist = arglist; // (Value_Arglist *)newReference((Value*)arglist);
@@ -119,7 +120,8 @@ Value_Pointer *idris2_makePointer(void *ptr_Raw) {
   return p;
 }
 
-Value_GCPointer *idris2_makeGCPointer(void *ptr_Raw, Value_Closure *onCollectFct) {
+Value_GCPointer *idris2_makeGCPointer(void *ptr_Raw,
+                                      Value_Closure *onCollectFct) {
   Value_GCPointer *p = IDRIS2_NEW_VALUE(Value_GCPointer);
   p->header.tag = GC_POINTER_TAG;
   p->p = idris2_makePointer(ptr_Raw);

--- a/support/refc/memoryManagement.h
+++ b/support/refc/memoryManagement.h
@@ -63,6 +63,7 @@ Value_String *idris2_mkEmptyString(size_t l);
 Value_String *idris2_mkString(char *);
 
 Value_Pointer *idris2_makePointer(void *);
-Value_GCPointer *idris2_makeGCPointer(void *ptr_Raw, Value_Closure *onCollectFct);
+Value_GCPointer *idris2_makeGCPointer(void *ptr_Raw,
+                                      Value_Closure *onCollectFct);
 Value_Buffer *idris2_makeBuffer(void *buf);
 Value_Array *idris2_makeArray(int length);

--- a/support/refc/memoryManagement.h
+++ b/support/refc/memoryManagement.h
@@ -2,17 +2,17 @@
 
 #include "cBackend.h"
 
-Value *newValue(size_t size);
-Value *newReference(Value *source);
-void removeReference(Value *source);
+Value *idris2_newValue(size_t size);
+Value *idris2_newReference(Value *source);
+void idris2_removeReference(Value *source);
 
-#define IDRIS2_NEW_VALUE(t) ((t *)newValue(sizeof(t)))
+#define IDRIS2_NEW_VALUE(t) ((t *)idris2_newValue(sizeof(t)))
 
-Value_Arglist *newArglist(int missing, int total);
-Value_Constructor *newConstructor(int total, int tag);
+Value_Arglist *idris2_newArglist(int missing, int total);
+Value_Constructor *idris2_newConstructor(int total, int tag);
 
 // copies arglist, no pointer bending
-Value_Closure *makeClosureFromArglist(fun_ptr_t f, Value_Arglist *);
+Value_Closure *idris2_makeClosureFromArglist(fun_ptr_t f, Value_Arglist *);
 
 Value *idris2_mkDouble(double d);
 #define idris2_mkChar(x)                                                       \
@@ -62,7 +62,7 @@ Value_Integer *idris2_mkIntegerLiteral(char *i);
 Value_String *idris2_mkEmptyString(size_t l);
 Value_String *idris2_mkString(char *);
 
-Value_Pointer *makePointer(void *);
-Value_GCPointer *makeGCPointer(void *ptr_Raw, Value_Closure *onCollectFct);
-Value_Buffer *makeBuffer(void *buf);
-Value_Array *makeArray(int length);
+Value_Pointer *idris2_makePointer(void *);
+Value_GCPointer *idris2_makeGCPointer(void *ptr_Raw, Value_Closure *onCollectFct);
+Value_Buffer *idris2_makeBuffer(void *buf);
+Value_Array *idris2_makeArray(int length);

--- a/support/refc/prim.c
+++ b/support/refc/prim.c
@@ -7,17 +7,17 @@ Value *idris2_Data_IORef_prim__newIORef(Value *erased, Value *input_value,
                                         Value *_world) {
   Value_IORef *ioRef = IDRIS2_NEW_VALUE(Value_IORef);
   ioRef->header.tag = IOREF_TAG;
-  ioRef->v = newReference(input_value);
+  ioRef->v = idris2_newReference(input_value);
   return (Value *)ioRef;
 }
 
 Value *idris2_Data_IORef_prim__writeIORef(Value *erased, Value *_ioref,
                                           Value *new_value, Value *_world) {
   Value_IORef *ioref = (Value_IORef *)_ioref;
-  newReference(new_value);
+  idris2_newReference(new_value);
   Value *old = ioref->v;
   ioref->v = new_value;
-  removeReference(old);
+  idris2_removeReference(old);
   return NULL;
 }
 
@@ -53,7 +53,7 @@ Value *idris2_System_Info_prim__os(void) {
 #endif
     );
   }
-  return newReference(osstring);
+  return idris2_newReference(osstring);
 }
 
 // NOTE: The codegen is obviously determined at compile time,
@@ -64,7 +64,7 @@ static Value *codegenstring = NULL;
 Value *idris2_System_Info_prim__codegen(void) {
   if (codegenstring == NULL)
     codegenstring = (Value *)idris2_mkString("refc");
-  return newReference(codegenstring);
+  return idris2_newReference(codegenstring);
 }
 
 Value *idris2_crash(Value *msg) {
@@ -83,10 +83,10 @@ Value *idris2_crash(Value *msg) {
 Value *idris2_Data_IOArray_Prims_prim__newArray(Value *erased, Value *_length,
                                                 Value *v, Value *_word) {
   int length = idris2_vp_to_Int64(_length);
-  Value_Array *a = makeArray(length);
+  Value_Array *a = idris2_makeArray(length);
 
   for (int i = 0; i < length; i++) {
-    a->arr[i] = newReference(v);
+    a->arr[i] = idris2_newReference(v);
   }
 
   return (Value *)a;
@@ -96,8 +96,8 @@ Value *idris2_Data_IOArray_Prims_prim__arraySet(Value *erased, Value *_array,
                                                 Value *index, Value *v,
                                                 Value *_word) {
   Value_Array *a = (Value_Array *)_array;
-  removeReference(a->arr[idris2_vp_to_Int64(index)]);
-  a->arr[idris2_vp_to_Int64(index)] = newReference(v);
+  idris2_removeReference(a->arr[idris2_vp_to_Int64(index)]);
+  a->arr[idris2_vp_to_Int64(index)] = idris2_newReference(v);
   return NULL;
 }
 
@@ -111,7 +111,7 @@ Value *idris2_Prelude_IO_prim__onCollect(Value *_erased, Value *_anyPtr,
                                          Value *_world) {
   Value_GCPointer *retVal = IDRIS2_NEW_VALUE(Value_GCPointer);
   retVal->header.tag = GC_POINTER_TAG;
-  retVal->p = (Value_Pointer *)newReference(_anyPtr);
+  retVal->p = (Value_Pointer *)idris2_newReference(_anyPtr);
   retVal->onCollectFct = (Value_Closure *)_freeingFunction;
   return (Value *)retVal;
 }
@@ -121,7 +121,7 @@ Value *idris2_Prelude_IO_prim__onCollectAny(Value *_anyPtr,
                                             Value *_world) {
   Value_GCPointer *retVal = IDRIS2_NEW_VALUE(Value_GCPointer);
   retVal->header.tag = GC_POINTER_TAG;
-  retVal->p = (Value_Pointer *)newReference(_anyPtr);
+  retVal->p = (Value_Pointer *)idris2_newReference(_anyPtr);
   retVal->onCollectFct = (Value_Closure *)_freeingFunction;
   return (Value *)retVal;
 }

--- a/support/refc/prim.h
+++ b/support/refc/prim.h
@@ -6,7 +6,7 @@
 
 Value *idris2_Data_IORef_prim__newIORef(Value *, Value *, Value *);
 #define idris2_Data_IORef_prim__readIORef(erased, ioref, world)                \
-  (newReference(((Value_IORef *)ioref)->v))
+  (idris2_newReference(((Value_IORef *)ioref)->v))
 
 Value *idris2_Data_IORef_prim__writeIORef(Value *, Value *, Value *, Value *);
 
@@ -21,7 +21,7 @@ Value *idris2_crash(Value *msg);
 Value *idris2_Data_IOArray_Prims_prim__newArray(Value *, Value *, Value *,
                                                 Value *);
 #define idris2_Data_IOArray_Prims_prim__arrayGet(rased, array, i, word)        \
-  (newReference(((Value_Array *)(array))->arr[idris2_vp_to_Int64(i)]))
+  (idris2_newReference(((Value_Array *)(array))->arr[idris2_vp_to_Int64(i)]))
 Value *idris2_Data_IOArray_Prims_prim__arraySet(Value *, Value *, Value *,
                                                 Value *, Value *);
 

--- a/support/refc/runtime.c
+++ b/support/refc/runtime.c
@@ -141,7 +141,8 @@ Value *idris2_trampoline(Value *closure) {
 
   fun_ptr_t f = ((Value_Closure *)closure)->f;
   Value_Arglist *_arglist = ((Value_Closure *)closure)->arglist;
-  Value_Arglist *arglist = (Value_Arglist *)idris2_newReference((Value *)_arglist);
+  Value_Arglist *arglist =
+      (Value_Arglist *)idris2_newReference((Value *)_arglist);
   idris2_removeReference(closure);
   while (1) {
     Value *retVal = f(arglist);

--- a/support/refc/runtime.c
+++ b/support/refc/runtime.c
@@ -1,21 +1,21 @@
 #include "runtime.h"
 #include "refc_util.h"
 
-void missing_ffi() {
+void idris2_missing_ffi() {
   fprintf(stderr, "Foreign function declared, but not defined.\n"
                   "Cannot call missing FFI - aborting.\n");
   exit(1);
 }
 
-void push_Arglist(Value_Arglist *arglist, Value *arg) {
+void idris2_push_Arglist(Value_Arglist *arglist, Value *arg) {
   IDRIS2_REFC_VERIFY(arglist->filled < arglist->total,
                      "unable to add more arguments to arglist");
 
-  arglist->args[arglist->filled] = newReference(arg);
+  arglist->args[arglist->filled] = idris2_newReference(arg);
   arglist->filled++;
 }
 
-int isUnique(Value *value) {
+int idris2_isUnique(Value *value) {
   if (value) {
     return value->header.refCounter == 1;
   }
@@ -23,7 +23,7 @@ int isUnique(Value *value) {
 }
 
 // necessary because not every variable passed as arguments is duplicated
-void deconstructArglist(Value_Arglist *arglist) {
+void idris2_deconstructArglist(Value_Arglist *arglist) {
   IDRIS2_REFC_VERIFY(arglist->header.refCounter > 0, "refCounter %lld",
                      (long long)arglist->header.refCounter);
   arglist->header.refCounter--;
@@ -33,17 +33,17 @@ void deconstructArglist(Value_Arglist *arglist) {
   }
 }
 
-void deconstructClosure(Value_Closure *clos) {
+void idris2_deconstructClosure(Value_Closure *clos) {
   IDRIS2_REFC_VERIFY(clos->header.refCounter > 0, "refCounter %lld",
                      (long long)clos->header.refCounter);
   clos->header.refCounter--;
   if (clos->header.refCounter == 0) {
-    deconstructArglist(clos->arglist);
+    idris2_deconstructArglist(clos->arglist);
     free(clos);
   }
 }
 
-void removeReuseConstructor(Value_Constructor *constr) {
+void idris2_removeReuseConstructor(Value_Constructor *constr) {
   if (!constr) {
     return;
   }
@@ -55,10 +55,10 @@ void removeReuseConstructor(Value_Constructor *constr) {
   }
 }
 
-Value_Arglist *makeArglistToApplyClosure(Value *_clos, Value *arg) {
+Value_Arglist *idris2_makeArglistToApplyClosure(Value *_clos, Value *arg) {
   // create a new arg list
   Value_Arglist *oldArgs = ((Value_Closure *)_clos)->arglist;
-  Value_Arglist *newArgs = newArglist(0, oldArgs->total);
+  Value_Arglist *newArgs = idris2_newArglist(0, oldArgs->total);
   newArgs->filled = oldArgs->filled + 1;
   // add argument to new arglist
   for (int i = 0; i < oldArgs->filled; i++) {
@@ -69,48 +69,48 @@ Value_Arglist *makeArglistToApplyClosure(Value *_clos, Value *arg) {
     if (_clos->header.refCounter <= 1)
       newArgs->args[i] = oldArgs->args[i];
     else
-      newArgs->args[i] = newReference(oldArgs->args[i]);
+      newArgs->args[i] = idris2_newReference(oldArgs->args[i]);
   }
   newArgs->args[oldArgs->filled] = arg;
   return newArgs;
 }
 
-Value *apply_closure(Value *_clos, Value *arg) {
-  Value_Arglist *newArgs = makeArglistToApplyClosure(_clos, arg);
+Value *idris2_apply_closure(Value *_clos, Value *arg) {
+  Value_Arglist *newArgs = idris2_makeArglistToApplyClosure(_clos, arg);
 
   Value_Closure *clos = (Value_Closure *)_clos;
   fun_ptr_t f = clos->f;
 
-  deconstructClosure(clos);
+  idris2_deconstructClosure(clos);
 
   // check if enough arguments exist
   if (newArgs->filled >= newArgs->total) {
     while (1) {
       Value *retVal = f(newArgs);
-      deconstructArglist(newArgs);
+      idris2_deconstructArglist(newArgs);
       if (!retVal || idris2_vp_is_unboxed(retVal) ||
           retVal->header.tag != COMPLETE_CLOSURE_TAG) {
         return retVal;
       }
       f = ((Value_Closure *)retVal)->f;
       newArgs = ((Value_Closure *)retVal)->arglist;
-      newArgs = (Value_Arglist *)newReference((Value *)newArgs);
-      removeReference(retVal);
+      newArgs = (Value_Arglist *)idris2_newReference((Value *)newArgs);
+      idris2_removeReference(retVal);
     }
   }
 
-  return (Value *)makeClosureFromArglist(f, newArgs);
+  return (Value *)idris2_makeClosureFromArglist(f, newArgs);
 }
 
-Value *tailcall_apply_closure(Value *_clos, Value *arg) {
-  Value_Arglist *newArgs = makeArglistToApplyClosure(_clos, arg);
+Value *idris2_tailcall_apply_closure(Value *_clos, Value *arg) {
+  Value_Arglist *newArgs = idris2_makeArglistToApplyClosure(_clos, arg);
 
   Value_Closure *clos = (Value_Closure *)_clos;
   fun_ptr_t f = ((Value_Closure *)clos)->f;
 
-  deconstructClosure(clos);
+  idris2_deconstructClosure(clos);
 
-  return (Value *)makeClosureFromArglist(f, newArgs);
+  return (Value *)idris2_makeClosureFromArglist(f, newArgs);
 }
 
 int idris2_extractInt(Value *v) {
@@ -135,25 +135,25 @@ int idris2_extractInt(Value *v) {
   }
 }
 
-Value *trampoline(Value *closure) {
+Value *idris2_trampoline(Value *closure) {
   if (!closure || idris2_vp_is_unboxed(closure))
     return closure;
 
   fun_ptr_t f = ((Value_Closure *)closure)->f;
   Value_Arglist *_arglist = ((Value_Closure *)closure)->arglist;
-  Value_Arglist *arglist = (Value_Arglist *)newReference((Value *)_arglist);
-  removeReference(closure);
+  Value_Arglist *arglist = (Value_Arglist *)idris2_newReference((Value *)_arglist);
+  idris2_removeReference(closure);
   while (1) {
     Value *retVal = f(arglist);
-    deconstructArglist(arglist);
+    idris2_deconstructArglist(arglist);
     if (!retVal || idris2_vp_is_unboxed(retVal) ||
         retVal->header.tag != COMPLETE_CLOSURE_TAG) {
       return retVal;
     }
     f = ((Value_Closure *)retVal)->f;
     arglist = ((Value_Closure *)retVal)->arglist;
-    arglist = (Value_Arglist *)newReference((Value *)arglist);
-    removeReference(retVal);
+    arglist = (Value_Arglist *)idris2_newReference((Value *)arglist);
+    idris2_removeReference(retVal);
   }
   return NULL;
 }

--- a/support/refc/runtime.h
+++ b/support/refc/runtime.h
@@ -2,14 +2,14 @@
 
 #include "cBackend.h"
 
-void missing_ffi();
+void idris2_missing_ffi();
 
-int isUnique(Value *value);
-void removeReuseConstructor(Value_Constructor *constr);
+int idris2_isUnique(Value *value);
+void idris2_removeReuseConstructor(Value_Constructor *constr);
 
-Value *apply_closure(Value *, Value *arg);
-void push_Arglist(Value_Arglist *arglist, Value *arg);
+Value *idris2_apply_closure(Value *, Value *arg);
+void idris2_push_Arglist(Value_Arglist *arglist, Value *arg);
 
 int idris2_extractInt(Value *);
-Value *trampoline(Value *closure);
-Value *tailcall_apply_closure(Value *_clos, Value *arg);
+Value *idris2_trampoline(Value *closure);
+Value *idris2_tailcall_apply_closure(Value *_clos, Value *arg);

--- a/support/refc/stringOps.c
+++ b/support/refc/stringOps.c
@@ -167,7 +167,8 @@ Value *stringIteratorNew(char *str) {
 
   Value_Arglist *arglist = idris2_newArglist(2, 2);
   Value *(*onCollectRaw)(Value_Arglist *) = onCollectStringIterator_arglist;
-  Value_Closure *onCollect = idris2_makeClosureFromArglist(onCollectRaw, arglist);
+  Value_Closure *onCollect =
+      idris2_makeClosureFromArglist(onCollectRaw, arglist);
 
   return (Value *)idris2_makeGCPointer(it, onCollect);
 }
@@ -188,7 +189,7 @@ Value *stringIteratorToString(void *a, char *str, Value *it_p,
                               Value_Closure *f) {
   String_Iterator *it = ((Value_GCPointer *)it_p)->p->p;
   return idris2_apply_closure(idris2_newReference((Value *)f),
-                       (Value *)idris2_mkString(it->str + it->pos));
+                              (Value *)idris2_mkString(it->str + it->pos));
 }
 
 Value *stringIteratorNext(char *s, Value *it_p) {

--- a/support/refc/stringOps.c
+++ b/support/refc/stringOps.c
@@ -103,14 +103,14 @@ Value *fastUnpack(char *str) {
     return (Value *)NULL;
   }
 
-  Value_Constructor *retVal = newConstructor(2, 1);
+  Value_Constructor *retVal = idris2_newConstructor(2, 1);
   retVal->args[0] = idris2_mkChar(str[0]);
 
   int i = 1;
-  Value_Constructor *current = retVal;
+  Value_Constructor *current = (Value_Constructor *)retVal;
   Value_Constructor *next;
   while (str[i] != '\0') {
-    next = newConstructor(2, 1);
+    next = idris2_newConstructor(2, 1);
     next->args[0] = idris2_mkChar(str[i]);
     current->args[1] = (Value *)next;
 
@@ -165,11 +165,11 @@ Value *stringIteratorNew(char *str) {
   it->pos = 0;
   memcpy(it->str, str, l + 1); // Take a copy of str, in case it gets GCed
 
-  Value_Arglist *arglist = newArglist(2, 2);
+  Value_Arglist *arglist = idris2_newArglist(2, 2);
   Value *(*onCollectRaw)(Value_Arglist *) = onCollectStringIterator_arglist;
-  Value_Closure *onCollect = makeClosureFromArglist(onCollectRaw, arglist);
+  Value_Closure *onCollect = idris2_makeClosureFromArglist(onCollectRaw, arglist);
 
-  return (Value *)makeGCPointer(it, onCollect);
+  return (Value *)idris2_makeGCPointer(it, onCollect);
 }
 
 Value *onCollectStringIterator(Value_Pointer *ptr, void *null) {
@@ -187,7 +187,7 @@ Value *onCollectStringIterator_arglist(Value_Arglist *arglist) {
 Value *stringIteratorToString(void *a, char *str, Value *it_p,
                               Value_Closure *f) {
   String_Iterator *it = ((Value_GCPointer *)it_p)->p->p;
-  return apply_closure(newReference((Value *)f),
+  return idris2_apply_closure(idris2_newReference((Value *)f),
                        (Value *)idris2_mkString(it->str + it->pos));
 }
 
@@ -201,9 +201,9 @@ Value *stringIteratorNext(char *s, Value *it_p) {
 
   it->pos++; // Ok to do this as StringIterator linear
 
-  Value_Constructor *retVal = newConstructor(2, 1);
+  Value_Constructor *retVal = idris2_newConstructor(2, 1);
   retVal->args[0] = (Value *)idris2_mkChar(c);
-  retVal->args[1] = newReference(it_p);
+  retVal->args[1] = idris2_newReference(it_p);
 
   return (Value *)retVal;
 }

--- a/tests/refc/callingConvention/expected
+++ b/tests/refc/callingConvention/expected
@@ -16,17 +16,17 @@ Value *Main_last
     } else if (NULL != var_0 /* Prelude.Basics.(::) [cons] */) {
         Value *var_2 = ((Value_Constructor*)var_0)->args[0];
         Value *var_3 = ((Value_Constructor*)var_0)->args[1];
-        newReference(var_2);
-        newReference(var_3);
-        removeReference(var_0);
-        removeReference(var_1);
+        idris2_newReference(var_2);
+        idris2_newReference(var_3);
+        idris2_removeReference(var_0);
+        idris2_removeReference(var_1);
         // start Main_last(var_3, var_2)                     // Main:7:20--7:24
-        Value_Arglist *arglist_135 = newArglist(0,2);
+        Value_Arglist *arglist_135 = idris2_newArglist(0,2);
         arglist_135->args[0] = var_3;
         arglist_135->args[1] = var_2;
         Value *(*fPtr_136)(Value_Arglist*) = Main_last_arglist;
                                                              // Main:7:20--7:24
-        Value *closure_136 = (Value*)makeClosureFromArglist(fPtr_136, arglist_135);
+        Value *closure_136 = (Value*)idris2_makeClosureFromArglist(fPtr_136, arglist_135);
                                                              // Main:7:20--7:24
         // end   Main_last(var_3, var_2)                     // Main:7:20--7:24
         tmp_134 = closure_136;
@@ -137,71 +137,71 @@ Value *Main_main(void);
 Value *Main_main_arglist(Value_Arglist* arglist);
 Value *Main_main(void)
 {
-    Value_Arglist *arglist_74 = newArglist(2,2);
+    Value_Arglist *arglist_74 = idris2_newArglist(2,2);
     Value *(*closure_75)(Value_Arglist*) = Main_main_9_arglist;
                                                              // Main:10:13--10:17
-    Value * var_8 = (Value*)makeClosureFromArglist(closure_75, arglist_74);
+    Value * var_8 = (Value*)idris2_makeClosureFromArglist(closure_75, arglist_74);
                                                              // Main:10:8--10:12
-    Value_Arglist *arglist_76 = newArglist(2,2);
+    Value_Arglist *arglist_76 = idris2_newArglist(2,2);
     Value *(*closure_77)(Value_Arglist*) = Main_main_10_arglist;
                                                              // Main:10:27--10:28
-    Value * var_9 = (Value*)makeClosureFromArglist(closure_77, arglist_76);
+    Value * var_9 = (Value*)idris2_makeClosureFromArglist(closure_77, arglist_76);
                                                              // Main:10:8--10:12
     Value * var_6 = (NULL /* Prelude.Basics.Nil */);         // Main:11:11--11:13
     Value * var_3 = (NULL /* Prelude.Basics.Lin */);         // Prelude.Types:605:11--605:20
-    Value_Arglist *arglist_78 = newArglist(1,1);
+    Value_Arglist *arglist_78 = idris2_newArglist(1,1);
     Value *(*closure_79)(Value_Arglist*) = Main_main_11_arglist;
                                                              // Main:11:21--11:22
-    Value * var_4 = (Value*)makeClosureFromArglist(closure_79, arglist_78);
+    Value * var_4 = (Value*)idris2_makeClosureFromArglist(closure_79, arglist_78);
                                                              // Prelude.Types:605:11--605:20
     // start csegen_44()
-    Value_Arglist *arglist_80 = newArglist(0,0);
+    Value_Arglist *arglist_80 = idris2_newArglist(0,0);
     Value *(*fPtr_81)(Value_Arglist*) = csegen_44_arglist;
-    Value *closure_81 = (Value*)makeClosureFromArglist(fPtr_81, arglist_80);
+    Value *closure_81 = (Value*)idris2_makeClosureFromArglist(fPtr_81, arglist_80);
     // end   csegen_44()
-    Value * var_0 = trampoline(closure_81);                  // Prelude.Types:1121:1--1138:48
+    Value * var_0 = idris2_trampoline(closure_81);           // Prelude.Types:1121:1--1138:48
     Value * var_1 = (Value*)idris2_mkIntegerLiteral("1");    // Prelude.Types:1121:1--1138:48
     Value * var_2 = (Value*)idris2_mkIntegerLiteral("5");    // Prelude.Types:1121:1--1138:48
     // start Prelude_Types_rangeFromTo_Range__dollara(var_0, var_1, var_2)
                                                              // Prelude.Types:1121:1--1138:48
-    Value_Arglist *arglist_82 = newArglist(0,3);
+    Value_Arglist *arglist_82 = idris2_newArglist(0,3);
     arglist_82->args[0] = var_0;
     arglist_82->args[1] = var_1;
     arglist_82->args[2] = var_2;
     Value *(*fPtr_83)(Value_Arglist*) = Prelude_Types_rangeFromTo_Range__dollara_arglist;
                                                              // Prelude.Types:1121:1--1138:48
-    Value *closure_83 = (Value*)makeClosureFromArglist(fPtr_83, arglist_82);
+    Value *closure_83 = (Value*)idris2_makeClosureFromArglist(fPtr_83, arglist_82);
                                                              // Prelude.Types:1121:1--1138:48
     // end   Prelude_Types_rangeFromTo_Range__dollara(var_0, var_1, var_2)
                                                              // Prelude.Types:1121:1--1138:48
-    Value * var_5 = trampoline(closure_83);                  // Prelude.Types:605:11--605:20
+    Value * var_5 = idris2_trampoline(closure_83);           // Prelude.Types:605:11--605:20
     // start Prelude_Types_List_mapAppend(var_3, var_4, var_5)
                                                              // Prelude.Types:605:11--605:20
-    Value_Arglist *arglist_84 = newArglist(0,3);
+    Value_Arglist *arglist_84 = idris2_newArglist(0,3);
     arglist_84->args[0] = var_3;
     arglist_84->args[1] = var_4;
     arglist_84->args[2] = var_5;
     Value *(*fPtr_85)(Value_Arglist*) = Prelude_Types_List_mapAppend_arglist;
                                                              // Prelude.Types:605:11--605:20
-    Value *closure_85 = (Value*)makeClosureFromArglist(fPtr_85, arglist_84);
+    Value *closure_85 = (Value*)idris2_makeClosureFromArglist(fPtr_85, arglist_84);
                                                              // Prelude.Types:605:11--605:20
     // end   Prelude_Types_List_mapAppend(var_3, var_4, var_5)
                                                              // Prelude.Types:605:11--605:20
-    Value * var_7 = trampoline(closure_85);                  // Main:11:11--11:13
+    Value * var_7 = idris2_trampoline(closure_85);           // Main:11:11--11:13
      // constructor Prelude.Basics.(::)                      // Main:11:11--11:13
-    Value_Constructor* constructor_86 = newConstructor(2, 1);
+    Value_Constructor* constructor_86 = idris2_newConstructor(2, 1);
                                                              // Main:11:11--11:13
     constructor_86->args[0] = var_6;
     constructor_86->args[1] = var_7;
     Value * var_10 = (Value*)constructor_86;                 // Main:10:8--10:12
     // start Prelude_Basics_flip(var_8, var_9, var_10)       // Main:10:8--10:12
-    Value_Arglist *arglist_87 = newArglist(0,3);
+    Value_Arglist *arglist_87 = idris2_newArglist(0,3);
     arglist_87->args[0] = var_8;
     arglist_87->args[1] = var_9;
     arglist_87->args[2] = var_10;
     Value *(*fPtr_88)(Value_Arglist*) = Prelude_Basics_flip_arglist;
                                                              // Main:10:8--10:12
-    Value *closure_88 = (Value*)makeClosureFromArglist(fPtr_88, arglist_87);
+    Value *closure_88 = (Value*)idris2_makeClosureFromArglist(fPtr_88, arglist_87);
                                                              // Main:10:8--10:12
     // end   Prelude_Basics_flip(var_8, var_9, var_10)       // Main:10:8--10:12
     return closure_88;
@@ -218,21 +218,21 @@ Value *Main_main_11
 )
 {
     // start csegen_44()
-    Value_Arglist *arglist_89 = newArglist(0,0);
+    Value_Arglist *arglist_89 = idris2_newArglist(0,0);
     Value *(*fPtr_90)(Value_Arglist*) = csegen_44_arglist;
-    Value *closure_90 = (Value*)makeClosureFromArglist(fPtr_90, arglist_89);
+    Value *closure_90 = (Value*)idris2_makeClosureFromArglist(fPtr_90, arglist_89);
     // end   csegen_44()
-    Value * var_1 = trampoline(closure_90);                  // Prelude.Types:1121:1--1138:48
+    Value * var_1 = idris2_trampoline(closure_90);           // Prelude.Types:1121:1--1138:48
     Value * var_2 = (Value*)idris2_mkIntegerLiteral("1");    // Prelude.Types:1121:1--1138:48
     // start Prelude_Types_rangeFromTo_Range__dollara(var_1, var_2, var_0)
                                                              // Prelude.Types:1121:1--1138:48
-    Value_Arglist *arglist_91 = newArglist(0,3);
+    Value_Arglist *arglist_91 = idris2_newArglist(0,3);
     arglist_91->args[0] = var_1;
     arglist_91->args[1] = var_2;
     arglist_91->args[2] = var_0;
     Value *(*fPtr_92)(Value_Arglist*) = Prelude_Types_rangeFromTo_Range__dollara_arglist;
                                                              // Prelude.Types:1121:1--1138:48
-    Value *closure_92 = (Value*)makeClosureFromArglist(fPtr_92, arglist_91);
+    Value *closure_92 = (Value*)idris2_makeClosureFromArglist(fPtr_92, arglist_91);
                                                              // Prelude.Types:1121:1--1138:48
     // end   Prelude_Types_rangeFromTo_Range__dollara(var_1, var_2, var_0)
                                                              // Prelude.Types:1121:1--1138:48
@@ -253,35 +253,35 @@ Value *Main_main_10
 {
     Value * var_2 = (Value*)idris2_mkIntegerLiteral("0");    // Main:10:30--10:36
     // start Main_last(var_1, var_2)                         // Main:10:30--10:36
-    Value_Arglist *arglist_93 = newArglist(0,2);
+    Value_Arglist *arglist_93 = idris2_newArglist(0,2);
     arglist_93->args[0] = var_1;
     arglist_93->args[1] = var_2;
     Value *(*fPtr_94)(Value_Arglist*) = Main_last_arglist;   // Main:10:30--10:36
-    Value *closure_94 = (Value*)makeClosureFromArglist(fPtr_94, arglist_93);
+    Value *closure_94 = (Value*)idris2_makeClosureFromArglist(fPtr_94, arglist_93);
                                                              // Main:10:30--10:36
     // end   Main_last(var_1, var_2)                         // Main:10:30--10:36
-    Value * var_3 = trampoline(closure_94);                  // Prelude.Show:110:1--112:50
+    Value * var_3 = idris2_trampoline(closure_94);           // Prelude.Show:110:1--112:50
     // start Prelude_Show_show_Show_Integer(var_3)           // Prelude.Show:110:1--112:50
-    Value_Arglist *arglist_95 = newArglist(0,1);
+    Value_Arglist *arglist_95 = idris2_newArglist(0,1);
     arglist_95->args[0] = var_3;
     Value *(*fPtr_96)(Value_Arglist*) = Prelude_Show_show_Show_Integer_arglist;
                                                              // Prelude.Show:110:1--112:50
-    Value *closure_96 = (Value*)makeClosureFromArglist(fPtr_96, arglist_95);
+    Value *closure_96 = (Value*)idris2_makeClosureFromArglist(fPtr_96, arglist_95);
                                                              // Prelude.Show:110:1--112:50
     // end   Prelude_Show_show_Show_Integer(var_3)           // Prelude.Show:110:1--112:50
-    Value * var_4 = trampoline(closure_96);
+    Value * var_4 = idris2_trampoline(closure_96);
     Value * var_5 = (Value*)idris2_mkString("\x0a""");
     Value *primVar_97 = strAppend(var_4, var_5);
-    removeReference(var_4);
-    removeReference(var_5);
+    idris2_removeReference(var_4);
+    idris2_removeReference(var_5);
     Value * var_6 = primVar_97;                              // Prelude.IO:98:22--98:34
     // start Prelude_IO_prim__putStr(var_6, var_0)           // Prelude.IO:98:22--98:34
-    Value_Arglist *arglist_98 = newArglist(0,2);
+    Value_Arglist *arglist_98 = idris2_newArglist(0,2);
     arglist_98->args[0] = var_6;
     arglist_98->args[1] = var_0;
     Value *(*fPtr_99)(Value_Arglist*) = Prelude_IO_prim__putStr_arglist;
                                                              // Prelude.IO:98:22--98:34
-    Value *closure_99 = (Value*)makeClosureFromArglist(fPtr_99, arglist_98);
+    Value *closure_99 = (Value*)idris2_makeClosureFromArglist(fPtr_99, arglist_98);
                                                              // Prelude.IO:98:22--98:34
     // end   Prelude_IO_prim__putStr(var_6, var_0)           // Prelude.IO:98:22--98:34
     return closure_99;
@@ -300,51 +300,51 @@ Value *Main_main_9
 ,   Value * var_0
 )
 {
-    Value_Arglist *arglist_100 = newArglist(5,5);
+    Value_Arglist *arglist_100 = idris2_newArglist(5,5);
     Value *(*closure_101)(Value_Arglist*) = Main_main_0_arglist;
-    Value * var_2 = (Value*)makeClosureFromArglist(closure_101, arglist_100);
+    Value * var_2 = (Value*)idris2_makeClosureFromArglist(closure_101, arglist_100);
                                                              // Prelude.IO:19:1--26:30
-    Value_Arglist *arglist_102 = newArglist(3,3);
+    Value_Arglist *arglist_102 = idris2_newArglist(3,3);
     Value *(*closure_103)(Value_Arglist*) = Main_main_1_arglist;
-    Value * var_3 = (Value*)makeClosureFromArglist(closure_103, arglist_102);
+    Value * var_3 = (Value*)idris2_makeClosureFromArglist(closure_103, arglist_102);
                                                              // Prelude.IO:19:1--26:30
-    Value_Arglist *arglist_104 = newArglist(5,5);
+    Value_Arglist *arglist_104 = idris2_newArglist(5,5);
     Value *(*closure_105)(Value_Arglist*) = Main_main_2_arglist;
-    Value * var_4 = (Value*)makeClosureFromArglist(closure_105, arglist_104);
+    Value * var_4 = (Value*)idris2_makeClosureFromArglist(closure_105, arglist_104);
                                                              // Prelude.IO:19:1--26:30
      // constructor Prelude.Interfaces.MkApplicative         // Prelude.IO:19:1--26:30
-    Value_Constructor* constructor_106 = newConstructor(3, 0);
+    Value_Constructor* constructor_106 = idris2_newConstructor(3, 0);
                                                              // Prelude.IO:19:1--26:30
     constructor_106->args[0] = var_2;
     constructor_106->args[1] = var_3;
     constructor_106->args[2] = var_4;
     Value * var_11 = (Value*)constructor_106;                // Main:10:13--10:17
-    Value_Arglist *arglist_107 = newArglist(5,5);
+    Value_Arglist *arglist_107 = idris2_newArglist(5,5);
     Value *(*closure_108)(Value_Arglist*) = Main_main_3_arglist;
-    Value * var_5 = (Value*)makeClosureFromArglist(closure_108, arglist_107);
+    Value * var_5 = (Value*)idris2_makeClosureFromArglist(closure_108, arglist_107);
                                                              // Prelude.Types:656:1--669:59
-    Value_Arglist *arglist_109 = newArglist(5,5);
+    Value_Arglist *arglist_109 = idris2_newArglist(5,5);
     Value *(*closure_110)(Value_Arglist*) = Main_main_4_arglist;
-    Value * var_6 = (Value*)makeClosureFromArglist(closure_110, arglist_109);
+    Value * var_6 = (Value*)idris2_makeClosureFromArglist(closure_110, arglist_109);
                                                              // Prelude.Types:656:1--669:59
-    Value_Arglist *arglist_111 = newArglist(2,2);
+    Value_Arglist *arglist_111 = idris2_newArglist(2,2);
     Value *(*closure_112)(Value_Arglist*) = Main_main_5_arglist;
-    Value * var_7 = (Value*)makeClosureFromArglist(closure_112, arglist_111);
+    Value * var_7 = (Value*)idris2_makeClosureFromArglist(closure_112, arglist_111);
                                                              // Prelude.Types:656:1--669:59
-    Value_Arglist *arglist_113 = newArglist(7,7);
+    Value_Arglist *arglist_113 = idris2_newArglist(7,7);
     Value *(*closure_114)(Value_Arglist*) = Main_main_6_arglist;
-    Value * var_8 = (Value*)makeClosureFromArglist(closure_114, arglist_113);
+    Value * var_8 = (Value*)idris2_makeClosureFromArglist(closure_114, arglist_113);
                                                              // Prelude.Types:656:1--669:59
-    Value_Arglist *arglist_115 = newArglist(2,2);
+    Value_Arglist *arglist_115 = idris2_newArglist(2,2);
     Value *(*closure_116)(Value_Arglist*) = Main_main_7_arglist;
-    Value * var_9 = (Value*)makeClosureFromArglist(closure_116, arglist_115);
+    Value * var_9 = (Value*)idris2_makeClosureFromArglist(closure_116, arglist_115);
                                                              // Prelude.Types:656:1--669:59
-    Value_Arglist *arglist_117 = newArglist(5,5);
+    Value_Arglist *arglist_117 = idris2_newArglist(5,5);
     Value *(*closure_118)(Value_Arglist*) = Main_main_8_arglist;
-    Value * var_10 = (Value*)makeClosureFromArglist(closure_118, arglist_117);
+    Value * var_10 = (Value*)idris2_makeClosureFromArglist(closure_118, arglist_117);
                                                              // Prelude.Types:656:1--669:59
      // constructor Prelude.Interfaces.MkFoldable            // Prelude.Types:656:1--669:59
-    Value_Constructor* constructor_119 = newConstructor(6, 0);
+    Value_Constructor* constructor_119 = idris2_newConstructor(6, 0);
                                                              // Prelude.Types:656:1--669:59
     constructor_119->args[0] = var_5;
     constructor_119->args[1] = var_6;
@@ -355,14 +355,14 @@ Value *Main_main_9
     Value * var_12 = (Value*)constructor_119;                // Main:10:13--10:17
     // start Prelude_Interfaces_for_(var_11, var_12, var_1, var_0)
                                                              // Main:10:13--10:17
-    Value_Arglist *arglist_120 = newArglist(0,4);
+    Value_Arglist *arglist_120 = idris2_newArglist(0,4);
     arglist_120->args[0] = var_11;
     arglist_120->args[1] = var_12;
     arglist_120->args[2] = var_1;
     arglist_120->args[3] = var_0;
     Value *(*fPtr_121)(Value_Arglist*) = Prelude_Interfaces_for__arglist;
                                                              // Main:10:13--10:17
-    Value *closure_121 = (Value*)makeClosureFromArglist(fPtr_121, arglist_120);
+    Value *closure_121 = (Value*)idris2_makeClosureFromArglist(fPtr_121, arglist_120);
                                                              // Main:10:13--10:17
     // end   Prelude_Interfaces_for_(var_11, var_12, var_1, var_0)
                                                              // Main:10:13--10:17
@@ -385,17 +385,17 @@ Value *Main_main_8
 ,   Value * var_0
 )
 {
-    removeReference(var_3);
-    removeReference(var_4);
+    idris2_removeReference(var_3);
+    idris2_removeReference(var_4);
     // start Prelude_Types_foldMap_Foldable_List(var_2, var_1, var_0)
                                                              // Prelude.Types:656:1--669:59
-    Value_Arglist *arglist_122 = newArglist(0,3);
+    Value_Arglist *arglist_122 = idris2_newArglist(0,3);
     arglist_122->args[0] = var_2;
     arglist_122->args[1] = var_1;
     arglist_122->args[2] = var_0;
     Value *(*fPtr_123)(Value_Arglist*) = Prelude_Types_foldMap_Foldable_List_arglist;
                                                              // Prelude.Types:656:1--669:59
-    Value *closure_123 = (Value*)makeClosureFromArglist(fPtr_123, arglist_122);
+    Value *closure_123 = (Value*)idris2_makeClosureFromArglist(fPtr_123, arglist_122);
                                                              // Prelude.Types:656:1--669:59
     // end   Prelude_Types_foldMap_Foldable_List(var_2, var_1, var_0)
                                                              // Prelude.Types:656:1--669:59
@@ -418,7 +418,7 @@ Value *Main_main_7
 ,   Value * var_0
 )
 {
-    removeReference(var_1);
+    idris2_removeReference(var_1);
     return var_0;
 }
 Value *Main_main_7_arglist(Value_Arglist* arglist)
@@ -440,19 +440,19 @@ Value *Main_main_6
 ,   Value * var_0
 )
 {
-    removeReference(var_4);
-    removeReference(var_5);
-    removeReference(var_6);
+    idris2_removeReference(var_4);
+    idris2_removeReference(var_5);
+    idris2_removeReference(var_6);
     // start Prelude_Types_foldlM_Foldable_List(var_3, var_2, var_1, var_0)
                                                              // Prelude.Types:656:1--669:59
-    Value_Arglist *arglist_124 = newArglist(0,4);
+    Value_Arglist *arglist_124 = idris2_newArglist(0,4);
     arglist_124->args[0] = var_3;
     arglist_124->args[1] = var_2;
     arglist_124->args[2] = var_1;
     arglist_124->args[3] = var_0;
     Value *(*fPtr_125)(Value_Arglist*) = Prelude_Types_foldlM_Foldable_List_arglist;
                                                              // Prelude.Types:656:1--669:59
-    Value *closure_125 = (Value*)makeClosureFromArglist(fPtr_125, arglist_124);
+    Value *closure_125 = (Value*)idris2_makeClosureFromArglist(fPtr_125, arglist_124);
                                                              // Prelude.Types:656:1--669:59
     // end   Prelude_Types_foldlM_Foldable_List(var_3, var_2, var_1, var_0)
                                                              // Prelude.Types:656:1--669:59
@@ -477,13 +477,13 @@ Value *Main_main_5
 ,   Value * var_0
 )
 {
-    removeReference(var_1);
+    idris2_removeReference(var_1);
     // start Prelude_Types_null_Foldable_List(var_0)         // Prelude.Types:656:1--669:59
-    Value_Arglist *arglist_126 = newArglist(0,1);
+    Value_Arglist *arglist_126 = idris2_newArglist(0,1);
     arglist_126->args[0] = var_0;
     Value *(*fPtr_127)(Value_Arglist*) = Prelude_Types_null_Foldable_List_arglist;
                                                              // Prelude.Types:656:1--669:59
-    Value *closure_127 = (Value*)makeClosureFromArglist(fPtr_127, arglist_126);
+    Value *closure_127 = (Value*)idris2_makeClosureFromArglist(fPtr_127, arglist_126);
                                                              // Prelude.Types:656:1--669:59
     // end   Prelude_Types_null_Foldable_List(var_0)         // Prelude.Types:656:1--669:59
     return closure_127;
@@ -505,17 +505,17 @@ Value *Main_main_4
 ,   Value * var_0
 )
 {
-    removeReference(var_3);
-    removeReference(var_4);
+    idris2_removeReference(var_3);
+    idris2_removeReference(var_4);
     // start Prelude_Types_foldl_Foldable_List(var_2, var_1, var_0)
                                                              // Prelude.Types:656:1--669:59
-    Value_Arglist *arglist_128 = newArglist(0,3);
+    Value_Arglist *arglist_128 = idris2_newArglist(0,3);
     arglist_128->args[0] = var_2;
     arglist_128->args[1] = var_1;
     arglist_128->args[2] = var_0;
     Value *(*fPtr_129)(Value_Arglist*) = Prelude_Types_foldl_Foldable_List_arglist;
                                                              // Prelude.Types:656:1--669:59
-    Value *closure_129 = (Value*)makeClosureFromArglist(fPtr_129, arglist_128);
+    Value *closure_129 = (Value*)idris2_makeClosureFromArglist(fPtr_129, arglist_128);
                                                              // Prelude.Types:656:1--669:59
     // end   Prelude_Types_foldl_Foldable_List(var_2, var_1, var_0)
                                                              // Prelude.Types:656:1--669:59
@@ -541,17 +541,17 @@ Value *Main_main_3
 ,   Value * var_0
 )
 {
-    removeReference(var_3);
-    removeReference(var_4);
+    idris2_removeReference(var_3);
+    idris2_removeReference(var_4);
     // start Prelude_Types_foldr_Foldable_List(var_2, var_1, var_0)
                                                              // Prelude.Types:656:1--669:59
-    Value_Arglist *arglist_130 = newArglist(0,3);
+    Value_Arglist *arglist_130 = idris2_newArglist(0,3);
     arglist_130->args[0] = var_2;
     arglist_130->args[1] = var_1;
     arglist_130->args[2] = var_0;
     Value *(*fPtr_131)(Value_Arglist*) = Prelude_Types_foldr_Foldable_List_arglist;
                                                              // Prelude.Types:656:1--669:59
-    Value *closure_131 = (Value*)makeClosureFromArglist(fPtr_131, arglist_130);
+    Value *closure_131 = (Value*)idris2_makeClosureFromArglist(fPtr_131, arglist_130);
                                                              // Prelude.Types:656:1--669:59
     // end   Prelude_Types_foldr_Foldable_List(var_2, var_1, var_0)
                                                              // Prelude.Types:656:1--669:59
@@ -577,12 +577,12 @@ Value *Main_main_2
 ,   Value * var_0
 )
 {
-    removeReference(var_3);
-    removeReference(var_4);
-    Value * var_5 = apply_closure(var_2, newReference(var_0));
+    idris2_removeReference(var_3);
+    idris2_removeReference(var_4);
+    Value * var_5 = idris2_apply_closure(var_2, idris2_newReference(var_0));
                                                              // Prelude.IO:24:9--24:16
-    Value * var_6 = apply_closure(var_1, var_0);             // Prelude.IO:25:11--25:18
-    return tailcall_apply_closure(var_5, var_6);
+    Value * var_6 = idris2_apply_closure(var_1, var_0);      // Prelude.IO:25:11--25:18
+    return idris2_tailcall_apply_closure(var_5, var_6);
 }
 Value *Main_main_2_arglist(Value_Arglist* arglist)
 {
@@ -602,8 +602,8 @@ Value *Main_main_1
 ,   Value * var_0
 )
 {
-    removeReference(var_0);
-    removeReference(var_2);
+    idris2_removeReference(var_0);
+    idris2_removeReference(var_2);
     return var_1;
 }
 Value *Main_main_1_arglist(Value_Arglist* arglist)
@@ -624,16 +624,16 @@ Value *Main_main_0
 ,   Value * var_0
 )
 {
-    removeReference(var_3);
-    removeReference(var_4);
+    idris2_removeReference(var_3);
+    idris2_removeReference(var_4);
     // start Prelude_IO_map_Functor_IO(var_2, var_1, var_0)  // Prelude.IO:15:1--17:38
-    Value_Arglist *arglist_132 = newArglist(0,3);
+    Value_Arglist *arglist_132 = idris2_newArglist(0,3);
     arglist_132->args[0] = var_2;
     arglist_132->args[1] = var_1;
     arglist_132->args[2] = var_0;
     Value *(*fPtr_133)(Value_Arglist*) = Prelude_IO_map_Functor_IO_arglist;
                                                              // Prelude.IO:15:1--17:38
-    Value *closure_133 = (Value*)makeClosureFromArglist(fPtr_133, arglist_132);
+    Value *closure_133 = (Value*)idris2_makeClosureFromArglist(fPtr_133, arglist_132);
                                                              // Prelude.IO:15:1--17:38
     // end   Prelude_IO_map_Functor_IO(var_2, var_1, var_0)  // Prelude.IO:15:1--17:38
     return closure_133;

--- a/tests/refc/reuse/expected
+++ b/tests/refc/reuse/expected
@@ -21,24 +21,24 @@ Value *Main_insert
     Value * tmp_88 = NULL;                                   // Main:6:24--6:31
     if (((Value_Constructor *)var_2)->tag == 0 /* Main.Leaf */) {
         Value_Constructor* constructor_89 = NULL;
-        if (isUnique(var_2)) {
+        if (idris2_isUnique(var_2)) {
             constructor_89 = (Value_Constructor*)var_2;
         }
         else {
-            removeReference(var_2);
+            idris2_removeReference(var_2);
         }
-        removeReference(var_0);
+        idris2_removeReference(var_0);
          // constructor Main.Leaf                            // Main:7:22--7:26
         if (! constructor_89) {                              // Main:7:22--7:26
-            constructor_89 = newConstructor(0, 0);           // Main:7:22--7:26
+            constructor_89 = idris2_newConstructor(0, 0);    // Main:7:22--7:26
         }                                                    // Main:7:22--7:26
         Value * var_3 = (Value*)constructor_89;              // Main:7:17--7:21
          // constructor Main.Leaf                            // Main:7:29--7:33
-        Value_Constructor* constructor_90 = newConstructor(0, 0);
+        Value_Constructor* constructor_90 = idris2_newConstructor(0, 0);
                                                              // Main:7:29--7:33
         Value * var_4 = (Value*)constructor_90;              // Main:7:17--7:21
          // constructor Main.Node                            // Main:7:17--7:21
-        Value_Constructor* constructor_91 = newConstructor(3, 1);
+        Value_Constructor* constructor_91 = idris2_newConstructor(3, 1);
                                                              // Main:7:17--7:21
         constructor_91->args[0] = var_3;
         constructor_91->args[1] = var_1;
@@ -49,14 +49,14 @@ Value *Main_insert
         Value *var_6 = ((Value_Constructor*)var_2)->args[1];
         Value *var_7 = ((Value_Constructor*)var_2)->args[2];
         Value_Constructor* constructor_92 = NULL;
-        if (isUnique(var_2)) {
+        if (idris2_isUnique(var_2)) {
             constructor_92 = (Value_Constructor*)var_2;
         }
         else {
-            newReference(var_5);
-            newReference(var_6);
-            newReference(var_7);
-            removeReference(var_2);
+            idris2_newReference(var_5);
+            idris2_newReference(var_6);
+            idris2_newReference(var_7);
+            idris2_removeReference(var_2);
         }
         Value * tmp_93 = NULL;                               // Prelude.EqOrd:121:3--121:6
         if (((Value_Constructor *)var_0)->tag == 0 /* Prelude.EqOrd.MkOrd */) {
@@ -68,51 +68,53 @@ Value *Main_insert
             Value *var_13 = ((Value_Constructor*)var_0)->args[5];
             Value *var_14 = ((Value_Constructor*)var_0)->args[6];
             Value *var_15 = ((Value_Constructor*)var_0)->args[7];
-            newReference(var_10);
-            Value * var_16 = apply_closure(var_10, newReference(var_1));
+            idris2_newReference(var_10);
+            Value * var_16 = idris2_apply_closure(var_10, idris2_newReference(var_1));
                                                              // Prelude.EqOrd:121:3--121:6
-            tmp_93 = apply_closure(var_16, newReference(var_6));
+            tmp_93 = idris2_apply_closure(var_16, idris2_newReference(var_6));
         }
         Value * var_19 = tmp_93;
         Value *tmp_94 = NULL;
         int64_t tmp_95 = idris2_extractInt(var_19);
         if (tmp_95 == UINT8_C(1)) {
-            removeReference(var_19);
+            idris2_removeReference(var_19);
             // start Main_insert(var_0, var_1, var_5)        // Main:8:48--8:54
-            Value_Arglist *arglist_96 = newArglist(0,3);
+            Value_Arglist *arglist_96 = idris2_newArglist(0,3);
             arglist_96->args[0] = var_0;
             arglist_96->args[1] = var_1;
             arglist_96->args[2] = var_5;
             Value *(*fPtr_97)(Value_Arglist*) = Main_insert_arglist;
                                                              // Main:8:48--8:54
-            Value *closure_97 = (Value*)makeClosureFromArglist(fPtr_97, arglist_96);
+            Value *closure_97 = (Value*)idris2_makeClosureFromArglist(fPtr_97, arglist_96);
                                                              // Main:8:48--8:54
             // end   Main_insert(var_0, var_1, var_5)        // Main:8:48--8:54
-            Value * var_17 = trampoline(closure_97);         // Main:8:42--8:46
+            Value * var_17 = idris2_trampoline(closure_97);  // Main:8:42--8:46
              // constructor Main.Node                        // Main:8:42--8:46
             if (! constructor_92) {                          // Main:8:42--8:46
-                constructor_92 = newConstructor(3, 1);       // Main:8:42--8:46
+                constructor_92 = idris2_newConstructor(3, 1);
+                                                             // Main:8:42--8:46
             }                                                // Main:8:42--8:46
             constructor_92->args[0] = var_17;
             constructor_92->args[1] = var_6;
             constructor_92->args[2] = var_7;
             tmp_94 = (Value*)constructor_92;
         } else if (tmp_95 == UINT8_C(0)) {
-            removeReference(var_19);
+            idris2_removeReference(var_19);
             // start Main_insert(var_0, var_1, var_7)        // Main:9:52--9:58
-            Value_Arglist *arglist_98 = newArglist(0,3);
+            Value_Arglist *arglist_98 = idris2_newArglist(0,3);
             arglist_98->args[0] = var_0;
             arglist_98->args[1] = var_1;
             arglist_98->args[2] = var_7;
             Value *(*fPtr_99)(Value_Arglist*) = Main_insert_arglist;
                                                              // Main:9:52--9:58
-            Value *closure_99 = (Value*)makeClosureFromArglist(fPtr_99, arglist_98);
+            Value *closure_99 = (Value*)idris2_makeClosureFromArglist(fPtr_99, arglist_98);
                                                              // Main:9:52--9:58
             // end   Main_insert(var_0, var_1, var_7)        // Main:9:52--9:58
-            Value * var_18 = trampoline(closure_99);         // Main:9:42--9:46
+            Value * var_18 = idris2_trampoline(closure_99);  // Main:9:42--9:46
              // constructor Main.Node                        // Main:9:42--9:46
             if (! constructor_92) {                          // Main:9:42--9:46
-                constructor_92 = newConstructor(3, 1);       // Main:9:42--9:46
+                constructor_92 = idris2_newConstructor(3, 1);
+                                                             // Main:9:42--9:46
             }                                                // Main:9:42--9:46
             constructor_92->args[0] = var_5;
             constructor_92->args[1] = var_6;


### PR DESCRIPTION
To really isolate the contribution in #3177 (removal of the arglist wrapper),
let us start by having a separate commit dealing with the primitives' renaming.