### PR TITLE
[ fix ] auto search returns no solution instead of ambiguous solution #3313

### DIFF
--- a/src/Core/AutoSearch.idr
+++ b/src/Core/AutoSearch.idr
@@ -142,6 +142,7 @@ anyOne fc env top [elab]
     = catch elab $
          \case
            err@(CantSolveGoal _ _ _ _ _) => throw err
+           err@(AmbiguousSearch _ _ _ _) => throw err
            _ => throw $ CantSolveGoal fc (gamma !(get Ctxt)) [] top Nothing
 anyOne fc env top (elab :: elabs)
     = tryUnify elab (anyOne fc env top elabs)

--- a/tests/idris2/error/error028/Issue3313.idr
+++ b/tests/idris2/error/error028/Issue3313.idr
@@ -1,0 +1,5 @@
+data Expr : Type -> Type where
+    Add : (Integral n) => n -> n -> Expr n
+
+eval : (Integral n) => Expr n -> n
+eval (Add x y) = x + y

--- a/tests/idris2/error/error028/expected
+++ b/tests/idris2/error/error028/expected
@@ -1,0 +1,15 @@
+1/1: Building Issue3313 (Issue3313.idr)
+Error: While processing right hand side of eval. Multiple solutions found in search of:
+    Integral n
+
+Issue3313:5:18--5:23
+ 1 | data Expr : Type -> Type where
+ 2 |     Add : (Integral n) => n -> n -> Expr n
+ 3 | 
+ 4 | eval : (Integral n) => Expr n -> n
+ 5 | eval (Add x y) = x + y
+                      ^^^^^
+
+Possible correct results:
+    conArg (implicitly bound at Issue3313:5:1--5:23)
+    conArg (implicitly bound at Issue3313:5:1--5:23)

--- a/tests/idris2/error/error028/run
+++ b/tests/idris2/error/error028/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check Issue3313.idr


### PR DESCRIPTION
# Description

This fixes #3313, where auto search reports no solution instead of an ambiguous solution. 

The root cause it that the `AmbiguousSearch` error is caught and then re-emitted as `CantSolveGoal`.

Prior to this change the code:
```idris
data Expr : Type -> Type where
    Add : (Integral n) => n -> n -> Expr n

eval : (Integral n) => Expr n -> n
eval (Add x y) = x + y
```
reports
```
1/1: Building src.Issue3313 (src/Issue3313.idr)
Error: While processing right hand side of eval. Can't find an implementation for Num n.

src.Issue3313:5:18--5:23
 1 | data Expr : Type -> Type where
 2 |     Add : (Integral n) => n -> n -> Expr n
 3 | 
 4 | eval : (Integral n) => Expr n -> n
 5 | eval (Add x y) = x + y
                      ^^^^^
```
and after the change it reports
```
1/1: Building Issue3313 (src/Issue3313.idr)
Error: While processing right hand side of eval. Multiple solutions found in search of:
    Integral n

Issue3313:5:18--5:23
 1 | data Expr : Type -> Type where
 2 |     Add : (Integral n) => n -> n -> Expr n
 3 | 
 4 | eval : (Integral n) => Expr n -> n
 5 | eval (Add x y) = x + y
                      ^^^^^

Possible correct results:
    conArg (implicitly bound at Issue3313:5:1--5:23)
    conArg (implicitly bound at Issue3313:5:1--5:23)
```
