### PR TITLE
[ enhancement ] update `buildIdris` Nix function to support withSource retroactively

### DIFF
--- a/nix/buildIdris.nix
+++ b/nix/buildIdris.nix
@@ -8,6 +8,12 @@
 #        in {
 #          lib = pkg.library { withSource = true; };
 #          bin = pkg.executable;
+#
+#          # implicitly without source:
+#          lib' = pkg.library'
+#
+#          # retroactively with source:
+#          lib'' = pkg.library'.withSource
 #        }
 #
 { src
@@ -34,79 +40,102 @@ let
   ipkgFileName = ipkgName + ".ipkg";
   idrName = "idris2-${idris2Version}";
   libSuffix = "lib/${idrName}";
-  propagatedIdrisLibraries = propagate idrisLibraryLibs;
-  libDirs =
-    lib.strings.makeSearchPath libSuffix propagatedIdrisLibraries;
+  libDirs = libs: lib.strings.makeSearchPath libSuffix libs;
   drvAttrs = builtins.removeAttrs attrs [
     "ipkgName"
     "idrisLibraries"
   ];
 
-  derivation = stdenv.mkDerivation (finalAttrs:
-    drvAttrs // {
-      pname = ipkgName;
-      inherit version;
-      src = src;
-      nativeBuildInputs = [ idris2 makeWrapper jq ] ++ attrs.nativeBuildInputs or [];
-      buildInputs = propagatedIdrisLibraries ++ attrs.buildInputs or [];
+  mkDerivation =
+    withSource:
+    let
+      applyWithSource = lib: if withSource then lib.withSource else lib;
+      propagatedIdrisLibraries = map applyWithSource (propagate idrisLibraryLibs);
+    in
+    stdenv.mkDerivation (
+      finalAttrs:
+      drvAttrs
+      // {
+        pname = ipkgName;
+        inherit src version;
+        nativeBuildInputs = [
+          idris2
+          makeWrapper
+          jq
+        ] ++ attrs.nativeBuildInputs or [ ];
+        buildInputs = propagatedIdrisLibraries ++ attrs.buildInputs or [ ];
 
-      env.IDRIS2_PACKAGE_PATH = libDirs;
+        env.IDRIS2_PACKAGE_PATH = libDirs propagatedIdrisLibraries;
 
-      buildPhase = ''
-        runHook preBuild
-        idris2 --build ${ipkgFileName}
-        runHook postBuild
+        buildPhase = ''
+          runHook preBuild
+          idris2 --build ${ipkgFileName}
+          runHook postBuild
+        '';
+
+        passthru = {
+          inherit propagatedIdrisLibraries;
+        } // (attrs.passthru or { });
+
+        shellHook = ''
+          export IDRIS2_PACKAGE_PATH="${finalAttrs.env.IDRIS2_PACKAGE_PATH}"
+        '';
+      }
+    );
+
+  mkExecutable =
+    withSource:
+    let
+      derivation = mkDerivation withSource;
+    in
+    derivation.overrideAttrs {
+      installPhase = ''
+        runHook preInstall
+        mkdir -p $out/bin
+        scheme_app="$(find ./build/exec -name '*_app')"
+        if [ "$scheme_app" = ''' ]; then
+          mv -- build/exec/* $out/bin/
+          chmod +x $out/bin/*
+          # ^ remove after Idris2 0.8.0 is released. will be superfluous:
+          # https://github.com/idris-lang/Idris2/pull/3189
+        else
+          bin_name="$(idris2 --dump-ipkg-json ${ipkgFileName} | jq -r '.executable')"
+
+          cd build/exec/''${bin_name}_app
+
+          rm -f ./libidris2_support.{so,dylib}
+
+          executable="''${bin_name}.so"
+          mv -- "$executable" "$out/bin/$bin_name"
+
+          # remaining .so or .dylib files can be moved to lib directory
+          for file in *{.so,.dylib}; do
+            mkdir -p $out/lib
+            mv -- "$file" "$out/lib/"
+          done
+
+          wrapProgram "$out/bin/$bin_name" \
+            --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ support ]}:$out/lib \
+            --prefix DYLD_LIBRARY_PATH : ${lib.makeLibraryPath [ support ]}:$out/lib
+
+        fi
+        runHook postInstall
       '';
 
-      passthru = {
-        inherit propagatedIdrisLibraries;
-      } // (attrs.passthru or {});
+      # allow an executable's dependencies to be built with source. this is convenient when
+      # building a development shell for the exectuable using `mkShell`'s `inputsFrom`.
+      passthru = derivation.passthru // {
+        withSource = mkExecutable true;
+      };
+    };
 
-      shellHook = ''
-        export IDRIS2_PACKAGE_PATH="${finalAttrs.env.IDRIS2_PACKAGE_PATH}"
-      '';
-    }
-  );
-
-in rec {
-  executable = derivation.overrideAttrs {
-    installPhase = ''
-      runHook preInstall
-      mkdir -p $out/bin
-      scheme_app="$(find ./build/exec -name '*_app')"
-      if [ "$scheme_app" = ''' ]; then
-        mv -- build/exec/* $out/bin/
-        chmod +x $out/bin/*
-        # ^ remove after Idris2 0.8.0 is released. will be superfluous:
-        # https://github.com/idris-lang/Idris2/pull/3189
-      else
-        bin_name="$(idris2 --dump-ipkg-json ${ipkgFileName} | jq -r '.executable')"
-
-        cd build/exec/''${bin_name}_app
-
-        rm -f ./libidris2_support.{so,dylib}
-
-        executable="''${bin_name}.so"
-        mv -- "$executable" "$out/bin/$bin_name"
-
-        # remaining .so or .dylib files can be moved to lib directory
-        for file in *{.so,.dylib}; do
-          mkdir -p $out/lib
-          mv -- "$file" "$out/lib/"
-        done
-
-        wrapProgram "$out/bin/$bin_name" \
-          --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ support ]}:$out/lib \
-          --prefix DYLD_LIBRARY_PATH : ${lib.makeLibraryPath [ support ]}:$out/lib
-
-      fi
-      runHook postInstall
-    '';
-  };
-
-  library = { withSource ? false }:
-    let installCmd = if withSource then "--install-with-src" else "--install";
-    in derivation.overrideAttrs {
+  mkLibrary =
+    withSource:
+    let
+      installCmd = if withSource then "--install-with-src" else "--install";
+      derivation = mkDerivation withSource;
+    in
+    derivation.overrideAttrs {
       installPhase = ''
         runHook preInstall
         mkdir -p $out/${libSuffix}
@@ -121,7 +150,33 @@ in rec {
         done
         runHook postInstall
       '';
+
+      # allow a library built without source to be changed to one with source
+      # via a passthru attribute; i.e. `(my-pkg.library {}).withSource`.
+      # this is convenient because a library derivation can be distributed as
+      # without-source by default but downstream projects can still build it
+      # with-source. We surface this regardless of whether the original library
+      # was built with source because that allows downstream to call this
+      # property unconditionally.
+      passthru = derivation.passthru // {
+        withSource = mkLibrary true;
+      };
     };
+
+in
+rec {
+  executable = mkExecutable false;
+
+  library =
+    {
+      withSource ? false,
+    }:
+    mkLibrary withSource;
+
+  # Make a library without source; you can still use the `withSource` attribute
+  # on the resulting derivation to build the library with source at a later time.
+  library' = mkLibrary false;
+
   # deprecated aliases:
   build = lib.warn "build is a deprecated alias for 'executable'." executable;
   installLibrary = lib.warn "installLibrary is a deprecated alias for 'library { }'." (library { });


### PR DESCRIPTION
# Description

This updates the existing `buildIdris` Nix function so that its outputs (both library and executable) support a `withSource` passthru attribute that can be used to get the given derivation and all of its dependencies built with sourcecode included after-the-fact. This means you don't need to decide up front -- a library can easily be built without source by default and then asked for its withSource variant specifically for a developer shell environment.

I've PRed similar changes to nixpkgs and I've been testing these changes in `nix-idris2-packages` for a while now.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

