### PR TITLE
[ refactor ] Use `List1` for determining parameters

### DIFF
--- a/libs/base/Language/Reflection/TTImp.idr
+++ b/libs/base/Language/Reflection/TTImp.idr
@@ -1,7 +1,7 @@
 module Language.Reflection.TTImp
 
+import public Data.List1
 import Data.Maybe
-import Data.String
 import public Language.Reflection.TT
 
 
@@ -129,7 +129,7 @@ mutual
 
   public export
   data DataOpt : Type where
-       SearchBy : List Name -> DataOpt -- determining arguments
+       SearchBy : List1 Name -> DataOpt -- determining arguments
        NoHints : DataOpt -- Don't generate search hints for constructors
        UniqueSearch : DataOpt -- auto implicit search must check result is unique
        External : DataOpt -- implemented externally

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -29,7 +29,7 @@ import public Libraries.Utils.Binary
 ||| version number if you're changing the version more than once in the same day.
 export
 ttcVersion : Int
-ttcVersion = 2025_02_09_00
+ttcVersion = 2025_02_12_00
 
 export
 checkTTCVersion : String -> Int -> Int -> Core ()

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -1795,14 +1795,14 @@ dropMutData n = update Ctxt { mutData $= filter (/= n) }
 
 export
 setDetermining : {auto c : Ref Ctxt Defs} ->
-                 FC -> Name -> List Name -> Core ()
+                 FC -> Name -> List1 Name -> Core ()
 setDetermining fc tyn args
     = do defs <- get Ctxt
          Just g <- lookupCtxtExact tyn (gamma defs)
               | _ => undefinedName fc tyn
          let TCon t a ps _ u cons ms det = definition g
               | _ => throw (GenericMsg fc (show (fullname g) ++ " is not a type constructor [setDetermining]"))
-         apos <- getPos 0 args (type g)
+         apos <- getPos 0 (forget args) (type g)
          updateDef tyn (const (Just (TCon t a ps apos u cons ms det)))
   where
     -- Type isn't normalised, but the argument names refer to those given

--- a/src/Idris/Elab/Interface.idr
+++ b/src/Idris/Elab/Interface.idr
@@ -102,11 +102,10 @@ mkIfaceData : {vars : _} ->
               FC -> WithDefault Visibility Private -> Env Term vars ->
               List (Maybe Name, RigCount, RawImp) ->
               Name -> Name -> List (Name, (RigCount, RawImp)) ->
-              List Name -> List (Name, RigCount, RawImp) -> Core ImpDecl
+              Maybe (List1 Name) -> List (Name, RigCount, RawImp) -> Core ImpDecl
 mkIfaceData {vars} ifc def_vis env constraints n conName ps dets meths
-    = let opts = if isNil dets
-                    then [NoHints, UniqueSearch]
-                    else [NoHints, UniqueSearch, SearchBy dets]
+    = let opts = [NoHints, UniqueSearch] ++
+                 maybe [] (singleton . SearchBy) dets
           pNames = map fst ps
           retty = apply (IVar vfc n) (map (IVar EmptyFC) pNames)
           conty = mkTy Implicit (map jname ps) $
@@ -331,7 +330,7 @@ elabInterface : {vars : _} ->
                 (constraints : List (Maybe Name, RawImp)) ->
                 Name ->
                 (params : List (Name, (RigCount, RawImp))) ->
-                (dets : List Name) ->
+                (dets : Maybe (List1 Name)) ->
                 (conName : Maybe (String, Name)) ->
                 List ImpDecl ->
                 Core ()

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1359,8 +1359,10 @@ dataOpt : OriginDesc -> Rule DataOpt
 dataOpt fname
     = (decorate fname Keyword (exactIdent "noHints") $> NoHints)
   <|> (decorate fname Keyword (exactIdent "uniqueSearch") $> UniqueSearch)
-  <|> (do decorate fname Keyword (exactIdent "search")
-          SearchBy <$> some (decorate fname Bound name))
+  <|> (do b   <- bounds $ decorate fname Keyword (exactIdent "search")
+          det <- mustWorkBecause b.bounds "Expected list of determining parameters" $
+                   some (decorate fname Bound name)
+          pure $ SearchBy det)
   <|> (decorate fname Keyword (exactIdent "external") $> External)
   <|> (decorate fname Keyword (exactIdent "noNewtype") $> NoNewtype)
 
@@ -1766,7 +1768,10 @@ parameters {auto fname : OriginDesc} {auto indents : IndentInfo}
             cons   <- constraints fname indents
             n      <- decorate fname Typ name
             params <- many ifaceParam
