### PR TITLE
[ fix ] fix macos ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ test: testenv
 	@echo "NOTE: \`${MAKE} test\` does not rebuild Idris or the libraries packaged with it; to do that run \`${MAKE}\`"
 	@if [ ! -x "${TARGET}" ]; then echo "ERROR: Missing IDRIS2 executable. Cannot run tests!\n"; exit 1; fi
 	@echo
-	@${MAKE} -C tests only=$(only) except=$(except) IDRIS2=${TARGET} IDRIS2_PREFIX=${TEST_PREFIX}
+	@${MAKE} -C tests only=$(only) except=$(except) IDRIS2=${TARGET} IDRIS2_PREFIX=${TEST_PREFIX} CPPFLAGS="${CPPFLAGS}" LDFLAGS="${LDFLAGS}"
 
 
 retest: testenv

--- a/config.mk
+++ b/config.mk
@@ -36,6 +36,12 @@ else
 	SHLIB_SUFFIX := .so
 endif
 
+# Find homebrew's libgmp on ARM macs
+ifneq (,$(wildcard /opt/homebrew/include/gmp.h))
+	CPPFLAGS += -I/opt/homebrew/include
+	LDFLAGS += -L/opt/homebrew/lib
+endif
+
 ifneq (, $(findstring freebsd, $(MACHINE)))
 	CFLAGS += -I$(shell /sbin/sysctl -n user.localbase)/include
 	LDFLAGS += -L$(shell /sbin/sysctl -n user.localbase)/lib

--- a/config.mk
+++ b/config.mk
@@ -37,9 +37,9 @@ else
 endif
 
 # Find homebrew's libgmp on ARM macs
-ifneq (,$(wildcard /opt/homebrew/include/gmp.h))
-	CPPFLAGS += -I/opt/homebrew/include
-	LDFLAGS += -L/opt/homebrew/lib
+ifneq (,$(wildcard ${HOMEBREW_PREFIX}/include/gmp.h))
+	CPPFLAGS += -I${HOMEBREW_PREFIX}/include
+	LDFLAGS += -L${HOMEBREW_PREFIX}/lib
 endif
 
 ifneq (, $(findstring freebsd, $(MACHINE)))

--- a/tests/refc/ccompilerArgs/run
+++ b/tests/refc/ccompilerArgs/run
@@ -20,8 +20,8 @@ cd ./library/
     make > /dev/null
 cd ..
 
-export CFLAGS="-I./library/ -O3"
-export LDFLAGS="-L./library/ -Wl,-S"
+export CFLAGS="-I./library/ -O3 ${CFLAGS}"
+export LDFLAGS="-L./library/ -Wl,-S ${LDFLAGS}"
 export LDLIBS="-lexternalc"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:./library/"
 export DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH:./library/"


### PR DESCRIPTION
# Description

On ARM macs, homebrew stashes libgmp in `/opt/homebrew`.  The compiler build fails unless you set CPATH or CPPFLAGS.   It looks like github is now using ARM macs and the CI is failing.  Pack updates also fail for this reason (stefan-hoeck/idris2-pack#283).

The PR changes `config.mk` to look for `/opt/homebrew/include/gmp.h` and update `CPPFLAGS` and `LDFLAGS` if it is there.
