### PR TITLE
[ cleanup ] Remove redundant `Ref` arguments

### DIFF
--- a/src/Compiler/CompileExpr.idr
+++ b/src/Compiler/CompileExpr.idr
@@ -162,12 +162,10 @@ dconFlag n
 
 toCExpTm : {vars : _} ->
            {auto c : Ref Ctxt Defs} ->
-           {auto s : Ref NextMN Int} ->
            Name -> Term vars ->
            Core (CExp vars)
 toCExp : {vars : _} ->
          {auto c : Ref Ctxt Defs} ->
-         {auto s : Ref NextMN Int} ->
          Name -> Term vars ->
          Core (CExp vars)
 
@@ -231,7 +229,6 @@ toCExp n tm
 mutual
   conCases : {vars : _} ->
              {auto c : Ref Ctxt Defs} ->
-             {auto s : Ref NextMN Int} ->
              Name -> List (CaseAlt vars) ->
              Core (List (CConAlt vars))
   conCases n [] = pure []
@@ -260,7 +257,6 @@ mutual
 
   constCases : {vars : _} ->
                {auto c : Ref Ctxt Defs} ->
-               {auto s : Ref NextMN Int} ->
                Name -> List (CaseAlt vars) ->
                Core (List (CConstAlt vars))
   constCases n [] = pure []
@@ -278,7 +274,6 @@ mutual
   -- once.
   getNewType : {vars : _} ->
                {auto c : Ref Ctxt Defs} ->
-               {auto s : Ref NextMN Int} ->
                FC -> CExp vars ->
                Name -> List (CaseAlt vars) ->
                Core (Maybe (CExp vars))
@@ -334,7 +329,6 @@ mutual
 
   getDef : {vars : _} ->
            {auto c : Ref Ctxt Defs} ->
-           {auto s : Ref NextMN Int} ->
            Name -> List (CaseAlt vars) ->
            Core (Maybe (CExp vars))
   getDef n [] = pure Nothing
@@ -346,7 +340,6 @@ mutual
 
   toCExpTree : {vars : _} ->
                {auto c : Ref Ctxt Defs} ->
-               {auto s : Ref NextMN Int} ->
                Name -> CaseTree vars ->
                Core (CExp vars)
   toCExpTree n alts@(Case _ x scTy (DelayCase ty arg sc :: rest))
@@ -360,7 +353,6 @@ mutual
 
   toCExpTree' : {vars : _} ->
                 {auto c : Ref Ctxt Defs} ->
-                {auto s : Ref NextMN Int} ->
                 Name -> CaseTree vars ->
                 Core (CExp vars)
   toCExpTree' n (Case _ x scTy alts@(ConCase _ _ _ _ :: _))

--- a/src/Compiler/LambdaLift.idr
+++ b/src/Compiler/LambdaLift.idr
@@ -619,8 +619,7 @@ lambdaLiftDef doLazyAnnots n (MkError exp)
 -- An empty list an error, because on success you will always get at least
 -- one definition, the lifted definition for the given name.
 export
-lambdaLift :  {auto c : Ref Ctxt Defs}
-           -> (doLazyAnnots : Bool)
+lambdaLift :  (doLazyAnnots : Bool)
            -> (Name,FC,CDef)
            -> Core (List (Name, LiftedDef))
 lambdaLift doLazyAnnots (n,_,def) = lambdaLiftDef doLazyAnnots n def

--- a/src/Compiler/LambdaLift.idr
+++ b/src/Compiler/LambdaLift.idr
@@ -404,6 +404,116 @@ dropped [] _ = []
 dropped (x::xs) (False::us) = x::(dropped xs us)
 dropped (x::xs) (True::us) = dropped xs us
 
