### PR TITLE
[ fix ] Address some proofs of void via impossible from issues #2250 and #3276

### DIFF
--- a/src/Core/Case/Util.idr
+++ b/src/Core/Case/Util.idr
@@ -26,11 +26,11 @@ getCons defs (NTCon _ tn _ _ _)
   where
     addTy : Name -> Core (Maybe DataCon)
     addTy cn
-        = do Just (idx, gdef) <- lookupCtxtExactI cn (gamma defs)
+        = do Just gdef <- lookupCtxtExact cn (gamma defs)
                   | _ => pure Nothing
              case (gdef.definition, gdef.type) of
                   (DCon t arity _, ty) =>
-                        pure . Just $ MkDataCon (Resolved idx) t arity
+                        pure . Just $ MkDataCon cn t arity
                   _ => pure Nothing
 getCons defs _ = pure []
 

--- a/src/Core/Case/Util.idr
+++ b/src/Core/Case/Util.idr
@@ -26,11 +26,11 @@ getCons defs (NTCon _ tn _ _ _)
   where
     addTy : Name -> Core (Maybe DataCon)
     addTy cn
-        = do Just gdef <- lookupCtxtExact cn (gamma defs)
+        = do Just (idx, gdef) <- lookupCtxtExactI cn (gamma defs)
                   | _ => pure Nothing
              case (gdef.definition, gdef.type) of
                   (DCon t arity _, ty) =>
-                        pure . Just $ MkDataCon cn t arity
+                        pure . Just $ MkDataCon (Resolved idx) t arity
                   _ => pure Nothing
 getCons defs _ = pure []
 

