### PR TITLE
[ fix ] False positives checking for conflicts in coverage checking

### DIFF
--- a/libs/papers/Language/IntrinsicTyping/Krivine.idr
+++ b/libs/papers/Language/IntrinsicTyping/Krivine.idr
@@ -522,6 +522,7 @@ namespace Machine
   public export
   vlam0 : (eq : ctx = []) -> (tr : Trace (Lam sc) env ctx) -> tr ~=~ Machine.Done {sc, env}
   vlam0 eq Done = Refl
+  vlam0 eq (Beta {arg = Element _ _, ctx = Element _ _} _) impossible
 
   public export
   vlamS : {0 env : ValidEnv g} -> {0 arg : ValidClosed a} ->
@@ -529,6 +530,7 @@ namespace Machine
           (eq : ctx = ValidEvalContext.(::) arg ctx') ->
           (tr : Trace (Lam sc) env ctx) ->
           (tr' : Trace sc (arg :: env) ctx' ** tr ~=~ Machine.Beta {sc, arg, env} tr')
+  vlamS {arg = (Element _ _)} {ctx' = (Element _ _)} eq Done impossible
   vlamS eq (Beta tr) with 0 (fst (biinjective @{CONS} eq))
     _ | Refl with 0 (snd (biinjective @{CONS} eq))
       _ | Refl = (tr ** Refl)

--- a/src/Core/Coverage.idr
+++ b/src/Core/Coverage.idr
@@ -112,8 +112,7 @@ conflict defs env nfty n
                 conflictNF (i + 1) t
                        !(sc defs (toClosure defaultOpts [] (Ref fc Bound x')))
       conflictNF i nf (NApp _ (NRef Bound n) [])
-          = do empty <- clearDefs defs
-               pure (Just [(n, !(quote empty env nf))])
+          = pure (Just [(n, !(quote defs env nf))])
       conflictNF i (NDCon _ n t a args) (NDCon _ n' t' a' args')
           = if t == t'
                then conflictArgs i (map snd args) (map snd args')

--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -1118,7 +1118,9 @@ processDef opts nest env fc n_in cs_in
                               pure (Just rtm))
                (\err => do defs <- get Ctxt
                            if not !(recoverableErr defs err)
-                              then pure Nothing
+                              then do
+                                log "declare.def.impossible" 5 "impossible because \{show err}"
+                                pure Nothing
                               else pure (Just tm))
       where
         closeEnv : Defs -> NF [] -> Core ClosedTerm

--- a/tests/idris2/coverage/coverage022/Issue3477.idr
+++ b/tests/idris2/coverage/coverage022/Issue3477.idr
@@ -1,0 +1,2 @@
+test : (xs : List Int) ->  2 = length xs -> (Int, Int)
+test (x1 :: x2 :: x3 :: []) pf = (x1, x2)

--- a/tests/idris2/coverage/coverage022/expected
+++ b/tests/idris2/coverage/coverage022/expected
@@ -1,0 +1,10 @@
+1/1: Building Issue3477 (Issue3477.idr)
+Error: test is not covering.
+
+Issue3477:1:1--1:55
+ 1 | test : (xs : List Int) ->  2 = length xs -> (Int, Int)
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Missing cases:
+    test [_, _] _
+

--- a/tests/idris2/coverage/coverage022/run
+++ b/tests/idris2/coverage/coverage022/run
@@ -1,0 +1,4 @@
+. ../../../testutils.sh
+
+# expect a coverage error
+check Issue3477.idr


### PR DESCRIPTION
# Description

This fixes #3477.  Idris considers `2 = length xs` as empty while checking missing cases in coverage checking, and it incorrectly accepts this as covering:
```idris
test : (xs : List Int) ->  2 = length xs -> (Int, Int)
test (x1 :: x2 :: x3 :: []) pf = (x1, x2)
```

There are two changes here:

I removed the `clearDefs` in `conflictNF` to allow the `length xs` to expand when `xs` is known.  _Let me know if there is a reason we don't allow expansions here._ It passes tests and it seems to be necessary to enable Idris to automatically use the `2 = length xs`. 

Without this change, the following `impossible` clauses are required:
```idris
test : (xs : List Int) ->  2 = length xs -> (Int, Int)
test (x1 :: x2 :: []) pf = (x1, x2)
test (x1 :: Nil) Refl impossible
test (x1 :: x2 :: x3 :: _) Refl impossible
```

The second change addresses the root cause.  When checking for clashes between types in `conflictMatch`, idris checks if the heads clash, and if not it proceeds to check the arguments. This is a problem when `S (S Z)` is compared to `length xs`. `S` and `length` do not clash, but it is not correct to then compare `S Z` against `xs`.  To remedy this, it is now only checking the spines in the case of matching data or type constructors. The helper function returns `Nothing` to indicate the spine should be checked.

`Krivine.idr` was relying on this bug. The code was covering, but coverage checking was accepting it for the wrong reason. It was discounting the other case when looking at `Element (EvalContext{}) _` vs `(::) (Arr{}) ctx` (here `::` is a function, not a constructor). `Element` vs `(::)` was not clashing, so it proceeded to compare the arguments and saw that `EvalContext{}` and `Arr{}` clashed (values headed by different constructors).  After this change, it needed an impossible clause to unblock the `(::)`. 

I've also added a test case, fixed a typo in a comment, and added a `log` message that I use do diagnose these `impossible` issues. This will break code that relies on false positives in coverage, but given that the rest of papers and frex are uneffected, I suspect that is rare.

