### PR TITLE
[new] Support literate Djot files

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -122,6 +122,9 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
   with `_builtin.<TAG>` (eg `_builtin.CONS`). This allows the identity optimisation
   to optimise conversions between list-shaped things.
 
+* [Djot](https://djot.net/) files can now be compiled as CommonMark style
+  Literate Idris files.
+
 ### Backend changes
 
 #### RefC Backend

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -56,6 +56,7 @@ Michael Morgan
 Milan Kral
 Molly Miller
 Mounir Boudia
+Nathan McCarty
 Nick Drozd
 Nicolas Biri
 Niklas Larsson

--- a/docs/source/reference/literate.rst
+++ b/docs/source/reference/literate.rst
@@ -86,7 +86,7 @@ Each of the following markup is recognised regardless of case:
 CommonMark
 **********
 
-We treat files with an extension of ``.md`` and ``.markdown`` as CommonMark style literate files.
+We treat Markdown files with an extension of ``.md`` or ``.markdown`` and Djot files with an extension of ``.dj`` as CommonMark style literate files.
 
 + CommonMark source blocks for idris sans options are recognised as visible code blocks::
 

--- a/src/Parser/Unlit.idr
+++ b/src/Parser/Unlit.idr
@@ -33,7 +33,7 @@ styleCMark : LiterateStyle
 styleCMark = MkLitStyle
               [("```idris", "```"), ("~~~idris", "~~~"), ("<!-- idris", "-->")]
               Nil
-              [".md", ".markdown"]
+              [".md", ".markdown", ".dj"]
 
 export
 styleTeX : LiterateStyle

--- a/tests/idris2/literate/literate020/IEdit.dj
+++ b/tests/idris2/literate/literate020/IEdit.dj
@@ -1,0 +1,29 @@
+```idris
+data Vect : Nat -> Type -> Type where
+     Nil : Vect Z a
+     (::) : a -> Vect k a -> Vect (S k) a
+```
+
+<!-- idris
+%name Vect xs, ys, zs
+-->
+
+```idris
+dupAll : Vect n a -> Vect n (a, a)
+dupAll xs = zipHere xs xs
+  where
+    zipHere : forall n . Vect n a -> Vect n b -> Vect n (a, b)
+```
+
+
+<!-- idris
+
+data Foobar = MkFoo
+
+-->
+
+
+```idris
+showFooBar : Foobar -> String
+showFooBar MkFoo = "MkFoo"
+```

--- a/tests/idris2/literate/literate020/expected
+++ b/tests/idris2/literate/literate020/expected
@@ -1,0 +1,4 @@
+1/1: Building IEdit (IEdit.dj)
+Main>     zipHere [] [] = []
+    zipHere (x :: xs) (y :: ys) = (x, y) :: zipHere xs ys
+Main> Bye for now!

--- a/tests/idris2/literate/literate020/input
+++ b/tests/idris2/literate/literate020/input
@@ -1,0 +1,2 @@
+:gd 15 zipHere
+:q

--- a/tests/idris2/literate/literate020/run
+++ b/tests/idris2/literate/literate020/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+idris2 IEdit.dj < input


### PR DESCRIPTION
[Djot](https://djot.net/) is a markup format that is derived from CommonMark, it's code block syntax is identical to CommonMark's, so we can support it as a CommonMark style literate formate by just adding the file extension.

# Description


## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

