### PR TITLE
`idris2 --init` doesnt check the name of a package

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -16,6 +16,9 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
   installed will be ignored by the compiler when it tries to use that library as
   a dependency for some other package.
 
+* The `idris2 --init` command now ensures that package names are
+  valid Idris2 identifiers.
+
 ### Building/Packaging changes
 
 * The Nix flake's `buildIdris` function now returns a set with `executable` and

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -903,8 +903,7 @@ processPackage : {auto c : Ref Ctxt Defs} ->
 processPackage opts (cmd, mfile)
     = withCtxt . withSyn . withROpts $ case cmd of
         Init =>
-          do --pkg <- coreLift interactive
-             Right pkg <- coreLift interactive
+          do Right pkg <- coreLift interactive
                | Left () => coreLift (exitWith (ExitFailure 1))
              let fp = fromMaybe (pkg.name ++ ".ipkg") mfile
              False <- coreLift (exists fp)

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -903,7 +903,9 @@ processPackage : {auto c : Ref Ctxt Defs} ->
 processPackage opts (cmd, mfile)
     = withCtxt . withSyn . withROpts $ case cmd of
         Init =>
-          do pkg <- coreLift interactive
+          do --pkg <- coreLift interactive
+             Right pkg <- coreLift interactive
+               | Left () => coreLift (exitWith (ExitFailure 1))
              let fp = fromMaybe (pkg.name ++ ".ipkg") mfile
              False <- coreLift (exists fp)
                | _ => throw (GenericMsg emptyFC ("File " ++ fp ++ " already exists"))

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -903,8 +903,8 @@ processPackage : {auto c : Ref Ctxt Defs} ->
 processPackage opts (cmd, mfile)
     = withCtxt . withSyn . withROpts $ case cmd of
         Init =>
-          do Right pkg <- coreLift interactive
-               | Left () => coreLift (exitWith (ExitFailure 1))
+          do Just pkg <- coreLift interactive
+               | Nothing => coreLift (exitWith (ExitFailure 1))
              let fp = fromMaybe (pkg.name ++ ".ipkg") mfile
              False <- coreLift (exists fp)
                | _ => throw (GenericMsg emptyFC ("File " ++ fp ++ " already exists"))

--- a/src/Idris/Package/Init.idr
+++ b/src/Idris/Package/Init.idr
@@ -68,7 +68,6 @@ prompt p = putStr p >> fflush stdout >> getLine
 
 export
 covering
---interactive : IO PkgDesc
 interactive : IO (Either () PkgDesc)
 interactive = do
   pname    <- prompt "Package name: "

--- a/src/Idris/Package/Init.idr
+++ b/src/Idris/Package/Init.idr
@@ -70,7 +70,7 @@ export
 covering
 interactive : IO (Either () PkgDesc)
 interactive = do
-  pname    <- prompt "Package name: "
+  pname <- prompt "Package name: "
   -- check to ensure that pname is a valid Idris2 identifier.
   case checkPackageName $ fastUnpack pname of 
     False => do () <- putStrLn "Package name is not a valid Idris Identifier."

--- a/src/Idris/Package/Init.idr
+++ b/src/Idris/Package/Init.idr
@@ -112,6 +112,6 @@ interactive = do
                                 True  => isIdentTrailing xs
 
     checkPackageName : List Char -> Bool
-    checkPackageName []      = False
+    checkPackageName []      = True
     checkPackageName (x::xs) = isIdentStart x &&
                                isIdentTrailing xs

--- a/src/Idris/Package/Init.idr
+++ b/src/Idris/Package/Init.idr
@@ -68,25 +68,23 @@ prompt p = putStr p >> fflush stdout >> getLine
 
 export
 covering
-interactive : IO (Either () PkgDesc)
+interactive : IO (Maybe PkgDesc)
 interactive = do
   pname <- prompt "Package name: "
-  -- check to ensure that pname is a valid Idris2 identifier.
-  case checkPackageName $ fastUnpack pname of
-    False => do () <- putStrLn "Package name is not a valid Idris Identifier."
-                pure $ Left ()
-    True  => do pauthors <- prompt "Package authors: "
-                poptions <- prompt "Package options: "
-                psource  <- prompt "Source directory: "
-                let sourcedir = mstring psource
-                modules  <- findModules sourcedir
-                let pkg : PkgDesc =
-                      { authors   := mstring pauthors
-                      , options   := (emptyFC,) <$> mstring poptions
-                      , modules   := modules
-                      , sourcedir := sourcedir
-                      } (initPkgDesc (fromMaybe "project" (mstring pname)))
-                pure $ Right pkg
+  let True = checkPackageName $ fastUnpack pname
+    | False => pure Nothing
+  pauthors <- prompt "Package authors: "
+  poptions <- prompt "Package options: "
+  psource  <- prompt "Source directory: "
+  let sourcedir = mstring psource
+  modules  <- findModules sourcedir
+  let pkg : PkgDesc =
+        { authors   := mstring pauthors
+        , options   := (emptyFC,) <$> mstring poptions
+        , modules   := modules
+        , sourcedir := sourcedir
+        } (initPkgDesc (fromMaybe "project" (mstring pname)))
+  pure $ Just pkg
 
   where
 

--- a/src/Idris/Package/Init.idr
+++ b/src/Idris/Package/Init.idr
@@ -72,7 +72,7 @@ interactive : IO (Either () PkgDesc)
 interactive = do
   pname <- prompt "Package name: "
   -- check to ensure that pname is a valid Idris2 identifier.
-  case checkPackageName $ fastUnpack pname of 
+  case checkPackageName $ fastUnpack pname of
     False => do () <- putStrLn "Package name is not a valid Idris Identifier."
                 pure $ Left ()
     True  => do pauthors <- prompt "Package authors: "
@@ -94,13 +94,13 @@ interactive = do
     mstring str = case trim str of
       "" => Nothing
       str => Just str
-   
+
     isIdentStart : Char -> Bool
     isIdentStart '_' = True
     isIdentStart x   = isUpper x ||
                        isAlpha x ||
                        x > chr 160
-    
+
     isIdentTrailing : List Char -> Bool
     isIdentTrailing []      = True
     isIdentTrailing (x::xs) = case isAlphaNum x ||


### PR DESCRIPTION
This PR closes #3232.

This issue stemmed from the lack of parsing in `interactive` found in `src/Idris/Package/Init.idr`. 