### PR TITLE
Update typedd.rst

### DIFF
--- a/docs/source/typedd/typedd.rst
+++ b/docs/source/typedd/typedd.rst
@@ -37,6 +37,8 @@ In ``Average.idr``, add:
     import Data.List -- for `length` on lists
     import System.REPL -- for `repl`
 
+Instead of entering ``6.0 + 3 * 12``, enter ``the Double (6.0 + 3 * 12)``.
+
 In ``AveMain.idr`` and ``Reverse.idr`` add:
 
 .. code-block:: idris


### PR DESCRIPTION
# Description

Entering the expression `6.0 + 3 * 12` in the REPL produces the following error on Idris 2:

> Error: Can't find an implementation for `FromDouble Integer`.

Instead, entering `the Double (6.0 + 3 * 12)` behaves as stated in the book.

## Should this change go in the CHANGELOG?

No

