### PR TITLE
[ fixup #2939 ] Make futures not interfere with optimisations

### DIFF
--- a/libs/contrib/System/Future.idr
+++ b/libs/contrib/System/Future.idr
@@ -12,11 +12,11 @@ data Future : Type -> Type where [external]
 %foreign "scheme:blodwen-await-future"
 prim__awaitFuture : {0 a : Type} -> Future a -> a
 
-export
+export %inline -- inlining is important for correct context in codegens
 fork : Lazy a -> Future a
 fork = prim__makeFuture
 
-export
+export %inline -- inlining is important for correct context in codegens
 await : Future a -> a
 await f = prim__awaitFuture f
 

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -171,8 +171,8 @@ mutual
            c' <- schExp cs (chezExtPrim cs) chezString 0 c
            pure $ mkWorld $ "(blodwen-register-object " ++ p' ++ " " ++ c' ++ ")"
   chezExtPrim cs i MakeFuture [_, work]
-      = do work' <- schExp cs (chezExtPrim cs) chezString 0 work
-           pure $ "(blodwen-make-future " ++ work' ++ ")"
+      = do work' <- schExp cs (chezExtPrim cs) chezString 0 $ NmForce EmptyFC LUnknown work
+           pure $ "(blodwen-make-future (lambda () " ++ work' ++ "))"
   chezExtPrim cs i prim args
       = schExtCommon cs (chezExtPrim cs) chezString i prim args
 

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -113,8 +113,8 @@ mutual
            c' <- schExp cs (racketPrim cs) racketString 0 c
            pure $ mkWorld $ "(blodwen-register-object " ++ p' ++ " " ++ c' ++ ")"
   racketPrim cs i MakeFuture [_, work]
-      = do work' <- schExp cs (racketPrim cs) racketString 0 work
-           pure $ mkWorld $ "(blodwen-make-future " ++ work' ++ ")"
+      = do work' <- schExp cs (racketPrim cs) racketString 0 $ NmForce EmptyFC LUnknown work
+           pure $ mkWorld $ "(blodwen-make-future (lambda () " ++ work' ++ "))"
   racketPrim cs i prim args
       = schExtCommon cs (racketPrim cs) racketString i prim args
 

--- a/tests/chez/futures002/Futures.idr
+++ b/tests/chez/futures002/Futures.idr
@@ -1,0 +1,14 @@
+module Futures
+
+import System.Future
+
+-- Checks the interference between CSE optimisations and de-optimisations
+-- and management of lazy values
+
+topLevelConstant : Lazy String
+topLevelConstant = "top-level indeed"
+
+main : IO ()
+main = do
+  let a = await $ fork topLevelConstant
+  putStrLn a

--- a/tests/chez/futures002/expected
+++ b/tests/chez/futures002/expected
@@ -1,0 +1,1 @@
+top-level indeed

--- a/tests/chez/futures002/run
+++ b/tests/chez/futures002/run
@@ -1,0 +1,5 @@
+. ../../testutils.sh
+
+idris2 --cg chez Futures.idr -p contrib --exec main
+
+rm -r build

--- a/tests/racket/barrier001/run
+++ b/tests/racket/barrier001/run
@@ -1,3 +1,3 @@
 . ../../testutils.sh
 
-run --cg chez Main.idr
+run --cg racket Main.idr

--- a/tests/racket/futures002/Futures.idr
+++ b/tests/racket/futures002/Futures.idr
@@ -1,0 +1,14 @@
+module Futures
+
+import System.Future
+
+-- Checks the interference between CSE optimisations and de-optimisations
+-- and management of lazy values
+
+topLevelConstant : Lazy String
+topLevelConstant = "top-level indeed"
+
+main : IO ()
+main = do
+  let a = await $ fork topLevelConstant
+  putStrLn a

--- a/tests/racket/futures002/expected
+++ b/tests/racket/futures002/expected
@@ -1,0 +1,1 @@
+top-level indeed

--- a/tests/racket/futures002/run
+++ b/tests/racket/futures002/run
@@ -1,0 +1,5 @@
+. ../../testutils.sh
+
+idris2 --cg racket Futures.idr -p contrib --exec main
+
+rm -r build


### PR DESCRIPTION
# Description

Fix in #2939 accidentally broke one (actually, inconsistent) assumption about how the lazy values are managed. This may lead to a crash, you can see an example in the newly added test. Incidentally, this does not crash on chez (yet) because of undocumented coindicence of two runtime representations in the current particular implementation (dynamically-typed languages, omg), but this can change in the future at any time. Racket fails properly.

I changed the way the primitive `prim__makeFuture` is called: now it reuses the way the forcing is actually implemented instead of trying to assume particular implementation. We should be more stable on potential future changes of the way lazy values are treated after this PR.

Pinging @mjustus as the merger of #2939.

UPD: Oh, and I found that one racket test actually run on chez, I think that was a copy-paste error, so I changed it.