### PR TITLE
Clean removes generated docs

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -255,3 +255,4 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 #### Documentation
 
 * Module docstrings are now displayed for namespace indexes when documentation is built via --mkdoc.
+* Generated documentation are now removed via --clean.

--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -254,5 +254,5 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 
 #### Documentation
 
-* Module docstrings are now displayed for namespace indexes when documentation is built via --mkdoc.
-* Generated documentation are now removed via --clean.
+* Module docstrings are now displayed for namespace indexes when documentation is built via `--mkdoc`.
+* Generated documentation are now removed via `--clean`.

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -847,16 +847,16 @@ clean pkg opts -- `opts` is not used but might be in the future
          let build = build_dir (dirs (options defs))
          let docBase = build </> "docs"
          let docDir = docBase </> "docs"
-         Right docfiles' <- coreLift $ listDir docDir
-           | Left err => pure ()
-         Right docfiles'' <- coreLift $ listDir docBase
-           | Left err => pure ()
-         traverse_ (\x => delete $ docDir </> x)
-                   docfiles'
-         traverse_ (\x => delete $ docBase </> x)
-                   docfiles''
-         deleteFolder docDir []
-         deleteFolder docBase []
+         () <- do Right docfiles' <- coreLift $ listDir docDir
+                    | Left err => pure ()
+                  traverse_ (\x => delete $ docDir </> x)
+                            docfiles'
+                  deleteFolder docDir []
+         () <- do Right docfiles'' <- coreLift $ listDir docBase
+                    | Left err => pure ()
+                  traverse_ (\x => delete $ docBase </> x)
+                            docfiles''
+                  deleteFolder docBase []
          runScript (postclean pkg)
   where
     delete : String -> Core ()

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -862,7 +862,7 @@ clean pkg opts -- `opts` is not used but might be in the future
         = do let ttFile = builddir </> joinPath ns </> mod
              delete $ ttFile <.> "ttc"
              delete $ ttFile <.> "ttm"
-   
+
     deleteDocBaseFolder : String -> Core ()
     deleteDocBaseFolder build
         = do let docBase = build </> "docs"

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -845,8 +845,8 @@ clean pkg opts -- `opts` is not used but might be in the future
                (executable pkg)
          -- clean out the generated docs
          let build = build_dir (dirs (options defs))
-         () <- deleteDocDirFolder build
-         () <- deleteDocBaseFolder build
+         () <- deleteDocsFolder $ build </> "docs" </> "docs"
+         () <- deleteDocsFolder $ build </> "docs"
          runScript (postclean pkg)
   where
     delete : String -> Core ()
@@ -863,23 +863,13 @@ clean pkg opts -- `opts` is not used but might be in the future
              delete $ ttFile <.> "ttc"
              delete $ ttFile <.> "ttm"
 
-    deleteDocBaseFolder : String -> Core ()
-    deleteDocBaseFolder build
-        = do let docBase = build </> "docs"
-             Right docbasefiles <- coreLift $ listDir docBase
+    deleteDocsFolder : String -> Core ()
+    deleteDocsFolder dir
+        = do Right docbasefiles <- coreLift $ listDir dir
                | Left err => pure ()
-             traverse_ (\x => delete $ docBase </> x)
+             traverse_ (\x => delete $ dir </> x)
                        docbasefiles
-             deleteFolder docBase []
-
-    deleteDocDirFolder : String -> Core ()
-    deleteDocDirFolder build
-        = do let docDir = build </> "docs" </> "docs"
-             Right docdirfiles <- coreLift $ listDir docDir
-               | Left err => pure ()
-             traverse_ (\x => delete $ docDir </> x)
-                       docdirfiles
-             deleteFolder docDir []
+             deleteFolder dir []
 
 -- Just load the given module, if it exists, which will involve building
 -- it if necessary

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -845,18 +845,8 @@ clean pkg opts -- `opts` is not used but might be in the future
                (executable pkg)
          -- clean out the generated docs
          let build = build_dir (dirs (options defs))
-         let docBase = build </> "docs"
-         let docDir = docBase </> "docs"
-         () <- do Right docfiles' <- coreLift $ listDir docDir
-                    | Left err => pure ()
-                  traverse_ (\x => delete $ docDir </> x)
-                            docfiles'
-                  deleteFolder docDir []
-         () <- do Right docfiles'' <- coreLift $ listDir docBase
-                    | Left err => pure ()
-                  traverse_ (\x => delete $ docBase </> x)
-                            docfiles''
-                  deleteFolder docBase []
+         () <- deleteDocDirFolder build
+         () <- deleteDocBaseFolder build
          runScript (postclean pkg)
   where
     delete : String -> Core ()
@@ -872,6 +862,24 @@ clean pkg opts -- `opts` is not used but might be in the future
         = do let ttFile = builddir </> joinPath ns </> mod
              delete $ ttFile <.> "ttc"
              delete $ ttFile <.> "ttm"
+   
+    deleteDocBaseFolder : String -> Core ()
+    deleteDocBaseFolder build
+        = do let docBase = build </> "docs"
+             Right docbasefiles <- coreLift $ listDir docBase
+               | Left err => pure ()
+             traverse_ (\x => delete $ docBase </> x)
+                       docbasefiles
+             deleteFolder docBase []
+
+    deleteDocDirFolder : String -> Core ()
+    deleteDocDirFolder build
+        = do let docDir = build </> "docs" </> "docs"
+             Right docdirfiles <- coreLift $ listDir docDir
+               | Left err => pure ()
+             traverse_ (\x => delete $ docDir </> x)
+                       docdirfiles
+             deleteFolder docDir []
 
 -- Just load the given module, if it exists, which will involve building
 -- it if necessary

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -845,8 +845,8 @@ clean pkg opts -- `opts` is not used but might be in the future
                (executable pkg)
          -- clean out the generated docs
          let build = build_dir (dirs (options defs))
-         () <- deleteDocsFolder $ build </> "docs" </> "docs"
-         () <- deleteDocsFolder $ build </> "docs"
+         deleteDocsFolder $ build </> "docs" </> "docs"
+         deleteDocsFolder $ build </> "docs"
          runScript (postclean pkg)
   where
     delete : String -> Core ()

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -843,6 +843,21 @@ clean pkg opts -- `opts` is not used but might be in the future
          deleteFolder builddir []
          maybe (pure ()) (\e => delete (outputdir </> e))
                (executable pkg)
+         -- clean out the generated docs
+         defs <- get Ctxt
+         let build = build_dir (dirs (options defs))
+         let docBase = build </> "docs"
+         let docDir = docBase </> "docs"
+         Right docfiles' <- coreLift $ listDir docDir
+           | Left err => pure ()
+         Right docfiles'' <- coreLift $ listDir docBase
+           | Left err => pure ()
+         traverse_ (\x => delete $ docDir </> x)
+                   docfiles'
+         traverse_ (\x => delete $ docBase </> x)
+                   docfiles''
+         deleteFolder docDir []
+         deleteFolder docBase []
          runScript (postclean pkg)
   where
     delete : String -> Core ()

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -844,7 +844,6 @@ clean pkg opts -- `opts` is not used but might be in the future
          maybe (pure ()) (\e => delete (outputdir </> e))
                (executable pkg)
          -- clean out the generated docs
-         defs <- get Ctxt
          let build = build_dir (dirs (options defs))
          let docBase = build </> "docs"
          let docDir = docBase </> "docs"


### PR DESCRIPTION
This PR enables `--clean` to remove documentation generated via `--mkdoc`.

This addresses one of the tasks in #1918.

