### PR TITLE
[ parser ] Add support for impossible lambdas

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -46,6 +46,9 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
   environment variable adds to the "Package Search Paths." Functionally this is
   not a breaking change.
 
+* The compiler now supports `impossible` in a non-case lambda. You can now
+  write `\ Refl impossible`.
+
 ### Backend changes
 
 #### RefC Backend

--- a/libs/test/Test/Golden.idr
+++ b/libs/test/Test/Golden.idr
@@ -427,7 +427,7 @@ testsInDir :
   (poolName : String) ->
   {default [] requirements : List Requirement} ->
   {default Nothing codegen : Codegen} ->
-  IO TestPool
+  Lazy (IO TestPool)
 testsInDir dirName poolName = do
   Right names <- listDir dirName
     | Left e => die $ "failed to list " ++ dirName ++ ": " ++ show e

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -782,10 +782,21 @@ mutual
            commit
            switch <- optional (bounds $ decoratedKeyword fname "case")
            case switch of
-             Nothing => continueLam
+             Nothing => continueLamImpossible <|> continueLam
              Just r  => continueLamCase r
 
      where
+       continueLamImpossible : Rule PTerm
+       continueLamImpossible = do
+           lhs <- bounds (opExpr plhs fname indents)
+           end <- bounds (decoratedKeyword fname "impossible")
+           pure (
+             let fc = boundToFC fname (mergeBounds lhs end)
+                 alt = (MkImpossible fc lhs.val)
+                 fcCase = boundToFC fname lhs
+                 n = MN "lcase" 0 in
+             (PLam fcCase top Explicit (PRef fcCase n) (PInfer fcCase) $
+                 PCase (virtualiseFC fc) [] (PRef fcCase n) [alt]))
 
        bindAll : List (RigCount, WithBounds PTerm, PTerm) -> PTerm -> PTerm
        bindAll [] scope = scope

--- a/tests/idris2/error/perror032/LambdaImpossible.idr
+++ b/tests/idris2/error/perror032/LambdaImpossible.idr
@@ -1,0 +1,2 @@
+foo : 2 = 3 -> Void
+foo = (\Refl impossible)

--- a/tests/idris2/error/perror032/expected
+++ b/tests/idris2/error/perror032/expected
@@ -1,0 +1,1 @@
+1/1: Building LambdaImpossible (LambdaImpossible.idr)

--- a/tests/idris2/error/perror032/run
+++ b/tests/idris2/error/perror032/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check LambdaImpossible.idr


### PR DESCRIPTION
# Description

A user on the Discord was having trouble figuring out the syntax for creating a lambda whose cases are impossible.  It is currently supported via a case lambda: `\case Refl impossible`, but not with a bare lambda. The error message is unclear on what to do.

With this change we can now write expressions like `\Refl impossible` for impossible lambdas.

## Should this change go in the CHANGELOG?

- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).
