### PR TITLE
List packages improvements

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -5,6 +5,17 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 
 ## [Next version]
 
+### CLI changes
+
+* The `idris2 --list-packages` command now outputs information about the
+  location and available TTC versions for each package it finds. It also shows
+  the current Idris2 TTC version so you can spot packages that do not have a
+  compatible TTC install. The TTC version tracks breaking changes to the
+  compiled binary format of Idris2 code and it is separate from Idris2's
+  semantic version (e.g. 0.7.0). A library without the correct TTC version
+  installed will be ignored by the compiler when it tries to use that library as
+  a dependency for some other package.
+
 ### Building/Packaging changes
 
 * The Nix flake's `buildIdris` function now returns a set with `executable` and

--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,7 @@
               make src/IdrisPaths.idr
             '';
           };
+          stdenv' = with pkgs; if stdenv.isDarwin then overrideSDK stdenv "11.0" else stdenv;
         in {
           checks = import ./nix/test.nix {
             inherit (pkgs) system stdenv runCommand lib;
@@ -76,7 +77,7 @@
             inherit pkgs idris-emacs-src idris2Pkg;
           });
           inherit buildIdris;
-          devShells.default = pkgs.mkShell {
+          devShells.default = pkgs.mkShell.override { stdenv = stdenv'; } {
             packages = idris2Pkg.buildInputs;
           };
         };

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -91,7 +91,7 @@ candidateDirs dname pkg bounds =
   mapMaybe checkBounds <$> getPackageDirs dname
 
   where checkBounds : PkgDir -> Maybe (String,Maybe PkgVersion)
-        checkBounds (MkPkgDir dirName pkgName ver ttcVersions) =
+        checkBounds (MkPkgDir dirName pkgName ver _) =
           do guard (pkgName == pkg && inBounds ver bounds)
              pure ((dname </> dirName), ver)
 

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -2,6 +2,7 @@ module Idris.SetOptions
 
 import Compiler.Common
 
+import Core.Binary
 import Core.Context
 import Core.Directory
 import Core.Metadata
@@ -38,6 +39,8 @@ record PkgDir where
   pkgName : String
   ||| Package version. Example `Just $ MkPkgVersion (0 ::: [3,0])`
   version : Maybe PkgVersion
+  ||| Versions of binary TTC format supported by library
+  ttcVersions : List Int
 
 record QualifiedPkgDir where
   constructor MkQualifiedPkgDir
@@ -48,28 +51,36 @@ record QualifiedPkgDir where
 
 -- dissects a directory name, trying to extract
 -- the corresponding package name and -version
-pkgDir : String -> PkgDir
-pkgDir str =
+pkgDir : (dirName : String) -> (ttcDirs : List Int) -> PkgDir
+pkgDir dirName ttcDirs =
    -- Split the dir name into parts concatenated by "-"
    -- treating the last part as the version number
    -- and the initial parts as the package name.
    -- For reasons of backwards compatibility, we also
    -- accept hyphenated directory names without a part
    -- corresponding to a version number.
-   case Lib.unsnoc $ split (== '-') str of
-     (Nil, last) => MkPkgDir str last Nothing
+   case Lib.unsnoc $ split (== '-') dirName of
+     (Nil, last) => MkPkgDir dirName last Nothing ttcDirs
      (init,last) =>
        case toVersion last of
-         Just v  => MkPkgDir str (concat $ intersperse "-" init) (Just v)
-         Nothing => MkPkgDir str str Nothing
+         Just v  => MkPkgDir dirName (concat $ intersperse "-" init) (Just v) ttcDirs
+         Nothing => MkPkgDir dirName dirName Nothing ttcDirs
   where
     toVersion : String -> Maybe PkgVersion
     toVersion = map MkPkgVersion
               . traverse parsePositive
               . split (== '.')
 
+listDirOrEmpty : String -> IO (List String)
+listDirOrEmpty dir = either (const []) id <$> listDir dir
+
 getPackageDirs : String -> IO (List PkgDir)
