### PR TITLE
[ fix ] Fix ability to declare fixities in `do`

### DIFF
--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -737,10 +737,10 @@ mutual
            pure $ seqFun fc ns tm' rest'
   expandDo side ps topfc ns (DoBind fc nameFC n rig ty tm :: rest)
       = do tm' <- desugarDo side ps ns tm
-           rest' <- expandDo side ps topfc ns rest
            whenJust (isConcreteFC nameFC) $ \nfc => addSemanticDecorations [(nfc, Bound, Just n)]
            ty' <- maybe (pure $ Implicit (virtualiseFC fc) False)
                         (\ty => desugarDo side ps ns ty) ty
+           rest' <- expandDo side ps topfc ns rest
            pure $ bindFun fc ns tm'
                 $ ILam nameFC rig Explicit (Just n) ty' rest'
   expandDo side ps topfc ns (DoBindPat fc pat ty exp alts :: rest)
@@ -749,12 +749,12 @@ mutual
            exp' <- desugarDo side ps ns exp
            alts' <- traverse (map snd . desugarClause ps True) alts
            let ps' = newps ++ ps
-           rest' <- expandDo side ps' topfc ns rest
            let fcOriginal = fc
            let fc = virtualiseFC fc
            let patFC = virtualiseFC (getFC bpat)
            ty' <- maybe (pure $ Implicit fc False)
                         (\ty => desugarDo side ps ns ty) ty
+           rest' <- expandDo side ps' topfc ns rest
            pure $ bindFun fc ns exp'
                 $ ILam EmptyFC top Explicit (Just (MN "_" 0))
                           ty'
@@ -788,12 +788,12 @@ mutual
                        (PatClause fc bpat rest'
                                   :: alts')
   expandDo side ps topfc ns (DoLetLocal fc decls :: rest)
-      = do rest' <- expandDo side ps topfc ns rest
-           decls' <- traverse (desugarDecl ps) decls
+      = do decls' <- traverse (desugarDecl ps) decls
+           rest' <- expandDo side ps topfc ns rest
            pure $ ILocal fc (concat decls') rest'
   expandDo side ps topfc ns (DoRewrite fc rule :: rest)
-      = do rest' <- expandDo side ps topfc ns rest
-           rule' <- desugarDo side ps ns rule
+      = do rule' <- desugarDo side ps ns rule
+           rest' <- expandDo side ps topfc ns rest
            pure $ IRewrite fc rule' rest'
 
   -- Replace all operator by function application

--- a/tests/idris2/operators/operators012/Y.idr
+++ b/tests/idris2/operators/operators012/Y.idr
@@ -1,0 +1,27 @@
+f : Nat
+f =
+  let (%^%) : Nat -> Nat -> Nat
+      (%^%) = (+)
+      private infixl 1 %^%
+  in 1 %^% 2
+
+g : Nat
+g = do
+  let (%^%%) : Nat -> Nat -> Nat
+      (%^%%) = (+)
+      private infixl 1 %^%%
+  1 %^%% 2
+
+crazy1 : Nat
+crazy1 = do
+  let (%^%%%) : Nat -> Nat -> Nat
+      (%^%%%) = (+)
+  rewrite let private infixl 1 %^%%% in the (Nat = Nat) Refl
+  1 %^%%% 2
+
+crazy2 : List Nat
+crazy2 = do
+  let (%^%%%%) : Nat -> Nat -> Nat
+      (%^%%%%) = (+)
+  x : (let private infixl 1 %^%%%% in Nat) <- [1]
+  pure $ x %^%%%% 2

--- a/tests/idris2/operators/operators012/expected
+++ b/tests/idris2/operators/operators012/expected
@@ -1,0 +1,1 @@
+1/1: Building Y (Y.idr)

--- a/tests/idris2/operators/operators012/run
+++ b/tests/idris2/operators/operators012/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check Y.idr


### PR DESCRIPTION
Fixity declarations are instructions to parsers, thus they can appear in a lot of places in code, e.g. in `let`s, `where`s, etc., and they work till the end of the module or hiding/redefinition, like pragmas. This indeed may be useful, say, we are definiting local function which uses some context in its closure, and we want to declare it as an infix operator: it's logical that you can declare a fixity of this function near the definition of a function, and it indeed works:

```idris
f : Nat
f =
  let (%^%) : Nat -> Nat -> Nat
      (%^%) = (+)
      private infixl 1 %^%
  in 1 %^% 2
```

But as soon as you try this in `do`-notation, it suddenly does not work:

```idris
g : Nat
g = do
  let (%^%%) : Nat -> Nat -> Nat
      (%^%%) = (+)
      private infixl 1 %^%%
  1 %^%% 2
```

```console
Error: Unknown operator '%^%%'

tests.idris2.operators.operators012.Y:13:3--13:11
 09 | g = do
 10 |   let (%^%%) : Nat -> Nat -> Nat
 11 |       (%^%%) = (+)
 12 |       private infixl 1 %^%%
 13 |   1 %^%% 2
        ^^^^^^^^
```

More strangely, you may find that **after** this function definition, this infix operator is fully usable. Looks like it should work in `do`-notation too and was meant to work.

I realised that management of fixities is implemented in an imperative way, and just the body after `let` was desuraged before the `let` itself, which leads to this error. I propose to change the order of management in order for `let`s with fixity declarations to work in the same way outside and inside `do`-notation.

I also found a little bit more obscure, but still seemingly viable cases of such management order, you can see them at the added test case.

Thanks to @GlebChili for discovering this issue.