### PR TITLE
[nix] allow `buildIdris` output to be used as a dependency in other `buildIdris` calls more directly

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710854652,
-        "narHash": "sha256-fKaaZQgVIK3+3G6SWOAMms3XKIPMYs/ErOXLT7iWCW0=",
+        "lastModified": 1719371271,
+        "narHash": "sha256-G3tm/ttP6PxnrrpCYIi4VBpJdGrwqr2pqRKuZlvTg2s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dbdb1f1b8b37ea37793eb596f4081dc0920821f8",
+        "rev": "267d115a04e93a3487d3c2c26e3af5704a0144cc",
         "type": "github"
       },
       "original": {

--- a/nix/buildIdris.nix
+++ b/nix/buildIdris.nix
@@ -17,11 +17,24 @@
 , ... }@attrs:
 
 let
+  # loop over idrisLibraries and normalize them by turning any that are
+  # direct outputs of the buildIdris function into the `.library {}`
+  # property.
+  idrisLibraryLibs = map (idrisLib:
+    if lib.isDerivation idrisLib
+    then idrisLib
+    else if builtins.isFunction idrisLib
+    then idrisLib {}
+    else if (builtins.isAttrs idrisLib && idrisLib ? "library")
+    then idrisLib.library {}
+    else throw "Found an Idris2 library dependency that was not the result of the buildIdris function"
+  ) idrisLibraries;
+
   propagate = libs: lib.unique (lib.concatMap (nextLib: [nextLib] ++ nextLib.propagatedIdrisLibraries) libs);
   ipkgFileName = ipkgName + ".ipkg";
   idrName = "idris2-${idris2Version}";
   libSuffix = "lib/${idrName}";
-  propagatedIdrisLibraries = propagate idrisLibraries;
+  propagatedIdrisLibraries = propagate idrisLibraryLibs;
   libDirs =
     lib.strings.makeSearchPath libSuffix propagatedIdrisLibraries;
   drvAttrs = builtins.removeAttrs attrs [


### PR DESCRIPTION
# Description

Following in the footsteps of a recent change to the Nixpkgs variant of `buildIdris`, this PR just makes it a bit easier to work with the output of the `buildIdris` function as an input to another Idris package. The changes are backwards compatible so they just provide more flexibility and better ergonomics going forward.

Before:
```nix
let myLib = buildIdris { ... };
in buildIdris {
  ...
  idrisLibraries = [ (myLib.library {}) ];
}
```

After:
```nix
let myLib = buildIdris { ... };
in buildIdris {
  ...
  idrisLibraries = [ myLib ];
}
```

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

