### PR TITLE
[ doc ] reference intro info on elab

### DIFF
--- a/docs/source/reference/pragmas.rst
+++ b/docs/source/reference/pragmas.rst
@@ -20,7 +20,7 @@ Global pragmas
 ``%language``
 --------------------
 
-Enable language extensions.  Currently, the only extension is ``ElabReflection``.
+Enable language extensions.  Currently, the only extension is [#ElabReflection]_.
 
 .. code-block:: idris
 
@@ -493,3 +493,4 @@ over the value syntactically, rather than by value, and can significantly speed
 up elaboration where large types are involved, at a cost of being less general.
 Try it if "with" is slow.
 
+.. [#ElabReflection] https://github.com/stefan-hoeck/idris2-elab-util/blob/main/src/Doc/Index.md


### PR DESCRIPTION
# Description

Hi,

I'm was not sure what elaborator reflection was and I saw references to it in the main docs but couldn't find any information introducing it. 

This PR links introductory material by @stefan-hoeck as discussed with @buzden over Discord.