### PR TITLE
[ fix ] Fix search around `%defaulthints`

### DIFF
--- a/src/Core/AutoSearch.idr
+++ b/src/Core/AutoSearch.idr
@@ -35,10 +35,8 @@ tryUnifyUnambig left right = tryUnifyUnambig' {preferLeftError} left $ const rig
 
 tryNoDefaultsFirst : {auto c : Ref Ctxt Defs} ->
                      {auto u : Ref UST UState} ->
-                     (defaults : Bool) ->
                      (Bool -> Core a) -> Core a
-tryNoDefaultsFirst False f = f False
-tryNoDefaultsFirst True  f = tryUnifyUnambig {preferLeftError=True} (f False) (f True)
+tryNoDefaultsFirst f = tryUnifyUnambig {preferLeftError=True} (f False) (f True)
 
 SearchEnv : List Name -> Type
 SearchEnv vars = List (NF vars, Closure vars)
@@ -573,7 +571,7 @@ searchType {vars} fc rigc defaults trying depth def checkdets top env target
                             pure ("Search: Trying " ++ show (length gn) ++
                                            " names " ++ show gn))
                  logNF "auto" 5 "For target" env nty
-                 tryNoDefaultsFirst defaults $ \d =>
+                 tryNoDefaultsFirst $ \d =>
                    searchNames fc rigc d (target :: trying) depth def top env ambigok g nty)
              (\err => tryGroups (Just $ fromMaybe err merr) nty gs)
 

--- a/src/Core/AutoSearch.idr
+++ b/src/Core/AutoSearch.idr
@@ -17,6 +17,22 @@ import Libraries.Data.WithDefault
 
 %default covering
 
+tryUnifyUnambig' : {auto c : Ref Ctxt Defs} ->
+                   {auto u : Ref UST UState} ->
+                   {default False preferLeftError : Bool} ->
+                   Core a -> (Error -> Core a) -> Core a
+tryUnifyUnambig' left right = handleUnify left $ \case
+  e@(AmbiguousSearch {}) => throw e
+  e                      => if preferLeftError
+                              then tryUnify (right e) (throw e)
+                              else right e
+
+tryUnifyUnambig : {auto c : Ref Ctxt Defs} ->
+                  {auto u : Ref UST UState} ->
+                  {default False preferLeftError : Bool} ->
+                  Core a -> Core a -> Core a
+tryUnifyUnambig left right = tryUnifyUnambig' {preferLeftError} left $ const right
+
 SearchEnv : List Name -> Type
 SearchEnv vars = List (NF vars, Closure vars)
 
@@ -250,10 +266,6 @@ searchLocalWith {vars} fc rigc defaults trying depth def top env (prf, ty) targe
          nty <- nf defs env ty
          findPos defs prf id nty target
   where
-    ambig : Error -> Bool
-    ambig (AmbiguousSearch _ _ _ _) = True
-    ambig _ = False
-
     clearEnvType : {idx : Nat} -> (0 p : IsVar nm idx vs) ->
                    FC -> Env Term vs -> Env Term vs
     clearEnvType First fc (b :: env)
@@ -300,8 +312,7 @@ searchLocalWith {vars} fc rigc defaults trying depth def top env (prf, ty) targe
               (target : NF vars) ->
               Core (Term vars)
     findPos defs p f nty@(NTCon pfc pn _ _ [(_, xty), (_, yty)]) target
-        = handleUnify (findDirect defs prf f nty target) (\e =>
-           if ambig e then throw e else
+        = tryUnifyUnambig (findDirect defs prf f nty target) $
              do fname <- maybe (throw (CantSolveGoal fc (gamma defs) [] top Nothing))
                                pure
                                !fstName
@@ -327,7 +338,7 @@ searchLocalWith {vars} fc rigc defaults trying depth def top env (prf, ty) targe
                                                          ytytm,
                                                          f arg])
                                      ytynf target)]
-                   else throw (CantSolveGoal fc (gamma defs) [] top Nothing))
+                   else throw (CantSolveGoal fc (gamma defs) [] top Nothing)
     findPos defs p f nty target
         = findDirect defs p f nty target
 
@@ -535,19 +546,13 @@ searchType {vars} fc rigc defaults trying depth def checkdets top env target
                                                    (NTCon tfc tyn t a args)
                              if defaults && checkdets
                                 then tryGroups Nothing nty (hintGroups sd)
