### PR TITLE
fix: help menu for `refine` command

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -25,6 +25,8 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
   where Idris2 will install the given package if `idris2 --install
   {ipkg-filename}` is called.
 
+* Remove reference to column number parameter in help menu for `refine` command.
+
 ### Building/Packaging changes
 
 * The Nix flake's `buildIdris` function now returns a set with `executable` and

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -40,6 +40,7 @@ Jens Petersen
 Joel Berkeley
 Joey Eremondi
 Johann Rudloff
+Justin Yang
 Kamil Shakirov
 Kevin Boulain
 LuoChen

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -2246,7 +2246,7 @@ knownCommands =
   explain ["mc", "makecase"] "Make case on term <n> defined on line <l>" ++
   explain ["mw", "makewith"] "Add with expression on term <n> defined on line <l>" ++
   [ ("intro", "Introduce unambiguous constructor in hole <n> defined on line <l>")
-  , ("refine", "Refine hole <h> with identifier <n> on line <l> and column <c>")
+  , ("refine", "Refine hole <h> with identifier <n> on line <l>")
   ] ++
   explain ["ps", "proofsearch"] "Search for a proof" ++
   [ ("psnext", "Show next proof")
@@ -2592,7 +2592,6 @@ editLineNamePTermArgCmd : ParseCmd -> (Bool -> Int -> Name -> PTerm -> EditCmd) 
 editLineNamePTermArgCmd parseCmd command doc =
   ( names
   , Args [ NamedCmdArg "l" NumberArg
-         , NamedCmdArg "c" NumberArg
          , NamedCmdArg "h" StringArg
          , NamedCmdArg "e" ExprArg
          ]

--- a/tests/idris2/repl/repl001/expected
+++ b/tests/idris2/repl/repl001/expected
@@ -34,7 +34,7 @@ Main>  <expr>                                                Evaluate an express
  :mc :makecase     <l:number> <n:string>               Make case on term <n> defined on line <l>
  :mw :makewith     <l:number> <n:string>               Add with expression on term <n> defined on line <l>
  :intro            <l:number> <n:string>               Introduce unambiguous constructor in hole <n> defined on line <l>
- :refine           <l:number> <c:number> <h:string> <e:expr>Refine hole <h> with identifier <n> on line <l> and column <c>
+ :refine           <l:number> <h:string> <e:expr>Refine hole <h> with identifier <n> on line <l>
  :ps :proofsearch  <l:number> <n:string> <h:[name]>    Search for a proof
  :psnext                                               Show next proof
  :gd               <l:number> <n:string> <r:number|0>  Try to generate a definition using proof-search
@@ -79,7 +79,7 @@ Main>  <expr>                                                Evaluate an express
  :mc :makecase     <l:number> <n:string>               Make case on term <n> defined on line <l>
  :mw :makewith     <l:number> <n:string>               Add with expression on term <n> defined on line <l>
  :intro            <l:number> <n:string>               Introduce unambiguous constructor in hole <n> defined on line <l>
- :refine           <l:number> <c:number> <h:string> <e:expr>Refine hole <h> with identifier <n> on line <l> and column <c>
+ :refine           <l:number> <h:string> <e:expr>Refine hole <h> with identifier <n> on line <l>
  :ps :proofsearch  <l:number> <n:string> <h:[name]>    Search for a proof
  :psnext                                               Show next proof
  :gd               <l:number> <n:string> <r:number|0>  Try to generate a definition using proof-search
@@ -124,7 +124,7 @@ Main>  <expr>                                                Evaluate an express
  :mc :makecase     <l:number> <n:string>               Make case on term <n> defined on line <l>
  :mw :makewith     <l:number> <n:string>               Add with expression on term <n> defined on line <l>
  :intro            <l:number> <n:string>               Introduce unambiguous constructor in hole <n> defined on line <l>
- :refine           <l:number> <c:number> <h:string> <e:expr>Refine hole <h> with identifier <n> on line <l> and column <c>
+ :refine           <l:number> <h:string> <e:expr>Refine hole <h> with identifier <n> on line <l>
  :ps :proofsearch  <l:number> <n:string> <h:[name]>    Search for a proof
  :psnext                                               Show next proof
  :gd               <l:number> <n:string> <r:number|0>  Try to generate a definition using proof-search

--- a/tests/idris2/repl/repl001/expected
+++ b/tests/idris2/repl/repl001/expected
@@ -34,7 +34,7 @@ Main>  <expr>                                                Evaluate an express
  :mc :makecase     <l:number> <n:string>               Make case on term <n> defined on line <l>
  :mw :makewith     <l:number> <n:string>               Add with expression on term <n> defined on line <l>
  :intro            <l:number> <n:string>               Introduce unambiguous constructor in hole <n> defined on line <l>
- :refine           <l:number> <h:string> <e:expr>Refine hole <h> with identifier <n> on line <l>
+ :refine           <l:number> <h:string> <e:expr>      Refine hole <h> with identifier <n> on line <l>
  :ps :proofsearch  <l:number> <n:string> <h:[name]>    Search for a proof
  :psnext                                               Show next proof
  :gd               <l:number> <n:string> <r:number|0>  Try to generate a definition using proof-search
@@ -79,7 +79,7 @@ Main>  <expr>                                                Evaluate an express
  :mc :makecase     <l:number> <n:string>               Make case on term <n> defined on line <l>
  :mw :makewith     <l:number> <n:string>               Add with expression on term <n> defined on line <l>
  :intro            <l:number> <n:string>               Introduce unambiguous constructor in hole <n> defined on line <l>
- :refine           <l:number> <h:string> <e:expr>Refine hole <h> with identifier <n> on line <l>
+ :refine           <l:number> <h:string> <e:expr>      Refine hole <h> with identifier <n> on line <l>
  :ps :proofsearch  <l:number> <n:string> <h:[name]>    Search for a proof
  :psnext                                               Show next proof
  :gd               <l:number> <n:string> <r:number|0>  Try to generate a definition using proof-search
@@ -124,7 +124,7 @@ Main>  <expr>                                                Evaluate an express
  :mc :makecase     <l:number> <n:string>               Make case on term <n> defined on line <l>
  :mw :makewith     <l:number> <n:string>               Add with expression on term <n> defined on line <l>
  :intro            <l:number> <n:string>               Introduce unambiguous constructor in hole <n> defined on line <l>
- :refine           <l:number> <h:string> <e:expr>Refine hole <h> with identifier <n> on line <l>
+ :refine           <l:number> <h:string> <e:expr>      Refine hole <h> with identifier <n> on line <l>
  :ps :proofsearch  <l:number> <n:string> <h:[name]>    Search for a proof
  :psnext                                               Show next proof
  :gd               <l:number> <n:string> <r:number|0>  Try to generate a definition using proof-search


### PR DESCRIPTION
# Description
Remove reference to column number parameter in the help menu for the `refine` command.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

