### PR TITLE
idris_support: fix environ for macOS

### DIFF
--- a/support/c/idris_support.c
+++ b/support/c/idris_support.c
@@ -23,6 +23,9 @@ char **_argv;
 extern char **_environ;
 #include "windows/win_utils.h"
 #define environ _environ
+#elif defined(__APPLE__)
+#include <crt_externs.h>
+#define environ (*_NSGetEnviron())
 #else
 extern char **environ;
 #endif


### PR DESCRIPTION
# Description

Fix environ for Apple: this version works on every macOS, unlike the generic one.