-            det    <- optional $ decoratedSymbol fname "|" *> sepBy1 (decoratedSymbol fname ",") (decorate fname Bound name)
+            det    <- optional $ do
+              b <- bounds $ decoratedSymbol fname "|"
+              mustWorkBecause b.bounds "Expected list of determining parameters" $
+                sepBy1 (decoratedSymbol fname ",") (decorate fname Bound name)
             decoratedKeyword fname "where"
             dc <- optional (recordConstructor fname)
             body <- blockAfter col (topDecl fname)

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1360,7 +1360,7 @@ dataOpt fname
     = (decorate fname Keyword (exactIdent "noHints") $> NoHints)
   <|> (decorate fname Keyword (exactIdent "uniqueSearch") $> UniqueSearch)
   <|> (do decorate fname Keyword (exactIdent "search")
-          SearchBy <$> forget <$> some (decorate fname Bound name))
+          SearchBy <$> some (decorate fname Bound name))
   <|> (decorate fname Keyword (exactIdent "external") $> External)
   <|> (decorate fname Keyword (exactIdent "noNewtype") $> NoNewtype)
 
@@ -1766,7 +1766,7 @@ parameters {auto fname : OriginDesc} {auto indents : IndentInfo}
             cons   <- constraints fname indents
             n      <- decorate fname Typ name
             params <- many ifaceParam
