### PR TITLE
include hidden files in artifact

### DIFF
--- a/.github/workflows/ci-idris2-and-libs.yml
+++ b/.github/workflows/ci-idris2-and-libs.yml
@@ -123,6 +123,7 @@ jobs:
       - name: Artifact Idris2 from previous version
         uses: actions/upload-artifact@v4
         with:
+          include-hidden-files: true
           name: ubuntu-installed-idris2-${{ env.IDRIS2_MINIMUM_COMPAT_VERSION }}-chez
           path: ~/.idris2/
 
@@ -157,6 +158,7 @@ jobs:
       - name: Artifact Bootstrapped Idris2
         uses: actions/upload-artifact@v4
         with:
+          include-hidden-files: true
           name: ubuntu-installed-bootstrapped-idris2-chez
           path: ~/.idris2/
 
@@ -188,6 +190,7 @@ jobs:
       - name: Artifact Bootstrapped Idris2
         uses: actions/upload-artifact@v4
         with:
+          include-hidden-files: true
           name: macos-installed-bootstrapped-idris2-chez
           path: ~/.idris2/
 
@@ -238,6 +241,7 @@ jobs:
       - name: Artifact Idris2 from chez
         uses: actions/upload-artifact@v4
         with:
+          include-hidden-files: true
           name: windows-installed-bootstrapped-idris2-chez
           path: ${{ env.IDRIS_PREFIX }}
 
@@ -284,6 +288,7 @@ jobs:
       - name: Artifact Bootstrapped Idris2
         uses: actions/upload-artifact@v4
         with:
+          include-hidden-files: true
           name: ubuntu-installed-bootstrapped-idris2-racket
           path: ~/.idris2/
 
@@ -403,6 +408,7 @@ jobs:
       - name: Artifact Idris2
         uses: actions/upload-artifact@v4
         with:
+          include-hidden-files: true
           name: idris2-nightly-chez
           path: ~/.idris2/
 


### PR DESCRIPTION
# Description

This fixes recent CI failures after GitHub stopped including hidden files in artifact uploads by default. The Idris2 compiler gets installed into one such hidden folder, so we need to include them.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

