### PR TITLE
fixed bugs that caused compiler to hang forever when there is `%tcinline` pragma

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -46,6 +46,9 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
   environment variable adds to the "Package Search Paths." Functionally this is
   not a breaking change.
 
+* Fixed a bug that caused compiler to hang forever when there is `%tcinline`
+  pragma.
+
 ### Backend changes
 
 #### RefC Backend

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -14,6 +14,7 @@ Andre Kuhlenschmidt
 André Videla
 Andy Lok
 Anthony Lodi
+Anton Ping
 Arnaud Bailly
 Brian Wignall
 Bryn Keller

--- a/src/Core/Termination/CallGraph.idr
+++ b/src/Core/Termination/CallGraph.idr
@@ -70,23 +70,24 @@ mutual
   findSC : {vars : _} ->
            {auto c : Ref Ctxt Defs} ->
            Defs -> Env Term vars -> Guardedness ->
+           List Name -> -- to avoid caseblock looping
            List (Term vars) -> -- LHS args
            Term vars -> -- RHS
            Core (List SCCall)
-  findSC {vars} defs env g pats (Bind fc n b sc)
+  findSC {vars} defs env g cbs pats (Bind fc n b sc)
        = pure $
             !(findSCbinder b) ++
-            !(findSC defs (b :: env) g (map weaken pats) sc)
+            !(findSC defs (b :: env) g cbs (map weaken pats) sc)
     where
       findSCbinder : Binder (Term vars) -> Core (List SCCall)
-      findSCbinder (Let _ c val ty) = findSC defs env g pats val
+      findSCbinder (Let _ c val ty) = findSC defs env g cbs pats val
       findSCbinder b = pure [] -- only types, no need to look
   -- If we're Guarded and find a Delay, continue with the argument as InDelay
-  findSC defs env Guarded pats (TDelay _ _ _ tm)
-      = findSC defs env InDelay pats tm
-  findSC defs env g pats (TDelay _ _ _ tm)
-      = findSC defs env g pats tm
-  findSC defs env g pats tm
+  findSC defs env Guarded cbs pats (TDelay _ _ _ tm)
+      = findSC defs env InDelay cbs pats tm
+  findSC defs env g cbs pats (TDelay _ _ _ tm)
+      = findSC defs env g cbs pats tm
+  findSC defs env g cbs pats tm
       = do let (fn, args) = getFnArgs tm
            -- if it's a 'case' or 'if' just go straight into the arguments
            Nothing <- handleCase fn args
@@ -97,42 +98,42 @@ mutual
     -- If we're InDelay and find a constructor (or a function call which is
     -- guaranteed to return a constructor; AllGuarded set), continue as InDelay
              (InDelay, Ref fc (DataCon _ _) cn, args) =>
-                 do scs <- traverse (findSC defs env InDelay pats) args
+                 do scs <- traverse (findSC defs env InDelay cbs pats) args
                     pure (concat scs)
              -- If we're InDelay otherwise, just check the arguments, the
              -- function call is okay
              (InDelay, _, args) =>
-                 do scs <- traverse (findSC defs env Unguarded pats) args
+                 do scs <- traverse (findSC defs env Unguarded cbs pats) args
                     pure (concat scs)
              (Guarded, Ref fc (DataCon _ _) cn, args) =>
                  do Just ty <- lookupTyExact cn (gamma defs)
                          | Nothing => do
                               log "totality" 50 $ "Lookup failed"
-                              findSCcall defs env Guarded pats fc cn args
-                    findSCcall defs env Guarded pats fc cn args
+                              findSCcall defs env Guarded cbs pats fc cn args
+                    findSCcall defs env Guarded cbs pats fc cn args
              (Toplevel, Ref fc (DataCon _ _) cn, args) =>
                  do Just ty <- lookupTyExact cn (gamma defs)
                          | Nothing => do
                               log "totality" 50 $ "Lookup failed"
-                              findSCcall defs env Guarded pats fc cn args
-                    findSCcall defs env Guarded pats fc cn args
+                              findSCcall defs env Guarded cbs pats fc cn args
+                    findSCcall defs env Guarded cbs pats fc cn args
              (_, Ref fc Func fn, args) =>
                  do logC "totality" 50 $
                        pure $ "Looking up type of " ++ show !(toFullNames fn)
                     Just ty <- lookupTyExact fn (gamma defs)
                          | Nothing => do
                               log "totality" 50 $ "Lookup failed"
-                              findSCcall defs env Unguarded pats fc fn args
-                    findSCcall defs env Unguarded pats fc fn args
+                              findSCcall defs env Unguarded cbs pats fc fn args
+                    findSCcall defs env Unguarded cbs pats fc fn args
              (_, f, args) =>
