### PR TITLE
[ base ] Add getThreadId

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -285,6 +285,8 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 
 * Added `System.Concurrency.channelGetWithTimeout` for the chez backend.
 
+* Added `System.Concurrency.getThreadId` for the chez backend.
+
 #### Contrib
 
 * `Data.List.Lazy` was moved from `contrib` to `base`.

--- a/libs/base/System/Concurrency.idr
+++ b/libs/base/System/Concurrency.idr
@@ -15,6 +15,8 @@ module System.Concurrency
 prim__setThreadData : {a : Type} -> a -> PrimIO ()
 %foreign "scheme:blodwen-get-thread-data"
 prim__getThreadData : (a : Type) -> PrimIO a
+%foreign "scheme:blodwen-get-thread-id"
+prim__getThreadId : PrimIO Int
 
 ||| Set the data stored in a thread's parameter to the given value.
 ||| Currently only supported under the scheme backends.
@@ -27,6 +29,12 @@ setThreadData val = primIO (prim__setThreadData val)
 export
 getThreadData : HasIO io => (a : Type) -> io a
 getThreadData a = primIO (prim__getThreadData a)
+
+||| Get the thread id of the current thread.
+||| Currently only supported under the scheme backends.
+export
+getThreadId : HasIO io => io Int
+getThreadId = primIO prim__getThreadId
 
 
 -- Mutexes

--- a/libs/base/System/Concurrency.idr
+++ b/libs/base/System/Concurrency.idr
@@ -15,7 +15,7 @@ module System.Concurrency
 prim__setThreadData : {a : Type} -> a -> PrimIO ()
 %foreign "scheme:blodwen-get-thread-data"
 prim__getThreadData : (a : Type) -> PrimIO a
-%foreign "scheme:blodwen-get-thread-id"
+%foreign "scheme,chez:blodwen-get-thread-id"
 prim__getThreadId : PrimIO Int
 
 ||| Set the data stored in a thread's parameter to the given value.
@@ -30,8 +30,7 @@ export
 getThreadData : HasIO io => (a : Type) -> io a
 getThreadData a = primIO (prim__getThreadData a)
 
-||| Get the thread id of the current thread.
-||| Currently only supported under the scheme backends.
+||| Get the thread id of the current thread (chez backend).
 export
 getThreadId : HasIO io => io Int
 getThreadId = primIO prim__getThreadId

--- a/libs/base/System/Concurrency.idr
+++ b/libs/base/System/Concurrency.idr
@@ -15,7 +15,7 @@ module System.Concurrency
 prim__setThreadData : {a : Type} -> a -> PrimIO ()
 %foreign "scheme:blodwen-get-thread-data"
 prim__getThreadData : (a : Type) -> PrimIO a
-%foreign "scheme,chez:blodwen-get-thread-id"
+%foreign "scheme,chez:get-thread-id"
 prim__getThreadId : PrimIO Int
 
 ||| Set the data stored in a thread's parameter to the given value.

--- a/support/chez/support.ss
+++ b/support/chez/support.ss
@@ -316,6 +316,9 @@
 (define (blodwen-thread-wait handle)
   (blodwen-semaphore-wait (thread-handle-semaphore handle)))
 
+(define (blodwen-get-thread-id)
+  (get-thread-id))
+
 ;; Thread mailboxes
 
 (define blodwen-thread-data

--- a/support/chez/support.ss
+++ b/support/chez/support.ss
@@ -316,9 +316,6 @@
 (define (blodwen-thread-wait handle)
   (blodwen-semaphore-wait (thread-handle-semaphore handle)))
 
-(define (blodwen-get-thread-id)
-  (get-thread-id))
-
 ;; Thread mailboxes
 
 (define blodwen-thread-data

--- a/tests/chez/chez038/ThreadId.idr
+++ b/tests/chez/chez038/ThreadId.idr
@@ -1,8 +1,13 @@
 module Main
 
+import System
 import System.Concurrency
 
 main : IO ()
 main = do
-    i <- getThreadId
-    putStrLn $ "Current thread id: " ++ (show i)
+    tid0  <- getThreadId
+    putStrLn $ "Current thread id: " ++ (show tid0)
+    i <- fork $ do
+      tid1 <- getThreadId
+      putStrLn $ "Forked thread id: " ++ (show tid1)
+    threadWait i

--- a/tests/chez/chez038/ThreadId.idr
+++ b/tests/chez/chez038/ThreadId.idr
@@ -1,0 +1,8 @@
+module Main
+
+import System.Concurrency
+
+main : IO ()
+main = do
+    i <- getThreadId
+    putStrLn $ "Current thread id: " ++ (show i)

--- a/tests/chez/chez038/expected
+++ b/tests/chez/chez038/expected
@@ -1,1 +1,2 @@
 Current thread id: 0
+Forked thread id: 1

--- a/tests/chez/chez038/expected
+++ b/tests/chez/chez038/expected
@@ -1,0 +1,1 @@
+Current thread id: 0

--- a/tests/chez/chez038/run
+++ b/tests/chez/chez038/run
@@ -1,0 +1,3 @@
+. ../../testutils.sh
+
+run ThreadId.idr


### PR DESCRIPTION
# Description

This PR adds the `getThreadId` function to `System.Concurrency` (chez backend).

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [X] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

