### PR TITLE
fix: typos in "Expressions"

### DIFF
--- a/docs/source/reference/pragmas.rst
+++ b/docs/source/reference/pragmas.rst
@@ -466,7 +466,7 @@ Pragmas that occur inside expressions.
 ``%runElab``
 --------------------
 
-The ``%runElab`` pragma can be used at the top level or as an expression. It takes the an elaboration
+The ``%runElab`` pragma can be used at the top level or as an expression. It takes an elaborator
 script as an argument which runs in the ``Elab`` monad, has access to Idris' type-checking machinery,
 and can generate code.
 


### PR DESCRIPTION
# Description

This fixes a typo.

Discussed with @buzden over the Discord channel.