### PR TITLE
Show module docstring for namespace indexes

### DIFF
--- a/.github/linters/.stylelintrc.json
+++ b/.github/linters/.stylelintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "stylelint-config-standard",
+  "rules": {
+    "selector-not-notation": "complex"
+  }
+}

--- a/.github/workflows/ci-super-linter.yml
+++ b/.github/workflows/ci-super-linter.yml
@@ -58,3 +58,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IGNORE_GENERATED_FILES: true
           NATURAL_LANGUAGE_CONFIG_FILE: '.textlintrc.yml'
+          CSS_FILE_NAME: '.stylelintrc.json'

--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -249,3 +249,6 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
   now functions of the same names that return values of the new record type so
   in most situations there should be no compatibility issues.
 
+#### Documentation
+
+* Module docstrings are now displayed for namespace indexes when documentation is built via --mkdoc.

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -44,6 +44,7 @@ LuoChen
 Marc Petit-Huguenin
 MarcelineVQ
 Marshall Bowers
+Matthew Mosior
 Mathew Polzin
 Matthew Wilson
 Matus Tejiscak

--- a/src/Idris/Doc/HTML.idr
+++ b/src/Idris/Doc/HTML.idr
@@ -216,14 +216,18 @@ renderDocIndex pkg moddocstrs = fastConcat $
         let cmoddocstr  = case lookup mod moddocstrs of
                             Nothing          => ""
                             Just cmoddocstr' => cmoddocstr'
-            cmoddocstr' = "<div class=\"namespace-indexes\">" ++ cmoddocstr ++ "</div>"
-        in "<li><div class=\"index-wrapper\"><div><a class=\"code\" href=\"docs/" ++
-           (show mod)                                                             ++
-           ".html\">"                                                             ++
-           (show mod)                                                             ++
-           "</a></div>"                                                           ++
-           cmoddocstr'                                                            ++
-           "</div></li>"
+        in """
+           <li>
+             <div class="index-wrapper">
+               <div class="index-namespace-url">
+                 <a class="code" href="docs/\{show mod}.html">\{show mod}</a>
+               </div>
+               <div class="index-namespace-doc">
+                 \{cmoddocstr}
+               </div>
+             </div>
+           </li>
+           """
 
 preserveLayout : String -> String
 preserveLayout d = "<pre>" ++ d ++ "</pre>"

--- a/src/Idris/Doc/HTML.idr
+++ b/src/Idris/Doc/HTML.idr
@@ -6,6 +6,7 @@ import Core.Directory
 
 import Data.String
 
+import Libraries.Data.SortedMap
 import Libraries.Text.PrettyPrint.Prettyprinter
 import Libraries.Text.PrettyPrint.Prettyprinter.Render.HTML
 import Libraries.Text.PrettyPrint.Prettyprinter.SimpleDocTree
@@ -200,19 +201,29 @@ htmlFooter : String
 htmlFooter = "</div><footer>Produced by Idris 2 version " ++ (showVersion True version) ++ "</footer></body></html>"
 
 export
-renderDocIndex : PkgDesc -> String
-renderDocIndex pkg = fastConcat $
+renderDocIndex : PkgDesc -> SortedMap ModuleIdent String -> String
+renderDocIndex pkg moddocstrs = fastConcat $
   [ htmlPreamble (name pkg) "" "index"
   , "<h1>Package ", name pkg, " - Namespaces</h1>"
   , "<ul class=\"names\">"] ++
-  (map moduleLink $ modules pkg) ++
+  (map (\x => moduleLink x moddocstrs) $ (modules pkg)) ++
   [ "</ul>"
   , htmlFooter
   ]
     where
-      moduleLink : (ModuleIdent, String) -> String
-      moduleLink (mod, filename) =
-         "<li><a class=\"code\" href=\"docs/" ++ (show mod) ++ ".html\">" ++ (show mod) ++ "</a></li>"
+      moduleLink : (ModuleIdent, String) -> SortedMap ModuleIdent String -> String
+      moduleLink (mod, filename) moddocstrs =
+        let cmoddocstr  = case lookup mod moddocstrs of
+                            Nothing          => ""
+                            Just cmoddocstr' => cmoddocstr'
+            cmoddocstr' = "<div class=\"namespace-indexes\">" ++ cmoddocstr ++ "</div>"
+        in "<div class=\"index-wrapper\"><div><li><a class=\"code\" href=\"docs/" ++
+           (show mod)                                                             ++
+           ".html\">"                                                             ++
+           (show mod)                                                             ++
+           "</a></li></div>"                                                      ++
+           cmoddocstr'                                                            ++
+           "</div>"
 
 preserveLayout : String -> String
 preserveLayout d = "<pre>" ++ d ++ "</pre>"

--- a/src/Idris/Doc/HTML.idr
+++ b/src/Idris/Doc/HTML.idr
@@ -217,13 +217,13 @@ renderDocIndex pkg moddocstrs = fastConcat $
                             Nothing          => ""
                             Just cmoddocstr' => cmoddocstr'
             cmoddocstr' = "<div class=\"namespace-indexes\">" ++ cmoddocstr ++ "</div>"
-        in "<div class=\"index-wrapper\"><div><li><a class=\"code\" href=\"docs/" ++
+        in "<li><div class=\"index-wrapper\"><div><a class=\"code\" href=\"docs/" ++
            (show mod)                                                             ++
            ".html\">"                                                             ++
            (show mod)                                                             ++
-           "</a></li></div>"                                                      ++
+           "</a></div>"                                                           ++
            cmoddocstr'                                                            ++
-           "</div>"
+           "</div></li>"
 
 preserveLayout : String -> String
 preserveLayout d = "<pre>" ++ d ++ "</pre>"

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -759,7 +759,8 @@ makeDoc pkg opts =
          )
          | errs => pure errs
 