+usedVars : {vars : _} ->
+            {auto l : Ref Lifts LDefs} ->
+            Used vars ->
+            Lifted vars ->
+            Used vars
+usedVars used (LLocal {idx} fc prf) =
+  markUsed {prf} idx used
+usedVars used (LAppName fc lazy n args) =
+  foldl (usedVars {vars}) used args
+usedVars used (LUnderApp fc n miss args) =
+  foldl (usedVars {vars}) used args
+usedVars used (LApp fc lazy c arg) =
+  usedVars (usedVars used arg) c
+usedVars used (LLet fc x val sc) =
+  let innerUsed = contractUsed $ usedVars (weakenUsed {outer=[x]} used) sc in
+      usedVars innerUsed val
+usedVars used (LCon fc n ci tag args) =
+  foldl (usedVars {vars}) used args
+usedVars used (LOp fc lazy fn args) =
+  foldl (usedVars {vars}) used args
+usedVars used (LExtPrim fc lazy fn args) =
+  foldl (usedVars {vars}) used args
+usedVars used (LConCase fc sc alts def) =
+    let defUsed = maybe used (usedVars used {vars}) def
+        scDefUsed = usedVars defUsed sc in
+        foldl usedConAlt scDefUsed alts
+  where
+    usedConAlt : {default Nothing lazy : Maybe LazyReason} ->
+                  Used vars -> LiftedConAlt vars -> Used vars
+    usedConAlt used (MkLConAlt n ci tag args sc) =
+      contractUsedMany {remove=args} (usedVars (weakenUsed used) sc)
+
+usedVars used (LConstCase fc sc alts def) =
+    let defUsed = maybe used (usedVars used {vars}) def
+        scDefUsed = usedVars defUsed sc in
+        foldl usedConstAlt scDefUsed alts
+  where
+    usedConstAlt : {default Nothing lazy : Maybe LazyReason} ->
+                    Used vars -> LiftedConstAlt vars -> Used vars
+    usedConstAlt used (MkLConstAlt c sc) = usedVars used sc
+usedVars used (LPrimVal _ _) = used
+usedVars used (LErased _) = used
+usedVars used (LCrash _ _) = used
+
+dropIdx : {vars : _} ->
+          {idx : _} ->
+          (outer : List Name) ->
+          (unused : Vect (length vars) Bool) ->
+          (0 p : IsVar x idx (outer ++ vars)) ->
+          Var (outer ++ (dropped vars unused))
+dropIdx [] (False::_) First = MkVar First
+dropIdx [] (True::_) First = assert_total $
+  idris_crash "INTERNAL ERROR: Referenced variable marked as unused"
+dropIdx [] (False::rest) (Later p) = Var.later $ dropIdx [] rest p
+dropIdx [] (True::rest) (Later p) = dropIdx [] rest p
+dropIdx (_::xs) unused First = MkVar First
+dropIdx (_::xs) unused (Later p) = Var.later $ dropIdx xs unused p
+
+dropUnused : {vars : _} ->
+              {auto _ : Ref Lifts LDefs} ->
+              {outer : List Name} ->
+              (unused : Vect (length vars) Bool) ->
+              (l : Lifted (outer ++ vars)) ->
+              Lifted (outer ++ (dropped vars unused))
+dropUnused _ (LPrimVal fc val) = LPrimVal fc val
+dropUnused _ (LErased fc) = LErased fc
+dropUnused _ (LCrash fc msg) = LCrash fc msg
+dropUnused {outer} unused (LLocal fc p) =
+  let (MkVar p') = dropIdx outer unused p in LLocal fc p'
+dropUnused unused (LCon fc n ci tag args) =
+  let args' = map (dropUnused unused) args in
+      LCon fc n ci tag args'
+dropUnused {outer} unused (LLet fc n val sc) =
+  let val' = dropUnused unused val
+      sc' = dropUnused {outer=n::outer} (unused) sc in
+      LLet fc n val' sc'
+dropUnused unused (LApp fc lazy c arg) =
+  let c' = dropUnused unused c
+      arg' = dropUnused unused arg in
+      LApp fc lazy c' arg'
+dropUnused unused (LOp fc lazy fn args) =
+  let args' = map (dropUnused unused) args in
+      LOp fc lazy fn args'
+dropUnused unused (LExtPrim fc lazy n args) =
+  let args' = map (dropUnused unused) args in
+      LExtPrim fc lazy n args'
+dropUnused unused (LAppName fc lazy n args) =
+  let args' = map (dropUnused unused) args in
+      LAppName fc lazy n args'
+dropUnused unused (LUnderApp fc n miss args) =
+  let args' = map (dropUnused unused) args in
+      LUnderApp fc n miss args'
+dropUnused {vars} {outer} unused (LConCase fc sc alts def) =
+  let alts' = map dropConCase alts in
+      LConCase fc (dropUnused unused sc) alts' (map (dropUnused unused) def)
+  where
+    dropConCase : LiftedConAlt (outer ++ vars) ->
+                  LiftedConAlt (outer ++ (dropped vars unused))
+    dropConCase (MkLConAlt n ci t args sc) =
+      let sc' = (rewrite sym $ appendAssociative args outer vars in sc)
+          droppedSc = dropUnused {vars=vars} {outer=args++outer} unused sc' in
+      MkLConAlt n ci t args (rewrite appendAssociative args outer (dropped vars unused) in droppedSc)
+dropUnused {vars} {outer} unused (LConstCase fc sc alts def) =
+  let alts' = map dropConstCase alts in
+      LConstCase fc (dropUnused unused sc) alts' (map (dropUnused unused) def)
+  where
+    dropConstCase : LiftedConstAlt (outer ++ vars) ->
+                    LiftedConstAlt (outer ++ (dropped vars unused))
+    dropConstCase (MkLConstAlt c val) = MkLConstAlt c (dropUnused unused val)
+
 mutual
   makeLam : {auto l : Ref Lifts LDefs} ->
             {vars : _} ->
@@ -482,116 +592,6 @@ mutual
   liftExp (CPrimVal fc c) = pure $ LPrimVal fc c
   liftExp (CErased fc) = pure $ LErased fc
   liftExp (CCrash fc str) = pure $ LCrash fc str
-
-  usedVars : {vars : _} ->
-             {auto l : Ref Lifts LDefs} ->
-             Used vars ->
-             Lifted vars ->
-             Used vars
-  usedVars used (LLocal {idx} fc prf) =
-    markUsed {prf} idx used
-  usedVars used (LAppName fc lazy n args) =
-    foldl (usedVars {vars}) used args
-  usedVars used (LUnderApp fc n miss args) =
-    foldl (usedVars {vars}) used args
-  usedVars used (LApp fc lazy c arg) =
-    usedVars (usedVars used arg) c
-  usedVars used (LLet fc x val sc) =
-    let innerUsed = contractUsed $ usedVars (weakenUsed {outer=[x]} used) sc in
-        usedVars innerUsed val
-  usedVars used (LCon fc n ci tag args) =
-    foldl (usedVars {vars}) used args
-  usedVars used (LOp fc lazy fn args) =
-    foldl (usedVars {vars}) used args
-  usedVars used (LExtPrim fc lazy fn args) =
-    foldl (usedVars {vars}) used args
-  usedVars used (LConCase fc sc alts def) =
-      let defUsed = maybe used (usedVars used {vars}) def
-          scDefUsed = usedVars defUsed sc in
-          foldl usedConAlt scDefUsed alts
-    where
-      usedConAlt : {default Nothing lazy : Maybe LazyReason} ->
-                   Used vars -> LiftedConAlt vars -> Used vars
-      usedConAlt used (MkLConAlt n ci tag args sc) =
-        contractUsedMany {remove=args} (usedVars (weakenUsed used) sc)
-
-  usedVars used (LConstCase fc sc alts def) =
-      let defUsed = maybe used (usedVars used {vars}) def
-          scDefUsed = usedVars defUsed sc in
-          foldl usedConstAlt scDefUsed alts
-    where
-      usedConstAlt : {default Nothing lazy : Maybe LazyReason} ->
-                     Used vars -> LiftedConstAlt vars -> Used vars
-      usedConstAlt used (MkLConstAlt c sc) = usedVars used sc
-  usedVars used (LPrimVal _ _) = used
-  usedVars used (LErased _) = used
-  usedVars used (LCrash _ _) = used
-
-  dropIdx : {vars : _} ->
-            {idx : _} ->
-            (outer : List Name) ->
-            (unused : Vect (length vars) Bool) ->
-            (0 p : IsVar x idx (outer ++ vars)) ->
-            Var (outer ++ (dropped vars unused))
-  dropIdx [] (False::_) First = MkVar First
-  dropIdx [] (True::_) First = assert_total $
-    idris_crash "INTERNAL ERROR: Referenced variable marked as unused"
-  dropIdx [] (False::rest) (Later p) = Var.later $ dropIdx [] rest p
-  dropIdx [] (True::rest) (Later p) = dropIdx [] rest p
-  dropIdx (_::xs) unused First = MkVar First
-  dropIdx (_::xs) unused (Later p) = Var.later $ dropIdx xs unused p
-
-  dropUnused : {vars : _} ->
-               {auto _ : Ref Lifts LDefs} ->
-               {outer : List Name} ->
-               (unused : Vect (length vars) Bool) ->
-               (l : Lifted (outer ++ vars)) ->
-               Lifted (outer ++ (dropped vars unused))
-  dropUnused _ (LPrimVal fc val) = LPrimVal fc val
-  dropUnused _ (LErased fc) = LErased fc
-  dropUnused _ (LCrash fc msg) = LCrash fc msg
-  dropUnused {outer} unused (LLocal fc p) =
-    let (MkVar p') = dropIdx outer unused p in LLocal fc p'
-  dropUnused unused (LCon fc n ci tag args) =
-    let args' = map (dropUnused unused) args in
-        LCon fc n ci tag args'
-  dropUnused {outer} unused (LLet fc n val sc) =
-    let val' = dropUnused unused val
-        sc' = dropUnused {outer=n::outer} (unused) sc in
-        LLet fc n val' sc'
-  dropUnused unused (LApp fc lazy c arg) =
-    let c' = dropUnused unused c
-        arg' = dropUnused unused arg in
-        LApp fc lazy c' arg'
-  dropUnused unused (LOp fc lazy fn args) =
-    let args' = map (dropUnused unused) args in
-        LOp fc lazy fn args'
-  dropUnused unused (LExtPrim fc lazy n args) =
-    let args' = map (dropUnused unused) args in
-        LExtPrim fc lazy n args'
-  dropUnused unused (LAppName fc lazy n args) =
-    let args' = map (dropUnused unused) args in
-        LAppName fc lazy n args'
-  dropUnused unused (LUnderApp fc n miss args) =
-    let args' = map (dropUnused unused) args in
-        LUnderApp fc n miss args'
-  dropUnused {vars} {outer} unused (LConCase fc sc alts def) =
-    let alts' = map dropConCase alts in
-        LConCase fc (dropUnused unused sc) alts' (map (dropUnused unused) def)
-    where
-      dropConCase : LiftedConAlt (outer ++ vars) ->
-                    LiftedConAlt (outer ++ (dropped vars unused))
-      dropConCase (MkLConAlt n ci t args sc) =
-        let sc' = (rewrite sym $ appendAssociative args outer vars in sc)
-            droppedSc = dropUnused {vars=vars} {outer=args++outer} unused sc' in
-        MkLConAlt n ci t args (rewrite appendAssociative args outer (dropped vars unused) in droppedSc)
-  dropUnused {vars} {outer} unused (LConstCase fc sc alts def) =
-    let alts' = map dropConstCase alts in
-        LConstCase fc (dropUnused unused sc) alts' (map (dropUnused unused) def)
-    where
-      dropConstCase : LiftedConstAlt (outer ++ vars) ->
-                      LiftedConstAlt (outer ++ (dropped vars unused))
-      dropConstCase (MkLConstAlt c val) = MkLConstAlt c (dropUnused unused val)
 
 export
 liftBody : {vars : _} -> {doLazyAnnots : Bool} ->

--- a/src/Compiler/RefC/RefC.idr
+++ b/src/Compiler/RefC/RefC.idr
@@ -900,8 +900,7 @@ createCFunctions n (MkAError exp) = throw $ InternalError "[refc] Error with exp
 -- not really total but this way this internal error does not contaminate everything else
 
 
-header : {auto c : Ref Ctxt Defs}
-      -> {auto f : Ref FunctionDefinitions (List String)}
+header : {auto f : Ref FunctionDefinitions (List String)}
       -> {auto o : Ref OutfileText Output}
       -> {auto il : Ref IndentLevel Nat}
       -> {auto h : Ref HeaderFiles (SortedSet String)}

--- a/src/Core/AutoSearch.idr
+++ b/src/Core/AutoSearch.idr
@@ -442,7 +442,6 @@ searchNames fc rigc defaults trying depth defining topty env ambig (n :: ns) tar
 
 concreteDets : {vars : _} ->
                {auto c : Ref Ctxt Defs} ->
-               {auto u : Ref UST UState} ->
                FC -> Bool ->
                Env Term vars -> (top : ClosedTerm) ->
                (pos : Nat) -> (dets : List Nat) ->
@@ -492,7 +491,6 @@ concreteDets {vars} fc defaults env top pos dets (arg :: args)
 
 checkConcreteDets : {vars : _} ->
                     {auto c : Ref Ctxt Defs} ->
-                    {auto u : Ref UST UState} ->
                     FC -> Bool ->
                     Env Term vars -> (top : ClosedTerm) ->
                     NF vars ->

--- a/src/Core/Case/CaseBuilder.idr
+++ b/src/Core/Case/CaseBuilder.idr
@@ -808,7 +808,6 @@ nextIdxByScore True RunTime xs      =
 -- and matchable type, which is multiplicity > 0.
 -- If so, it's okay to match on it
 sameType : {ns : _} ->
-           {auto i : Ref PName Int} ->
            {auto c : Ref Ctxt Defs} ->
            FC -> Phase -> Name ->
            Env Term ns -> List (NamedPats ns (p :: ps)) ->
@@ -906,7 +905,6 @@ countDiff xs = length (distinct [] (map getFirstCon xs))
             else distinct (p :: acc) ps
 
 getScore : {ns : _} ->
-           {auto i : Ref PName Int} ->
            {auto c : Ref Ctxt Defs} ->
            FC -> Phase -> Name ->
            List (NamedPats ns (p :: ps)) ->
@@ -921,7 +919,6 @@ getScore fc phase name npss
 ||| Pick the leftmost matchable thing with all constructors in the
 ||| same family, or all variables, or all the same type constructor.
 pickNextViable : {p, ns, ps : _} ->
-           {auto i : Ref PName Int} ->
            {auto c : Ref Ctxt Defs} ->
            FC -> Phase -> Name -> List (NamedPats ns (p :: ps)) ->
            Core (n ** NVar n (p :: ps))

--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -898,27 +898,27 @@ filterM p (x :: xs)
          else filterM p xs
 
 export
-newRef : (x : label) -> t -> Core (Ref x t)
+newRef : (0 x : label) -> t -> Core (Ref x t)
 newRef x val
     = do ref <- coreLift (newIORef val)
          pure (MkRef ref)
 
 export %inline
-get : (x : label) -> {auto ref : Ref x a} -> Core a
+get : (0 x : label) -> {auto ref : Ref x a} -> Core a
 get x {ref = MkRef io} = coreLift (readIORef io)
 
 export %inline
-put : (x : label) -> {auto ref : Ref x a} -> a -> Core ()
+put : (0 x : label) -> {auto ref : Ref x a} -> a -> Core ()
 put x {ref = MkRef io} val = coreLift (writeIORef io val)
 
 export %inline
-update : (x : label) -> {auto ref : Ref x a} -> (a -> a) -> Core ()
+update : (0 x : label) -> {auto ref : Ref x a} -> (a -> a) -> Core ()
 update x f
   = do v <- get x
        put x (f v)
 
 export
-wrapRef : (x : label) -> {auto ref : Ref x a} ->
+wrapRef : (0 x : label) -> {auto ref : Ref x a} ->
           (a -> Core ()) ->
           Core b ->
           Core b

--- a/src/Core/Termination/SizeChange.idr
+++ b/src/Core/Termination/SizeChange.idr
@@ -167,8 +167,7 @@ postCompose h ch2 s work f _ ch1
        insert (f, h, ch) work
 
 mutual
-  addGraph : {auto c : Ref Ctxt Defs} ->
-             (f, g : Name) -> Graph {- f g -} ->
+  addGraph : (f, g : Name) -> Graph {- f g -} ->
              WorkList ->
              SCSet ->
              SCSet
@@ -188,8 +187,7 @@ mutual
         -- And then we need to close over all of these new paths too
         transitiveClosure work_post s
 
-  transitiveClosure : {auto c : Ref Ctxt Defs} ->
-                      WorkList ->
+  transitiveClosure : WorkList ->
                       SCSet ->
                       SCSet
   transitiveClosure work s

--- a/src/Core/UnifyState.idr
+++ b/src/Core/UnifyState.idr
@@ -559,7 +559,6 @@ addDelayedHoleName (idx, h) = update UST { delayedHoles $= insert idx h }
 
 export
 checkDelayedHoles : {auto u : Ref UST UState} ->
-                    {auto c : Ref Ctxt Defs} ->
                     Core (Maybe Error)
 checkDelayedHoles
     = do ust <- get UST

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -829,13 +829,7 @@ mutual
            pure $ IRewrite fc rule' rest'
 
   -- Replace all operator by function application
-  desugarTree : {auto s : Ref Syn SyntaxInfo} ->
-                {auto b : Ref Bang BangData} ->
-                {auto c : Ref Ctxt Defs} ->
-                {auto u : Ref UST UState} ->
-                {auto m : Ref MD Metadata} ->
-                {auto o : Ref ROpts REPLOpts} ->
-                Side -> List Name -> Tree (OpStr, Maybe $ OperatorLHSInfo PTerm) PTerm ->
+  desugarTree : Side -> List Name -> Tree (OpStr, Maybe $ OperatorLHSInfo PTerm) PTerm ->
                 Core PTerm
   desugarTree side ps (Infix loc eqFC (OpSymbols $ UN $ Basic "=", _) l r) -- special case since '=' is special syntax
       = pure $ PEq eqFC !(desugarTree side ps l) !(desugarTree side ps r)

--- a/src/Idris/IDEMode/CaseSplit.idr
+++ b/src/Idris/IDEMode/CaseSplit.idr
@@ -146,7 +146,6 @@ updateAll defs l (rs :: rss)
 -- replacements
 getReplaces : {auto c : Ref Ctxt Defs} ->
               {auto s : Ref Syn SyntaxInfo} ->
-              {auto o : Ref ROpts REPLOpts} ->
               List (Name, RawImp) -> Core Updates
 getReplaces updates
     = do strups <- traverse toStrUpdate updates
@@ -154,7 +153,6 @@ getReplaces updates
 
 showImpossible : {auto c : Ref Ctxt Defs} ->
                  {auto s : Ref Syn SyntaxInfo} ->
-                 {auto o : Ref ROpts REPLOpts} ->
                  (indent : Nat) -> RawImp -> Core String
 showImpossible indent lhs
     = do clause <- pterm (map defaultKindedName lhs) -- hack

--- a/src/Idris/IDEMode/REPL.idr
+++ b/src/Idris/IDEMode/REPL.idr
@@ -308,9 +308,6 @@ Cast REPLOpt REPLOption where
 
 
 displayIDEResult : {auto c : Ref Ctxt Defs} ->
-       {auto u : Ref UST UState} ->
-       {auto s : Ref Syn SyntaxInfo} ->
-       {auto m : Ref MD Metadata} ->
        {auto o : Ref ROpts REPLOpts} ->
        File -> Integer -> IDEResult -> Core ()
 displayIDEResult outf i  (REPL $ REPLError err)
@@ -457,9 +454,6 @@ displayIDEResult outf i (REPL Exited) = printIDEResult outf i (AString "")
 
 
 handleIDEResult : {auto c : Ref Ctxt Defs} ->
-       {auto u : Ref UST UState} ->
-       {auto s : Ref Syn SyntaxInfo} ->
-       {auto m : Ref MD Metadata} ->
        {auto o : Ref ROpts REPLOpts} ->
        File -> Integer -> IDEResult -> Core ()
 handleIDEResult outf i (REPL Exited) = idePutStrLn outf i "Bye for now!"

--- a/src/Idris/ModTree.idr
+++ b/src/Idris/ModTree.idr
@@ -310,7 +310,6 @@ buildDeps fname
               errs => pure errs -- Error happened, give up
 
 getAllBuildMods : {auto c : Ref Ctxt Defs} ->
-                  {auto s : Ref Syn SyntaxInfo} ->
                   {auto o : Ref ROpts REPLOpts} ->
                   FC -> (done : List BuildMod) ->
                   (allFiles : List String) ->

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -544,10 +544,7 @@ build pkg opts
          runScript (postbuild pkg)
          pure []
 
-installBuildArtifactFrom : {auto o : Ref ROpts REPLOpts} ->
-              {auto c : Ref Ctxt Defs} ->
-              String ->
-              String -> String -> ModuleIdent -> Core ()
+installBuildArtifactFrom : String -> String -> String -> ModuleIdent -> Core ()
 
 installBuildArtifactFrom file_extension builddir destdir ns
     = do let filename_trunk = ModuleIdent.toPath ns
@@ -606,8 +603,7 @@ installFrom builddir destdir ns = do
       ignore $ coreLift $ copyFile obj dest)
     objPaths
 
-installSrcFrom : {auto c : Ref Ctxt Defs} ->
-                 String -> String -> (ModuleIdent, FileName) -> Core ()
+installSrcFrom : String -> String -> (ModuleIdent, FileName) -> Core ()
 installSrcFrom wdir destdir (ns, srcRelPath)
     = do let srcfile = ModuleIdent.toPath ns
          let srcPath = wdir </> srcRelPath
@@ -853,7 +849,6 @@ foldWithKeysC {a} {b} fk fv = go []
                    nd
 
 clean : {auto c : Ref Ctxt Defs} ->
-        {auto o : Ref ROpts REPLOpts} ->
         PkgDesc ->
         List CLOpt ->
         Core ()

--- a/src/Idris/Pretty.idr
+++ b/src/Idris/Pretty.idr
@@ -443,7 +443,6 @@ render = render colorAnn
 
 export
 renderWithDecorations :
-  {auto c : Ref Ctxt Defs} ->
   {auto o : Ref ROpts REPLOpts} ->
   (ann -> Maybe ann') ->
   Doc ann ->

--- a/src/Idris/ProcessIdr.idr
+++ b/src/Idris/ProcessIdr.idr
@@ -149,7 +149,6 @@ addImport imp
          setNS topNS
 
 readImportMeta : {auto c : Ref Ctxt Defs} ->
-                 {auto u : Ref UST UState} ->
                  Import -> Core (Bool, (Namespace, Int))
 readImportMeta imp
     = do Right ttcFileName <- nsToPath (loc imp) (path imp)
@@ -274,7 +273,6 @@ unchangedHash hashFn ttcFileName sourceFileName
 
 export
 getCG : {auto o : Ref ROpts REPLOpts} ->
-        {auto c : Ref Ctxt Defs} ->
         CG -> Core (Maybe Codegen)
 getCG Chez = pure $ Just codegenChez
 getCG ChezSep = pure $ Just codegenChezSep

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -1241,9 +1241,7 @@ mutual
 
   export
   displayResult : {auto c : Ref Ctxt Defs} ->
-         {auto u : Ref UST UState} ->
          {auto s : Ref Syn SyntaxInfo} ->
-         {auto m : Ref MD Metadata} ->
          {auto o : Ref ROpts REPLOpts} -> REPLResult -> Core ()
   displayResult (REPLError err) = printResult err
   displayResult (Evaluated x Nothing) = printResult $ prettyBy Syntax x
@@ -1316,13 +1314,9 @@ mutual
   ||| assumption that the user has just entered the REPL via CLI arguments that
   ||| they may have used incorrectly.
   export
-  displayStartupErrors : {auto c : Ref Ctxt Defs} ->
-         {auto u : Ref UST UState} ->
-         {auto s : Ref Syn SyntaxInfo} ->
-         {auto m : Ref MD Metadata} ->
-         {auto o : Ref ROpts REPLOpts} -> REPLResult -> Core ()
+  displayStartupErrors : {auto o : Ref ROpts REPLOpts} ->
+                         REPLResult -> Core ()
   displayStartupErrors (ErrorLoadingFile x err) =
     let suggestion = nearMatchOptSuggestion x
-    in
-      printError (fileLoadingError x err suggestion)
+     in printError (fileLoadingError x err suggestion)
   displayStartupErrors _ = pure ()

--- a/src/Idris/REPL/FuzzySearch.idr
+++ b/src/Idris/REPL/FuzzySearch.idr
@@ -23,9 +23,7 @@ import Libraries.Data.WithDefault
 
 export
 fuzzySearch : {auto c : Ref Ctxt Defs}
-           -> {auto u : Ref UST UState}
            -> {auto s : Ref Syn SyntaxInfo}
-           -> {auto m : Ref MD Metadata}
            -> {auto o : Ref ROpts REPLOpts}
            -> PTerm
            -> Core REPLResult

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -267,7 +267,7 @@ dirOption dirs Prefix
 --          Bash Autocompletions
 --------------------------------------------------------------------------------
 
-findIpkg : {auto c : Ref Ctxt Defs} -> Core (List String)
+findIpkg : Core (List String)
 findIpkg =
   do Just srcdir <- coreLift currentDir
        | Nothing => throw (InternalError "Can't get current directory")

--- a/src/TTImp/Elab/Ambiguity.idr
+++ b/src/TTImp/Elab/Ambiguity.idr
@@ -308,7 +308,6 @@ filterCore f (x :: xs)
 
 pruneByType : {vars : _} ->
               {auto c : Ref Ctxt Defs} ->
-              {auto u : Ref UST UState} ->
               Env Term vars -> NF vars -> List RawImp ->
               Core (List RawImp)
 pruneByType env target alts

--- a/src/TTImp/Elab/Check.idr
+++ b/src/TTImp/Elab/Check.idr
@@ -730,7 +730,6 @@ convertWithLazy
         : {vars : _} ->
           {auto c : Ref Ctxt Defs} ->
           {auto u : Ref UST UState} ->
-          {auto e : Ref EST (EState vars)} ->
           (withLazy : Bool) ->
           FC -> ElabInfo -> Env Term vars -> Glued vars -> Glued vars ->
           Core UnifyResult
@@ -775,7 +774,6 @@ export
 convert : {vars : _} ->
           {auto c : Ref Ctxt Defs} ->
           {auto u : Ref UST UState} ->
-          {auto e : Ref EST (EState vars)} ->
           FC -> ElabInfo -> Env Term vars -> Glued vars -> Glued vars ->
           Core UnifyResult
 convert = convertWithLazy False
@@ -789,7 +787,6 @@ export
 checkExp : {vars : _} ->
            {auto c : Ref Ctxt Defs} ->
            {auto u : Ref UST UState} ->
-           {auto e : Ref EST (EState vars)} ->
            RigCount -> ElabInfo -> Env Term vars -> FC ->
            (term : Term vars) ->
            (got : Glued vars) -> (expected : Maybe (Glued vars)) ->

--- a/src/TTImp/Elab/Dot.idr
+++ b/src/TTImp/Elab/Dot.idr
@@ -19,9 +19,7 @@ import TTImp.TTImp
 export
 registerDot : {vars : _} ->
               {auto c : Ref Ctxt Defs} ->
-              {auto m : Ref MD Metadata} ->
               {auto u : Ref UST UState} ->
-              {auto e : Ref EST (EState vars)} ->
               RigCount -> Env Term vars ->
               FC -> DotReason ->
               Term vars -> Glued vars ->

--- a/src/TTImp/Elab/ImplicitBind.idr
+++ b/src/TTImp/Elab/ImplicitBind.idr
@@ -289,8 +289,7 @@ normaliseHolesScope defs env (Bind fc n b sc)
 normaliseHolesScope defs env tm = normaliseHoles defs env tm
 
 export
-bindImplicits : {auto c : Ref Ctxt Defs} ->
-                {vars : _} ->
+bindImplicits : {vars : _} ->
                 FC -> BindMode ->
                 Defs -> Env Term vars ->
                 List (Name, ImplBinding vars) ->

--- a/src/TTImp/Elab/Quote.idr
+++ b/src/TTImp/Elab/Quote.idr
@@ -222,9 +222,7 @@ checkQuote rig elabinfo nest env fc tm exp
 export
 checkQuoteName : {vars : _} ->
                  {auto c : Ref Ctxt Defs} ->
-                 {auto m : Ref MD Metadata} ->
                  {auto u : Ref UST UState} ->
-                 {auto e : Ref EST (EState vars)} ->
                  RigCount -> ElabInfo ->
                  NestedNames vars -> Env Term vars ->
                  FC -> Name -> Maybe (Glued vars) ->

--- a/src/TTImp/Elab/Record.idr
+++ b/src/TTImp/Elab/Record.idr
@@ -202,7 +202,6 @@ export
 recUpdate : {vars : _} ->
             {auto c : Ref Ctxt Defs} ->
             {auto u : Ref UST UState} ->
-            {auto e : Ref EST (EState vars)} ->
             RigCount -> ElabInfo -> FC ->
             NestedNames vars -> Env Term vars ->
             List IFieldUpdate ->

--- a/src/TTImp/Elab/Term.idr
+++ b/src/TTImp/Elab/Term.idr
@@ -279,7 +279,10 @@ checkTerm rig elabinfo nest env (IWithUnambigNames fc ns rhs) exp
 --         {auto m : Ref MD Metadata} ->
 --         {auto u : Ref UST UState} ->
 --         {auto e : Ref EST (EState vars)} ->
---         RigCount -> ElabInfo -> Env Term vars -> RawImp ->
+--         {auto s : Ref Syn SyntaxInfo} ->
+--         {auto o : Ref ROpts REPLOpts} ->
+--         RigCount -> ElabInfo ->
+--         NestedNames vars -> Env Term vars -> RawImp ->
 --         Maybe (Glued vars) ->
 --         Core (Term vars, Glued vars)
 -- If we've just inserted an implicit coercion (in practice, that's either
@@ -311,7 +314,10 @@ onLHS _ = False
 --            {auto m : Ref MD Metadata} ->
 --            {auto u : Ref UST UState} ->
 --            {auto e : Ref EST (EState vars)} ->
---            RigCount -> ElabInfo -> Env Term vars -> RawImp -> Maybe (Glued vars) ->
+--            {auto s : Ref Syn SyntaxInfo} ->
+--            {auto o : Ref ROpts REPLOpts} ->
+--            RigCount -> ElabInfo ->
+--            NestedNames vars -> Env Term vars -> RawImp -> Maybe (Glued vars) ->
 --            Core (Term vars, Glued vars)
 TTImp.Elab.Check.checkImp rigc elabinfo nest env tm exp
     = do res <- checkTerm rigc elabinfo nest env tm exp

--- a/src/TTImp/Interactive/CaseSplit.idr
+++ b/src/TTImp/Interactive/CaseSplit.idr
@@ -313,8 +313,7 @@ combine (Invalid :: xs) acc = combine xs acc
 combine (x :: xs) acc = combine xs (x :: acc)
 
 export
-getSplitsLHS : {auto m : Ref MD Metadata} ->
-               {auto c : Ref Ctxt Defs} ->
+getSplitsLHS : {auto c : Ref Ctxt Defs} ->
                {auto u : Ref UST UState} ->
                {auto s : Ref Syn SyntaxInfo} ->
                {auto o : Ref ROpts REPLOpts} ->

--- a/src/TTImp/Interactive/ExprSearch.idr
+++ b/src/TTImp/Interactive/ExprSearch.idr
@@ -138,7 +138,6 @@ initSearchOpts rec depth
                    Nothing
 
 search : {auto c : Ref Ctxt Defs} ->
-         {auto m : Ref MD Metadata} ->
          {auto u : Ref UST UState} ->
          FC -> RigCount ->
          SearchOpts -> List Name -> ClosedTerm ->
@@ -167,7 +166,6 @@ getAllEnv {vars = v :: vs} {done} fc p (b :: env)
 -- Search recursively, but only if the given name wasn't solved by unification
 searchIfHole : {vars : _} ->
                {auto c : Ref Ctxt Defs} ->
-               {auto m : Ref MD Metadata} ->
                {auto u : Ref UST UState} ->
                FC -> SearchOpts -> List Name -> ClosedTerm ->
                Env Term vars -> ArgInfo vars ->
@@ -274,7 +272,6 @@ mkCandidates fc f ds (((arg, ds') :: next) :: argss)
 -- If there are any remaining holes, search fails.
 searchName : {vars : _} ->
              {auto c : Ref Ctxt Defs} ->
-             {auto m : Ref MD Metadata} ->
              {auto u : Ref UST UState} ->
              FC -> RigCount -> SearchOpts -> List Name ->
              Env Term vars -> NF vars -> ClosedTerm ->
@@ -319,7 +316,6 @@ searchName fc rigc opts hints env target topty (n, ndef)
 
 getSuccessful : {vars : _} ->
                 {auto c : Ref Ctxt Defs} ->
-                {auto m : Ref MD Metadata} ->
                 {auto u : Ref UST UState} ->
                 FC -> RigCount -> SearchOpts -> Bool ->
                 Env Term vars -> Term vars -> ClosedTerm ->
@@ -344,7 +340,6 @@ getSuccessful {vars} fc rig opts mkHole env ty topty all
 
 searchNames : {vars : _} ->
               {auto c : Ref Ctxt Defs} ->
-              {auto m : Ref MD Metadata} ->
               {auto u : Ref UST UState} ->
               FC -> RigCount -> SearchOpts -> List Name -> Env Term vars ->
               Term vars -> ClosedTerm ->
@@ -372,7 +367,6 @@ searchNames fc rig opts hints env ty topty (n :: ns)
 
 tryRecursive : {vars : _} ->
                {auto c : Ref Ctxt Defs} ->
-               {auto m : Ref MD Metadata} ->
                {auto u : Ref UST UState} ->
                FC -> RigCount -> SearchOpts -> List Name ->
                Env Term vars -> Term vars -> ClosedTerm ->
@@ -441,7 +435,6 @@ usableLocal loc _ _ = True
 
 searchLocalWith : {vars : _} ->
                   {auto c : Ref Ctxt Defs} ->
-                  {auto m : Ref MD Metadata} ->
                   {auto u : Ref UST UState} ->
                   FC -> Bool ->
                   RigCount -> SearchOpts -> List Name -> Env Term vars ->
@@ -521,7 +514,6 @@ searchLocalWith {vars} fc nofn rig opts hints env ((p, pty) :: rest) ty topty
 
 searchLocal : {vars : _} ->
               {auto c : Ref Ctxt Defs} ->
-              {auto m : Ref MD Metadata} ->
               {auto u : Ref UST UState} ->
               FC -> RigCount -> SearchOpts -> List Name ->
               Env Term vars -> Term vars -> ClosedTerm ->
@@ -535,7 +527,6 @@ searchLocal fc rig opts hints env ty topty
 
 makeHelper : {vars : _} ->
              {auto c : Ref Ctxt Defs} ->
-             {auto m : Ref MD Metadata} ->
              {auto u : Ref UST UState} ->
              FC -> RigCount -> SearchOpts ->
              Env Term vars ->
@@ -598,7 +589,6 @@ makeHelper fc rig opts env letty targetty ((locapp, ds) :: next)
 
 tryIntermediateWith : {vars : _} ->
                       {auto c : Ref Ctxt Defs} ->
-                      {auto m : Ref MD Metadata} ->
                       {auto u : Ref UST UState} ->
                       FC -> RigCount -> SearchOpts -> List Name ->
                       Env Term vars -> List (Term vars, Term vars) ->
@@ -644,7 +634,6 @@ tryIntermediateWith fc rig opts hints env ((p, pty) :: rest) ty topty
 -- the job
 tryIntermediate : {vars : _} ->
                   {auto c : Ref Ctxt Defs} ->
-                  {auto m : Ref MD Metadata} ->
                   {auto u : Ref UST UState} ->
                   FC -> RigCount -> SearchOpts -> List Name ->
                   Env Term vars -> Term vars -> ClosedTerm ->
@@ -659,7 +648,6 @@ tryIntermediate fc rig opts hints env ty topty
 -- things like dependent pairs and singleton types before proceeding.
 tryIntermediateRec : {vars : _} ->
                      {auto c : Ref Ctxt Defs} ->
-                     {auto m : Ref MD Metadata} ->
                      {auto u : Ref UST UState} ->
                      FC -> RigCount -> SearchOpts -> List Name ->
                      Env Term vars ->
@@ -695,7 +683,6 @@ tryIntermediateRec fc rig opts hints env ty topty (Just rd)
 
 searchType : {vars : _} ->
              {auto c : Ref Ctxt Defs} ->
-             {auto m : Ref MD Metadata} ->
              {auto u : Ref UST UState} ->
              FC -> RigCount -> SearchOpts -> List Name -> Env Term vars ->
              ClosedTerm ->
@@ -768,7 +755,6 @@ searchType fc rig opts hints env topty _ ty
                              ++ tryIntRec)
 
 searchHole : {auto c : Ref Ctxt Defs} ->
-             {auto m : Ref MD Metadata} ->
              {auto u : Ref UST UState} ->
              FC -> RigCount -> SearchOpts -> List Name -> Name ->
              Nat -> ClosedTerm ->

--- a/src/TTImp/Interactive/GenerateDef.idr
+++ b/src/TTImp/Interactive/GenerateDef.idr
@@ -108,8 +108,7 @@ splittableNames (INamedApp _ f _ _)
     = splittableNames f
 splittableNames _ = []
 
-trySplit : {auto m : Ref MD Metadata} ->
-           {auto c : Ref Ctxt Defs} ->
+trySplit : {auto c : Ref Ctxt Defs} ->
            {auto u : Ref UST UState} ->
            {auto s : Ref Syn SyntaxInfo} ->
            {auto o : Ref ROpts REPLOpts} ->

--- a/src/TTImp/Interactive/MakeLemma.idr
+++ b/src/TTImp/Interactive/MakeLemma.idr
@@ -85,8 +85,7 @@ mkApp loc n args
 -- Return a top level type for the lemma, and an expression which applies
 -- the lemma to solve a hole with 'locs' arguments
 export
-makeLemma : {auto m : Ref MD Metadata} ->
-            {auto c : Ref Ctxt Defs} ->
+makeLemma : {auto c : Ref Ctxt Defs} ->
             {auto s : Ref Syn SyntaxInfo} ->
             FC -> Name -> Nat -> ClosedTerm ->
             Core (RawImp, RawImp)

--- a/src/TTImp/Unelab.idr
+++ b/src/TTImp/Unelab.idr
@@ -166,8 +166,7 @@ mutual
                -- TODO: actually grab the fnopts?
                pure $ Just $ ICase fc [] tm (Implicit fc False) pats'
 
-  dropParams : {auto c : Ref Ctxt Defs} ->
-               List (Name, Nat) -> (IRawImp, Glued vars) ->
+  dropParams : List (Name, Nat) -> (IRawImp, Glued vars) ->
                Core (IRawImp, Glued vars)
   dropParams nest (tm, ty)
      = case getFnArgs tm [] of


### PR DESCRIPTION
# Description

1. Removed `showInfo`, which simply returns `False`
2. Non mutual functions moved out of the mutual block in `LambdaLift.idr`
3. Label arguments made erased
4. Removed redundant `Ref` arguments

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

