### PR TITLE
[ new ] add docs-for-type-of IDE command

### DIFF
--- a/src/Idris/IDEMode/REPL.idr
+++ b/src/Idris/IDEMode/REPL.idr
@@ -199,6 +199,10 @@ process (MakeWith l n)
     = replWrap $ Idris.REPL.process (Editing (MakeWith False (fromInteger l) (UN $ mkUserName n)))
 process (DocsFor n modeOpt)
     = replWrap $ Idris.REPL.process (Doc $ APTerm (PRef EmptyFC (UN $ mkUserName n)))
+process (DocsForTypeOf n modeOpt)
+    = do (REPL (TermChecked itm ity)) <- Idris.REPL.process $ (Check $ PRef replFC (UN $ mkUserName n))
+           | err => pure $ REPL $ REPLError (pretty0 $ show err)
+         process (DocsFor (prettyBy Syntax ity) modeOpt)
 process (Apropos n)
     = do todoCmd "apropros"
          pure $ REPL $ Printed emptyDoc
@@ -513,5 +517,5 @@ replIDE
          case res of
               REPL _ => printError $ reflow "Running idemode but output isn't"
               IDEMode _ inf outf => do
-                send outf (ProtocolVersion 2 1) -- TODO: Move this info somewhere more central
+                send outf (ProtocolVersion 2 2) -- TODO: Move this info somewhere more central
                 loop


### PR DESCRIPTION
# Description

I've decided to try to implement the issue #3157 in this PR. Right now it's a draft as long as I haven't resolved several issues:
1) I haven't tested it yet, because I don't see any clear way to install Idris without touching the main one (which is connected to $HOME/.idris2)
2) The problem is, after getting the type of the hole, I have only `IPTerm` representation of it. Thus, for calling `process (DocsFor ? modeOpt)` I need to use either already done function, or to extract the type name somehow

## Should this change go in the CHANGELOG?

Definitely yes as a feature implementation

- [ ]  If this is a fix, user-facing change, a compiler change, or a new paper
implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

