### PR TITLE
[fix] include stdio header in readline C code in example so it builds on all systems

### DIFF
--- a/samples/FFI-readline/readline_glue/idris_readline.c
+++ b/samples/FFI-readline/readline_glue/idris_readline.c
@@ -1,39 +1,30 @@
-#include <stdio.h>
 #include <readline/readline.h>
-#include <string.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
-rl_compentry_func_t* my_compentry;
+rl_compentry_func_t *my_compentry;
 
-char* compentry_wrapper(const char* text, int i) {
-    char* res = my_compentry(text, i); // Idris frees this
-    if (res != NULL) {
-        char* comp = malloc(strlen(res)+1); // Readline frees this
-        strcpy(comp, res);
-        return comp;
-    }
-    else {
-        return NULL;
-    }
-}
-
-void idrisrl_setCompletion(rl_compentry_func_t* fn) {
-    rl_completion_entry_function = compentry_wrapper;
-    my_compentry = fn;
-}
-
-char* getString(void* str) {
-    return (char*)str;
-}
-
-void* mkString(char* str) {
-    return (void*)str;
-}
-
-void* nullString() {
+char *compentry_wrapper(const char *text, int i) {
+  char *res = my_compentry(text, i); // Idris frees this
+  if (res != NULL) {
+    char *comp = malloc(strlen(res) + 1); // Readline frees this
+    strcpy(comp, res);
+    return comp;
+  } else {
     return NULL;
+  }
 }
 
-int isNullString(void* str) {
-    return str == NULL;
+void idrisrl_setCompletion(rl_compentry_func_t *fn) {
+  rl_completion_entry_function = compentry_wrapper;
+  my_compentry = fn;
 }
+
+char *getString(void *str) { return (char *)str; }
+
+void *mkString(char *str) { return (void *)str; }
+
+void *nullString() { return NULL; }
+
+int isNullString(void *str) { return str == NULL; }

--- a/samples/FFI-readline/readline_glue/idris_readline.c
+++ b/samples/FFI-readline/readline_glue/idris_readline.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <readline/readline.h>
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
Closes #1179.

# Description

On some systems this sample already builds fine, on others it hits the error that `FILE` is not defined. Including `stdio` fixes the problem and even aligns with the example code given in the readline manpages.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

