### PR TITLE
When searching for packages, rule out incompatible TTC versions

### DIFF
--- a/src/Idris/Driver.idr
+++ b/src/Idris/Driver.idr
@@ -182,7 +182,7 @@ stMain cgs opts
               | False => pure ()
 
            -- If there's a --build or --install, just do that then quit
-           done <- processPackageOpts opts
+           done <- flip catch quitWithError $ processPackageOpts opts
 
            when (not done) $ flip catch quitWithError $
               do when (checkVerbose opts) $ -- override Quiet if implicitly set

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -939,7 +939,7 @@ processPackage : {auto c : Ref Ctxt Defs} ->
                  (PkgCommand, Maybe String) ->
                  Core ()
 processPackage opts (cmd, mfile)
-    = withCtxt . withSyn . withROpts $ case cmd of -- withWarnings .
+    = withCtxt . withSyn . withROpts $ case cmd of
         Init =>
           do Just pkg <- coreLift interactive
                | Nothing => coreLift (exitWith (ExitFailure 1))

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -369,6 +369,8 @@ tryAll ps f = go [<] ps
           Failed errs <- f x | Resolved res => pure (Resolved res)
           go (se <>< map (prepend x) errs) xs
 
+||| Add all dependencies (transitively) from the given package file into the
+||| context so modules from each is accessible during compilation.
 addDeps :
     {auto c : Ref Ctxt Defs} ->
     {auto s : Ref Syn SyntaxInfo} ->
@@ -384,7 +386,7 @@ addDeps pkg = do
   where
     -- Note: findPkgDir throws an error if a package is not found
     -- *unless* --ignore-missing-ipkg is enabled
-    -- therefore, findPkgDir returns Nothing, skip the package
+    -- therefore, if findPkgDir returns Nothing, skip the package
     --
     -- We use a backtracking algorithm here: If several versions of
     -- a package are installed, we must try all, which are are

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -100,7 +100,7 @@ candidateDirs dname pkg bounds =
              pure ((dname </> dirName), ver)
 
         checkTTCVersion : PkgDir -> Maybe PkgDir
-        checkTTCVersion pkg = if isJust (find (== ttcVersion) pkg.ttcVersions)
+        checkTTCVersion pkg = if ttcVersion `elem` pkg.ttcVersions
                                  then Just pkg
                                  else Nothing
 

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -89,20 +89,50 @@ getPackageDirs dname = do
 ||| Only package's with build artifacts for the correct TTC version for the
 ||| compiler will be considered.
 export
-candidateDirs : String -> String -> PkgVersionBounds ->
-                IO (List (String, Maybe PkgVersion))
-candidateDirs dname pkg bounds =
-  mapMaybe (checkBounds <=< checkTTCVersion) <$> getPackageDirs dname
+candidateDirs :
+    Ref Ctxt Defs =>
+    String -> String -> PkgVersionBounds ->
+    Core (List (String, Maybe PkgVersion))
+candidateDirs dname pkgName bounds = do
+  dirs <- coreLift (getPackageDirs dname)
+  checkedDirs <- traverse check dirs
+  pure (catMaybes checkedDirs)
 
-  where checkBounds : PkgDir -> Maybe (String, Maybe PkgVersion)
-        checkBounds (MkPkgDir dirName pkgName ver _) =
-          do guard (pkgName == pkg && inBounds ver bounds)
-             pure ((dname </> dirName), ver)
+  where
+    data CandidateError = OutOfBounds | TTCMismatch
 
