### PR TITLE
Migrate contrib:Data.Vect.Views.Extra to base:Data.Vect.Views

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -205,6 +205,8 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 
 #### Base
 
+* `Data.Vect.Views.Extra` was moved from `contrib` to `base`.
+
 * `Data.List.Lazy` was moved from `contrib` to `base`.
 
 * Added an `Interpolation` implementation for primitive decimal numeric types and `Nat`.
@@ -286,6 +288,8 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 * Added `System.Concurrency.channelGetWithTimeout` for the chez backend.
 
 #### Contrib
+
+* `Data.Vect.Views.Extra` was moved from `contrib` to `base`.
 
 * `Data.List.Lazy` was moved from `contrib` to `base`.
 

--- a/libs/base/Data/Vect/Views.idr
+++ b/libs/base/Data/Vect/Views.idr
@@ -1,5 +1,5 @@
-||| Additional views for Vect
-module Data.Vect.Views.Extra
+||| Views for Vect
+module Data.Vect.Views
 
 import Control.WellFounded
 import Data.Vect

--- a/libs/base/base.ipkg
+++ b/libs/base/base.ipkg
@@ -98,6 +98,7 @@ modules = Control.App,
           Data.Vect.AtIndex,
           Data.Vect.Elem,
           Data.Vect.Quantifiers,
+          Data.Vect.Views,
           Data.Void,
           Data.Zippable,
 

--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -94,7 +94,6 @@ modules = Control.ANSI,
           Data.Vect.Properties.Fin,
           Data.Vect.Extra,
           Data.Vect.Sort,
-          Data.Vect.Views.Extra,
 
           Debug.Buffer,
 

--- a/tests/idris2/with/with011/WithImplicits.idr
+++ b/tests/idris2/with/with011/WithImplicits.idr
@@ -1,5 +1,5 @@
 import Data.Vect
-import Data.Vect.Views.Extra
+import Data.Vect.Views
 
 mergeSort : Ord a => {n : _} -> Vect n a -> Vect n a
 mergeSort input with (splitRec input)


### PR DESCRIPTION
# Description

Moves `Data.Vect.Views.Extra` to `Data.Vect.Views`.
This mirrors the structure of Data.List.Views, and is consistent with the location mentioned in TDDwI.

## Should this change go in the CHANGELOG?

Yes (Has already been added)
