### PR TITLE
[ parser ] Fix issue parsing unquote

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -46,6 +46,9 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
   environment variable adds to the "Package Search Paths." Functionally this is
   not a breaking change.
 
+* The compiler now parses `~x.fun` as unquoting `x` rather than `x.fun`
+  and `~(f 5).fun` as unquoting `(f 5)` rather than `(f 5).fun`.
+
 ### Backend changes
 
 #### RefC Backend

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -631,7 +631,7 @@ mutual
                   decoratedSymbol fname "]"
                   pure ts
            pure (PQuoteDecl (boundToFC fname b) (collectDefs (concat b.val)))
-    <|> do b <- bounds (decoratedSymbol fname "~" *> simpleExpr fname indents)
+    <|> do b <- bounds (decoratedSymbol fname "~" *> simplerExpr fname indents)
            pure (PUnquote (boundToFC fname b) b.val)
     <|> do start <- bounds (symbol "(")
            bracketedExpr fname start indents

--- a/tests/idris2/error/perror031/Issue3251.idr
+++ b/tests/idris2/error/perror031/Issue3251.idr
@@ -1,0 +1,19 @@
+import Language.Reflection
+
+(.fun) : Nat -> Nat
+
+x : TTImp
+
+f : Nat -> TTImp
+
+useX : TTImp
+useX = `(g (~x).fun)
+
+useX' : TTImp
+useX' = `(g ~x.fun)
+
+useFX : TTImp
+useFX = `(g (~(f 5)).fun)
+
+useFX' : TTImp
+useFX' = `(g ~(f 5).fun)

--- a/tests/idris2/error/perror031/expected
+++ b/tests/idris2/error/perror031/expected
@@ -1,0 +1,1 @@
+1/1: Building Issue3251 (Issue3251.idr)

--- a/tests/idris2/error/perror031/run
+++ b/tests/idris2/error/perror031/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check Issue3251.idr


### PR DESCRIPTION
# Description

This PR addresses #3251 - where unquote was picking up postfix expressions where it wasn't expected. 

Previously, `(g ~(f 5).fun)` would unquote all of `(f 5).fun` and now it only unquotes `(f 5)`.  Similarly `~x.fun` would unquote `x.fun` and now it only unquotes `x`.

The code from #3251 is used as a test case.

## Should this change go in the CHANGELOG?

I've added it to CHANGELOG_NEXT since it may break existing code.
