### PR TITLE
[ codegen ] get rid of artifacts introduced when optimizing `IO`

### DIFF
--- a/src/Compiler/Opts/ConstantFold.idr
+++ b/src/Compiler/Opts/ConstantFold.idr
@@ -92,7 +92,6 @@ constFold rho (CLam fc x y)
 -- Expressions of the type `let x := y in x` can be introduced
 -- by the compiler when inlining monadic code (for instance, `io_bind`).
 -- They can be replaced by `y`.
-constFold rho (CLet fc x inl y $ CLocal {idx = 0} _ _) = constFold rho y
 constFold rho (CLet fc x inl y z) =
     let val := constFold rho y
      in case replace val of

--- a/src/Compiler/Opts/ConstantFold.idr
+++ b/src/Compiler/Opts/ConstantFold.idr
@@ -101,6 +101,8 @@ constFold rho (CApp fc (CRef fc2 n) [x]) =
             v                   => CApp fc (CRef fc2 n) [v]
      else CApp fc (CRef fc2 n) [constFold rho x]
 constFold rho (CApp fc x xs) = CApp fc (constFold rho x) (constFold rho <$> xs)
+constFold rho (CCon fc x UNIT tag []) = CErased fc
+constFold rho (CCon fc x RECORD tag [y]) = constFold rho y
 constFold rho (CCon fc x y tag xs) = CCon fc x y tag $ constFold rho <$> xs
 constFold rho (COp fc BelieveMe [CErased _, CErased _ , x]) = constFold rho x
 constFold rho (COp {arity} fc fn xs) =

--- a/src/Compiler/Opts/ConstantFold.idr
+++ b/src/Compiler/Opts/ConstantFold.idr
@@ -92,12 +92,11 @@ constFold rho (CLam fc x y)
 -- Expressions of the type `let x := y in x` can be introduced
 -- by the compiler when inlining monadic code (for instance, `io_bind`).
 -- They can be replaced by `y`.
+constFold rho (CLet fc x inl y $ CLocal {idx = 0} _ _) = constFold rho y
 constFold rho (CLet fc x inl y z) =
     let val := constFold rho y
      in case replace val of
-          True  => case constFold (val::rho) z of
-            CLocal {idx = 0} _ _ => val
-            body                 => body
+          True  => constFold (val::rho) z
           False => case constFold (wk (mkSizeOf [x]) rho) z of
             CLocal {idx = 0} _ _ => val
             body                 => CLet fc x inl val body

--- a/src/Compiler/Opts/ConstantFold.idr
+++ b/src/Compiler/Opts/ConstantFold.idr
@@ -141,12 +141,8 @@ constFold rho (COp {arity} fc fn xs) =
     constRight fc fn args = COp fc fn args
 
 constFold rho (CExtPrim fc p xs) = CExtPrim fc p $ constFold rho <$> xs
-constFold rho (CForce fc x y) =
-  let val = constFold rho y
-   in if replace val then val else CForce fc x val
-constFold rho (CDelay fc x y) =
-  let val = constFold rho y
-   in if replace val then val else CDelay fc x val
+constFold rho (CForce fc x y) = CForce fc x $ constFold rho y
+constFold rho (CDelay fc x y) = CDelay fc x $ constFold rho y
 constFold rho (CConCase fc sc xs x)
   = CConCase fc (constFold rho sc) (foldAlt <$> xs) (constFold rho <$> x)
   where

--- a/tests/codegen/fix3375/Prog.idr
+++ b/tests/codegen/fix3375/Prog.idr
@@ -1,0 +1,30 @@
+module Prog
+
+import Data.IORef
+
+%default total
+
+%inline
+release : IORef Nat -> IO ()
+release ref = pure ()
+
+%inline
+readAndRelease : IORef Nat -> IO Nat
+readAndRelease ref = do
+  v <- readIORef ref
+  release ref
+  pure v
+
+setget : IORef Nat -> IORef Nat -> IO (Nat,Nat)
+setget r1 r2 = do
+  writeIORef r1 100
+  x <- readAndRelease r1
+  y <- readAndRelease r2
+  pure (x,y)
+
+main : IO ()
+main = do
+  r1 <- newIORef Z
+  r2 <- newIORef Z
+  p  <- setget r1 r2
+  printLn p

--- a/tests/codegen/fix3375/Prog.idr
+++ b/tests/codegen/fix3375/Prog.idr
@@ -22,9 +22,21 @@ setget r1 r2 = do
   y <- readAndRelease r2
   pure (x,y)
 