-getPackageDirs dname = map pkgDir . either (const []) id <$> listDir dname
+getPackageDirs dname = do
+  packageDirNames <- listDirOrEmpty dname
+  traverse (\d => pkgDir d <$> ttcVersions d) packageDirNames
+  where
+    ttcVersions : String -> IO (List Int)
+    ttcVersions dir = catMaybes . map parsePositive <$> listDirOrEmpty (dname </> dir)
 
 -- Get a list of all the candidate directories that match a package spec
 -- in a given path. Return an empty list on file error (e.g. path not existing)
@@ -80,7 +91,7 @@ candidateDirs dname pkg bounds =
   mapMaybe checkBounds <$> getPackageDirs dname
 
   where checkBounds : PkgDir -> Maybe (String,Maybe PkgVersion)
-        checkBounds (MkPkgDir dirName pkgName ver) =
+        checkBounds (MkPkgDir dirName pkgName ver ttcVersions) =
           do guard (pkgName == pkg && inBounds ver bounds)
              pure ((dname </> dirName), ver)
 
@@ -163,15 +174,41 @@ listPackages : {auto c : Ref Ctxt Defs} ->
                Core ()
 listPackages
     = do pkgs <- sortBy (compare `on` (pkgName . pkgDir)) <$> findPackages
+         printIdrisTTCVersion
          traverse_ (iputStrLn . pkgDesc) pkgs
   where
+    printIdrisTTCVersion : Core ()
+    printIdrisTTCVersion = iputStrLn $
+      pretty0 "Idris2 TTC Version: \{show ttcVersion}" <+> line <+>
+      (replicateChar 5 '─')
+
+    pkgTTCVersions : PkgDir -> Doc IdrisAnn
+    pkgTTCVersions (MkPkgDir _ _ _ ttcVersions) =
+      pretty0 "├ TTC Versions:" <++> prettyTTCVersions
+      where
+        colorize : Int -> Doc IdrisAnn
+        colorize version =
+          if version == ttcVersion
+             then pretty0 $ show version
+             else warning (pretty0 $ show version)
+
+        prettyTTCVersions : Doc IdrisAnn
+        prettyTTCVersions = (concatWith (\x,y => x <+> "," <++> y)) $ colorize <$> sort ttcVersions
+
     pkgPath : String -> Doc IdrisAnn
-    pkgPath path = line <+> (indent 2 $ pretty0 "↳ \{path}")
+    pkgPath path = pretty0 "└ \{path}"
+
+    extraInfo : QualifiedPkgDir -> Doc IdrisAnn
+    extraInfo (MkQualifiedPkgDir path pkg) =
+      let extra = indent 2 $
+        pkgTTCVersions pkg <+> line <+>
+        pkgPath path
+      in line <+> extra
 
     pkgDesc : QualifiedPkgDir -> Doc IdrisAnn
-    pkgDesc (MkQualifiedPkgDir path (MkPkgDir _ pkgName version)) =
+    pkgDesc pkg@(MkQualifiedPkgDir _ (MkPkgDir _ pkgName version _)) =
       pretty0 pkgName <++> parens (pretty0 $ maybe "unversioned" show version)
-        <+> pkgPath path
+        <+> extraInfo pkg
 
 dirOption : {auto c : Ref Ctxt Defs} ->
             {auto o : Ref ROpts REPLOpts} ->

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -159,7 +159,8 @@ listPackages
          traverse_ (iputStrLn . pkgDesc) pkgs
   where
     pkgDesc : PkgDir -> Doc IdrisAnn
-    pkgDesc (MkPkgDir _ pkgName version) = pretty0 pkgName <++> parens (byShow version)
+    pkgDesc (MkPkgDir _ pkgName version) =
+      pretty0 pkgName <++> parens (pretty0 $ maybe "unversioned" show version)
 
 dirOption : {auto c : Ref Ctxt Defs} ->
             {auto o : Ref ROpts REPLOpts} ->

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -165,9 +165,13 @@ listPackages
     = do pkgs <- sortBy (compare `on` (pkgName . pkgDir)) <$> findPackages
          traverse_ (iputStrLn . pkgDesc) pkgs
   where
