### PR TITLE
Doc: module naming constraints

### DIFF
--- a/docs/source/tutorial/modules.rst
+++ b/docs/source/tutorial/modules.rst
@@ -76,15 +76,13 @@ error messages: ``with MyModule.(>>=) do ...``
 
 If a file contains a module declaration ``module Foo.Bar.MyModule``, its
 path relative to the ``sourcedir`` specified in the ``.ipkg`` project file
-(defaults to `.`) must be ``./Foo/Bar/MyModule.idr``. If you are not using an
+(defaults to ``.``) must be ``./Foo/Bar/MyModule.idr``. If you are not using an
 ``.ipkg`` project file, the path must be relative to the directory you are
 running Idris from. Similarly, an ``import`` statement also refers to such a
 relative filepath stripped of its file extension, using dots to separate
 directories. As in the example above, all modules names and directories must be
-capitalised identifiers. The main module, with the ``main`` function, must be
-called ``Main`` — although its filename need not be ``Main.idr``. This is the
-only case where a filename does not have to match with the respective module
-name.
+capitalised identifiers. If a file does not contain a module declaration, it
+is considered to be a module whose identifier is ``Main``.
 
 Export Modifiers
 ================

--- a/docs/source/tutorial/modules.rst
+++ b/docs/source/tutorial/modules.rst
@@ -74,14 +74,14 @@ The ``with`` keyword in expressions comes in two variants:
 This is particularly useful with ``do`` notation, where it can often improve
 error messages: ``with MyModule.(>>=) do ...``
 
-There is no formal link between the module name and its filename,
-although it is generally advisable to use the same name for each. An
-``import`` statement refers to a filename, using dots to separate
-directories. For example, ``import foo.bar`` would import the file
-``foo/bar.idr``, which would conventionally have the module declaration
-``module foo.bar``. The only requirement for module names is that the
-main module, with the ``main`` function, must be called
-``Main`` — although its filename need not be ``Main.idr``.
+If a file contains a module declaration ``module Foo.Bar.MyModule``, its
+full path must end in ``Foo/Bar/MyModule.idr``. Similarly, an ``import``
+statement also refers to a filepath stripped of its file extension, using dots
+to separate directories. As in the example above, all modules names and
+directories must be capitalised identifiers. The main module, with the ``main``
+function, must be called ``Main`` — although its filename need not be
+``Main.idr``. This is the only case where a filename does not have to match with
+the respective module name.
 
 Export Modifiers
 ================

--- a/docs/source/tutorial/modules.rst
+++ b/docs/source/tutorial/modules.rst
@@ -75,14 +75,16 @@ This is particularly useful with ``do`` notation, where it can often improve
 error messages: ``with MyModule.(>>=) do ...``
 
 If a file contains a module declaration ``module Foo.Bar.MyModule``, its
-path relative to the ``.ipkg`` project file (or the directory you are running
-Idris from) must be ``./Foo/Bar/MyModule.idr``. Similarly, an ``import``
-statement also refers to such a relative filepath stripped of its file extension,
-using dots to separate directories. As in the example above, all modules names
-and directories must be capitalised identifiers. The main module, with the
-``main`` function, must be called ``Main`` — although its filename need not be
-``Main.idr``. This is the only case where a filename does not have to match with
-the respective module name.
+path relative to the ``sourcedir`` specified in the ``.ipkg`` project file
+(defaults to `.`) must be ``./Foo/Bar/MyModule.idr``. If you are not using an
+``.ipkg`` project file, the path must be relative to the directory you are
+running Idris from. Similarly, an ``import`` statement also refers to such a
+relative filepath stripped of its file extension, using dots to separate
+directories. As in the example above, all modules names and directories must be
+capitalised identifiers. The main module, with the ``main`` function, must be
+called ``Main`` — although its filename need not be ``Main.idr``. This is the
+only case where a filename does not have to match with the respective module
+name.
 
 Export Modifiers
 ================

--- a/docs/source/tutorial/modules.rst
+++ b/docs/source/tutorial/modules.rst
@@ -75,11 +75,12 @@ This is particularly useful with ``do`` notation, where it can often improve
 error messages: ``with MyModule.(>>=) do ...``
 
 If a file contains a module declaration ``module Foo.Bar.MyModule``, its
-full path must end in ``Foo/Bar/MyModule.idr``. Similarly, an ``import``
-statement also refers to a filepath stripped of its file extension, using dots
-to separate directories. As in the example above, all modules names and
-directories must be capitalised identifiers. The main module, with the ``main``
-function, must be called ``Main`` — although its filename need not be
+path relative to the ``.ipkg`` project file (or the directory you are running
+the Idris from) must be ``./Foo/Bar/MyModule.idr``. Similarly, an ``import``
+statement also refers to such a relative filepath stripped of its file extension,
+using dots to separate directories. As in the example above, all modules names
+and directories must be capitalised identifiers. The main module, with the
+``main`` function, must be called ``Main`` — although its filename need not be
 ``Main.idr``. This is the only case where a filename does not have to match with
 the respective module name.
 

--- a/docs/source/tutorial/modules.rst
+++ b/docs/source/tutorial/modules.rst
@@ -76,7 +76,7 @@ error messages: ``with MyModule.(>>=) do ...``
 
 If a file contains a module declaration ``module Foo.Bar.MyModule``, its
 path relative to the ``.ipkg`` project file (or the directory you are running
-the Idris from) must be ``./Foo/Bar/MyModule.idr``. Similarly, an ``import``
+Idris from) must be ``./Foo/Bar/MyModule.idr``. Similarly, an ``import``
 statement also refers to such a relative filepath stripped of its file extension,
 using dots to separate directories. As in the example above, all modules names
 and directories must be capitalised identifiers. The main module, with the


### PR DESCRIPTION
# Description

The Crash Course material on naming modules is apparently out of date. It does not mention that identifiers in module names must be capitalized (I used UK spelling in my revision), or that they must match the filename path.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).