-       Right () <- coreLift $ writeFile (docBase </> "index.html") $ renderDocIndex pkg
+       Right () <- do syn <- get Syn
+                      coreLift $ writeFile (docBase </> "index.html") $ renderDocIndex pkg (modDocstrings syn)
          | Left err => fileError (docBase </> "index.html") err
 
        errs <- for cssFiles $ \ cssFile => do

--- a/support/docs/alternative.css
+++ b/support/docs/alternative.css
@@ -245,3 +245,28 @@ body.index .container a:visited {
 body.index .container a:hover {
   color: #04819e;
 }
+
+.index-wrapper {
+  display: flex;
+  flex-direction: row;
+  column-gap: 5%;
+}
+
+.index-namespace-doc {
+   flex: 3;
+}
+
+.index-namespace-url {
+   flex: 1;
+}
+
+@media (max-width: 800px) {
+  .index-wrapper {
+    flex-direction: column;
+  }
+  .index-namespace-doc {
+    width: 100%;
+  }
+  .index-namespace-url {
+    width: 100%;
+}

--- a/support/docs/alternative.css
+++ b/support/docs/alternative.css
@@ -269,4 +269,5 @@ body.index .container a:hover {
   }
   .index-namespace-url {
     width: 100%;
+  }
 }

--- a/support/docs/alternative.css
+++ b/support/docs/alternative.css
@@ -253,20 +253,22 @@ body.index .container a:hover {
 }
 
 .index-namespace-doc {
-   flex: 3;
+  flex: 3;
 }
 
 .index-namespace-url {
-   flex: 1;
+  flex: 1;
 }
 
 @media (max-width: 800px) {
   .index-wrapper {
     flex-direction: column;
   }
+
   .index-namespace-doc {
     width: 100%;
   }
+
   .index-namespace-url {
     width: 100%;
   }

--- a/support/docs/blackandwhite.css
+++ b/support/docs/blackandwhite.css
@@ -254,20 +254,22 @@ body.index .container a:hover {
 }
 
 .index-namespace-doc {
-   flex: 3;
+  flex: 3;
 }
 
 .index-namespace-url {
-   flex: 1;
+  flex: 1;
 }
 
 @media (max-width: 800px) {
   .index-wrapper {
     flex-direction: column;
   }
+
   .index-namespace-doc {
     width: 100%;
   }
+
   .index-namespace-url {
     width: 100%;
   }

--- a/support/docs/blackandwhite.css
+++ b/support/docs/blackandwhite.css
@@ -270,4 +270,5 @@ body.index .container a:hover {
   }
   .index-namespace-url {
     width: 100%;
+  }
 }

--- a/support/docs/blackandwhite.css
+++ b/support/docs/blackandwhite.css
@@ -246,3 +246,28 @@ body.index .container a:visited {
 body.index .container a:hover {
   color: #04819e;
 }
+
+.index-wrapper {
+  display: flex;
+  flex-direction: row;
+  column-gap: 5%;
+}
+
+.index-namespace-doc {
+   flex: 3;
+}
+
+.index-namespace-url {
+   flex: 1;
+}
+
+@media (max-width: 800px) {
+  .index-wrapper {
+    flex-direction: column;
+  }
+  .index-namespace-doc {
+    width: 100%;
+  }
+  .index-namespace-url {
+    width: 100%;
+}

--- a/support/docs/default.css
+++ b/support/docs/default.css
@@ -265,4 +265,5 @@ body.index .container a:hover {
   }
   .index-namespace-url {
     width: 100%;
+  }
 }

--- a/support/docs/default.css
+++ b/support/docs/default.css
@@ -241,3 +241,12 @@ body.index .container a:visited {
 body.index .container a:hover {
   color: #04819e;
 }
+
+.index-wrapper {
+  display: flex;
+  justify-content: space-between;
+}
+
+.namespace-indexes {
+   flex-basis: 50%;
+}

--- a/support/docs/default.css
+++ b/support/docs/default.css
@@ -248,5 +248,5 @@ body.index .container a:hover {
 }
 
 .namespace-indexes {
-   flex-basis: 50%;
+  flex-basis: 50%;
 }

--- a/support/docs/default.css
+++ b/support/docs/default.css
@@ -244,9 +244,25 @@ body.index .container a:hover {
 
 .index-wrapper {
   display: flex;
-  justify-content: space-between;
+  flex-direction: row;
+  column-gap: 5%;
 }
 
-.namespace-indexes {
-  flex-basis: 50%;
+.index-namespace-doc {
+   flex: 3;
+}
+
+.index-namespace-url {
+   flex: 1;
+}
+
+@media (max-width: 800px) {
+  .index-wrapper {
+    flex-direction: column;
+  }
+  .index-namespace-doc {
+    width: 100%;
+  }
+  .index-namespace-url {
+    width: 100%;
 }

--- a/support/docs/default.css
+++ b/support/docs/default.css
@@ -249,20 +249,22 @@ body.index .container a:hover {
 }
 
 .index-namespace-doc {
-   flex: 3;
+  flex: 3;
 }
 
 .index-namespace-url {
-   flex: 1;
+  flex: 1;
 }
 
 @media (max-width: 800px) {
   .index-wrapper {
     flex-direction: column;
   }
+
   .index-namespace-doc {
     width: 100%;
   }
+
   .index-namespace-url {
     width: 100%;
   }


### PR DESCRIPTION
This PR addresses [3014](https://github.com/idris-lang/Idris2/issues/3014) and adds functionality for adding docstrings for each applicable module when created via `--mkdoc`.

Closes #3014.