### PR TITLE
Error Message Potpourri

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -27,6 +27,8 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 
 * Remove reference to column number parameter in help menu for `refine` command.
 
+* CLI errors will now be printed to `stderr` instead of `stdout`.
+
 ### Building/Packaging changes
 
 * The Nix flake's `buildIdris` function now returns a set with `executable` and

--- a/src/Idris/CommandLine.idr
+++ b/src/Idris/CommandLine.idr
@@ -2,6 +2,9 @@ module Idris.CommandLine
 
 import Idris.Env
 import Idris.Version
+import Idris.Doc.Display
+import Idris.Doc.String
+import Idris.Pretty
 
 import Core.Options
 
@@ -525,6 +528,17 @@ findNearMatchOpt arg =
        Right [(InputFile _)] => Nothing
        Right [_] => Just argWithDashes
        _ => Nothing
+
+||| Suggest an opt that would have matched if only the user had prefixed it with
+||| double-dashes. It is common to see the user error of specifying a command
+||| like "idris2 repl ..." when they mean to write "idris2 --repl ..."
+export
+nearMatchOptSuggestion : String -> Maybe (Doc IdrisAnn)
+nearMatchOptSuggestion arg =
+    findNearMatchOpt arg <&>
+      \opt =>
+        (reflow "Did you mean to type" <++>
+          (dquotes . meta $ pretty0 opt) <+> "?")
 
 ||| List of all command line option flags.
 export

--- a/src/Idris/CommandLine.idr
+++ b/src/Idris/CommandLine.idr
@@ -507,12 +507,24 @@ export
 getOpts : List String -> Either String (List CLOpt)
 getOpts opts = parseOpts options opts
 
-
 export covering
 getCmdOpts : IO (Either String (List CLOpt))
 getCmdOpts = do (_ :: opts) <- getArgs
                     | _ => pure (Left "Invalid command line")
                 pure $ getOpts opts
+
+||| Find an opt that would have matched if only the user had prefixed it with
+||| double-dashes. It is common to see the user error of specifying a command
+||| like "idris2 repl ..." when they mean to write "idris2 --repl ..."
+export
+findNearMatchOpt : String -> Maybe String
+findNearMatchOpt arg =
+  let argWithDashes = "--\{arg}"
+  in
+  case (getOpts [argWithDashes]) of
+       Right [(InputFile _)] => Nothing
+       Right [_] => Just argWithDashes
+       _ => Nothing
 
 ||| List of all command line option flags.
 export

--- a/src/Idris/Driver.idr
+++ b/src/Idris/Driver.idr
@@ -203,7 +203,7 @@ stMain cgs opts
                                    pure Done
                       Just f => logTime 1 "Loading main file" $ do
                                   res <- loadMainFile f
-                                  displayErrors res
+                                  displayStartupErrors res
                                   pure res
 
                  doRepl <- catch (postOptions result opts)

--- a/src/Idris/Driver.idr
+++ b/src/Idris/Driver.idr
@@ -160,6 +160,7 @@ stMain cgs opts
          let ideSocket = ideModeSocket opts
          let outmode = if ide then IDEMode 0 stdin stdout else REPL InfoLvl
          o <- newRef ROpts (REPL.Opts.defaultOpts Nothing outmode cgs)
+         updateEnv
          fname <- case (findInputs opts) of
                        Just (fname ::: Nil) => pure $ Just fname
                        Nothing => pure Nothing