-                 do scs <- traverse (findSC defs env Unguarded pats) args
+                 do scs <- traverse (findSC defs env Unguarded cbs pats) args
                     pure (concat scs)
       where
         handleCase : Term vars -> List (Term vars) -> Core (Maybe (List SCCall))
         handleCase (Ref fc nt n) args
             = do n' <- toFullNames n
                  if caseFn n'
-                    then Just <$> findSCcall defs env g pats fc n args
+                    then Just <$> findSCcall defs env g cbs pats fc n args
                     else pure Nothing
         handleCase _ _ = pure Nothing
 
@@ -303,23 +304,24 @@ mutual
   findSCcall : {vars : _} ->
                {auto c : Ref Ctxt Defs} ->
                Defs -> Env Term vars -> Guardedness ->
+               List Name -> -- to avoid caseblock looping
                List (Term vars) ->
                FC -> Name -> List (Term vars) ->
                Core (List SCCall)
-  findSCcall defs env g pats fc fn_in args
+  findSCcall defs env g cbs pats fc fn_in args
         -- Under 'assert_total' we assume that all calls are fine, so leave
         -- the size change list empty
       = do fn <- getFullName fn_in
            logC "totality.termination.sizechange" 10 $ do pure $ "Looking under " ++ show !(toFullNames fn)
            aSmaller <- resolved (gamma defs) (NS builtinNS (UN $ Basic "assert_smaller"))
            cond [(fn == NS builtinNS (UN $ Basic "assert_total"), pure [])
-                ,(caseFn fn,
-                    do scs1 <- traverse (findSC defs env g pats) args
+                ,(caseFn fn && not (elem fn cbs),
+                    do scs1 <- traverse (findSC defs env g (fn::cbs) pats) args
                        mps  <- getCasePats defs fn pats args
-                       scs2 <- traverse (findInCase defs g) $ fromMaybe [] mps
+                       scs2 <- traverse (findInCase defs g (fn::cbs)) $ fromMaybe [] mps
                        pure (concat (scs1 ++ scs2)))
               ]
-              (do scs <- traverse (findSC defs env g pats) args
+              (do scs <- traverse (findSC defs env g cbs pats) args
                   pure ([MkSCCall fn
                            (fromListList
                                 (map (mkChange defs aSmaller pats) args))
@@ -328,15 +330,16 @@ mutual
 
   findInCase : {auto c : Ref Ctxt Defs} ->
                Defs -> Guardedness ->
+               List Name -> -- to avoid caseblock looping
                (vs ** (Env Term vs, List (Term vs), Term vs)) ->
                Core (List SCCall)
-  findInCase defs g (_ ** (env, pats, tm))
+  findInCase defs g cbs (_ ** (env, pats, tm))
      = do logC "totality" 10 $
                    do ps <- traverse toFullNames pats
                       pure ("Looking in case args " ++ show ps)
           logTermNF "totality" 10 "        =" env tm
           rhs <- normaliseOpts tcOnly defs env tm
-          findSC defs env g pats (delazy defs rhs)
+          findSC defs env g cbs pats (delazy defs rhs)
 
 findCalls : {auto c : Ref Ctxt Defs} ->
             Defs -> (vars ** (Env Term vars, Term vars, Term vars)) ->
@@ -344,7 +347,7 @@ findCalls : {auto c : Ref Ctxt Defs} ->
 findCalls defs (_ ** (env, lhs, rhs_in))
    = do let pargs = getArgs (delazy defs lhs)
         rhs <- normaliseOpts tcOnly defs env rhs_in
-        findSC defs env Toplevel pargs (delazy defs rhs)
+        findSC defs env Toplevel [] pargs (delazy defs rhs)
 
 getSC : {auto c : Ref Ctxt Defs} ->
         Defs -> Def -> Core (List SCCall)

--- a/src/Core/Value.idr
+++ b/src/Core/Value.idr
@@ -41,7 +41,7 @@ withArgHoles = MkEvalOpts False True False False False Nothing [] CBN
 
 export
 tcOnly : EvalOpts
-tcOnly = { tcInline := True } withArgHoles
+tcOnly = { tcInline := True, fuel := Just 1000 } withArgHoles
 
 export
 onLHS : EvalOpts

--- a/tests/idris2/total/total025/Issue-2995.idr
+++ b/tests/idris2/total/total025/Issue-2995.idr
@@ -1,0 +1,18 @@
+-- see https://github.com/idris-lang/Idris2/issues/2995
+
+%default total
+
+-- %tcinline -- uncomment this, your compiler will hang forever
+-- terminate after adding fuel
+zs : Stream Nat
+zs = Z :: zs
+
+-- %tcinline -- uncomment this, your compiler will hang forever
+-- terminate after adding fuel
+zs' : Stream Nat -> Stream Nat
+zs' xs = Z :: zs' xs
+
+-- %tcinline -- uncomment this, your compiler will hang forever
+-- terminate after adding fuel
+zs'' : Stream Nat -> Stream Nat
+zs'' = \xs => Z :: zs'' xs

--- a/tests/idris2/total/total025/Issue-2995.idr
+++ b/tests/idris2/total/total025/Issue-2995.idr
@@ -2,17 +2,14 @@
 
 %default total
 
--- %tcinline -- uncomment this, your compiler will hang forever
--- terminate after adding fuel
+%tcinline
 zs : Stream Nat
 zs = Z :: zs
 
--- %tcinline -- uncomment this, your compiler will hang forever
--- terminate after adding fuel
+%tcinline
 zs' : Stream Nat -> Stream Nat
 zs' xs = Z :: zs' xs
 
--- %tcinline -- uncomment this, your compiler will hang forever
--- terminate after adding fuel
+%tcinline
 zs'' : Stream Nat -> Stream Nat
 zs'' = \xs => Z :: zs'' xs

--- a/tests/idris2/total/total025/expected
+++ b/tests/idris2/total/total025/expected
@@ -1,0 +1,1 @@
+1/1: Building Issue-2995 (Issue-2995.idr)

--- a/tests/idris2/total/total025/run
+++ b/tests/idris2/total/total025/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check Issue-2995.idr

--- a/tests/idris2/total/total026/Issue-2995.idr
+++ b/tests/idris2/total/total026/Issue-2995.idr
@@ -1,0 +1,18 @@
+-- see https://github.com/idris-lang/Idris2/issues/2995
+
+%default total
+
+-- %tcinline
+incAll : Stream Nat -> Stream Nat
+incAll (x::xs) = S x :: incAll xs
+
+-- %tcinline -- uncomment this, your compiler will hang forever
+-- hang after adding fuel
+incAll' : Stream Nat -> Stream Nat
+incAll' = \(x::xs) => S x :: incAll' xs
+
+-- %tcinline -- uncomment this, your compiler will hang forever
+-- hang after adding fuel
+incAll'' : Stream Nat -> Stream Nat
+incAll'' = \ys => case ys of
+    (x :: xs) => S x :: incAll'' xs

--- a/tests/idris2/total/total026/Issue-2995.idr
+++ b/tests/idris2/total/total026/Issue-2995.idr
@@ -2,17 +2,15 @@
 
 %default total
 
--- %tcinline
+%tcinline
 incAll : Stream Nat -> Stream Nat
 incAll (x::xs) = S x :: incAll xs
 
--- %tcinline -- uncomment this, your compiler will hang forever
--- hang after adding fuel
+%tcinline
 incAll' : Stream Nat -> Stream Nat
 incAll' = \(x::xs) => S x :: incAll' xs
 
--- %tcinline -- uncomment this, your compiler will hang forever
--- hang after adding fuel
+%tcinline
 incAll'' : Stream Nat -> Stream Nat
 incAll'' = \ys => case ys of
     (x :: xs) => S x :: incAll'' xs

--- a/tests/idris2/total/total026/expected
+++ b/tests/idris2/total/total026/expected
@@ -1,0 +1,1 @@
+1/1: Building Issue-2995 (Issue-2995.idr)

--- a/tests/idris2/total/total026/run
+++ b/tests/idris2/total/total026/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check Issue-2995.idr


### PR DESCRIPTION
# Description
* Two new tests are added: total025 and total026. they all caused compiler to hang without this fix.
* Modify `fuel` field in Core/Value.idr to `Just 1000`. This fixed only half of the problem. total025 now terminates with fuel, bug total026 still hangs.
* Add parameters `cbs` in file Core/Termination/CallGraph.idr. This fixed the second test total026.

The cause of looping in total026 is pretty complicated. Consider such an example:
```
%tcinline
incAll' : Stream Nat -> Stream Nat
incAll' = \(x::xs) => S x :: incAll' xs
```
The lambda function with pattern matching `\(x::xs) => ...` is actually encoded in such way(`f` is a fresh variable):
```
incAll' = f
f (x::xs) => S x :: incAll' xs
```
In CallGraph.idr, such `f` is called a case function, and they are treated specially: each time `findSCall` meets a case function, it will jump to the definition of the case function, and it won't be treated as regular function call.
After tcinlining, `f` becomes a recursive definition:
```
incAll' = f
f (x::xs) => S x :: f xs
```
In such way, `findSCall` in CallGraph.idr will loop forever here, since it corresponds to a program of infinite length:
```
incAll' =  \(x::xs) => S x :: (\(x::xs) => S x :: (\(x::xs) => S x :: (\(x::xs) =>  ... ))) ...)
```
The fix in CallGraph.idr introduce a new parameter `cbs`. Each time `findSCall` enters a case function, it appends the function name to `cbs`. If it's already there, `findSCall` then will treat it as a regular function call.





