### PR TITLE
[ base ] Implement `Foldable` and `Traversable` for `Identity`

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -215,6 +215,8 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 
 * Export `System.Signal.signalCode` and `System.Signal.toSignal`.
 
+* Added implementations of `Foldable` and `Traversable` for `Control.Monad.Identity`
+
 #### Contrib
 
 * `Data.List.Lazy` was moved from `contrib` to `base`.

--- a/libs/base/Control/Monad/Identity.idr
+++ b/libs/base/Control/Monad/Identity.idr
@@ -25,6 +25,19 @@ Monad Identity where
     (Id x) >>= k = k x
 
 public export
+Foldable Identity where
+  foldr f init (Id x) = f x init
+  foldl f init (Id x) = f init x
+  null _ = False
+  foldlM f init (Id x) = f init x
+  toList (Id x) = [x]
+  foldMap f (Id x) = f x
+
+public export
+Traversable Identity where
+  traverse f (Id x) = Id <$> f x
+
+public export
 Show a => Show (Identity a) where
   showPrec d (Id x) = showCon d "Id" $ showArg x
 


### PR DESCRIPTION
# Description

This allows us to simply reuse more general code, e.g. for any `Foldable`, for single items without creation of intermediate singleton lists or anything.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

