### PR TITLE
[ funext ] Add a proof for funext variants with the other quantities

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -127,6 +127,9 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 
 * Removed need for the runtime value of the implicit argument in `succNotLTEpred`.
 
+* Added `funExt0` and `funExt1`, functions analogous to `funExt` but for functions
+  with quantities 0 and 1 respectively.
+
 #### Contrib
 
 * `Data.List.Lazy` was moved from `contrib` to `base`.

--- a/libs/base/Control/Function/FunExt.idr
+++ b/libs/base/Control/Function/FunExt.idr
@@ -10,3 +10,11 @@ module Control.Function.FunExt
 public export
 interface FunExt where
   funExt : {0 b : a -> Type} -> {0 f, g : (x : a) -> b x} -> ((x : a) -> f x = g x) -> f = g
+
+export
+funExt0 : FunExt => {0 b : a -> Type} -> {0 f, g : (0 x : a) -> b x} -> ((x : a) -> f x = g x) -> f = g
+funExt0 prf = rewrite funExt {f = \x => f x} {g = \y => g y} prf in Refl
+
+export
+funExt1 : FunExt => {0 b : a -> Type} -> {0 f, g : (1 x : a) -> b x} -> ((x : a) -> f x = g x) -> f = g
+funExt1 prf = rewrite funExt {f = \x => f x} {g = \y => g y} prf in Refl


### PR DESCRIPTION
# Description

We have a `FunExt` interface containing general enough proposition, for omega-quantitied functions. But this property is also useful for functions taking arguments with the other quantities as well. Thankfully, these properties are derivable from the existing one, so I propose to add them with their proofs to the library.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