+    pkgPath : String -> Doc IdrisAnn
+    pkgPath path = line <+> (indent 2 $ pretty0 "↳ \{path}")
+
     pkgDesc : QualifiedPkgDir -> Doc IdrisAnn
     pkgDesc (MkQualifiedPkgDir path (MkPkgDir _ pkgName version)) =
-      pretty0 path <++> pretty0 pkgName <++> parens (pretty0 $ maybe "unversioned" show version)
+      pretty0 pkgName <++> parens (pretty0 $ maybe "unversioned" show version)
+        <+> pkgPath path
 
 dirOption : {auto c : Ref Ctxt Defs} ->
             {auto o : Ref ROpts REPLOpts} ->


### PR DESCRIPTION
# Description

This makes some improvements to the output of the `--list-packages` Idris2 option. Mostly, my aim was to make it more apparent when different "advanced" installs of Idris and libraries has created a problem because libraries aren't installed with the same TTC version as Idris2. The improvements also make it clear when you have multiple installs of a library in your package path and where these libraries are -- useful because Idris only "sees" the first one it encounters.

Before, an example of output for a complex install might be:
```
base (Just 0.7.0)
base (Just 0.7.0)
contrib (Just 0.7.0)
contrib (Just 0.7.0)
linear (Just 0.7.0)
linear (Just 0.7.0)
network (Just 0.7.0)
network (Just 0.7.0)
prelude (Just 0.7.0)
prelude (Just 0.7.0)
test (Just 0.7.0)
test (Just 0.7.0)
```

After (I've mucked with the TTC folders to illustrate the output's utility):
```
Idris2 TTC Version: 2024060800
─────
base (0.7.0)
  ├ TTC Versions: 1034060801, 2024060800
  └ /Users/matt/.idris2/idris2-0.7.0
base (0.7.0)
  ├ TTC Versions: 2024060800
  └ /nix/store/lwhmll13r9dhz1s7nawdka9d9wj5xhwj-idris2-0.7.0/idris2-0.7.0
contrib (0.7.0)
  ├ TTC Versions: 1034060801
  └ /Users/matt/.idris2/idris2-0.7.0
contrib (0.7.0)
  ├ TTC Versions: 2024060800
  └ /nix/store/lwhmll13r9dhz1s7nawdka9d9wj5xhwj-idris2-0.7.0/idris2-0.7.0
linear (0.7.0)
  ├ TTC Versions: 2024060800
  └ /Users/matt/.idris2/idris2-0.7.0
linear (0.7.0)
  ├ TTC Versions: 2024060800
  └ /nix/store/lwhmll13r9dhz1s7nawdka9d9wj5xhwj-idris2-0.7.0/idris2-0.7.0
network (0.7.0)
  ├ TTC Versions: 2024060800
  └ /Users/matt/.idris2/idris2-0.7.0
network (0.7.0)
  ├ TTC Versions: 2024060800
  └ /nix/store/lwhmll13r9dhz1s7nawdka9d9wj5xhwj-idris2-0.7.0/idris2-0.7.0
prelude (0.7.0)
  ├ TTC Versions: 2024060800
  └ /Users/matt/.idris2/idris2-0.7.0
prelude (0.7.0)
  ├ TTC Versions: 2024060800
  └ /nix/store/lwhmll13r9dhz1s7nawdka9d9wj5xhwj-idris2-0.7.0/idris2-0.7.0
test (0.7.0)
  ├ TTC Versions: 2024060800
  └ /Users/matt/.idris2/idris2-0.7.0
test (0.7.0)
  ├ TTC Versions: 2024060800
  └ /nix/store/lwhmll13r9dhz1s7nawdka9d9wj5xhwj-idris2-0.7.0/idris2-0.7.0
```

What doesn't show up above is that mismatched versions of TTC show up in yellow given a terminal that supports colors.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

