### PR TITLE
[ fix ] Report chez failures

### DIFF
--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -535,7 +535,8 @@ compileToSO prof chez appDirRel outSsAbs
          Right () <- coreLift $ writeFile tmpFileAbs build
             | Left err => throw (FileErr tmpFileAbs err)
          coreLift_ $ chmodRaw tmpFileAbs 0o755
-         coreLift_ $ system [chez, "--script", tmpFileAbs]
+         0 <- coreLift $ system [chez, "--script", tmpFileAbs]
+            | status => throw (InternalError "Chez exited with return code \{show status}")
          pure ()
 
 ||| Compile a TT expression to Chez Scheme using incremental module builds
@@ -703,7 +704,8 @@ incCompile c s sourceFile
                           show ssFile ++ "))"
                Right () <- coreLift $ writeFile tmpFileAbs build
                   | Left err => throw (FileErr tmpFileAbs err)
-               coreLift_ $ system [chez, "--script", tmpFileAbs]
+               0 <- coreLift $ system [chez, "--script", tmpFileAbs]
+                  | status => throw (InternalError "Chez exited with return code \{show status}")
                pure (Just (soFilename, mapMaybe fst fgndefs))
 
 ||| Codegen wrapper for Chez scheme implementation.

--- a/tests/chez/chez037/Hello.idr
+++ b/tests/chez/chez037/Hello.idr
@@ -1,0 +1,2 @@
+main : IO ()
+main = putStrLn "Hello"

--- a/tests/chez/chez037/expected
+++ b/tests/chez/chez037/expected
@@ -1,0 +1,1 @@
+Error: INTERNAL ERROR: Chez exited with return code 1

--- a/tests/chez/chez037/run
+++ b/tests/chez/chez037/run
@@ -1,0 +1,2 @@
+. ../../testutils.sh
+CHEZ=false idris2 -c Hello.idr -o hello


### PR DESCRIPTION
# Description

If chez exits with a status code other than 0 during compilation, Idris ignores the error and completes successfully, leaving a non-working executable. For example, this occurs when an out of memory error occurs during compilation.  I've changed `Chez.idr` to check the return code and throw an `InternalError` reporting the code if it is not zero.

Before this change, `CHEZ=false idris2 -c Hello.idr -o hello` would complete successfully, but `./build/exec/hello` would report:
```
./build/exec/hello: line 15: /Users/dunham/code/i2/Idris2/build/exec/hello_app/hello.so: No such file or directory
```
after the change, the compilation step fails with:
```
Error: INTERNAL ERROR: Chez exited with return code 1
```

