### PR TITLE
[ base ] Better set's `toList` implementation + preparation for cleanup

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -244,6 +244,8 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
   `SIsNonZero` was made to be an alias for `ItIsSucc`, was marked as deprecated,
   and won't work on LHS anymore.
 
+* Deprecated `toList` function in favor of `Prelude.toList` in `Data.SortedSet`.
+
 #### Contrib
 
 * `Data.List.Lazy` was moved from `contrib` to `base`.

--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -95,6 +95,9 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 
 * Typst files can be compiled as Literate Idris
 
+* `min` was renamed to `leftMost` in `Libraries.Data.Sorted{Map|Set}` in order
+  to be defined as in `base`.
+
 ### Backend changes
 
 #### RefC Backend
@@ -245,6 +248,8 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
   and won't work on LHS anymore.
 
 * Deprecated `toList` function in favor of `Prelude.toList` in `Data.SortedSet`.
+
+* Several functions like `pop`, `differenceMap` and `toSortedMap` were added to `Data.Sorted{Map|Set}`
 
 #### Contrib
 

--- a/libs/base/Data/SortedMap.idr
+++ b/libs/base/Data/SortedMap.idr
@@ -189,6 +189,11 @@ rightMost : SortedMap key val -> Maybe (key,val)
 rightMost = map unDPair . rightMost . unM
 
 
+||| Pops the leftmost key and corresponding value from the map
+export
+pop : SortedMap k v -> Maybe ((k, v), SortedMap k v)
+pop = map (bimap unDPair M) . pop . unM
+
 export
 (Show k, Show v) => Show (SortedMap k v) where
    show m = "fromList " ++ (show $ toList m)

--- a/libs/base/Data/SortedMap/Dependent.idr
+++ b/libs/base/Data/SortedMap/Dependent.idr
@@ -451,6 +451,13 @@ rightMost : SortedDMap k v -> Maybe (x : k ** v x)
 rightMost Empty = Nothing
 rightMost (M _ t) = Just $ treeRightMost t
 
+||| Pops the leftmost key and corresponding value from the map
+export
+pop : SortedDMap k v -> Maybe ((x : k ** v x), SortedDMap k v)
+pop m = do
+  kv@(k ** _) <- leftMost m
+  pure (kv, delete k m)
+
 export
 (Show k, {x : k} -> Show (v x)) => Show (SortedDMap k v) where
    show m = "fromList " ++ (show $ toList m)

--- a/libs/base/Data/SortedSet.idr
+++ b/libs/base/Data/SortedSet.idr
@@ -4,8 +4,6 @@ import Data.Maybe
 import Data.SortedMap
 import Data.SortedMap.Dependent
 
-%hide Prelude.toList
-
 export
 data SortedSet k = SetWrapper (Data.SortedMap.SortedMap k ())
 
@@ -42,17 +40,22 @@ fromList : Ord k => List k -> SortedSet k
 fromList l = SetWrapper (Data.SortedMap.fromList (map (\i => (i, ())) l))
 
 export
-toList : SortedSet k -> List k
-toList (SetWrapper m) = keys m
-
-export
 Foldable SortedSet where
-  foldr f z = foldr f z . Data.SortedSet.toList
-  foldl f z = foldl f z . Data.SortedSet.toList
+  foldr f z = foldr f z . toList
+  foldl f z = foldl f z . toList
 
   null (SetWrapper m) = null m
 
-  foldMap f = foldMap f . Data.SortedSet.toList
+  foldMap f = foldMap f . toList
+
+  toList (SetWrapper m) = keys m
+
+-- Remove as soon as 0.8.0 (or greater) is released
+||| Use `Prelude.toList` instead
+%deprecate
+public export %inline
+toList : SortedSet k -> List k
+toList = Prelude.toList
 
 ||| Set union. Inserts all elements of x into y
 export
@@ -98,7 +101,7 @@ Eq k => Eq (SortedSet k) where
 
 export
 Show k => Show (SortedSet k) where
-   show m = "fromList " ++ (show $ toList m)
+   show m = "fromList " ++ show (Prelude.toList m)
 
 export
 keySet : SortedMap k v -> SortedSet k

--- a/libs/base/Data/SortedSet.idr
+++ b/libs/base/Data/SortedSet.idr
@@ -113,6 +113,29 @@ namespace Dependent
   keySet : SortedDMap k v -> SortedSet k
   keySet = SetWrapper . cast . map (const ())
 
