### PR TITLE
[ fix ] Forward data declarations are linear

### DIFF
--- a/src/TTImp/ProcessData.idr
+++ b/src/TTImp/ProcessData.idr
@@ -425,7 +425,7 @@ processData {vars} eopts nest env fc def_vis mbtot (MkImpLater dfc n_in ty_raw)
          arity <- getArity defs [] fullty
 
          -- Add the type constructor as a placeholder
-         tidx <- addDef n (newDef fc n linear vars fullty def_vis
+         tidx <- addDef n (newDef fc n top vars fullty def_vis
                           (TCon 0 arity [] [] defaultFlags [] Nothing Nothing))
          addMutData (Resolved tidx)
          defs <- get Ctxt

--- a/tests/idris2/data/data005/Issue1204.idr
+++ b/tests/idris2/data/data005/Issue1204.idr
@@ -1,0 +1,8 @@
+data Tm = Foo Nat
+
+mutual
+  Env : Type
+  Env = List Clos
+
+  data Clos : Type where
+    Cl : Tm -> Env -> Clos

--- a/tests/idris2/data/data005/Issue586.idr
+++ b/tests/idris2/data/data005/Issue586.idr
@@ -1,0 +1,9 @@
+mutual
+  public export
+  ListT : (m : Type -> Type) -> (a : Type) -> Type
+  ListT m a = m (ListStruct m a)
+
+  public export
+  data ListStruct : (m : Type -> Type) -> (a : Type) -> Type where
+    Nil  : ListStruct m a
+    (::) : a -> ListT m a -> ListStruct m a

--- a/tests/idris2/data/data005/Issue586b.idr
+++ b/tests/idris2/data/data005/Issue586b.idr
@@ -1,0 +1,5 @@
+data X : Type
+data Y : Type -> Type
+
+f : Type
+f = Y X

--- a/tests/idris2/data/data005/expected
+++ b/tests/idris2/data/data005/expected
@@ -1,0 +1,3 @@
+1/1: Building Issue586 (Issue586.idr)
+1/1: Building Issue586b (Issue586b.idr)
+1/1: Building Issue1204 (Issue1204.idr)

--- a/tests/idris2/data/data005/run
+++ b/tests/idris2/data/data005/run
@@ -1,0 +1,5 @@
+. ../../../testutils.sh
+
+check Issue586.idr
+check Issue586b.idr
+check Issue1204.idr


### PR DESCRIPTION
# Description

This fixes #586 and #1204 (included as tests).  The occurs because forward data declarations are tagged as `linear`, I have changed it to `top`. I don't know why they were tagged as `linear` in the first place, so there is a chesterton's fence situation here, but if #586 is a bug then they probably should not be. If they were marked linear to distinguish forward declarations from empty types, that is now handled by #3480.

Previously, the following code would error with "Trying to use linear name Main.X in non-linear context." It now checks.
```idris
data X : Type

f : Type
f = Maybe X
```
