### PR TITLE
[ fix ] Fix option loss when an optional argument is missed

### DIFF
--- a/src/Idris/CommandLine.idr
+++ b/src/Idris/CommandLine.idr
@@ -474,7 +474,9 @@ processArgs flag (AutoNat a :: as) (x :: xs) f =
 processArgs flag (Required a :: as) (x :: xs) f =
   processArgs flag as xs (f x)
 processArgs flag (Optional a :: as) (x :: xs) f =
-  processArgs flag as xs (f $ toMaybe (not (isPrefixOf "-" x)) x)
+  if isPrefixOf "-" x
+    then processArgs flag as (x :: xs) (f Nothing)
+    else processArgs flag as xs (f $ Just x)
 
 matchFlag : (d : OptDesc) -> List String ->
             Either String (Maybe (List CLOpt, List String))

--- a/tests/Main.idr
+++ b/tests/Main.idr
@@ -199,6 +199,9 @@ linearLibraryTests = testsInDir "linear" "Linear library" {requirements = [Chez,
 codegenTests : IO TestPool
 codegenTests = testsInDir "codegen" "Code generation"
 
+commandLineTests : IO TestPool
+commandLineTests = testsInDir "cli" "Command-line interface"
+
 main : IO ()
 main = runner $
   [ !ttimpTests
@@ -240,6 +243,7 @@ main = runner $
   , !vmcodeInterpTests
   , !templateTests
   , !codegenTests
+  , !commandLineTests
   ]
   ++ !(traverse idrisTestsAllSchemes [Chez, Racket])
   ++ map (testPaths "allbackends" . idrisTestsAllBackends) [Chez, Node, Racket, C]

--- a/tests/cli/optional001/run
+++ b/tests/cli/optional001/run
@@ -1,0 +1,3 @@
+. ../../testutils.sh
+
+idris2 --clean --log 0

--- a/tests/cli/optional001/test.ipkg
+++ b/tests/cli/optional001/test.ipkg
@@ -1,0 +1,1 @@
+package test


### PR DESCRIPTION
# Description

If an optional argument is expected and the following option comes instead, it is skipped. For example, in the command
```shell
idris2 --build --quiet
```
`--quiet` will be missed. And the command
```shell
idris2 --clean --log 0
```
will be processed as
```shell
idris2 0 --clean
```

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

