### PR TITLE
[ refactor ] export signal to code conversions

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -213,6 +213,8 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 
 * Added `fromRight` and `fromLeft` for extracting values out of `Either`, equivalent to `fromJust` for `Just`.
 
+* Export `System.Signal.signalCode` and `System.Signal.toSignal`.
+
 #### Contrib
 
 * `Data.List.Lazy` was moved from `contrib` to `base`.

--- a/libs/base/System/Signal.idr
+++ b/libs/base/System/Signal.idr
@@ -105,6 +105,7 @@ Eq Signal where
   SigPosix x == SigPosix y = x == y
   _ == _ = False
 
+export
 signalCode : Signal -> Int
 signalCode SigINT   = prim__sigint
 signalCode SigABRT  = prim__sigabrt
@@ -117,6 +118,7 @@ signalCode (SigPosix SigTRAP ) = prim__sigtrap
 signalCode (SigPosix SigUser1) = prim__sigusr1
 signalCode (SigPosix SigUser2) = prim__sigusr2
 
+export
 toSignal : Int -> Maybe Signal
 toSignal (-1) = Nothing
 toSignal x    = lookup x codes

--- a/libs/base/System/Signal.idr
+++ b/libs/base/System/Signal.idr
@@ -105,6 +105,8 @@ Eq Signal where
   SigPosix x == SigPosix y = x == y
   _ == _ = False
 
+||| Converts a `Signal` to its integer representation to be used
+||| in FFI calls.
 export
 signalCode : Signal -> Int
 signalCode SigINT   = prim__sigint
@@ -118,6 +120,7 @@ signalCode (SigPosix SigTRAP ) = prim__sigtrap
 signalCode (SigPosix SigUser1) = prim__sigusr1
 signalCode (SigPosix SigUser2) = prim__sigusr2
 
+||| Tries to convert an integer to the corresponding `Signal`.
 export
 toSignal : Int -> Maybe Signal
 toSignal (-1) = Nothing


### PR DESCRIPTION
# Description

In this small but potentially breaking change, `System.Signa.signalCode` and `toSignal` are `export`ed, since these conversions are useful when one wants to define different signal handling routines while sticking to the already existing `Signal` type.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

