### PR TITLE
fix(base): runtime-erase implicit length argument to Vect's `dropElem`.

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -147,6 +147,9 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 * Moved definition of `Data.Vect.nubBy` to the global scope as `nubByImpl` to
   allow compile time proofs on `nubBy` and `nub`.
 
+* Removed need for the runtime value of the implicit length argument in
+  `Data.Vect.Elem.dropElem`.
+
 #### Contrib
 
 * `Data.List.Lazy` was moved from `contrib` to `base`.

--- a/libs/base/Data/Vect/Elem.idr
+++ b/libs/base/Data/Vect/Elem.idr
@@ -94,9 +94,9 @@ mapElem (There e) = There (mapElem e)
 ||| @xs The vector to be removed from
 ||| @p A proof that the element to be removed is in the vector
 public export
-dropElem : {k : _} -> (xs : Vect (S k) t) -> Elem x xs -> Vect k t
-dropElem           (x::ys)  Here         = ys
-dropElem {k = S k} (x::ys) (There later) = x :: dropElem ys later
+dropElem : (xs : Vect (S k) t) -> Elem x xs -> Vect k t
+dropElem (x::ys)         Here         = ys
+dropElem (x::ys@(_::_)) (There later) = x :: dropElem ys later
 
 ||| Erase the indices, returning the bounded numeric position of the element
 public export


### PR DESCRIPTION
# Description

This makes it possible to call the function in more situations. It also brings its signature in line with the overloads on `List`, `List1` and `SnocList`.

The previous implementation of `Data.Vect.Elem.dropElem` required the length of the `Vect` to be available at runtime. This was used in order to recurse in the case that the `Elem` is not `Here`. However, it turns out that this is not actually necessary. Idris can deduce that the tail must be non-empty if it contains an `Elem`.

## Should this change go in the CHANGELOG?

- [x] If this is a fix, user-facing change, a compiler change, or a new paper implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also `CONTRIBUTORS.md`).

