### PR TITLE
Add fromTTImp, fromName, and fromDecls

### DIFF
--- a/libs/base/Language/Reflection/TT.idr
+++ b/libs/base/Language/Reflection/TT.idr
@@ -170,6 +170,12 @@ data Name = NS Namespace Name -- name in a namespace
 
 %name Name nm
 
+%nameLit fromName
+
+public export
+fromName : Name -> Name
+fromName nm = nm
+
 export
 dropNS : Name -> Name
 dropNS (NS _ n) = dropNS n

--- a/libs/base/Language/Reflection/TTImp.idr
+++ b/libs/base/Language/Reflection/TTImp.idr
@@ -222,6 +222,18 @@ mutual
 
   %name Decl decl
 
+%TTImpLit fromTTImp
+
+public export
+fromTTImp : TTImp -> TTImp
+fromTTImp s = s
+
+%declsLit fromDecls
+
+public export
+fromDecls : List Decl -> List Decl
+fromDecls decls = decls
+
 public export
 getFC : TTImp -> FC
 getFC (IVar fc _)                = fc

--- a/tests/idris2/reflection/reflection020/FromDecls.idr
+++ b/tests/idris2/reflection/reflection020/FromDecls.idr
@@ -6,8 +6,6 @@ import FromTTImp
 
 %language ElabReflection
 
-%declsLit fromDecls
-
 record NatDecl where
     constructor MkNatDecl
     var : String

--- a/tests/idris2/reflection/reflection020/FromName.idr
+++ b/tests/idris2/reflection/reflection020/FromName.idr
@@ -2,8 +2,6 @@ import Language.Reflection
 
 %language ElabReflection
 
-%nameLit fromName
-
 data MyName = MkMyName String
 
 myName : Name -> Elab MyName

--- a/tests/idris2/reflection/reflection020/FromTTImp.idr
+++ b/tests/idris2/reflection/reflection020/FromTTImp.idr
@@ -2,8 +2,6 @@ import Language.Reflection
 
 %language ElabReflection
 
-%TTImpLit fromTTImp
-
 public export
 data NatExpr : Type where
      Plus : NatExpr -> NatExpr -> NatExpr


### PR DESCRIPTION
This follows on from #2930. Now that we've had a version bump, we can bind `fromTTImp`, `fromName`, and `fromDecls` in base.