### PR TITLE
Nix `buildIdris` improvement: precisely target executable

### DIFF
--- a/nix/buildIdris.nix
+++ b/nix/buildIdris.nix
@@ -67,16 +67,18 @@ in rec {
         # ^ remove after Idris2 0.8.0 is released. will be superfluous:
         # https://github.com/idris-lang/Idris2/pull/3189
       else
+        executable="$(idris2 --dump-ipkg-json ${ipkgFileName} | jq -r '.executable').so"
+
         cd build/exec/*_app
 
-        rm -f ./libidris2_support.so
+        rm -f ./libidris2_support.{so,dylib}
 
-        executable="$(idris2 --dump-ipkg-json ${ipkgFileName} | jq -r '.executable').so"
         bin_name="''${executable%.so}"
         mv -- "$executable" "$out/bin/$bin_name"
 
         # remaining .so or .dylib files can be moved to lib directory
         for file in *{.so,.dylib}; do
+          mkdir -p $out/lib
           mv -- "$file" "$out/lib/"
         done
 

--- a/nix/buildIdris.nix
+++ b/nix/buildIdris.nix
@@ -74,14 +74,16 @@ in rec {
         executable="$(idris2 --dump-ipkg-json ${ipkgFileName} | jq -r '.executable').so"
         bin_name="''${executable%.so}"
         mv -- "$executable" "$out/bin/$bin_name"
-        wrapProgram "$out/bin/$bin_name" \
-          --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ support ]} \
-          --prefix DYLD_LIBRARY_PATH : ${lib.makeLibraryPath [ support ]}
 
         # remaining .so or .dylib files can be moved to lib directory
         for file in *{.so,.dylib}; do
           mv -- "$file" "$out/lib/"
         done
+
+        wrapProgram "$out/bin/$bin_name" \
+          --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ support ]}:$out/lib \
+          --prefix DYLD_LIBRARY_PATH : ${lib.makeLibraryPath [ support ]}:$out/lib
+
       fi
       runHook postInstall
     '';

--- a/nix/buildIdris.nix
+++ b/nix/buildIdris.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, idris2Version, idris2, support, makeWrapper }:
+{ stdenv, lib, idris2Version, idris2, jq, support, makeWrapper }:
 # Usage: let
 #          pkg = idris2Pkg.buildIdris {
 #            src = ...;
@@ -34,7 +34,7 @@ let
       pname = ipkgName;
       inherit version;
       src = src;
-      nativeBuildInputs = [ idris2 makeWrapper ] ++ attrs.nativeBuildInputs or [];
+      nativeBuildInputs = [ idris2 makeWrapper jq ] ++ attrs.nativeBuildInputs or [];
       buildInputs = propagatedIdrisLibraries ++ attrs.buildInputs or [];
 
       IDRIS2_PACKAGE_PATH = libDirs;
@@ -68,13 +68,19 @@ in rec {
         # https://github.com/idris-lang/Idris2/pull/3189
       else
         cd build/exec/*_app
+
         rm -f ./libidris2_support.so
-        for file in *.so; do
-          bin_name="''${file%.so}"
-          mv -- "$file" "$out/bin/$bin_name"
-          wrapProgram "$out/bin/$bin_name" \
-            --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ support ]} \
-            --prefix DYLD_LIBRARY_PATH : ${lib.makeLibraryPath [ support ]}
+
+        executable="$(idris2 --dump-ipkg-json ${ipkgFileName} | jq -r '.executable').so"
+        bin_name="''${executable%.so}"
+        mv -- "$executable" "$out/bin/$bin_name"
+        wrapProgram "$out/bin/$bin_name" \
+          --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ support ]} \
+          --prefix DYLD_LIBRARY_PATH : ${lib.makeLibraryPath [ support ]}
+
+        # remaining .so or .dylib files can be moved to lib directory
+        for file in *{.so,.dylib}; do
+          mv -- "$file" "$out/lib/"
         done
       fi
       runHook postInstall

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, chez, clang, gmp, fetchFromGitHub, makeWrapper, installShellFiles, support, idris2Version
+{ stdenv, lib, chez, clang, gmp, makeWrapper, installShellFiles, support, idris2Version
 , srcRev, gambit, nodejs, zsh, idris2Bootstrap ? null }:
 
 # Uses scheme to bootstrap the build of idris2
@@ -11,7 +11,12 @@ stdenv.mkDerivation rec {
   pname = "idris2";
   version = idris2Version;
 
-  src = ../.;
+  # we don't rebuild Idris when changing the buildIdris nix
+  # function:
+  src = with lib.fileset; toSource {
+    root = ../.;
+    fileset = difference ../. ../nix/buildIdris.nix;
+  };
 
   strictDeps = true;
   nativeBuildInputs = [ makeWrapper installShellFiles clang chez ]

--- a/nix/support.nix
+++ b/nix/support.nix
@@ -6,7 +6,12 @@ stdenv'.mkDerivation rec {
   pname = "libidris2_support";
   version = idris2Version;
 
-  src = ../.;
+  # we don't rebuild Idris when changing the buildIdris nix
+  # function:
+  src = with lib.fileset; toSource {
+    root = ../.;
+    fileset = difference ../. ../nix/buildIdris.nix;
+  };
 
   strictDeps = true;
   buildInputs = [ gmp ];


### PR DESCRIPTION
# Description

- The Nix `buildIdris` function now precisely targets the executable and also any C libraries built alongside the executable so less work needs to be done to package an application that ships its own shared library.
- The Nix derivations for the `support` libraries and compiler don't rebuild when only the `buildIdris` function changes anymore.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).