-            det    <- option [] $ decoratedSymbol fname "|" *> sepBy (decoratedSymbol fname ",") (decorate fname Bound name)
+            det    <- optional $ decoratedSymbol fname "|" *> sepBy1 (decoratedSymbol fname ",") (decorate fname Bound name)
             decoratedKeyword fname "where"
             dc <- optional (recordConstructor fname)
             body <- blockAfter col (topDecl fname)

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -589,7 +589,7 @@ mutual
                     Name ->
                     (doc : String) ->
                     (params : List (BasicMultiBinder' nm)) ->
-                    (det : List Name) ->
+                    (det : Maybe (List1 Name)) ->
                     (conName : Maybe (String, Name)) ->
                     List (PDecl' nm) ->
                     PDeclNoFC' nm

--- a/src/TTImp/Parser.idr
+++ b/src/TTImp/Parser.idr
@@ -578,7 +578,7 @@ dataOpt
   <|> do exactIdent "uniqueSearch"
          pure UniqueSearch
   <|> do exactIdent "search"
-         ns <- forget <$> some name
+         ns <- some name
          pure (SearchBy ns)
 
 dataOpts : EmptyRule (List DataOpt)

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -323,7 +323,7 @@ mutual
 
   public export
   data DataOpt : Type where
-       SearchBy : List Name -> DataOpt -- determining arguments
+       SearchBy : List1 Name -> DataOpt -- determining arguments
        NoHints : DataOpt -- Don't generate search hints for constructors
        UniqueSearch : DataOpt -- auto implicit search must check result is unique
        External : DataOpt -- implemented externally

--- a/tests/base/deriving_functor/DeriveFunctor.idr
+++ b/tests/base/deriving_functor/DeriveFunctor.idr
@@ -8,6 +8,8 @@ import Deriving.Functor
 %logging "derive.functor.clauses" 1
 %logging "derive.functor.assumption" 10
 
+%hide List1
+
 list : Functor List
 list = %runElab derive
 

--- a/tests/base/deriving_functor/expected
+++ b/tests/base/deriving_functor/expected
@@ -79,16 +79,16 @@ LOG derive.functor.clauses:1:
   mapEqMap f (MkEqMap x3) = MkEqMap (map (map f) x3)
 LOG derive.functor.clauses:1: 
   mapCont : {0 r : _} -> {0 a, b : Type} -> (a -> b) -> Cont r a -> Cont r b
-  mapCont f (MkCont x2) = MkCont (\ {arg:6040} => x2 (\ {arg:6042} => {arg:6040} (f {arg:6042})))
+  mapCont f (MkCont x2) = MkCont (\ {arg:6041} => x2 (\ {arg:6043} => {arg:6041} (f {arg:6043})))
 LOG derive.functor.clauses:1: 
   mapCont2 : {0 r, e : _} -> {0 a, b : Type} -> (a -> b) -> Cont2 r e a -> Cont2 r e b
-  mapCont2 f (MkCont2 x3) = MkCont2 (\ {arg:6132} => \ {arg:6139} => x3 {arg:6132} (\ {arg:6141} => {arg:6139} (f {arg:6141})))
+  mapCont2 f (MkCont2 x3) = MkCont2 (\ {arg:6133} => \ {arg:6140} => x3 {arg:6133} (\ {arg:6142} => {arg:6140} (f {arg:6142})))
 LOG derive.functor.clauses:1: 
   mapCont2' : {0 r, e : _} -> {0 a, b : Type} -> (a -> b) -> Cont2' r e a -> Cont2' r e b
-  mapCont2' f (MkCont2' x3) = MkCont2' (\ {arg:6246} => x3 (mapFst (\ t => \ {arg:6248} => t (f {arg:6248})) {arg:6246}))
+  mapCont2' f (MkCont2' x3) = MkCont2' (\ {arg:6247} => x3 (mapFst (\ t => \ {arg:6249} => t (f {arg:6249})) {arg:6247}))
 LOG derive.functor.clauses:1: 
   mapCont2'' : {0 r, e : _} -> {0 a, b : Type} -> (a -> b) -> Cont2'' r e a -> Cont2'' r e b
-  mapCont2'' f (MkCont2'' x3) = MkCont2'' (\ {arg:6370} => x3 (Delay (mapFst (\ t => \ {arg:6373} => t (Delay (f {arg:6373}))) {arg:6370})))
+  mapCont2'' f (MkCont2'' x3) = MkCont2'' (\ {arg:6371} => x3 (Delay (mapFst (\ t => \ {arg:6374} => t (Delay (f {arg:6374}))) {arg:6371})))
 LOG derive.functor.clauses:1: 
   mapWithImplicits : {0 a, b : Type} -> (a -> b) -> WithImplicits a -> WithImplicits b
   mapWithImplicits f (MkImplicit {x = x1} x2) = MkImplicit {x = f x1} (f x2)

--- a/tests/base/deriving_show/DeriveShow.idr
+++ b/tests/base/deriving_show/DeriveShow.idr
@@ -8,6 +8,8 @@ import Deriving.Show
 %logging "derive.show.clauses" 1
 %logging "derive.show.assumption" 10
 
+%hide List1
+
 namespace Enum
 
   data Enum = A | B | C

--- a/tests/base/deriving_traversable/expected
+++ b/tests/base/deriving_traversable/expected
@@ -65,7 +65,7 @@ LOG derive.traversable.clauses:1:
   traverseIVect : {0 m : _} -> {0 a, b : Type} -> {0 f : Type -> Type} -> Applicative f => (a -> f b) -> IVect {n = m} a -> f (IVect {n = m} b)
   traverseIVect f (MkIVect x2) = MkIVect <$> (traverse f x2)
 LOG derive.traversable.clauses:1: 
-  traverseEqMap : {0 key, eq : _} -> {0 a, b : Type} -> {0 f : Type -> Type} -> Applicative f => (a -> f b) -> EqMap key {{conArg:13929} = eq} a -> f (EqMap key {{conArg:13929} = eq} b)
+  traverseEqMap : {0 key, eq : _} -> {0 a, b : Type} -> {0 f : Type -> Type} -> Applicative f => (a -> f b) -> EqMap key {{conArg:16433} = eq} a -> f (EqMap key {{conArg:16433} = eq} b)
   traverseEqMap f (MkEqMap x3) = MkEqMap <$> (traverse (traverse f) x3)
 LOG derive.traversable.clauses:1: 
   traverseTree : {0 l : _} -> {0 a, b : Type} -> {0 f : Type -> Type} -> Applicative f => (a -> f b) -> Tree l a -> f (Tree l b)

--- a/tests/idris2/data/data004/EmptySearch.idr
+++ b/tests/idris2/data/data004/EmptySearch.idr
@@ -1,0 +1,2 @@
+data X : Type where
+  [search]

--- a/tests/idris2/data/data004/expected
+++ b/tests/idris2/data/data004/expected
@@ -1,0 +1,8 @@
+1/1: Building EmptySearch (EmptySearch.idr)
+Error: Expected list of determining parameters.
+
+EmptySearch:2:4--2:10
+ 1 | data X : Type where
+ 2 |   [search]
+        ^^^^^^
+

--- a/tests/idris2/data/data004/run
+++ b/tests/idris2/data/data004/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check EmptySearch.idr

--- a/tests/idris2/data/record022/EmptySearch.idr
+++ b/tests/idris2/data/record022/EmptySearch.idr
@@ -1,0 +1,2 @@
+record R where
+  [search]

--- a/tests/idris2/data/record022/expected
+++ b/tests/idris2/data/record022/expected
@@ -1,0 +1,8 @@
+1/1: Building EmptySearch (EmptySearch.idr)
+Error: Expected list of determining parameters.
+
+EmptySearch:2:4--2:10
+ 1 | record R where
+ 2 |   [search]
+        ^^^^^^
+

--- a/tests/idris2/data/record022/run
+++ b/tests/idris2/data/record022/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check EmptySearch.idr

--- a/tests/idris2/interface/interface034/Main.idr
+++ b/tests/idris2/interface/interface034/Main.idr
@@ -1,0 +1,1 @@
+interface Iface | where

--- a/tests/idris2/interface/interface034/expected
+++ b/tests/idris2/interface/interface034/expected
@@ -1,7 +1,7 @@
 1/1: Building Main (Main.idr)
-Error: Expected end of input.
+Error: Expected list of determining parameters.
 
-Main:1:1--1:10
+Main:1:17--1:18
  1 | interface Iface | where
-     ^^^^^^^^^
+                     ^
 

--- a/tests/idris2/interface/interface034/expected
+++ b/tests/idris2/interface/interface034/expected
@@ -1,0 +1,7 @@
+1/1: Building Main (Main.idr)
+Error: Expected end of input.
+
+Main:1:1--1:10
+ 1 | interface Iface | where
+     ^^^^^^^^^
+

--- a/tests/idris2/interface/interface034/run
+++ b/tests/idris2/interface/interface034/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check Main.idr

--- a/tests/idris2/reflection/reflection003/expected
+++ b/tests/idris2/reflection/reflection003/expected
@@ -1,4 +1,7 @@
 1/1: Building refprims (refprims.idr)
+LOG 0: Name: Data.List1.(++)
+LOG 0: Type: (%pi Rig0 Implicit (Just a) %type (%pi RigW Explicit (Just xs) (Data.List1.List1 a) (%pi RigW Explicit (Just ys) (Data.List1.List1 a) (Data.List1.List1 a))))
+LOG 0: Pretty Type: (xs : List1 a) -> (ys : List1 a) -> List1 a
 LOG 0: Name: Prelude.Types.List.(++)
 LOG 0: Type: (%pi Rig0 Implicit (Just a) %type (%pi RigW Explicit (Just xs) (Prelude.Basics.List a) (%pi RigW Explicit (Just ys) (Prelude.Basics.List a) (Prelude.Basics.List a))))
 LOG 0: Pretty Type: (xs : List a) -> (ys : List a) -> List a

--- a/tests/idris2/reflection/reflection032/DeterminingData.idr
+++ b/tests/idris2/reflection/reflection032/DeterminingData.idr
@@ -1,0 +1,23 @@
+import Language.Reflection
+
+%language ElabReflection
+
+decl : List Decl
+decl = `[
+  data Wrap : (phantom : Type) -> (a : Type) -> Type where
+    -- whereas this will give us the right behaviour
+    [search a]
+    MkWrap : a -> Wrap ph a
+]
+
+%runElab declare decl
+
+%hint
+zero : Wrap Bool Nat
+zero = MkWrap 0
+
+getWrappedVal : Wrap ph a => a
+getWrappedVal @{MkWrap w} = w
+
+test : Main.getWrappedVal === Z
+test = Refl

--- a/tests/idris2/reflection/reflection032/DeterminingRecord.idr
+++ b/tests/idris2/reflection/reflection032/DeterminingRecord.idr
@@ -1,0 +1,24 @@
+import Language.Reflection
+
+%language ElabReflection
+
+decl : List Decl
+decl = `[
+  record Wrap (phantom : Type) (a : Type) where
+    -- whereas this will give us the right behaviour
+    [search a]
+    constructor MkWrap
+    unWrap : a
+]
+
+%runElab declare decl
+
+%hint
+zero : Wrap Bool Nat
+zero = MkWrap 0
+
+getWrappedVal : Wrap ph a => a
+getWrappedVal @{w} = unWrap w
+
+test : Main.getWrappedVal === Z
+test = Refl

--- a/tests/idris2/reflection/reflection032/expected
+++ b/tests/idris2/reflection/reflection032/expected
@@ -1,0 +1,2 @@
+1/1: Building DeterminingData (DeterminingData.idr)
+1/1: Building DeterminingRecord (DeterminingRecord.idr)

--- a/tests/idris2/reflection/reflection032/run
+++ b/tests/idris2/reflection/reflection032/run
@@ -1,0 +1,4 @@
+. ../../../testutils.sh
+
+check DeterminingData.idr
+check DeterminingRecord.idr


### PR DESCRIPTION
# Description

The determining parameters are stored in `List`, but an empty list is never used. I suggest reflecting this in the signature with `List1`.

Also, the parser allows an empty list of determining parameters in interfaces, which is simply ignored during elaboration. I suggest making this a parser error:
```idris
interface Iface | where
```

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

