### PR TITLE
[ elab ] Change quantity of the `search` function's argument to `0`

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -193,6 +193,9 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 
 * `Functor` is implemented for `PiInfo` from `Language.Reflection.TT`.
 
+* Quantity of the argument for the type being searched in the `search` function
+  from `Language.Reflection` was changed to be zero.
+
 #### Contrib
 
 * `Data.List.Lazy` was moved from `contrib` to `base`.

--- a/libs/base/Language/Reflection.idr
+++ b/libs/base/Language/Reflection.idr
@@ -287,5 +287,5 @@ catch elab = try (Just <$> elab) (pure Nothing)
 ||| Run proof search to attempt to find a value of the input type.
 ||| Useful to check whether a give interface constraint is satisfied.
 export
-search : Elaboration m => (ty : Type) -> m (Maybe ty)
+search : Elaboration m => (0 ty : Type) -> m (Maybe ty)
 search ty = catch $ check {expected = ty} `(%search)

--- a/tests/idris2/reflection/reflection030/SearchZero.idr
+++ b/tests/idris2/reflection/reflection030/SearchZero.idr
@@ -1,0 +1,25 @@
+import Language.Reflection
+
+%default total
+
+scr : ty -> ty -> Elab ty
+scr l r = do
+  Just x <- search $ Semigroup ty
+    | Nothing => pure l
+  pure $ l <+> r
+
+%language ElabReflection
+
+data N = A | B | C | D
+
+X : N
+X = %runElab scr B C
+
+xCorr : X = B
+xCorr = Refl
+
+Y : List Nat
+Y = %runElab scr [1, 2, 3] [4, 5]
+
+yCorr : Y = [1, 2, 3, 4, 5]
+yCorr = Refl

--- a/tests/idris2/reflection/reflection030/expected
+++ b/tests/idris2/reflection/reflection030/expected
@@ -1,0 +1,1 @@
+1/1: Building SearchZero (SearchZero.idr)

--- a/tests/idris2/reflection/reflection030/run
+++ b/tests/idris2/reflection/reflection030/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check SearchZero.idr


### PR DESCRIPTION
# Description

Or else we are unable to work with types that contain zeroin inside

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

