### PR TITLE
Support more flexible requirements for Golden tests

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -242,28 +242,8 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 
 #### Test
 
-* Renamed `Requirement` to `BackendRequirement`. A new interface has been
-  introduced with the name `Requirement`, so you should proactively adopt the new
-  `BackendRequirement` name anywhere you've used `Test.Golden.Requirement`
-  previously to avoid potentially difficult to understand compiler errors.
-
-* Both the `TestPool` type and the `testsInDir` helper have been reworked to
-  support a more flexible definition of a "requirement." Any `TestPool` or use
-  of `testsInDir` that does _not_ specify any constraints/requirements need not
-  change at all. A `TestPool` with existing requirements shouldn't need to
-  change, either, unless you'd like to use your own `Requirement` type going
-  forward instead of the default `BackendRequirement`. If you have a
-  `testsInDir` with requirements, it will need to change to a `testsInDir'`;
-  note the tick (apostrophe) in the name. In full, make the following change.
-
-      testsInDir "testdir" "My Tests" {requirements = [C, Node]
-
-  Should be refactored to:
-
-      testsInDir' "testdir" "My Tests" [C, Node]
-
-* The new `Requirement` interface in `Test.Golden` can be implemented for any
-  type you would like to use to specify requirements for a test pool. This makes
-  it quite easy to write test pools that are skipped based on any number of
-  things.
+* Replaced `Requirement` data type with a new record that can be used to create
+  any requirement needed. The constructors for the old `Requirement` type are
+  now functions of the same names that return values of the new record type so
+  in most situations there should be no compatibility issues.
 

--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -238,3 +238,32 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 #### Network
 
 * Add a missing function parameter (the flag) in the C implementation of `idrnet_recv_bytes`
+
+
+#### Test
+
+* Renamed `Requirement` to `BackendRequirement`. A new interface has been
+  introduced with the name `Requirement`, so you should proactively adopt the new
+  `BackendRequirement` name anywhere you've used `Test.Golden.Requirement`
+  previously to avoid potentially difficult to understand compiler errors.
+
+* Both the `TestPool` type and the `testsInDir` helper have been reworked to
+  support a more flexible definition of a "requirement." Any `TestPool` or use
+  of `testsInDir` that does _not_ specify any constraints/requirements need not
+  change at all. A `TestPool` with existing requirements shouldn't need to
+  change, either, unless you'd like to use your own `Requirement` type going
+  forward instead of the default `BackendRequirement`. If you have a
+  `testsInDir` with requirements, it will need to change to a `testsInDir'`;
+  note the tick (apostrophe) in the name. In full, make the following change.
+
+      testsInDir "testdir" "My Tests" {requirements = [C, Node]
+
+  Should be refactored to:
+
+      testsInDir' "testdir" "My Tests" [C, Node]
+
+* The new `Requirement` interface in `Test.Golden` can be implemented for any
+  type you would like to use to specify requirements for a test pool. This makes
+  it quite easy to write test pools that are skipped based on any number of
+  things.
+

--- a/libs/test/README.md
+++ b/libs/test/README.md
@@ -50,11 +50,11 @@ The second argument to `MkTestPool` (empty in the above example) is a list of
 constraints that need to be satisfied to be able to run the tests in the given
 pool. An empty list means no requirements. If your tests required racket to be
 installed, you could for instance specify `[Racket]`.
-See the [`BackendRequirement` type](./Test/Golden.idr#L343) for more.
+See the [`Requirement` type](./Test/Golden.idr#L335) for more.
 
 You may have requirements for a particular `TestPool` that aren't simply "The
-Node Backend can be used." To represent your own requirements, create a type
-that implements the `Requirement` interface and use values of that type instead.
+Node Backend can be used." To represent your own requirements, create your own
+values of the `Requirement` type.
 
 The third argument to `MkTestPool` is an optional backend. In the example we
 did not specify any but if you want to use the reference counting C backend
@@ -103,6 +103,5 @@ test case as the expectation.
 
 If you'd like to make a `TestPool` that automatically picks up all the tests
 from a particular directory, you can use the `testsInDir` helper function from
-the `Test.Golden` module. Note that if you'd like to specify requirements for
-your `TestPool`, use the `testsInDir'` helper instead.
+the `Test.Golden` module.
 

--- a/libs/test/README.md
+++ b/libs/test/README.md
@@ -50,7 +50,11 @@ The second argument to `MkTestPool` (empty in the above example) is a list of
 constraints that need to be satisfied to be able to run the tests in the given
 pool. An empty list means no requirements. If your tests required racket to be
 installed, you could for instance specify `[Racket]`.
-See the [`Requirement` type](./Test/Golden.idr#L228) for more.
+See the [`BackendRequirement` type](./Test/Golden.idr#L343) for more.
+
+You may have requirements for a particular `TestPool` that aren't simply "The
+Node Backend can be used." To represent your own requirements, create a type
+that implements the `Requirement` interface and use values of that type instead.
 
 The third argument to `MkTestPool` is an optional backend. In the example we
 did not specify any but if you want to use the reference counting C backend
@@ -94,3 +98,11 @@ can choose whether the output produced by a new test run should become the new
 You can even skip the step of creating an `expected` file altogether when you
 write a new test case and use interactive mode to accept the output of your
 test case as the expectation.
+
+### testsInDir
+
+If you'd like to make a `TestPool` that automatically picks up all the tests
+from a particular directory, you can use the `testsInDir` helper function from
+the `Test.Golden` module. Note that if you'd like to specify requirements for
+your `TestPool`, use the `testsInDir'` helper instead.
+

--- a/libs/test/Test/Golden.idr
+++ b/libs/test/Test/Golden.idr
@@ -341,6 +341,10 @@ export
 Show Requirement where
   show = name
 
+export
+Eq Requirement where
+  (==) = (==) `on` name
+
 ||| Some test may involve Idris' backends and have requirements.
 ||| We define here the ones supported by Idris
 public export

--- a/libs/test/Test/Golden.idr
+++ b/libs/test/Test/Golden.idr
@@ -328,7 +328,7 @@ pathLookup names = do
                                          y <- extensions]
   firstExists candidates
 
-||| A test requirement. The String value returned from `satsify` witnesses requirement.
+||| A test requirement. The String value returned from `satisfy` witnesses requirement.
 ||| Return Nothing to indicate the requirement is not met and tests relying on it
 ||| should be skipped.
 public export

--- a/libs/test/Test/Golden.idr
+++ b/libs/test/Test/Golden.idr
@@ -634,8 +634,8 @@ poolRunner opts pool
     checkReq req = do
       mfp <- satisfy req
       let msg = case mfp of
-                  Nothing => "✗ " ++ (name req) ++ " not found"
-                  Just fp => "✓ Found " ++ (name req) ++ " at " ++ fp
+                  Nothing => "✗ \{name req}  not found"
+                  Just fp => "✓ Found \{name req} at \{fp}"
       pure (mfp, msg)
 
     separator : String

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -75,19 +75,19 @@ idrisTestsEvaluator = testsInDir "idris2/evaluator" "Evaluation"
 idrisTestsREPL : IO TestPool
 idrisTestsREPL = testsInDir "idris2/repl" "REPL commands and help"
 
-idrisTestsAllSchemes : BackendRequirement -> IO TestPool
+idrisTestsAllSchemes : Requirement -> IO TestPool
 idrisTestsAllSchemes cg = testsInDir "allschemes"
       ("Test across all scheme backends: " ++ show cg ++ " instance")
       {codegen = Just cg}
 
-idrisTestsAllBackends : BackendRequirement -> TestPool
+idrisTestsAllBackends : Requirement -> TestPool
 idrisTestsAllBackends cg = MkTestPool
       ("Test across all backends: " ++ show cg ++ " instance")
       [] (Just cg)
        -- RefC implements IEEE standard and distinguishes between 0.0 and -0.0
        -- unlike other backends. So turn this test for now.
-      $ ([ "issue2362" ] <* guard (cg /= C))
-      ++ ([ "popen2" ] <* guard (cg /= Node))
+      $ ([ "issue2362" ] <* guard (cg.name /= "refc"))
+      ++ ([ "popen2" ] <* guard (cg.name /= "node"))
       ++ [ -- Evaluator
        "evaluator004",
        -- Unfortunately the behaviour of Double is platform dependent so the
@@ -186,15 +186,15 @@ templateTests = testsInDir "templates" "Test templates"
 -- that only runs if all backends are
 -- available.
 baseLibraryTests : IO TestPool
-baseLibraryTests = testsInDir' "base" "Base library" [Chez, Node]
+baseLibraryTests = testsInDir "base" "Base library" {requirements = [Chez, Node]}
 
 -- same behavior as `baseLibraryTests`
 contribLibraryTests : IO TestPool
-contribLibraryTests = testsInDir' "contrib" "Contrib library" [Chez, Node]
+contribLibraryTests = testsInDir "contrib" "Contrib library" {requirements = [Chez, Node]}
 
 -- same behavior as `baseLibraryTests`
 linearLibraryTests : IO TestPool
-linearLibraryTests = testsInDir' "linear" "Linear library" [Chez, Node]
+linearLibraryTests = testsInDir "linear" "Linear library" {requirements = [Chez, Node]}
 
 codegenTests : IO TestPool
 codegenTests = testsInDir "codegen" "Code generation"

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -86,8 +86,8 @@ idrisTestsAllBackends cg = MkTestPool
       [] (Just cg)
        -- RefC implements IEEE standard and distinguishes between 0.0 and -0.0
        -- unlike other backends. So turn this test for now.
-      $ ([ "issue2362" ] <* guard (cg.name /= "refc"))
-      ++ ([ "popen2" ] <* guard (cg.name /= "node"))
+      $ ([ "issue2362" ] <* guard (cg /= C))
+      ++ ([ "popen2" ] <* guard (cg /= Node))
       ++ [ -- Evaluator
        "evaluator004",
        -- Unfortunately the behaviour of Double is platform dependent so the

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -75,12 +75,12 @@ idrisTestsEvaluator = testsInDir "idris2/evaluator" "Evaluation"
 idrisTestsREPL : IO TestPool
 idrisTestsREPL = testsInDir "idris2/repl" "REPL commands and help"
 
-idrisTestsAllSchemes : Requirement -> IO TestPool
+idrisTestsAllSchemes : BackendRequirement -> IO TestPool
 idrisTestsAllSchemes cg = testsInDir "allschemes"
       ("Test across all scheme backends: " ++ show cg ++ " instance")
       {codegen = Just cg}
 
-idrisTestsAllBackends : Requirement -> TestPool
+idrisTestsAllBackends : BackendRequirement -> TestPool
 idrisTestsAllBackends cg = MkTestPool
       ("Test across all backends: " ++ show cg ++ " instance")
       [] (Just cg)
@@ -186,15 +186,15 @@ templateTests = testsInDir "templates" "Test templates"
 -- that only runs if all backends are
 -- available.
 baseLibraryTests : IO TestPool
-baseLibraryTests = testsInDir "base" "Base library" {requirements = [Chez, Node]}
+baseLibraryTests = testsInDir' "base" "Base library" [Chez, Node]
 
 -- same behavior as `baseLibraryTests`
 contribLibraryTests : IO TestPool
-contribLibraryTests = testsInDir "contrib" "Contrib library" {requirements = [Chez, Node]}
+contribLibraryTests = testsInDir' "contrib" "Contrib library" [Chez, Node]
 
 -- same behavior as `baseLibraryTests`
 linearLibraryTests : IO TestPool
-linearLibraryTests = testsInDir "linear" "Linear library" {requirements = [Chez, Node]}
+linearLibraryTests = testsInDir' "linear" "Linear library" [Chez, Node]
 
 codegenTests : IO TestPool
 codegenTests = testsInDir "codegen" "Code generation"


### PR DESCRIPTION
# Description

This change to how Golden tests handle requirements for a pool of tests makes the test framework much more versatile. It is a breaking change but most code using the test lib (including the compiler test suite) won't need to change in response to it.

## Details

I've introduced a new `Requirement` record type to allow projects using this library to define their own types of requirements. Existing constructors of the old `Requirement` type have been rewritten as same-named functions returning values of the new record type.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

