### PR TITLE
Add pipeline operators

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -98,6 +98,8 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 
 #### Prelude
 
+* Added pipeline operators `(|>)` and `(<|)`.
+
 #### Base
 
 * `Data.List.Lazy` was moved from `contrib` to `base`.

--- a/libs/prelude/Prelude/Basics.idr
+++ b/libs/prelude/Prelude/Basics.idr
@@ -97,6 +97,26 @@ public export
 ($) : forall a, b . ((x : a) -> b x) -> (x : a) -> b x
 ($) f a = f a
 
+||| Pipeline style function application, useful for chaining
+||| functions into a series of transformations, reading top
+||| to bottom.
+|||
+||| ```idris example
+||| [[1], [2], [3]] |> join |> map (* 2)
+||| ```
+public export
+(|>) : a -> (a -> b) -> b
+a |> f = f a
+
+||| Backwards pipeline style function application, similar to $.
+|||
+||| ```idris example
+||| unpack <| "hello" ++ "world"
+||| ```
+public export
+(<|) : (a -> b) -> a -> b
+f <| a = f a
+
 -------------------
 -- PROOF HELPERS --
 -------------------

--- a/libs/prelude/Prelude/Ops.idr
+++ b/libs/prelude/Prelude/Ops.idr
@@ -24,7 +24,8 @@ export infixr 4 <$>, $>, <$
 export infixl 8 <+>
 
 -- Utility operators
-export infixr 9 ., .:, |>
+export infixr 9 ., .:
 export infixr 0 $, <|
+export infixl 0 |>
 
 export infixl 9 `div`, `mod`

--- a/libs/prelude/Prelude/Ops.idr
+++ b/libs/prelude/Prelude/Ops.idr
@@ -24,7 +24,7 @@ export infixr 4 <$>, $>, <$
 export infixl 8 <+>
 
 -- Utility operators
-export infixr 9 ., .:
-export infixr 0 $
+export infixr 9 ., .:, |>
+export infixr 0 $, <|
 
 export infixl 9 `div`, `mod`

--- a/src/Libraries/Data/PosMap.idr
+++ b/src/Libraries/Data/PosMap.idr
@@ -10,8 +10,8 @@ import Core.FC
 
 import Data.List
 
-%hide Prelude.Ops.infixr.(|>)
 %hide Prelude.Ops.infixr.(<|)
+%hide Prelude.Ops.infixl.(|>)
 
 %default total
 

--- a/src/Libraries/Data/PosMap.idr
+++ b/src/Libraries/Data/PosMap.idr
@@ -10,6 +10,9 @@ import Core.FC
 
 import Data.List
 
+%hide Prelude.Ops.infixr.(|>)
+%hide Prelude.Ops.infixr.(<|)
+
 %default total
 
 export infixr 5 <|, <:

--- a/tests/idris2/misc/import009/Import.idr
+++ b/tests/idris2/misc/import009/Import.idr
@@ -2,6 +2,8 @@ module Import
 
 import Test
 
+%hide Prelude.Ops.infixr.(|>)
+
 (|>) : (s : HasComp x) => {0 a, b, c : x} -> a ~> b -> b ~> c -> a ~> c
 a |> b = comp s a b
 

--- a/tests/idris2/misc/import009/Import.idr
+++ b/tests/idris2/misc/import009/Import.idr
@@ -2,7 +2,7 @@ module Import
 
 import Test
 
-%hide Prelude.Ops.infixr.(|>)
+%hide Prelude.Ops.infixl.(|>)
 
 (|>) : (s : HasComp x) => {0 a, b, c : x} -> a ~> b -> b ~> c -> a ~> c
 a |> b = comp s a b

--- a/tests/idris2/misc/import009/expected
+++ b/tests/idris2/misc/import009/expected
@@ -2,13 +2,13 @@
 2/2: Building Import (Import.idr)
 Error: Unknown operator '~:>'
 
-Import:9:1--9:8
- 5 | (|>) : (s : HasComp x) => {0 a, b, c : x} -> a ~> b -> b ~> c -> a ~> c
- 6 | a |> b = comp s a b
- 7 | 
- 8 | (~:>) : Type -> Type -> Type
- 9 | a ~:> b = Pair a b
-     ^^^^^^^
+Import:11:1--11:8
+ 07 | (|>) : (s : HasComp x) => {0 a, b, c : x} -> a ~> b -> b ~> c -> a ~> c
+ 08 | a |> b = comp s a b
+ 09 | 
+ 10 | (~:>) : Type -> Type -> Type
+ 11 | a ~:> b = Pair a b
+      ^^^^^^^
 
 1/3: Building Prefix (Prefix.idr)
 Error: While processing right hand side of test. When unifying:

--- a/tests/idris2/operators/operators001/Test.idr
+++ b/tests/idris2/operators/operators001/Test.idr
@@ -6,7 +6,7 @@ import Data.Vect
 private typebind infixr 0 =@
 private infixr 0 -@
 
-%hide Prelude.Ops.infixr.(|>)
+%hide Prelude.Ops.infixl.(|>)
 
 -- typebind infixr 1 =@@
 
@@ -79,4 +79,3 @@ compose (a |> a') (b |> b') =
   (x : (y : a) @@ (a' y -> b)) |>
        (y : a' x.fst) @@
             b' (x.snd y)
-

--- a/tests/idris2/operators/operators001/Test.idr
+++ b/tests/idris2/operators/operators001/Test.idr
@@ -6,6 +6,8 @@ import Data.Vect
 private typebind infixr 0 =@
 private infixr 0 -@
 
+%hide Prelude.Ops.infixr.(|>)
+
 -- typebind infixr 1 =@@
 
 0 (=@) : (a : Type) -> (a -> Type) -> Type

--- a/tests/prelude/operators001/Test.idr
+++ b/tests/prelude/operators001/Test.idr
@@ -1,0 +1,8 @@
+
+testPipelineRight : Bool
+testPipelineRight =
+    ([[1], [2], [3]] |> join |> map (* 2)) == [2,4,6]
+
+testPipelineLeft : Bool
+testPipelineLeft =
+    (unpack <| "hello" ++ "world") == ['h', 'e', 'l', 'l', 'o', 'w', 'o', 'r', 'l', 'd']

--- a/tests/prelude/operators001/expected
+++ b/tests/prelude/operators001/expected
@@ -1,0 +1,1 @@
+1/1: Building Test (Test.idr)

--- a/tests/prelude/operators001/run
+++ b/tests/prelude/operators001/run
@@ -1,0 +1,3 @@
+. ../../testutils.sh
+
+check Test.idr


### PR DESCRIPTION
# Description
Adds the pipeline operators `|>` and `<|` known from other functional languages like F# and Elixir.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