+||| Removes all given keys from the given map
+export
+differenceMap : SortedMap k v -> SortedSet k -> SortedMap k v
+differenceMap x y = foldr delete x y
+
+||| Leaves only given keys in the given map
+export
+intersectionMap : SortedMap k v -> SortedSet k -> SortedMap k v
+intersectionMap x y = differenceMap x (keySet $ differenceMap x y)
+
 export
 singleton : Ord k => k -> SortedSet k
 singleton = insert' empty
+
+export %inline
+toSortedMap : SortedSet k -> SortedMap k ()
+toSortedMap (SetWrapper m) = m
+
+export %inline
+fromSortedMap : SortedMap k () -> SortedSet k
+fromSortedMap = SetWrapper
+
+||| Pops the leftmost element from the set
+export
+pop : SortedSet k -> Maybe (k, SortedSet k)
+pop (SetWrapper m) = bimap fst fromSortedMap <$> pop m

--- a/src/Compiler/Opts/ToplevelConstants.idr
+++ b/src/Compiler/Opts/ToplevelConstants.idr
@@ -82,7 +82,7 @@ appendDef t = do
   put SortTag $ {triples $= (:< t)} st
 
 getCalls : Ref SortTag SortST => Name -> Core (List Name)
-getCalls n = map (maybe [] SortedSet.toList . lookup n . graph) (get SortTag)
+getCalls n = map (maybe [] Prelude.toList . lookup n . graph) (get SortTag)
 
 getTriple : Ref SortTag SortST => Name -> Core (Maybe (Name,FC,NamedDef))
 getTriple n = map (lookup n . map) (get SortTag)

--- a/src/Compiler/RefC/RefC.idr
+++ b/src/Compiler/RefC/RefC.idr
@@ -408,7 +408,7 @@ dropUnusedOwnedVars : Owned -> SortedSet AVar -> (List String, Owned)
 dropUnusedOwnedVars owned usedVars =
     let actualOwned = intersection owned usedVars in
     let shouldDrop = difference owned actualOwned in
-    (varName <$> SortedSet.toList shouldDrop, actualOwned)
+    (varName <$> Prelude.toList shouldDrop, actualOwned)
 
 -- if the constructor is unique use it, otherwise add it to should drop vars and create null constructor
 addReuseConstructor : {auto a : Ref ArgCounter Nat}
@@ -825,7 +825,7 @@ createCFunctions n (MkAFun args anf) = do
          emit EmptyFC "Value *var_\{show j} = var_arglist[\{show i}];"
          pure $ i + 1) 0 args
       pure ()
-    removeVars (varName <$> SortedSet.toList shouldDrop)
+    removeVars (varName <$> Prelude.toList shouldDrop)
     _ <- newRef EnvTracker (MkEnv bodyFreeVars empty)
     emit EmptyFC $ "return \{!(cStatementsFromANF anf InTailPosition)};"
     decreaseIndentation
