### PR TITLE
[ perf ] Use alternative better GC on chez

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -115,6 +115,8 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
   evaluated. Now when a delayed expression is lifted by CSE, it is compiled
   using Scheme's `delay` and `force` to memoize them.
 
+* More efficient `collect-request-handler` is used.
+
 #### Racket
 
 * Fixed CSE soundness bug that caused delayed expressions to sometimes be eagerly

--- a/src/Compiler/Scheme/ChezSep.idr
+++ b/src/Compiler/Scheme/ChezSep.idr
@@ -237,7 +237,7 @@ compileToSS c chez appdir tm = do
   main <- schExp empty (Chez.chezExtPrim empty) Chez.chezString 0 ctm
   Core.writeFile (appdir </> "mainprog.ss") $ build $ sepBy "\n"
     [ schHeader (map snd libs) [lib.name | lib <- chezLibs]
-    , "(collect-request-handler (lambda () (collect) (blodwen-run-finalisers)))"
+    , collectRequestHandler
     , main
     , schFooter
     ]


### PR DESCRIPTION
# Description

At least @edwinb and I are using this `collect-request-handler` for at least more than half of a year and we were discussing at the last weekly Idris chat that it's time to make all users happy being able to use this.

In case you doubt, you can try this GC handler and play with [this patcher](https://github.com/buzden/deptycheck/blob/master/.patch-chez-gc-handler) which replaces only the handler in the given `*.ss` file (recompiling the `*.so` one) or installed app name (using `pack`).

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