@@ -172,7 +173,6 @@ stMain cgs opts
                                      \{renderedSuggestion}
                                      """
          update ROpts { mainfile := fname }
-         updateEnv
 
          finish <- showInfo opts
          when (not finish) $ do
@@ -249,7 +249,7 @@ stMain cgs opts
                 {auto o : Ref ROpts REPLOpts} ->
                 Error -> Core a
   quitWithError err = do
-    doc <- perror err
+    doc <- display err
     msg <- render doc
     coreLift (die msg)
 

--- a/src/Idris/Error.idr
+++ b/src/Idris/Error.idr
@@ -747,7 +747,7 @@ perrorRaw (CyclicImports ns)
         <++> concatWith (surround " -> ") (pretty0 <$> ns)
 perrorRaw ForceNeeded = pure $ errorDesc (reflow "Internal error when resolving implicit laziness")
 perrorRaw (InternalError str) = pure $ errorDesc (reflow "INTERNAL ERROR" <+> colon) <++> pretty0 str
-perrorRaw (UserError str) = pure $ errorDesc ("Error" <+> colon) <++> pretty0 str
+perrorRaw (UserError str) = pure . errorDesc $ pretty0 str
 perrorRaw (NoForeignCC fc specs) = do
     let cgs = fst <$> availableCGs (options !(get Ctxt))
     let res = vsep [ errorDesc (reflow ("The given specifier '" ++ show specs ++ "' was not accepted by any backend. Available backends") <+> colon)

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -896,7 +896,7 @@ runRepl fname = do
       Nothing => pure ()
       Just fn => do
         errs <- loadMainFile fn
-        displayErrors errs
+        displayStartupErrors errs
   repl {u} {s}
 
 ||| If the user did not provide a package file we can look in the working

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -1321,10 +1321,7 @@ mutual
          {auto m : Ref MD Metadata} ->
          {auto o : Ref ROpts REPLOpts} -> REPLResult -> Core ()
   displayStartupErrors (ErrorLoadingFile x err) =
-    let suggestion = findNearMatchOpt x <&>
-                        \opt =>
-                          (reflow "Did you mean to type" <++>
-                            (dquotes . meta $ pretty0 opt) <+> "?")
+    let suggestion = nearMatchOptSuggestion x
     in
       printError (fileLoadingError x err suggestion)
   displayStartupErrors _ = pure ()

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -26,6 +26,7 @@ import Core.SchemeEval
 
 import Parser.Unlit
 
+import Idris.CommandLine
 import Idris.Desugar
 import Idris.Doc.Display
 import Idris.Doc.String
@@ -1226,6 +1227,17 @@ mutual
   handleResult Exited = iputStrLn (reflow "Bye for now!")
   handleResult other = do { displayResult other ; repl }
 
+  fileLoadingError : (fname : String) -> (err : FileError) -> (suggestion : Maybe (Doc IdrisAnn)) -> Doc IdrisAnn
+  fileLoadingError fname err suggestion =
+    let suggestion = maybe "" (hardline <+>) suggestion
+    in
+    hardline <+>
+    (indent 2 $
+      error ((reflow "Error loading file") <++> (dquotes $ pretty0 fname) <+> colon) <++>
+        pretty0 (show err) <+>
+      suggestion) <+>
+    hardline
+
   export
   displayResult : {auto c : Ref Ctxt Defs} ->
          {auto u : Ref UST UState} ->
@@ -1243,7 +1255,7 @@ mutual
   displayResult (ErrorLoadingModule x err)
     = printResult (reflow "Error loading module" <++> pretty0 x <+> colon <++> !(perror err))
   displayResult (ErrorLoadingFile x err)
-    = printResult (reflow "Error loading file" <++> pretty0 x <+> colon <++> pretty0 (show err))
+    = printResult (fileLoadingError x err Nothing)
   displayResult (ErrorsBuildingFile x errs)
     = printResult (reflow "Error(s) building file" <++> pretty0 x) -- messages already displayed while building
   displayResult NoFileLoaded = printResult (reflow "No file can be reloaded")
@@ -1295,17 +1307,24 @@ mutual
       cmdInfo : (List String, CmdArg, String) -> String
       cmdInfo (cmds, args, text) = " " ++ col 18 36 (showSep " " cmds) (show args) text
 
+  ||| Display errors that may occur when starting the REPL.
+  ||| Does not force the REPL to exit, just prints the error(s).
+  |||
+  ||| NOTE: functionally the only reason to consider this function specialized
+  ||| to "startup" is that it will provide suggestions to the user under the
+  ||| assumption that the user has just entered the REPL via CLI arguments that
+  ||| they may have used incorrectly.
   export
-  displayErrors : {auto c : Ref Ctxt Defs} ->
+  displayStartupErrors : {auto c : Ref Ctxt Defs} ->
          {auto u : Ref UST UState} ->
          {auto s : Ref Syn SyntaxInfo} ->
          {auto m : Ref MD Metadata} ->
          {auto o : Ref ROpts REPLOpts} -> REPLResult -> Core ()
-  displayErrors (ErrorLoadingFile x err)
-    = printError $
-        hardline <+>
-        (indent 2 $
-          error ((reflow "Error loading file") <++> (dquotes $ pretty0 x) <+> colon) <++>
-            pretty0 (show err)) <+>
-        hardline
-  displayErrors _ = pure ()
+  displayStartupErrors (ErrorLoadingFile x err) =
+    let suggestion = findNearMatchOpt x <&>
+                        \opt =>
+                          (reflow "Did you mean to type" <++>
+                            (dquotes . meta $ pretty0 opt) <+> "?")
+    in
+      printError (fileLoadingError x err suggestion)
+  displayStartupErrors _ = pure ()

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -1302,5 +1302,10 @@ mutual
          {auto m : Ref MD Metadata} ->
          {auto o : Ref ROpts REPLOpts} -> REPLResult -> Core ()
   displayErrors (ErrorLoadingFile x err)
-    = printError (reflow "File error in" <++> pretty0 x <+> colon <++> pretty0 (show err))
+    = printError $
+        hardline <+>
+        (indent 2 $
+          error ((reflow "Error loading file") <++> (dquotes $ pretty0 x) <+> colon) <++>
+            pretty0 (show err)) <+>
+        hardline
   displayErrors _ = pure ()

--- a/src/Protocol/SExp.idr
+++ b/src/Protocol/SExp.idr
@@ -2,12 +2,9 @@ module Protocol.SExp
 
 import Data.List
 import Data.List1
+import Data.String
 
 %default total
-
--- should be in base somewhere!
-join : String -> List String -> String
-join sep xs = concat $ intersperse sep xs
 
 public export
 data SExp = SExpList (List SExp)
@@ -26,7 +23,7 @@ escape = pack . concatMap escapeChar . unpack
 
 export
 Show SExp where
-  show (SExpList xs) = assert_total $ "(" ++ join " " (map show xs) ++ ")"
+  show (SExpList xs) = assert_total $ "(" ++ joinBy " " (map show xs) ++ ")"
   show (StringAtom str) = "\"" ++ escape str ++ "\""
   show (BoolAtom b) = ":" ++ show b
   show (IntegerAtom i) = show i

--- a/tests/idris2/error/error008/expected
+++ b/tests/idris2/error/error008/expected
@@ -1,2 +1,4 @@
-File error in DoesntExist.idr: File Not Found
+
+  Error loading file "DoesntExist.idr": File Not Found
+
 Main> Bye for now!

--- a/tests/idris2/error/error012/expected
+++ b/tests/idris2/error/error012/expected
@@ -1,1 +1,3 @@
-File error in nothere.idr: File Not Found
+
+  Error loading file "nothere.idr": File Not Found
+

--- a/tests/idris2/error/error032/expected
+++ b/tests/idris2/error/error032/expected
@@ -1,2 +1,2 @@
-[1mError:[0m Expected at most one input file but was given: repl, pkg.ipkg
-Did you mean to type "[38;5;2m--repl[0m"?
+Error: Expected at most one input file but was given: repl, pkg.ipkg
+Did you mean to type "--repl"?

--- a/tests/idris2/error/error032/expected
+++ b/tests/idris2/error/error032/expected
@@ -1,0 +1,2 @@
+[1mError:[0m Expected at most one input file but was given: repl, pkg.ipkg
+Did you mean to type "[38;5;2m--repl[0m"?

--- a/tests/idris2/error/error032/run
+++ b/tests/idris2/error/error032/run
@@ -1,0 +1,5 @@
+. ../../../testutils.sh
+
+# it is common to hear about folks doing this by accident when they mean
+# to do `idris2 --repl pkg.ipkg`.
+idris2 repl pkg.ipkg 2>&1

--- a/tests/idris2/error/perror008/expected
+++ b/tests/idris2/error/perror008/expected
@@ -57,13 +57,13 @@ Issue710f:2:15--2:19
  2 |   constructor cons
                    ^^^^
 ... (1 others)
-Uncaught error: Error: Expected a capitalised identifier, got: ggg.
+Error: Expected a capitalised identifier, got: ggg.
 
 Issue1224a:1:8--1:11
  1 | module ggg
             ^^^
 
-Uncaught error: Error: Expected a capitalised identifier, got: ggg.
+Error: Expected a capitalised identifier, got: ggg.
 
 Issue1224b:1:8--1:11
  1 | import ggg

--- a/tests/idris2/error/perror008/run
+++ b/tests/idris2/error/perror008/run
@@ -1,11 +1,11 @@
 . ../../../testutils.sh
 
-check Issue710a.idr || true
-check Issue710b.idr || true
-check Issue710c.idr || true
-check Issue710d.idr || true
-check Issue710e.idr || true
-check Issue710f.idr || true
+check Issue710a.idr 2>&1 || true
+check Issue710b.idr 2>&1 || true
+check Issue710c.idr 2>&1 || true
+check Issue710d.idr 2>&1 || true
+check Issue710e.idr 2>&1 || true
+check Issue710f.idr 2>&1 || true
 
-check Issue1224a.idr || true
-check Issue1224b.idr || true
+check Issue1224a.idr 2>&1 || true
+check Issue1224b.idr 2>&1 || true

--- a/tests/idris2/error/perror011/expected
+++ b/tests/idris2/error/perror011/expected
@@ -1,11 +1,11 @@
-Uncaught error: Error: Bracket is not properly closed.
+Error: Bracket is not properly closed.
 
 Issue1345:2:1--2:2
  1 | infixr 0 -->
  2 | (-->) : (Type -> Type) -> (Type -> Type) -> Type
      ^
 
-Uncaught error: Error: Bracket is not properly closed.
+Error: Bracket is not properly closed.
 
 Issue1496-1:5:24--5:25
  1 | module Main
@@ -15,7 +15,7 @@ Issue1496-1:5:24--5:25
  5 |   show (Really err) =  ["RR"
                             ^
 
-Uncaught error: Error: Bracket is not properly closed.
+Error: Bracket is not properly closed.
 
 Issue1496-2:2:1--2:2
  1 | module X

--- a/tests/idris2/error/perror011/run
+++ b/tests/idris2/error/perror011/run
@@ -1,6 +1,6 @@
 . ../../../testutils.sh
 
-check Issue1345.idr || true
-check Issue1496-1.idr || true
-check Issue1496-2.idr || true
+check Issue1345.idr 2>&1 || true
+check Issue1496-1.idr 2>&1 || true
+check Issue1496-2.idr 2>&1 || true
 idris2 --build foo.ipkg

--- a/tests/idris2/misc/import004/expected
+++ b/tests/idris2/misc/import004/expected
@@ -1,2 +1,2 @@
-Uncaught error: Error: Module imports form a cycle: Cycle2 -> Cycle1 -> Cycle1
-Uncaught error: Error: Module imports form a cycle: Loop -> Loop
+Error: Module imports form a cycle: Cycle2 -> Cycle1 -> Cycle1
+Error: Module imports form a cycle: Loop -> Loop

--- a/tests/idris2/misc/import004/run
+++ b/tests/idris2/misc/import004/run
@@ -1,4 +1,4 @@
 . ../../../testutils.sh
 
-idris2 Cycle1.idr
-idris2 Loop.idr
+idris2 2>&1 Cycle1.idr
+idris2 2>&1 Loop.idr


### PR DESCRIPTION
# Description

I tried to keep the following isolated in their own commits so we can just ditch anything folks don't like.

----
Whereas the CLI for the REPL currently only pays attention to one argument as an input file but quietly ignores the rest, I've made it an error to specify multiple input files:
```
Uncaught error: Error: Expected at most one input file but was given: file1.idr, file2.idr
```
This is further improved (described in the last section below) by using `die` instead of an uncaught `throw` so the error doesn't look so unexpected.

----
Whereas the REPL previously printed an error about a file loaded with `:l` in monochrome without fanfare, I've indented the error message, given it room to stand out, and written the context of the error in the standard `IdrisAnn` color for error messages.
```
Main> :l "file1.idr"

  Error loading file "file1.idr": File Not Found

Main> [...]
```

----
Whereas on launch the REPL previously printed a subtly different error when a requested file could not be loaded than it did when using the `:l` command inside the REPL, I've aligned the two errors (and indeed refactored them to use the same code). I've also added a suggestion specifically for this startup use-case because it is common to see people intend to run e.g. `idris2 --repl ...` but instead type `idris2 repl ...` which causes the REPL to attempt to load a file named "repl" -- the suggestion is that the user may have meant to write `idris2 --repl ...` so this should ease the pain of a common mistake.
```
 $ ./build/exec/idris2 repl
     ____    __     _         ___
    /  _/___/ /____(_)____   |__ \
    / // __  / ___/ / ___/   __/ /     Version 0.7.0-c1fc0b346
  _/ // /_/ / /  / (__  )   / __/      https://www.idris-lang.org
 /___/\__,_/_/  /_/____/   /____/      Type :? for help

Welcome to Idris 2.  Enjoy yourself!

  Error loading file "repl": File Not Found
  Did you mean to type "--repl"?

Main> [...]
```

----
As mentioned above, this PR finally switches from uncaught `throw` for rendering errors from the CLI over to using `die` so we get a less buggy looking printout. This commit also adds in a suggestion when relevant similar to the one seen within the REPL session for the above case.
```
 $ ./build/exec/idris2 build idris2.ipkg
Error: Expected at most one input file but was given: build, idris2.ipkg
Did you mean to type "--build"?
```

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

