### PR TITLE
[ fix ] compile time typecase for functions

### DIFF
--- a/src/Core/Normalise/Eval.idr
+++ b/src/Core/Normalise/Eval.idr
@@ -368,6 +368,8 @@ parameters (defs : Defs, topopts : EvalOpts)
     -- Type of type matching, in typecase
     tryAlt env loc opts fc stk (NType _ _) (ConCase (UN (Basic "Type")) tag [] sc)
          = evalTree env loc opts fc stk sc
+    tryAlt env loc opts fc stk (NType _ _) (ConCase _ _ _ _)
+         = pure NoMatch
     -- Arrow matching, in typecase
     tryAlt {more}
            env loc opts fc stk (NBind pfc x (Pi fc' r e aty) scty) (ConCase (UN (Basic "->")) tag [s,t] sc)
@@ -375,6 +377,9 @@ parameters (defs : Defs, topopts : EvalOpts)
                   [aty,
                    MkNFClosure opts env (NBind pfc x (Lam fc' r e aty) scty)]
                   sc
+    tryAlt {more}
+           env loc opts fc stk (NBind pfc x (Pi fc' r e aty) scty) (ConCase nm tag args sc)
+       = pure NoMatch
     -- Delay matching
     tryAlt env loc opts fc stk (NDelay _ _ ty arg) (DelayCase tyn argn sc)
          = evalTree env (ty :: arg :: loc) opts fc stk sc

--- a/tests/idris2/evaluator/evaluator005/TypeCase.idr
+++ b/tests/idris2/evaluator/evaluator005/TypeCase.idr
@@ -1,0 +1,7 @@
+data The : (a : Type) -> a -> Type where
+  Is : (x : a) -> The a x
+
+tcase : Type -> Type
+tcase (The a _) = a
+tcase a = a
+

--- a/tests/idris2/evaluator/evaluator005/expected
+++ b/tests/idris2/evaluator/evaluator005/expected
@@ -1,0 +1,4 @@
+1/1: Building TypeCase (TypeCase.idr)
+Main> Int -> Int
+Main> Type
+Main> Bye for now!

--- a/tests/idris2/evaluator/evaluator005/input
+++ b/tests/idris2/evaluator/evaluator005/input
@@ -1,0 +1,3 @@
+tcase (Int -> Int)
+tcase Type
+:q

--- a/tests/idris2/evaluator/evaluator005/run
+++ b/tests/idris2/evaluator/evaluator005/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+idris2 TypeCase.idr < input


### PR DESCRIPTION
# Description

Compile time typecase gets stuck when comparing a type constructor case alt to either a Pi type or `Type`.  This is happening because the code path for the happy case is present:
```idris
    tryAlt {more}
           env loc opts fc stk (NBind pfc x (Pi fc' r e aty) scty) (ConCase (UN (Basic "->")) tag [s,t] sc)
```
but the non-matching case falls back to `GotStuck`. I've added cases for `NoMatch` for both Pi types and `Type`.

This issue was reported in the idrus-help-forum on discord.

Previously, given the code from the discord discussion:
```idris
data The : (a : Type) -> a -> Type where
  Is : (x : a) -> The a x

tcase : Type -> Type
tcase (The a _) = a
tcase a = a
```
the REPL would evaluate `tcase (Int -> Int)` to `tcase (Int -> Int)`. Getting stuck at:
```
LOG eval.casetree.stuck:5: Got stuck matching ({arg:8} : [closure]) -> [closure] against Main.The {e:0} {e:1} => [0] {e:0}[0]
```
With the fix, it now reduces to `Int -> Int`.  The case for `Type` is similar.
