### PR TITLE
[ fix ] make buildIdris nix function still work when there are more than one app directories in the build output

### DIFF
--- a/nix/buildIdris.nix
+++ b/nix/buildIdris.nix
@@ -80,13 +80,13 @@ in rec {
         # ^ remove after Idris2 0.8.0 is released. will be superfluous:
         # https://github.com/idris-lang/Idris2/pull/3189
       else
-        executable="$(idris2 --dump-ipkg-json ${ipkgFileName} | jq -r '.executable').so"
+        bin_name="$(idris2 --dump-ipkg-json ${ipkgFileName} | jq -r '.executable')"
 
-        cd build/exec/*_app
+        cd build/exec/''${bin_name}_app
 
         rm -f ./libidris2_support.{so,dylib}
 
-        bin_name="''${executable%.so}"
+        executable="''${bin_name}.so"
         mv -- "$executable" "$out/bin/$bin_name"
 
         # remaining .so or .dylib files can be moved to lib directory


### PR DESCRIPTION
# Description

Up until now I've never seen an app with more than one `_app` directory in the build output of Idris2, but I saw one today. This small change makes the Nix `buildIdris` function handle the multi-app-directory build artifacts without issue.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

