### PR TITLE
[ fix ] check indentation after = in declarations

### DIFF
--- a/libs/base/System/Clock.idr
+++ b/libs/base/System/Clock.idr
@@ -53,10 +53,10 @@ Eq (Clock type) where
 public export
 Ord (Clock type) where
   compare (MkClock seconds1 nanoseconds1) (MkClock seconds2 nanoseconds2) =
-  case compare seconds1 seconds2 of
-    LT => LT
-    GT => GT
-    EQ => compare nanoseconds1 nanoseconds2
+    case compare seconds1 seconds2 of
+      LT => LT
+      GT => GT
+      EQ => compare nanoseconds1 nanoseconds2
 
 public export
 Show (Clock type) where

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1231,6 +1231,7 @@ mutual
        = do b <- bounds $ do
                    decoratedSymbol fname "="
                    mustWork $ do
+                     continue indents
                      rhs <- typeExpr pdef fname indents
                      ws <- option [] $ whereBlock fname col
                      pure (rhs, ws)

--- a/src/Idris/Pretty.idr
+++ b/src/Idris/Pretty.idr
@@ -313,7 +313,7 @@ mutual
     prettyPrec d (PDelay _ tm) = parenthesise (d > startPrec) $ "Delay" <++> prettyPrec appPrec tm
     prettyPrec d (PForce _ tm) = parenthesise (d > startPrec) $ "Force" <++> prettyPrec appPrec tm
     prettyPrec d (PAutoApp _ f a) =
-    parenthesise (d > startPrec) $ group $ prettyPrec leftAppPrec f <++> "@" <+> braces (pretty a)
+      parenthesise (d > startPrec) $ group $ prettyPrec leftAppPrec f <++> "@" <+> braces (pretty a)
     prettyPrec d (PNamedApp _ f n (PRef _ a)) =
       parenthesise (d > startPrec) $ group $
         if n == rawName a

--- a/tests/idris2/error/perror033/DeclIndent.idr
+++ b/tests/idris2/error/perror033/DeclIndent.idr
@@ -1,0 +1,4 @@
+namespace A
+  test : (x : Type -> Type) -> Type
+  test x =
+ x Type

--- a/tests/idris2/error/perror033/expected
+++ b/tests/idris2/error/perror033/expected
@@ -1,0 +1,11 @@
+1/1: Building DeclIndent (DeclIndent.idr)
+Error: Couldn't parse any alternatives:
+1: Unexpected end of expression.
+
+DeclIndent:4:2--4:3
+ 1 | namespace A
+ 2 |   test : (x : Type -> Type) -> Type
+ 3 |   test x =
+ 4 |  x Type
+      ^
+... (2 others)

--- a/tests/idris2/error/perror033/run
+++ b/tests/idris2/error/perror033/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check DeclIndent.idr


### PR DESCRIPTION
# Description

This PR improves the checking of indentation in function declarations.  The issue was brought up by @Russoul on discord.  The current parser accepts the following code, despite an outdent past the beginning of the function declaration:
```idris
namespace A
  test : (x : Type -> Type) -> Type
  test x =
 x Type
```
After the change, this gives:
```
1: Unexpected end of expression.

DeclIndent:4:2--4:3
 1 | namespace A
 2 |   test : (x : Type -> Type) -> Type
 3 |   test x =
 4 |  x Type
      ^
... (2 others)
```
I addressed this by adding an indentation check after the `=`.  My initial fix was to add the check to `typeExpr`, but this broke parsing at the repl, which runs `typeExpr` with an indentation of 0.  Fixing this issue required two indentation fixes in the Idris source, and it may affect user code that is improperly indented.

Idris has a similar issue with `let`, which I initially fixed. But there were a lot of locations in the Idris source that had improper indentation, so I suspect fixing that would have a much bigger impact on end-users. I have left that change out of this PR.

## Should this change go in the CHANGELOG?

- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

As it is fairly minor and just a fix, I wasn't sure if this should go in the change log and left it out.
