### PR TITLE
[ re #3314, #34 ] Tighten the location information for implicits

### DIFF
--- a/src/TTImp/Elab/App.idr
+++ b/src/TTImp/Elab/App.idr
@@ -187,7 +187,8 @@ mutual
            metaval <- metaVar fc argRig env nm metaty
            let fntm = App fc tm metaval
            fnty <- sc defs (toClosure defaultOpts env metaval)
-           when (bindingVars elabinfo) $ update EST $ addBindIfUnsolved nm argRig Implicit env metaval metaty
+           when (bindingVars elabinfo) $ update EST $
+             addBindIfUnsolved nm (getLoc (getFn tm)) argRig Implicit env metaval metaty
            checkAppWith rig elabinfo nest env fc
                         fntm fnty (n, 1 + argpos) expargs autoargs namedargs kr expty
 
@@ -220,7 +221,7 @@ mutual
                    metaval <- metaVar fc argRig env nm metaty
                    let fntm = App fc tm metaval
                    fnty <- sc defs (toClosure defaultOpts env metaval)
-                   update EST $ addBindIfUnsolved nm argRig AutoImplicit env metaval metaty
+                   update EST $ addBindIfUnsolved nm (getLoc (getFn tm)) argRig AutoImplicit env metaval metaty
                    checkAppWith rig elabinfo nest env fc
                                 fntm fnty (n, 1 + argpos) expargs autoargs namedargs kr expty
            else do defs <- get Ctxt
@@ -277,7 +278,7 @@ mutual
                    metaval <- metaVar fc argRig env nm metaty
                    let fntm = App fc tm metaval
                    fnty <- sc defs (toClosure defaultOpts env metaval)
-                   update EST $ addBindIfUnsolved nm argRig AutoImplicit env metaval metaty
+                   update EST $ addBindIfUnsolved nm (getLoc (getFn tm)) argRig AutoImplicit env metaval metaty
                    checkAppWith rig elabinfo nest env fc
                                 fntm fnty (n, 1 + argpos) expargs autoargs namedargs kr expty
            else do defs <- get Ctxt

--- a/src/TTImp/Elab/Term.idr
+++ b/src/TTImp/Elab/Term.idr
@@ -224,7 +224,7 @@ checkTerm rig elabinfo nest env (Implicit fc b) (Just gexpty)
          when (b && bindingVars elabinfo) $
             do expty <- getTerm gexpty
                -- Explicit because it's an explicitly given thing!
-               update EST $ addBindIfUnsolved nm rig Explicit env metaval expty
+               update EST $ addBindIfUnsolved nm fc rig Explicit env metaval expty
          pure (metaval, gexpty)
 checkTerm rig elabinfo nest env (Implicit fc b) Nothing
     = do nmty <- genName "implicit_type"
@@ -234,7 +234,7 @@ checkTerm rig elabinfo nest env (Implicit fc b) Nothing
          metaval <- metaVar fc rig env nm ty
          -- Add to 'bindIfUnsolved' if 'b' set
          when (b && bindingVars elabinfo) $
-            update EST $ addBindIfUnsolved nm rig Explicit env metaval ty
+            update EST $ addBindIfUnsolved nm fc rig Explicit env metaval ty
          pure (metaval, gnf env ty)
 checkTerm rig elabinfo nest env (IWithUnambigNames fc ns rhs) exp
     = do -- enter the scope -> add unambiguous names

--- a/tests/idris2/error/error028/expected
+++ b/tests/idris2/error/error028/expected
@@ -11,5 +11,5 @@ Issue3313:5:18--5:23
                       ^^^^^
 
 Possible correct results:
-    conArg (implicitly bound at Issue3313:5:1--5:23)
-    conArg (implicitly bound at Issue3313:5:1--5:23)
+    conArg (implicitly bound at Issue3313:5:7--5:10)
+    conArg (implicitly bound at Issue3313:5:1--5:5)

--- a/tests/idris2/error/error029/Issue34.idr
+++ b/tests/idris2/error/error029/Issue34.idr
@@ -1,0 +1,9 @@
+data T : Type -> Type where
+  Leaf : T a
+  Node : Ord a => a -> T a -> T a -> T a
+
+zipWith : (a -> a -> a) -> T a -> T a -> T a
+zipWith f Leaf _ = Leaf
+zipWith f _ Leaf = Leaf
+zipWith f (Node x lx rx) (Node y ly ry)
+  = Node (f x y) (zipWith f lx ly) (zipWith f rx ry)

--- a/tests/idris2/error/error029/expected
+++ b/tests/idris2/error/error029/expected
@@ -1,0 +1,15 @@
+1/1: Building Issue34 (Issue34.idr)
+Error: While processing right hand side of zipWith. Multiple solutions found in search of:
+    Ord a
+
+Issue34:9:5--9:53
+ 5 | zipWith : (a -> a -> a) -> T a -> T a -> T a
+ 6 | zipWith f Leaf _ = Leaf
+ 7 | zipWith f _ Leaf = Leaf
+ 8 | zipWith f (Node x lx rx) (Node y ly ry)
+ 9 |   = Node (f x y) (zipWith f lx ly) (zipWith f rx ry)
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Possible correct results:
+    conArg (implicitly bound at Issue34:8:12--8:16)
+    conArg (implicitly bound at Issue34:8:27--8:31)

--- a/tests/idris2/error/error029/run
+++ b/tests/idris2/error/error029/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check Issue34.idr

--- a/tests/idris2/interactive/interactive042/expected
+++ b/tests/idris2/interactive/interactive042/expected
@@ -30,7 +30,7 @@ Error: While processing right hand side of f. When unifying:
     Either b b
 and:
     Either b b
-Mismatch between: b (implicitly bound at Issue35-2:2:1--2:14) and b.
+Mismatch between: b (implicitly bound at Issue35-2:2:1--2:2) and b.
 
 Issue35-2:2:13--2:14
  1 | f : { a, b : Type } -> Either a b -> Either b a
@@ -42,7 +42,7 @@ Error: While processing right hand side of f. When unifying:
     Either b {b:826}
 and:
     Either {b:826} b
-Mismatch between: {b:826} (implicitly bound at Issue35-2:2:1--2:14) and b.
+Mismatch between: {b:826} (implicitly bound at Issue35-2:2:1--2:2) and b.
 
 Issue35-2:2:13--2:14
  1 | f : { a, b : Type } -> Either a b -> Either b a
@@ -54,7 +54,7 @@ Error: While processing right hand side of f. When unifying:
     Prelude.Either b {b:826}
 and:
     Prelude.Either {b:826} b
-Mismatch between: {b:826} (implicitly bound at Issue35-2:2:1--2:14) and b.
+Mismatch between: {b:826} (implicitly bound at Issue35-2:2:1--2:2) and b.
 
 Issue35-2:2:13--2:14
  1 | f : { a, b : Type } -> Either a b -> Either b a

--- a/tests/idris2/interface/interface016/expected
+++ b/tests/idris2/interface/interface016/expected
@@ -10,5 +10,5 @@ TwoNum:4:7--4:8
            ^
 
 Possible correct results:
-    conArg (implicitly bound at TwoNum:4:3--4:8)
-    conArg (implicitly bound at TwoNum:2:1--4:8)
+    conArg (implicitly bound at TwoNum:4:3--4:4)
+    conArg (implicitly bound at TwoNum:2:1--2:2)


### PR DESCRIPTION
When implicitly binding a variable, use the location of the head function/constructor that expects it. This way we can differentiate multiple implicits bound on the same LHS.

Note that this does not resolve the issue 34: there the location is then further muddled by the fact that where-bound functions are lifted to the toplevel.