### PR TITLE
Document moved SplitRec View to contrib

### DIFF
--- a/docs/source/typedd/typedd.rst
+++ b/docs/source/typedd/typedd.rst
@@ -304,7 +304,7 @@ generates a case tree splitting on ``input1`` and ``input2`` instead of the
 This doesn't yet get past the totality checker, however, because it doesn't
 know about looking inside pairs.
 
-For the ``SplitRec`` view in the exercise 2 after Chapter 10-2, ``import Data.Vect.Views.Extra`` from ``contrib`` library.
+For the ``SplitRec`` view in exercise 2 after Chapter 10-2, ``import Data.Vect.Views.Extra`` from ``contrib`` library.
 
 For the ``VList`` view in exercise 4 after Chapter 10-2, ``import Data.List.Views.Extra`` from ``contrib`` library.
 

--- a/docs/source/typedd/typedd.rst
+++ b/docs/source/typedd/typedd.rst
@@ -304,7 +304,9 @@ generates a case tree splitting on ``input1`` and ``input2`` instead of the
 This doesn't yet get past the totality checker, however, because it doesn't
 know about looking inside pairs.
 
-For the ``VList`` view in the exercise 4 after Chapter 10-2 ``import Data.List.Views.Extra`` from ``contrib`` library.
+For the ``SplitRec`` view in the exercise 2 after Chapter 10-2, ``import Data.Vect.Views.Extra`` from ``contrib`` library.
+
+For the ``VList`` view in exercise 4 after Chapter 10-2, ``import Data.List.Views.Extra`` from ``contrib`` library.
 
 In ``DataStore.idr``: Well this is embarrassing - I've no idea how Idris 1 lets
 this through! I think perhaps it's too "helpful" when solving unification


### PR DESCRIPTION
In Idris2, `Data.Vect.Views` from the `base` library has been moved to `Data.Vect.Views.Extra` in the `contrib` library. This has so far remained undocumented in TDDwI: Changes Required.