### PR TITLE
[ fix ] Increasing timeout for channelGetWithTimeout test

### DIFF
--- a/tests/chez/channels008/Main.idr
+++ b/tests/chez/channels008/Main.idr
@@ -17,7 +17,7 @@ main : IO ()
 main =
   do c    <- makeChannel
      tids <- for [0..11] $ \n => fork $ producer c n
-     vals <- for [0..11] $ \_ => channelGetWithTimeout c 5000
+     vals <- for [0..11] $ \_ => channelGetWithTimeout c 15000
      ignore $ traverse (\t => threadWait t) tids
      putStrLn $ show $ sum $ fromMaybe 0 <$> vals
 


### PR DESCRIPTION
# Description

This PR bumps the timeout for the new `channelGetWithTimeout` function from `5000` to `15000`  in the `channels008` test.

This should help `channels008` pass consistently as it occasionally fails when this test is run non-locally via the merge pipelines/jobs.