### PR TITLE
dont execute effect in toMaybeT if condition is not met

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/Idris2.iml
+++ b/.idea/Idris2.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.10" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/Idris2.iml" filepath="$PROJECT_DIR$/.idea/Idris2.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -127,6 +127,8 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 
 * Removed need for the runtime value of the implicit argument in `succNotLTEpred`.
 
+* `toMaybeT` no longer executes its effect if the condition is not met.
+
 #### Contrib
 
 * `Data.List.Lazy` was moved from `contrib` to `base`.

--- a/libs/base/Control/Monad/Maybe.idr
+++ b/libs/base/Control/Monad/Maybe.idr
@@ -74,7 +74,8 @@ fromMaybeT v x = runMaybeT x >>= maybe v pure
 public export
 %inline
 toMaybeT : Functor m => Bool -> m a -> MaybeT m a
-toMaybeT b m = MkMaybeT $ map (\a => toMaybe b a) m
+toMaybeT True m = MkMaybeT $ map Just m
+toMaybeT False _ = MkMaybeT $ pure Nothing
 
 ||| Map over the underlying computation.
 public export


### PR DESCRIPTION
# Description

I'm not sure about this, but is it a bug that
```
toMaybeT : Functor m => Bool -> m a -> MaybeT m a
toMaybeT b m = MkMaybeT $ map (\a => toMaybe b a) m
```
always executes its `m` effect.

If so, this fixes that.

See also
```
toMaybe : Bool -> Lazy a -> Maybe a
toMaybe True  j = Just j
toMaybe False _ = Nothing
```

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

