### PR TITLE
[ fix #3339 ] Set the global test locale

### DIFF
--- a/tests/testutils.sh
+++ b/tests/testutils.sh
@@ -109,6 +109,9 @@ if [ -z "$PREFIX_CHANGED" ] && [ -n "$IDRIS2_PREFIX" ]; then
     export PREFIX_CHANGED=1
 fi
 
+# Set the most neutral locale for reproducibility
+export LC_ALL=C.UTF-8
+
 # Remove test directory from output
 # Useful for consistency of output between machines
 # Usage: run SomeTest.idr | filter_test_dir


### PR DESCRIPTION
# Description

Sets the locale in the `testutils.sh`. I think, this is right place do to this, since no other test wants to observe the same problem in the future.