--- a/src/Core/Coverage.idr
+++ b/src/Core/Coverage.idr
@@ -148,7 +148,7 @@ isEmpty defs env _ = pure False
 altMatch : CaseAlt vars -> CaseAlt vars -> Bool
 altMatch _ (DefaultCase _) = True
 altMatch (DelayCase _ _ t) (DelayCase _ _ t') = True
-altMatch (ConCase n t _ _) (ConCase n' t' _ _) = t == t' && n == n'
+altMatch (ConCase n t _ _) (ConCase n' t' _ _) = t == t'
 altMatch (ConstCase c _) (ConstCase c' _) = c == c'
 altMatch _ _ = False
 

--- a/src/Core/Coverage.idr
+++ b/src/Core/Coverage.idr
@@ -148,7 +148,7 @@ isEmpty defs env _ = pure False
 altMatch : CaseAlt vars -> CaseAlt vars -> Bool
 altMatch _ (DefaultCase _) = True
 altMatch (DelayCase _ _ t) (DelayCase _ _ t') = True
-altMatch (ConCase _ t _ _) (ConCase _ t' _ _) = t == t'
+altMatch (ConCase n t _ _) (ConCase n' t' _ _) = t == t' && n == n'
 altMatch (ConstCase c _) (ConstCase c' _) = c == c'
 altMatch _ _ = False
 

--- a/src/TTImp/Impossible.idr
+++ b/src/TTImp/Impossible.idr
@@ -45,7 +45,6 @@ match nty (n, i, rty)
 dropNoMatch : {auto c : Ref Ctxt Defs} ->
               Maybe (NF []) -> List (Name, Int, GlobalDef) ->
               Core (List (Name, Int, GlobalDef))
-dropNoMatch _ [t] = pure [t]
 dropNoMatch Nothing ts = pure ts
 dropNoMatch (Just nty) ts
     = -- if the return type of a thing in ts doesn't match nty, drop it

--- a/src/TTImp/Impossible.idr
+++ b/src/TTImp/Impossible.idr
@@ -168,6 +168,8 @@ mutual
   mkTerm (INamedApp fc fn nm arg) mty exps autos named
      = mkTerm fn mty exps autos ((nm, arg) :: named)
   mkTerm (IPrimVal fc c) _ _ _ _ = pure (PrimVal fc c)
+  mkTerm (IAlternative _ (UniqueDefault tm) _) mty exps autos named
+     = mkTerm tm mty exps autos named
   mkTerm tm _ _ _ _ = nextVar (getFC tm)
 
 -- Given an LHS that is declared 'impossible', build a term to match from,

--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -221,6 +221,8 @@ recoverableErr defs (CantSolveEq fc gam env l r)
                         !(nf defs env r)
 recoverableErr defs (BadDotPattern _ _ ErasedArg _ _) = pure True
 recoverableErr defs (CyclicMeta _ _ _ _) = pure False
+-- Don't mark a case as impossible because we can't see the constructor.
+recoverableErr defs (InvisibleName _ _ _) = pure True
 recoverableErr defs (AllFailed errs)
     = anyM (recoverableErr defs) (map snd errs)
 recoverableErr defs (WhenUnifying _ _ _ _ _ err)

--- a/tests/idris2/coverage/coverage021/Head.idr
+++ b/tests/idris2/coverage/coverage021/Head.idr
@@ -1,0 +1,9 @@
+total
+head : List a -> a
+head (x :: xs) = x
+head () impossible
+
+total
+head' : List a -> a
+head' (x :: xs) = x
+head' Z impossible

--- a/tests/idris2/coverage/coverage021/Issue2250a.idr
+++ b/tests/idris2/coverage/coverage021/Issue2250a.idr
@@ -1,0 +1,19 @@
+View : Type -> Type
+View a = a -> Type
+
+-- Pre-image view
+data (.inv) : (f : a -> b) -> View b where
+  Choose : (x : a) -> f.inv (f x)
+
+LessThanOrEqualTo : Nat -> Nat -> Type
+LessThanOrEqualTo n k = (+n).inv k
+
+Ex1 : 3 `LessThanOrEqualTo` 5
+Ex1 = Choose 2
+
+Bug : Not (3 `LessThanOrEqualTo` 5)
+Bug Refl impossible
+
+Yikes : Void
+Yikes = Bug Ex1
+

--- a/tests/idris2/coverage/coverage021/Issue2250b.idr
+++ b/tests/idris2/coverage/coverage021/Issue2250b.idr
@@ -1,0 +1,11 @@
+import Data.Nat
+
+%default total
+
+f : n `LTE` m -> Void
+f Z impossible
+f (LTESucc x) = f x
+
+x : Void
+x = f $ LTEZero {right=Z}
+

--- a/tests/idris2/coverage/coverage021/Issue2250c.idr
+++ b/tests/idris2/coverage/coverage021/Issue2250c.idr
@@ -1,0 +1,7 @@
+%default total
+
+g : Not Bool
+g () impossible
+
+f : Void
+f = g True

--- a/tests/idris2/coverage/coverage021/Issue3276.idr
+++ b/tests/idris2/coverage/coverage021/Issue3276.idr
@@ -1,0 +1,21 @@
+%default total
+
+namespace Bits8
+  export
+  data LessThan : Bits8 -> Bits8 -> Type where
+    MkLessThan : (a < b) === True -> LessThan a b
+
+  export
+  %hint
+  mkLessThan : (a < b) === True -> LessThan a b
+  mkLessThan = MkLessThan
+
+data Digit : Bits8 -> Type where
+  MkDigit : (x : Bits8) -> {auto prf1 : LessThan 47 x} -> {auto prf2 : LessThan x 58} -> Digit x
+
+prf1 : Digit 51
+prf1 = MkDigit 51
+
+dis0 : Digit 51 -> Void
+dis0 (MkDigit _ {prf1=Refl}) impossible
+

--- a/tests/idris2/coverage/coverage021/Visibility.idr
+++ b/tests/idris2/coverage/coverage021/Visibility.idr
@@ -1,0 +1,8 @@
+%default total
+namespace Blah
+    export
+    data Foo : Type where
+        MkFoo : Foo
+
+boom : Foo -> Void
+boom Z impossible

--- a/tests/idris2/coverage/coverage021/expected
+++ b/tests/idris2/coverage/coverage021/expected
@@ -10,7 +10,7 @@ Issue2250a:14:1--14:36
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Missing cases:
-    Bug (Choose m)
+    Bug _
 
 Error: Yikes is not covering.
 
@@ -69,8 +69,7 @@ Issue2250c:3:1--3:13
      ^^^^^^^^^^^^
 
 Missing cases:
-    g False
-    g True
+    g _
 
 1/1: Building Issue3276 (Issue3276.idr)
 Error: dis0 is not covering.
@@ -84,7 +83,7 @@ Issue3276:19:1--19:24
       ^^^^^^^^^^^^^^^^^^^^^^^
 
 Missing cases:
-    dis0 (MkDigit e)
+    dis0 _
 
 1/1: Building Visibility (Visibility.idr)
 Error: boom is not covering.
@@ -98,7 +97,7 @@ Visibility:7:1--7:19
      ^^^^^^^^^^^^^^^^^^
 
 Missing cases:
-    boom MkFoo
+    boom _
 
 1/1: Building Head (Head.idr)
 Error: head is not covering.

--- a/tests/idris2/coverage/coverage021/expected
+++ b/tests/idris2/coverage/coverage021/expected
@@ -1,0 +1,78 @@
+1/1: Building Issue2250a (Issue2250a.idr)
+Error: Bug is not covering.
+
+Issue2250a:14:1--14:36
+ 10 | 
+ 11 | Ex1 : 3 `LessThanOrEqualTo` 5
+ 12 | Ex1 = Choose 2
+ 13 | 
+ 14 | Bug : Not (3 `LessThanOrEqualTo` 5)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Missing cases:
+    Bug (Choose m)
+
+Error: Yikes is not covering.
+
+Issue2250a:17:1--17:13
+ 13 | 
+ 14 | Bug : Not (3 `LessThanOrEqualTo` 5)
+ 15 | Bug Refl impossible
+ 16 | 
+ 17 | Yikes : Void
+      ^^^^^^^^^^^^
+
+Calls non covering function Main.Bug
+1/1: Building Issue2250b (Issue2250b.idr)
+Error: f is not covering.
+
+Issue2250b:5:1--5:22
+ 1 | import Data.Nat
+ 2 | 
+ 3 | %default total
+ 4 | 
+ 5 | f : n `LTE` m -> Void
+     ^^^^^^^^^^^^^^^^^^^^^
+
+Missing cases:
+    f LTEZero
+
+Error: x is not covering.
+
+Issue2250b:9:1--9:9
+ 5 | f : n `LTE` m -> Void
+ 6 | f Z impossible
+ 7 | f (LTESucc x) = f x
+ 8 | 
+ 9 | x : Void
+     ^^^^^^^^
+
+Calls non covering function Main.f
+1/1: Building Issue3276 (Issue3276.idr)
+Error: dis0 is not covering.
+
+Issue3276:19:1--19:24
+ 15 | 
+ 16 | prf1 : Digit 51
+ 17 | prf1 = MkDigit 51
+ 18 | 
+ 19 | dis0 : Digit 51 -> Void
+      ^^^^^^^^^^^^^^^^^^^^^^^
+
+Missing cases:
+    dis0 (MkDigit e)
+
+1/1: Building Visibility (Visibility.idr)
+Error: boom is not covering.
+
+Visibility:7:1--7:19
+ 3 |     export
+ 4 |     data Foo : Type where
+ 5 |         MkFoo : Foo
+ 6 | 
+ 7 | boom : Foo -> Void
+     ^^^^^^^^^^^^^^^^^^
+
+Missing cases:
+    boom MkFoo
+

--- a/tests/idris2/coverage/coverage021/expected
+++ b/tests/idris2/coverage/coverage021/expected
@@ -48,6 +48,30 @@ Issue2250b:9:1--9:9
      ^^^^^^^^
 
 Calls non covering function Main.f
+1/1: Building Issue2250c (Issue2250c.idr)
+Error: f is not covering.
+
+Issue2250c:6:1--6:9
+ 2 | 
+ 3 | g : Not Bool
+ 4 | g () impossible
+ 5 | 
+ 6 | f : Void
+     ^^^^^^^^
+
+Calls non covering function Main.g
+Error: g is not covering.
+
+Issue2250c:3:1--3:13
+ 1 | %default total
+ 2 | 
+ 3 | g : Not Bool
+     ^^^^^^^^^^^^
+
+Missing cases:
+    g False
+    g True
+
 1/1: Building Issue3276 (Issue3276.idr)
 Error: dis0 is not covering.
 
@@ -75,4 +99,23 @@ Visibility:7:1--7:19
 
 Missing cases:
     boom MkFoo
+
+1/1: Building Head (Head.idr)
+Error: head is not covering.
+
+Head:1:1--2:19
+ 1 | total
+ 2 | head : List a -> a
+
+Missing cases:
+    head []
+
+Error: head' is not covering.
+
+Head:6:1--7:20
+ 6 | total
+ 7 | head' : List a -> a
+
+Missing cases:
+    head' []
 

--- a/tests/idris2/coverage/coverage021/run
+++ b/tests/idris2/coverage/coverage021/run
@@ -1,0 +1,6 @@
+. ../../../testutils.sh
+
+check Issue2250a.idr
+check Issue2250b.idr
+check Issue3276.idr
+check Visibility.idr

--- a/tests/idris2/coverage/coverage021/run
+++ b/tests/idris2/coverage/coverage021/run
@@ -2,5 +2,7 @@
 
 check Issue2250a.idr
 check Issue2250b.idr
+check Issue2250c.idr
 check Issue3276.idr
 check Visibility.idr
+check Head.idr


### PR DESCRIPTION
# Description

This PR addresses a few issues in #2250 and issue #3276.  They are caused by an issue with `IAlternative` in impossible clauses, a type confusion issue in impossible clauses, and treatment of out of hidden constructors as impossible. An additional issue was brought up in #2250 that is not addressed here.  I'll first discuss the issues and how I resolved them and then discuss a frex issue that should be patched before merging.

## Issues fixed

The `IAlternative` issue is illustrated at the top of #2550:
```idris
%default total

g : Not Bool
g () impossible

f : Void
f = g True
```
Here the `impossible` clause is accepted because the type doesn't match at all, but when it is converted by `mkTerm` to a term for coverage checking, the ambiguous `()` is converted to a pattern variable which is then considered to cover everything. I addressed this by choosing the default alternative.  I didn't see a way to determine the appropriate alternative at that point in the code.  A user will have to explicitly say `Unit` or `Pair` to get the other option in an impossible clause.

The type confusion issue is illustrated in #2250 by:
```idris
import Data.Nat
%default total

f : n `LTE` m -> Void
f Z impossible
f (LTESucc x) = f x

x : Void
x = f $ LTEZero {right=Z}
```
Here `Z` is impossible because it has the wrong type, but during coverage checking only the constructor tag is looked at and `Z` is confused with `LTEZero`.  I addressed this by also checking that the name matches.  I coerce the names to resolved names in `getCons` because some constructor names were resolved in the context and others were not.

Finally, in #3276 there was a false impossible because a constructor was not visible. I adjusted `recoverableError` to not consider `InvisibleName` to be evidence of impossible.

The issues fixed in #2250 and #3276 are included as test cases.

## Frex

Frex is relying on the ambiguity bug with Pair/MkPair in one location.  The function is indeed covering, but Idris cannot capable of determining that if `MkPair` is used instead of `(,)`. The current code is only working because of the above bug.  This can be addressed with the following patch to frex, which pushes the impossible match down to a separate case tree:

```diff
diff --git a/src/Frexlet/Monoid/Frex/Structure.idr b/src/Frexlet/Monoid/Frex/Structure.idr
index 8ccc22e..0164d67 100644
--- a/src/Frexlet/Monoid/Frex/Structure.idr
+++ b/src/Frexlet/Monoid/Frex/Structure.idr
@@ -159,8 +159,10 @@ MultHomomorphism a s (i, ConsUlt i1 x is) (j,ConsUlt j1 y js)
   = ( a.cong 2 (Dyn 0 .*. Dyn 1) [_,_] [_,_] [i_eq_j, i1_eq_i2]
     , x_eq_y
     ) :: is_eq_js
-MultHomomorphism _ _ (_, Ultimate _) (_, ConsUlt _ _ _) (MkAnd _ _) impossible
-MultHomomorphism _ _ (_, ConsUlt _ _ _) (_, Ultimate _) (MkAnd _ _) impossible
+MultHomomorphism _ _ (_, Ultimate _) (_, ConsUlt _ _ _) x with (x)
+  _ | MkAnd _ _ impossible
+MultHomomorphism _ _ (_, ConsUlt _ _ _) (_, Ultimate _) x with (x)
+  _ | MkAnd _ _ impossible
 
 public export
 AppendHomomorphismProperty : (a : Monoid) -> (x : Setoid) ->
```