@@ -913,7 +913,7 @@ header = do
       /* \{ generatedString "RefC" } */
 
       """
-    let headerFiles = SortedSet.toList !(get HeaderFiles)
+    let headerFiles = Prelude.toList !(get HeaderFiles)
     fns <- get FunctionDefinitions
     update OutfileText $ appendL $
         [initLines] ++

--- a/src/Compiler/Scheme/ChezSep.idr
+++ b/src/Compiler/Scheme/ChezSep.idr
@@ -201,7 +201,7 @@ compileToSS c chez appdir tm = do
                   chezLibraryName
                   (SortedMap.lookup cuid cui.byId)
               ++ ")"
-            | cuid <- SortedSet.toList cu.dependencies
+            | cuid <- Prelude.toList cu.dependencies
             ]
       let exports = sepBy " " $ catMaybes
             -- constructors don't generate Scheme definitions

--- a/src/Compiler/Separate.idr
+++ b/src/Compiler/Separate.idr
@@ -62,7 +62,7 @@ record CompilationUnit def where
 export
 Hashable def => Hashable (CompilationUnit def) where
   hashWithSalt h cu =
-    h `hashWithSalt` SortedSet.toList cu.dependencies
+    h `hashWithSalt` Prelude.toList cu.dependencies
       `hashWithSalt` cu.definitions
 
 private
@@ -281,7 +281,7 @@ getCompilationUnits {def} defs =
       dependencies : SortedSet CompilationUnitId
       dependencies = SortedSet.fromList $ do
         ns <- List1.forget nss  -- NS contained within
-        depsNS <- SortedSet.toList $  -- NS we depend on
+        depsNS <- Prelude.toList $  -- NS we depend on
           fromMaybe SortedSet.empty $
             SortedMap.lookup ns nsDeps
 

--- a/src/Core/Case/CaseBuilder.idr
+++ b/src/Core/Case/CaseBuilder.idr
@@ -1321,7 +1321,7 @@ findExtraDefaults fc defs ctree@(Case {name = var} idx el ty altsIn)
        nfty <- nf defs fenv ty
        extraCases <- identifyUnreachableDefaults fc defs nfty altsIn
        extraCases' <- concat <$> traverse findExtraAlts altsIn
-       pure (SortedSet.toList extraCases ++ extraCases')
+       pure (Prelude.toList extraCases ++ extraCases')
   where
     findExtraAlts : CaseAlt vars -> Core (List Int)
     findExtraAlts (ConCase x tag args ctree') = findExtraDefaults fc defs ctree'

--- a/src/Core/Termination/SizeChange.idr
+++ b/src/Core/Termination/SizeChange.idr
@@ -230,7 +230,7 @@ findLoops s
       map (foldMap checkNonDesc) loops
     where
       filterEndos : (Graph -> Bool) -> SCSet -> NameMap (List Graph)
-      filterEndos p = mapWithKey (\f, m => filter p (Data.SortedSet.toList (lookupSet f m)))
+      filterEndos p = mapWithKey (\f, m => filter p (Prelude.toList (lookupSet f m)))
 
 findNonTerminatingLoop : SCSet -> Maybe (Name, Graph)
 findNonTerminatingLoop s = findNonTerminating (findLoops s)

--- a/src/Libraries/Data/Graph.idr
+++ b/src/Libraries/Data/Graph.idr
@@ -38,7 +38,7 @@ tarjan {cuid} deps = loop initial (SortedMap.keys deps)
     strongConnect ts v =
         let ts'' = case SortedMap.lookup v deps of
               Nothing => ts'  -- no edges
-              Just edgeSet => loop ts' (SortedSet.toList edgeSet)
+              Just edgeSet => loop ts' (Prelude.toList edgeSet)
           in case SortedMap.lookup v ts''.vertices of
               Nothing => { impossibleHappened := True } ts''
               Just vtv =>

--- a/src/Libraries/Data/SortedMap.idr
+++ b/src/Libraries/Data/SortedMap.idr
@@ -1,3 +1,4 @@
+-- Remove as soon as 0.8.0 (or greater) is released
 module Libraries.Data.SortedMap
 
 %default total
@@ -324,20 +325,20 @@ adjust k f m =
     Nothing => m
     Just v => insert k (f v) m
 
-treeMin : Tree n k v o -> (k, v)
-treeMin (Leaf k v) = (k, v)
-treeMin (Branch2 t _ _) = treeMin t
-treeMin (Branch3 t _ _ _ _) = treeMin t
+treeLeftMost : Tree n k v o -> (k, v)
+treeLeftMost (Leaf k v) = (k, v)
+treeLeftMost (Branch2 t _ _) = treeLeftMost t
+treeLeftMost (Branch3 t _ _ _ _) = treeLeftMost t
 
 export
-min : SortedMap k v -> Maybe (k, v)
-min Empty = Nothing
-min (M _ t) = Just (treeMin t)
+leftMost : SortedMap k v -> Maybe (k, v)
+leftMost Empty = Nothing
+leftMost (M _ t) = Just $ treeLeftMost t
 
 export
 pop : SortedMap k v -> Maybe ((k, v), SortedMap k v)
 pop m = do
-  (k, v) <- min m
+  (k, v) <- leftMost m
   pure ((k, v), delete k m)
 
 export

--- a/src/Libraries/Data/SortedSet.idr
+++ b/src/Libraries/Data/SortedSet.idr
@@ -29,15 +29,21 @@ fromList : Ord k => List k -> SortedSet k
 fromList l = SetWrapper (Data.SortedMap.fromList (map (\i => (i, ())) l))
 
 export
-toList : SortedSet k -> List k
-toList (SetWrapper m) = Data.SortedMap.keys m
-
-export
 Foldable SortedSet where
-  foldr f z xs = foldr f z (Data.SortedSet.toList xs)
-  foldl f z xs = foldl f z (Data.SortedSet.toList xs)
+  foldr f z = foldr f z . toList
+  foldl f z = foldl f z . toList
 
   null (SetWrapper m) = null m
+
+  foldMap f = foldMap f . toList
+
+  toList (SetWrapper m) = Data.SortedMap.keys m
+
+||| use `Prelude.toList`
+%deprecate
+export %inline
+toList : SortedSet k -> List k
+toList = Prelude.toList
 
 ||| Set union. Inserts all elements of x into y
 export
@@ -81,7 +87,7 @@ Ord k => Monoid (SortedSet k) where
 
 export
 Show k => Show (SortedSet k) where
-  show = show . SortedSet.toList
+  show = show . Prelude.toList
 
 export
 singleton : Ord k => k -> SortedSet k

--- a/src/Libraries/Data/SortedSet.idr
+++ b/src/Libraries/Data/SortedSet.idr
@@ -1,3 +1,4 @@
+-- Remove as soon as 0.8.0 (or greater) is released
 module Libraries.Data.SortedSet
 
 import Data.Maybe
@@ -97,9 +98,10 @@ export
 toSortedMap : SortedSet k -> SortedMap k ()
 toSortedMap (SetWrapper m) = m
 
+||| Returns the leftmost (least) value
 export
-min : SortedSet k -> Maybe k
-min (SetWrapper m) = fst <$> min m
+leftMost : SortedSet k -> Maybe k
+leftMost (SetWrapper m) = fst <$> leftMost m
 
 export
 pop : SortedSet k -> Maybe (k, SortedSet k)

--- a/src/TTImp/Elab/Record.idr
+++ b/src/TTImp/Elab/Record.idr
@@ -211,7 +211,7 @@ recUpdate : {vars : _} ->
 recUpdate rigc elabinfo iloc nest env flds rec grecty
       = do let dups = checkForDuplicates flds empty empty
            unless (null dups) $
-             throw (DuplicatedRecordUpdatePath iloc $ SortedSet.toList dups)
+             throw (DuplicatedRecordUpdatePath iloc $ Prelude.toList dups)
            defs <- get Ctxt
            rectynf <- getNF grecty
            let Just rectyn = getRecordType env rectynf

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -797,7 +797,7 @@ export
 definedInBlock : Namespace -> -- namespace to resolve names
                  List ImpDecl -> List Name
 definedInBlock ns decls =
-    SortedSet.toList $ foldl (defName ns) empty decls
+    Prelude.toList $ foldl (defName ns) empty decls
   where
     getName : ImpTy -> Name
     getName (MkImpTy _ n _) = n.val

--- a/tests/idris2/reflection/reflection027/TraverseWithConst.idr
+++ b/tests/idris2/reflection/reflection027/TraverseWithConst.idr
@@ -19,7 +19,7 @@ names = runConst . mapATTImp' f where
 logNames : TTImp -> Elab ()
 logNames expr = do
   logSugaredTerm "elab.test" 0 "term being analysed" expr
-  logMsg "elab.test" 0 "- names: \{show $ SortedSet.toList $ names expr}"
+  logMsg "elab.test" 0 "- names: \{show $ Prelude.toList $ names expr}"
 
 %runElab logNames `(f (a b) (c d))
 %runElab logNames `(Prelude.id $ Prelude.pure 5)


### PR DESCRIPTION
# Description

This is mainly the less controversial part of #3392, reimplementing and deprecating completely useless specialised `toList` function from `SortedSet`.

Additionally, this PR contains some preparation to future removing the redundant `Libraries.Data.Sorted{Set|Map}` from the compiler's internal lib, the fact coming from times when `Sorted{Set|Map}` were in `contrib`. But currently, they cannot be replaced, because implementations in the compiler's lib have several functions that are missing in the implementation at `base`, so I suggest adding them there, while also doing the same thing with deprecating specialised `toList`, so that we just could remove those redundant modules once we've released new version of the compiler.

I made all changed in different commits in order to make review easier.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

