### PR TITLE
[ fix ] fix windows CI, aligned_alloc not supported on win32

### DIFF
--- a/support/refc/memoryManagement.c
+++ b/support/refc/memoryManagement.c
@@ -2,7 +2,8 @@
 #include "runtime.h"
 
 Value *idris2_newValue(size_t size) {
-#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) /* C11 */
+#if !defined(_WIN32) && defined(__STDC_VERSION__) &&                           \
+    (__STDC_VERSION__ >= 201112) /* C11 */
   Value *retVal = (Value *)aligned_alloc(
       sizeof(void *),
       ((size + sizeof(void *) - 1) / sizeof(void *)) * sizeof(void *));


### PR DESCRIPTION
# Description

The support code calls `aligned_alloc` which does not appear to be supported on windows, and is not defined in the `stdlib.h` header file. The latest GitHub windows image has turned the warning about this into an error, causing ci to fail.

I’ve updated the condition in `memoryManagement.c` to use the fallback branch which calls `malloc` when building on windows.
