### PR TITLE
Update typedd.rst

### DIFF
--- a/docs/source/typedd/typedd.rst
+++ b/docs/source/typedd/typedd.rst
@@ -60,6 +60,12 @@ match on:
     createEmpties : {n : _} -> Vect n (Vect 0 elem)
     transposeMat : {n : _} -> Vect m (Vect n elem) -> Vect n (Vect m elem)
 
+For the same reason, we also need to change the type of ``length`` to:
+
+.. code-block:: idris
+
+    length : {n : _} -> Vect n elem -> Nat
+
 Chapter 4
 ---------
 


### PR DESCRIPTION
# Description

The following `length`:

    length : Vect n elem -> Nat
    length {n} xs = n

produces the following error on Idris 2:

> Error: While processing right hand side of `length`. `n` is not accessible in this context.

Turning `n` into a *bound implicit* name behaves as described in the book.

## Should this change go in the CHANGELOG?

No