-        checkTTCVersion : PkgDir -> Maybe PkgDir
-        checkTTCVersion pkg = if ttcVersion `elem` pkg.ttcVersions
-                                 then Just pkg
-                                 else Nothing
+    checkNameAndBounds : PkgDir -> Either CandidateError PkgDir
+    checkNameAndBounds pkg =
+      if pkg.pkgName == pkgName && inBounds pkg.version bounds
+         then Right pkg
+         else Left OutOfBounds
+
+    checkTTCVersion : PkgDir -> Either CandidateError PkgDir
+    checkTTCVersion pkg =
+      if ttcVersion `elem` pkg.ttcVersions
+         then Right pkg
+         else Left TTCMismatch
+
+    unpack : PkgDir -> (String, Maybe PkgVersion)
+    unpack (MkPkgDir dirName pkgName ver _) =
+      ((dname </> dirName), ver)
+
+    check : PkgDir -> Core (Maybe (String, Maybe PkgVersion))
+    check pkg =
+      let checkedPkg = checkNameAndBounds pkg >>= checkTTCVersion
+      in
+      case checkedPkg of
+        Right pkg'       => pure . Just $ unpack pkg'
+        Left OutOfBounds => pure Nothing
+        Left TTCMismatch => do
+          let pkgVersion = maybe "unversioned" (\v => "version \{show v} of") pkg.version
+          recordWarning $ GenericWarn EmptyFC $
+                 """
+                 Found \{pkgVersion} package \{pkg.pkgName} installed with no compatible binaries for the current Idris2 compiler.
+
+                 Reinstall \{pkg.pkgName} with the current Idris2 compiler to resolve the issue.
+                 """
+          pure Nothing
 
 ||| Find all package directories (plus version) matching
 ||| the given package name and version bounds. Results
@@ -123,10 +153,10 @@ findPkgDirs p bounds = do
   localdir <- pkgLocalDirectory
 
   -- Get candidate directories from the local package directory
-  locFiles <- coreLift $ candidateDirs localdir p bounds
+  locFiles <- candidateDirs localdir p bounds
   -- Look in all the package paths too
   d <- getDirs
-  pkgFiles <- coreLift $ traverse (\d => candidateDirs d p bounds) d.package_search_paths
+  pkgFiles <- traverse (\d => candidateDirs d p bounds) d.package_search_paths
 
   -- If there's anything locally, use that and ignore the global ones
   let allFiles = if isNil locFiles

