### PR TITLE
[ base ] Add casts between `Int` and `ExitCode`

### DIFF
--- a/libs/base/System.idr
+++ b/libs/base/System.idr
@@ -294,11 +294,20 @@ data ExitCode : Type where
   ||| @prf   Proof that the int value is non-zero.
   ExitFailure : (errNo    : Int) -> (So (not $ errNo == 0)) => ExitCode
 
+export
+Cast Int ExitCode where
+  cast 0 = ExitSuccess
+  cast code = ExitFailure code @{believe_me Oh}
+
+export
+Cast ExitCode Int where
+  cast ExitSuccess = 0
+  cast (ExitFailure code) = code
+
 ||| Exit the program normally, with the specified status.
 export
 exitWith : HasIO io => ExitCode -> io a
-exitWith ExitSuccess = primIO $ believe_me $ prim__exit 0
-exitWith (ExitFailure code) = primIO $ believe_me $ prim__exit code
+exitWith = primIO . believe_me . prim__exit . cast
 
 ||| Exit the program with status value 1, indicating failure.
 ||| If you want to specify a custom status value, see `exitWith`.


### PR DESCRIPTION
# Description

`system` returns `Int`, and `exitWith` takes `ExitCode`. So it is useful to have casts between the two. In particular this is needed for #3427, because most code generators use `system` for `executeExpr`.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