-                                else handleUnify
+                                else tryUnifyUnambig
                                        (searchLocalVars fc rigc defaults trying' depth def top env nty)
-                                       (\e => if ambig e
-                                                 then throw e
-                                                 else tryGroups Nothing nty (hintGroups sd))
+                                       (tryGroups Nothing nty (hintGroups sd))
                      else throw (CantSolveGoal fc (gamma defs) [] top Nothing)
               _ => do logNF "auto" 10 "Next target: " env nty
                       searchLocalVars fc rigc defaults trying' depth def top env nty
   where
-    ambig : Error -> Bool
-    ambig (AmbiguousSearch _ _ _ _) = True
-    ambig _ = False
-
     -- Take the earliest error message (that's when we look inside pairs,
     -- typically, and it's best to be more precise)
     tryGroups : Maybe Error ->
@@ -555,15 +560,14 @@ searchType {vars} fc rigc defaults trying depth def checkdets top env target
     tryGroups (Just err) nty [] = throw err
     tryGroups Nothing nty [] = throw (CantSolveGoal fc (gamma !(get Ctxt)) [] top Nothing)
     tryGroups merr nty ((ambigok, g) :: gs)
-        = handleUnify
+        = tryUnifyUnambig'
              (do logC "auto" 5
                         (do gn <- traverse getFullName g
                             pure ("Search: Trying " ++ show (length gn) ++
                                            " names " ++ show gn))
                  logNF "auto" 5 "For target" env nty
                  searchNames fc rigc defaults (target :: trying) depth def top env ambigok g nty)
-             (\err => if ambig err then throw err
-                         else tryGroups (Just $ fromMaybe err merr) nty gs)
+             (\err => tryGroups (Just $ fromMaybe err merr) nty gs)
 
 -- Declared in Core.Unify as:
 -- search : {vars : _} ->

--- a/tests/idris2/interface/interface031/DefaulthintWithDep.idr
+++ b/tests/idris2/interface/interface031/DefaulthintWithDep.idr
@@ -1,0 +1,67 @@
+interface X where
+  x : Nat
+
+f : X => Nat
+f = x + 1
+
+namespace NoHintArg
+
+  %defaulthint
+  DefaultX : X
+  DefaultX = D where
+    [D] X where x = 5
+
+  fDef : Nat
+  fDef = f
+
+namespace WithDefaultHintArg
+
+  interface Y' where
+    y : Nat
+
+  [YY] Y' where
+    y = 6
+
+  %defaulthint
+  YY' : Y'
+  YY' = YY
+
+  %defaulthint
+  DefaultX : Y' => X
+  DefaultX = D where
+    [D] X where x = 5
+
+  fDef : Nat
+  fDef = f
+
+namespace JustHint
+
+  interface Y'' where
+    y : Nat
+
+  Y'' where
+    y = 6
+
+  %hint
+  DefaultX : Y'' => X
+  DefaultX = D where
+    [D] X where x = 5
+
+  fDef : Nat
+  fDef = f
+
+namespace WithHintArg
+
+  interface Y''' where
+    y : Nat
+
+  Y''' where
+    y = 6
+
+  %defaulthint
+  DefaultX : Y''' => X
+  DefaultX = D where
+    [D] X where x = 5
+
+  fDef : Nat
+  fDef = f

--- a/tests/idris2/interface/interface031/expected
+++ b/tests/idris2/interface/interface031/expected
@@ -1,0 +1,1 @@
+1/1: Building DefaulthintWithDep (DefaulthintWithDep.idr)

--- a/tests/idris2/interface/interface031/run
+++ b/tests/idris2/interface/interface031/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check DefaulthintWithDep.idr

--- a/tests/idris2/interface/interface032/DefaulthintInterfaceBug.idr
+++ b/tests/idris2/interface/interface032/DefaulthintInterfaceBug.idr
@@ -1,0 +1,42 @@
+namespace Data
+
+  interface X where
+    x : Nat
+
+  data Y : Type where
+    MkY : Nat -> Y
+
+  Y => X where
+    x @{MkY y} = y
+
+  %defaulthint
+  DefY : Y
+  DefY = MkY 6
+
+  f : X => IO ()
+  f = printLn x
+
+  main : IO ()
+  main = f
+
+namespace Interface
+
+  interface X' where
+    x' : Nat
+
+  interface Y' where
+    constructor MkY
+    y' : Nat
+
+  Y' => X' where
+    x' = y'
+
+  %defaulthint
+  DefY' : Y'
+  DefY' = MkY 6
+
+  f' : X' => IO ()
+  f' = printLn x'
+
+  main : IO ()
+  main = f'

--- a/tests/idris2/interface/interface032/expected
+++ b/tests/idris2/interface/interface032/expected
@@ -1,0 +1,1 @@
+1/1: Building DefaulthintInterfaceBug (DefaulthintInterfaceBug.idr)

--- a/tests/idris2/interface/interface032/run
+++ b/tests/idris2/interface/interface032/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check DefaulthintInterfaceBug.idr


### PR DESCRIPTION
Fixes #2850, fixes #2932.

The root cause of both fixed problems was errorneous proparation of the `defaults` flag down to search of *dependencies* of found hint candidates. Default hint may require non-default implementation as an `auto`-argument and vice versa. You can see cases in reported issues being fixed.

Some special error treatement was added to make sure we leave adequate error messages in case of the whole search went bad.

This PR is split to several commits to make review easier.