--- a/tests/idris2/error/perror011/expected
+++ b/tests/idris2/error/perror011/expected
@@ -22,4 +22,8 @@ Issue1496-2:2:1--2:2
  2 | [
      ^
 
-Uncaught error: Pretty:5:24--5:25:Lexer error ("Bracket is not properly closed.")
+Error: Bracket is not properly closed.
+
+Pretty:5:24--5:25
+                            ^
+

--- a/tests/idris2/error/perror011/run
+++ b/tests/idris2/error/perror011/run
@@ -3,4 +3,4 @@
 check Issue1345.idr 2>&1 || true
 check Issue1496-1.idr 2>&1 || true
 check Issue1496-2.idr 2>&1 || true
-idris2 --build foo.ipkg
+idris2 --build foo.ipkg 2>&1 || true

--- a/tests/idris2/misc/import006/expected
+++ b/tests/idris2/misc/import006/expected
@@ -1,1 +1,1 @@
-Uncaught error: Module imports form a cycle: A.B -> A.B
+Error: Module imports form a cycle: A.B -> A.B

--- a/tests/idris2/misc/import006/run
+++ b/tests/idris2/misc/import006/run
@@ -1,3 +1,3 @@
 . ../../../testutils.sh
 
-idris2 --build cyclic.ipkg
+idris2 --build cyclic.ipkg 2>&1

--- a/tests/idris2/misc/import008/Exe/depends/lib-0
+++ b/tests/idris2/misc/import008/Exe/depends/lib-0
@@ -1,1 +1,0 @@
-../../Lib/build/ttc/

--- a/tests/idris2/misc/import008/run
+++ b/tests/idris2/misc/import008/run
@@ -1,11 +1,16 @@
 . ../../../testutils.sh
 
+mkdir -p Exe/depends/lib-0
+
 rm -rf Exe/build
 rm -rf Lib/build
 
 cd Lib
 idris2 --build
 cd ..
+cp -R Lib/build/ttc/* Exe/depends/lib-0/
 cd Exe
 check --find-ipkg Mod.idr
 run --find-ipkg Mod.idr
+
+rm -rf Exe/depends/lib-0

--- a/tests/idris2/pkg/pkg003/expected
+++ b/tests/idris2/pkg/pkg003/expected
@@ -17,4 +17,4 @@ Overridable options are:
     --output-dir <dir>
 
 Packages must have an '.ipkg' extension: "malformed-package-name".
-Uncaught error: File error (non-existent-package.ipkg): File Not Found
+Error: File error in non-existent-package.ipkg : File Not Found

--- a/tests/idris2/pkg/pkg003/run
+++ b/tests/idris2/pkg/pkg003/run
@@ -1,11 +1,11 @@
 . ../../../testutils.sh
 
-idris2 --build testpkg.ipkg
+idris2 --build testpkg.ipkg 2>&1
 rm -rf  build/
-idris2 --build testpkg.ipkg --quiet
-idris2 --build testpkg.ipkg --verbose
-idris2 --build testpkg.ipkg --codegen gambit
-idris2 --build testpkg.ipkg --ide-mode
-idris2 --build malformed-package-name
-idris2 --build non-existent-package.ipkg
+idris2 --build testpkg.ipkg --quiet 2>&1
+idris2 --build testpkg.ipkg --verbose 2>&1
+idris2 --build testpkg.ipkg --codegen gambit 2>&1
+idris2 --build testpkg.ipkg --ide-mode 2>&1
+idris2 --build malformed-package-name 2>&1
+idris2 --build non-existent-package.ipkg 2>&1
 rm -rf  build/

--- a/tests/idris2/pkg/pkg006/expected
+++ b/tests/idris2/pkg/pkg006/expected
@@ -1,7 +1,7 @@
-Uncaught error: EmptyFC:Failed to resolve the dependencies for test3:
+Error: Failed to resolve the dependencies for test3:
   required foo >= 0.4 && < 0.5 but no matching version is installed
 
-Uncaught error: EmptyFC:Failed to resolve the dependencies for test4:
+Error: Failed to resolve the dependencies for test4:
   required baz any but no matching version is installed
 
 Warning: Deprecation warning: version numbers must now be of the form x.y.z

--- a/tests/idris2/pkg/pkg006/run
+++ b/tests/idris2/pkg/pkg006/run
@@ -7,11 +7,11 @@ for folder in ./depends/*; do
   mkdir -p "${folder}/${TTC_VERSION}"
 done
 
-idris2 --build test1.ipkg
-idris2 --build test2.ipkg
-idris2 --build test3.ipkg
-idris2 --build test4.ipkg
-idris2 --build test5.ipkg
+idris2 --build test1.ipkg 2>&1
+idris2 --build test2.ipkg 2>&1
+idris2 --build test3.ipkg 2>&1
+idris2 --build test4.ipkg 2>&1
+idris2 --build test5.ipkg 2>&1
 
 for folder in ./depends/*; do
   rmdir "${folder}/${TTC_VERSION}"

--- a/tests/idris2/pkg/pkg006/run
+++ b/tests/idris2/pkg/pkg006/run
@@ -1,7 +1,18 @@
 . ../../../testutils.sh
 
+TTC_VERSION="$(idris2 --ttc-version)"
+
+# the mock dependencies must have a compatible TTC folder
+for folder in ./depends/*; do
+  mkdir -p "${folder}/${TTC_VERSION}"
+done
+
 idris2 --build test1.ipkg
 idris2 --build test2.ipkg
 idris2 --build test3.ipkg
 idris2 --build test4.ipkg
 idris2 --build test5.ipkg
+
+for folder in ./depends/*; do
+  rmdir "${folder}/${TTC_VERSION}"
+done

--- a/tests/idris2/pkg/pkg013/run
+++ b/tests/idris2/pkg/pkg013/run
@@ -1,3 +1,14 @@
 . ../../../testutils.sh
 
+TTC_VERSION="$(idris2 --ttc-version)"
+
+# the mock dependencies must have a compatible TTC folder
+for folder in ./depends/*; do
+  mkdir -p "${folder}/${TTC_VERSION}"
+done
+
 idris2 --build test.ipkg --log package.depends:10 | filter_test_dir
+
+for folder in ./depends/*; do
+  rmdir "${folder}/${TTC_VERSION}"
+done

--- a/tests/idris2/pkg/pkg014/run
+++ b/tests/idris2/pkg/pkg014/run
@@ -1,3 +1,14 @@
 . ../../../testutils.sh
 
+TTC_VERSION="$(idris2 --ttc-version)"
+
+# the mock dependencies must have a compatible TTC folder
+for folder in ./depends/*; do
+  mkdir -p "${folder}/${TTC_VERSION}"
+done
+
 idris2 --build test.ipkg --log package.depends:10 | filter_test_dir
+
+for folder in ./depends/*; do
+  rmdir "${folder}/${TTC_VERSION}"
+done

--- a/tests/idris2/pkg/pkg015/expected
+++ b/tests/idris2/pkg/pkg015/expected
@@ -1,4 +1,4 @@
-Uncaught error: EmptyFC:Failed to resolve the dependencies for test:
+Error: Failed to resolve the dependencies for test:
   foo-0.2.0; baz-0.3.0; required quux any but no matching version is installed
   foo-0.2.0; baz-0.2.0; bar-0.1.1; required baz < 0.2.0 but assigned version 0.2.0 which is out of bounds
   foo-0.2.0; baz-0.2.0; bar-0.1.0; required prz > 0.1.0 but no matching version is installed

--- a/tests/idris2/pkg/pkg015/run
+++ b/tests/idris2/pkg/pkg015/run
@@ -1,3 +1,14 @@
 . ../../../testutils.sh
 
+TTC_VERSION="$(idris2 --ttc-version)"
+
+# the mock dependencies must have a compatible TTC folder
+for folder in ./depends/*; do
+  mkdir -p "${folder}/${TTC_VERSION}"
+done
+
 idris2 --build test.ipkg --log package.depends:10
+
+for folder in ./depends/*; do
+  rmdir "${folder}/${TTC_VERSION}"
+done

--- a/tests/idris2/pkg/pkg015/run
+++ b/tests/idris2/pkg/pkg015/run
@@ -7,7 +7,7 @@ for folder in ./depends/*; do
   mkdir -p "${folder}/${TTC_VERSION}"
 done
 
-idris2 --build test.ipkg --log package.depends:10
+idris2 --build test.ipkg --log package.depends:10 2>&1
 
 for folder in ./depends/*; do
   rmdir "${folder}/${TTC_VERSION}"

--- a/tests/idris2/pkg/pkg018/expected
+++ b/tests/idris2/pkg/pkg018/expected
@@ -1,14 +1,12 @@
-Uncaught error: Error: Unrecognised property "depend".
+Error: Unrecognised property "depend".
 
 "bad.ipkg":2:1--2:7
  1 | package bad
  2 | depend = contrib
      ^^^^^^
-
-Uncaught error: Error: Expected string.
+Error: Expected string.
 
 "bad2.ipkg":2:13--2:16
  1 | package bad
  2 | sourcedir = src
                  ^^^
-

--- a/tests/idris2/pkg/pkg018/run
+++ b/tests/idris2/pkg/pkg018/run
@@ -1,4 +1,4 @@
 . ../../../testutils.sh
 
-idris2 --build bad.ipkg
-idris2 --build bad2.ipkg
+idris2 --build bad.ipkg 2>&1
+idris2 --build bad2.ipkg 2>&1

--- a/tests/idris2/pkg/pkg021/expected
+++ b/tests/idris2/pkg/pkg021/expected
@@ -1,0 +1,6 @@
+expect error:
+Uncaught error: Can't find package testpkg (any)
+
+expect success:
+Main> Imported module Stuff
+Main> Bye for now!

--- a/tests/idris2/pkg/pkg021/input
+++ b/tests/idris2/pkg/pkg021/input
@@ -1,0 +1,2 @@
+:import Stuff
+:q

--- a/tests/idris2/pkg/pkg021/run
+++ b/tests/idris2/pkg/pkg021/run
@@ -1,0 +1,24 @@
+. ../../../testutils.sh
+
+INSTALL_DIR="$(idris2 --dump-installdir test.ipkg)"
+TTC_VERSION="$(idris2 --ttc-version)"
+
+rm -rf "${INSTALL_DIR}"
+rm -rf ./secondary_install
+
+# install package, copy install to a second location, bork the first location
+# by using a bad TTC version subfolder.
+idris2 --install test.ipkg > /dev/null
+
+mkdir -p ./secondary_install
+cp -R "${INSTALL_DIR}" ./secondary_install/
+mv "${INSTALL_DIR}/${TTC_VERSION}" "${INSTALL_DIR}/12345"
+
+echo "expect error:"
+idris2 -p testpkg < input
+append_package_path ./secondary_install
+echo ""
+echo "expect success:"
+idris2 -p testpkg < input
+
+rm -rf ./secondary_install

--- a/tests/idris2/pkg/pkg021/src/Stuff.idr
+++ b/tests/idris2/pkg/pkg021/src/Stuff.idr
@@ -1,0 +1,2 @@
+module Stuff
+

--- a/tests/idris2/pkg/pkg021/test.ipkg
+++ b/tests/idris2/pkg/pkg021/test.ipkg
@@ -1,0 +1,8 @@
+package testpkg
+version = 0.3.0
+
+-- modules to install
+modules = Stuff
+
+sourcedir = "src"
+

--- a/tests/testutils.sh
+++ b/tests/testutils.sh
@@ -78,6 +78,10 @@ clean_names() {
     awk "$_awk_clean_name"
 }
 
+append_package_path() {
+    export IDRIS2_PACKAGE_PATH="$IDRIS2_PACKAGE_PATH$SEP$1"
+}
+
 # Folder containing the currently running test
 if [ "$OS" = "windows" ]; then
     test_dir="$(cygpath -m "$(pwd)")"


### PR DESCRIPTION
# Description

Prior to this change, the first package matching version requirements would be used by the compiler -- if that package was only installed with an incompatible TTC version, it simply cannot be used. After this change, we skip package directories with only incompatible TTC versions which allows the compiler to find a farther down option (if one exists) in some other directory that does have a compatible TTC vesrion.

For example, if you've got an incompatible package named `foo` at `~/.idris2/idris2-0.7.0/foo-0/12345` and a compatible package at `~/extra/idris2/foo-0/56789` this PR allows the compiler to succeed given `~/extra/idris2` is in `IDRIS2_PACKAGE_PATH`. Prior to this PR, that would not have worked.

When a package is passed over due to incompatible TTC version, you see the following warning:
```
Warning: Found version 0 of package pg-idris-tests installed with no compatible binaries for the current Idris2 compiler.

Reinstall pg-idris-tests with the current Idris2 compiler to resolve the issue.
```

Note that for successful dependency resolution (not for dependency resolution failures) this warning is currently output twice. That's not great, but it's better than 0 warnings. The cause is two calls to the code that resolves package dependecies in two different parts of the build process. It's not trivial to squash because we only want the warning to emit when a dependency is used, so we don't want to cache/warn only on first crawl of a depedency directory (which may not be when we need a particular dependency), but that would be the easiest place to cache something. This isn't an unsolvable problem, just not one I am going to spend the time on at this moment for a warning that is pretty edge-case to begin with.

- [x] Add a test.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

