### PR TITLE
Fix annoying warning when running tests on some macOS machines

### DIFF
--- a/.github/workflows/ci-idris2-and-libs.yml
+++ b/.github/workflows/ci-idris2-and-libs.yml
@@ -448,7 +448,7 @@ jobs:
           name: windows-installed-bootstrapped-idris2-chez
           path: ${{ env.IDRIS_PREFIX }}
       - name: Install build dependencies
-        uses: Bogdanp/setup-racket@v1.4
+        uses: Bogdanp/setup-racket@v1.11
         with:
           variant: 'CS'
           version: 'stable'

--- a/tests/testutils.sh
+++ b/tests/testutils.sh
@@ -110,7 +110,11 @@ if [ -z "$PREFIX_CHANGED" ] && [ -n "$IDRIS2_PREFIX" ]; then
 fi
 
 # Set the most neutral locale for reproducibility
-export LC_ALL=C.UTF-8
+if [ "$OS" = "darwin" ]; then
+    export LANG=C LC_CTYPE=UTF-8
+else
+    export LC_ALL=C.UTF-8
+fi
 
 # Remove test directory from output
 # Useful for consistency of output between machines


### PR DESCRIPTION
# Description

On my machine when I run the test suite, every single test case complains with:
```
../../testutils.sh: line 113: warning: setlocale: LC_ALL: cannot change locale (C.UTF-8): No such file or directory
```
This seems to be a common issue with macOS, though I can't explain why we don't see that warning in CI. Nevertheless, I found a solution that feels reasonable enough and certainly cleans up the warnings on my machine.

I also bumped the version of the racket setup action being used in response to GitHub's warning about the version of NodeJS that action was using.

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

