### PR TITLE
Use single, linear callback in `newSocket`

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -325,6 +325,7 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 #### Network
 
 * Add a missing function parameter (the flag) in the C implementation of `idrnet_recv_bytes`
+* Change linear `newSocket` to use a single action
 
 #### Test
 

--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -325,7 +325,7 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 #### Network
 
 * Add a missing function parameter (the flag) in the C implementation of `idrnet_recv_bytes`
-* Change linear `newSocket` to use a single action
+* Merge callbacks in linear `newSocket` into one single, linear callback
 
 #### Test
 

--- a/libs/network/Control/Linear/Network.idr
+++ b/libs/network/Control/Linear/Network.idr
@@ -3,6 +3,7 @@ module Control.Linear.Network
 -- An experimental linear type based API to sockets
 
 import public Data.Either
+import public Data.Linear.LEither
 import public Data.Maybe
 
 import Control.Linear.LIO
@@ -45,20 +46,16 @@ Next Receive True  = Socket Open
 Next Close   True  = Socket Closed
 Next _       False = Socket Closed
 
-data LEither' : Type -> Type -> Type where
-  Left : a -> LEither' a b
-  Right : b -@ LEither' a b
-
 export
 newSocket : LinearIO io
       => (fam  : SocketFamily)
       -> (ty   : SocketType)
       -> (pnum : ProtocolNumber)
-      -> (1 f : (1 sock : LEither' SocketError (Socket Ready)) -> L io ())
+      -> (1 f : (1 sock : LEither (!* SocketError) (Socket Ready)) -> L io ())
       -> L io ()
 newSocket fam ty pnum f
     = do Right rawsock <- socket fam ty pnum
-               | Left err => f (Left err)
+               | Left err => f (Left $ MkBang err)
          f (Right $ MkSocket rawsock)
 
 export


### PR DESCRIPTION
# Description

I reckon `newSocket` is unnecessarily restrictive. I was unable to use it to create a pair (`LPair`) of sockets, as the closures that produce them aren't themselves linear. To make them linear, I merged them and used `LEither`.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