+%noinline
+nestedLet : Nat -> Nat
+nestedLet x =
+  let z := x in let y := z in y
+
+%noinline
+nestedLetNoArg : Nat
+nestedLetNoArg =
+  let z := 10 * 10 in let y := z in y
+
 main : IO ()
 main = do
   r1 <- newIORef Z
   r2 <- newIORef Z
   p  <- setget r1 r2
   printLn p
+  printLn (nestedLet 10)
+  printLn nestedLetNoArg

--- a/tests/codegen/fix3375/Prog.idr
+++ b/tests/codegen/fix3375/Prog.idr
@@ -23,13 +23,21 @@ setget r1 r2 = do
   pure (x,y)
 
 %noinline
-nestedLet : Nat -> Nat
-nestedLet x =
-  let z := x in let y := z in y
+letNoReplace : Nat -> Nat
+letNoReplace x = let z := x * x in z
 
 %noinline
-nestedLetNoArg : Nat
-nestedLetNoArg =
+letReplace : Nat
+letReplace = let z := 10 * 10 in z
+
+%noinline
+nestedLetNoReplace : Nat -> Nat
+nestedLetNoReplace x =
+  let z := x * x in let y := z in y
+
+%noinline
+nestedLetReplace : Nat
+nestedLetReplace =
   let z := 10 * 10 in let y := z in y
 
 main : IO ()
@@ -38,5 +46,7 @@ main = do
   r2 <- newIORef Z
   p  <- setget r1 r2
   printLn p
-  printLn (nestedLet 10)
-  printLn nestedLetNoArg
+  printLn (letNoReplace 10)
+  printLn letReplace
+  printLn (nestedLetNoReplace 10)
+  printLn nestedLetReplace

--- a/tests/codegen/fix3375/run
+++ b/tests/codegen/fix3375/run
@@ -1,0 +1,6 @@
+. ../../testutils.sh
+
+idris2 --quiet --codegen node -o prog.js Prog.idr
+
+grep "const \$[a-z0-9]\+ = undefined;" build/exec/prog.js
+grep "const \$[a-z0-9]\+ = \$[a-z0-9]\+;" build/exec/prog.js

--- a/tests/idris2/total/total022/expected
+++ b/tests/idris2/total/total022/expected
@@ -16,14 +16,14 @@ Compile time tree: case {arg:0} of
     Just {e:0} {e:1} => case {e:1} of
       Refl {e:2} {e:3} => f {arg:2} {arg:1} {arg:2} Nothing
 Compiled: \ {arg:0}, {arg:1}, {arg:2}, {arg:3} => case {arg:0} of
-  { Prelude.Basics.Nil {tag = 0} [nil] => case {arg:3} of  { Prelude.Types.Nothing {tag = 0} [nothing] => Builtin.MkUnit {tag = 0} [unit]; _ => case {arg:3} of  { Prelude.Types.Just {tag = 1} [just] {e:1} => Main.f {arg:2} {arg:1} {arg:2} (Prelude.Types.Nothing {tag = 0} [nothing])}}
+  { Prelude.Basics.Nil {tag = 0} [nil] => case {arg:3} of  { Prelude.Types.Nothing {tag = 0} [nothing] => ___; _ => case {arg:3} of  { Prelude.Types.Just {tag = 1} [just] {e:1} => Main.f {arg:2} {arg:1} {arg:2} (Prelude.Types.Nothing {tag = 0} [nothing])}}
   ; Prelude.Basics.(::) {tag = 1} [cons] {e:6} {e:7} => case {arg:3} of  { Prelude.Types.Nothing {tag = 0} [nothing] => Main.f {e:7} {arg:1} {arg:2} (Prelude.Types.Nothing {tag = 0} [nothing]); _ => case {arg:3} of  { Prelude.Types.Just {tag = 1} [just] {e:1} => Main.f {arg:2} {arg:1} {arg:2} (Prelude.Types.Nothing {tag = 0} [nothing])}}
   ; _ => case {arg:3} of
            { Prelude.Types.Just {tag = 1} [just] {e:1} => Main.f {arg:2} {arg:1} {arg:2} (Prelude.Types.Nothing {tag = 0} [nothing])
            }
   }
 Refers to: Main.f, Prelude.Basics.List, Prelude.Basics.(::), Builtin.MkUnit, Builtin.(===), Prelude.Types.Nothing
-Refers to (runtime): Main.f, Prelude.Basics.Nil, Prelude.Basics.(::), Builtin.MkUnit, Prelude.Types.Nothing, Prelude.Types.Just
+Refers to (runtime): Main.f, Prelude.Basics.Nil, Prelude.Basics.(::), Prelude.Types.Nothing, Prelude.Types.Just
 Flags: total
 Size change:
   Builtin.MkUnit:


### PR DESCRIPTION
# Description

This fixes #3375 by adding two additional rules to constant folding.

