### PR TITLE
Correct ipkg comment docs

### DIFF
--- a/docs/source/reference/packages.rst
+++ b/docs/source/reference/packages.rst
@@ -116,7 +116,7 @@ Other common fields which may be present in an ``ipkg`` file are:
 Comments
 ---------
 
-Package files support comments using the standard Idris singleline ``--`` and multiline ``{- -}`` format.
+Package files support comments using the standard Idris singleline ``--`` format.
 
 Using Package files
 ===================


### PR DESCRIPTION
# Description

stefan-hoeck/idris2-pack#307  -- Neither Idris2 nor Pack actually support multiline comments in ipkg files.

## Should this change go in the CHANGELOG?

Not IMO.