### PR TITLE
add a constructor to the Category interface

### DIFF
--- a/libs/contrib/Control/Category.idr
+++ b/libs/contrib/Control/Category.idr
@@ -5,6 +5,7 @@ import Data.Morphisms
 
 public export
 interface Category (0 cat : obj -> obj -> Type) | cat where
+  constructor MkCategory
   id  : cat a a
   (.) : cat b c -> cat a b -> cat a c
 


### PR DESCRIPTION
# Description

Adding constructors to category interface

We should probably also move this outside contrib, maybe have other things that are categories to go along with it

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

