### PR TITLE
[ refactor ] Refactoring types for log topic validation

### DIFF
--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -262,7 +262,7 @@ cCall fc cfn clib args ret collectSafe
                            pure (Just clib)
          argTypes <- traverse (cftySpec fc . snd) args
          retType <- cftySpec fc ret
-         let callConv = if collectSafe then " __collect_safe" else ""
+         let callConv : Builder = if collectSafe then " __collect_safe" else ""
          let call = "((foreign-procedure" ++ callConv ++ " " ++ showB cfn ++ " ("
                       ++ sepBy " " argTypes ++ ") " ++ retType ++ ") "
                       ++ sepBy " " !(traverse buildArg args) ++ ")"

--- a/src/Core/Context/Log.idr
+++ b/src/Core/Context/Log.idr
@@ -44,21 +44,18 @@ unverifiedLogging str n = do
 %inline
 export
 logging : {auto c : Ref Ctxt Defs} ->
-          (s : String) -> {auto 0 _ : KnownTopic s} ->
-          Nat -> Core Bool
-logging str n = unverifiedLogging str n
+          LogTopic -> Nat -> Core Bool
+logging s n = unverifiedLogging s.topic n
 
 ||| Log message with a term, translating back to human readable names first.
 export
 logTerm : {vars : _} ->
           {auto c : Ref Ctxt Defs} ->
-          (s : String) ->
-          {auto 0 _ : KnownTopic s} ->
-          Nat -> Lazy String -> Term vars -> Core ()
-logTerm str n msg tm
-    = when !(logging str n)
+          LogTopic -> Nat -> Lazy String -> Term vars -> Core ()
+logTerm s n msg tm
+    = when !(logging s n)
         $ do tm' <- toFullNames tm
-             logString str n $ msg ++ ": " ++ show tm'
+             logString s.topic n $ msg ++ ": " ++ show tm'
 
 export
 log' : {auto c : Ref Ctxt Defs} ->
@@ -77,17 +74,14 @@ log' lvl msg
 ||| `do` before `pure` in this case ensures the correct bounds.
 export
 log : {auto c : Ref Ctxt Defs} ->
-      (s : String) ->
-      {auto 0 _ : KnownTopic s} ->
-      Nat -> Lazy String -> Core ()
-log str n msg
-    = when !(logging str n)
-        $ logString str n msg
+      LogTopic -> Nat -> Lazy String -> Core ()
+log s n msg
+    = when !(logging s n)
+        $ logString s.topic n msg
 
 export
 unverifiedLogC : {auto c : Ref Ctxt Defs} ->
-                 (s : String) ->
-                 Nat -> Core String -> Core ()
+                 String -> Nat -> Core String -> Core ()
 unverifiedLogC str n cmsg
     = when !(unverifiedLogging str n)
         $ do msg <- cmsg
@@ -96,10 +90,8 @@ unverifiedLogC str n cmsg
 %inline
 export
 logC : {auto c : Ref Ctxt Defs} ->
-       (s : String) ->
-       {auto 0 _ : KnownTopic s} ->
-       Nat -> Core String -> Core ()
-logC str = unverifiedLogC str
+       LogTopic -> Nat -> Core String -> Core ()
+logC s = unverifiedLogC s.topic
 
 nano : Integer
 nano = 1000000000

--- a/src/Core/Normalise.idr
+++ b/src/Core/Normalise.idr
@@ -167,75 +167,68 @@ getArity defs env tm = getValArity defs env !(nf defs env tm)
 export
 logNF : {vars : _} ->
         {auto c : Ref Ctxt Defs} ->
-        (s : String) ->
-        {auto 0 _ : KnownTopic s} ->
-        Nat -> Lazy String -> Env Term vars -> NF vars -> Core ()
-logNF str n msg env tmnf
-    = when !(logging str n) $
+        LogTopic -> Nat -> Lazy String -> Env Term vars -> NF vars -> Core ()
+logNF s n msg env tmnf
+    = when !(logging s n) $
         do defs <- get Ctxt
            tm <- quote defs env tmnf
            tm' <- toFullNames tm
-           logString str n (msg ++ ": " ++ show tm')
+           logString s.topic n (msg ++ ": " ++ show tm')
 
 -- Log message with a term, reducing holes and translating back to human
 -- readable names first
 export
 logTermNF' : {vars : _} ->
              {auto c : Ref Ctxt Defs} ->
-             (s : String) ->
-             {auto 0 _ : KnownTopic s} ->
+             LogTopic ->
              Nat -> Lazy String -> Env Term vars -> Term vars -> Core ()
-logTermNF' str n msg env tm
+logTermNF' s n msg env tm
     = do defs <- get Ctxt
          tmnf <- normaliseHoles defs env tm
          tm' <- toFullNames tmnf
-         logString str n (msg ++ ": " ++ show tm')
+         logString s.topic n (msg ++ ": " ++ show tm')
 
 export
 logTermNF : {vars : _} ->
             {auto c : Ref Ctxt Defs} ->
-            (s : String) ->
-            {auto 0 _ : KnownTopic s} ->
+            LogTopic ->
             Nat -> Lazy String -> Env Term vars -> Term vars -> Core ()
-logTermNF str n msg env tm
-    = when !(logging str n) $ logTermNF' str n msg env tm
+logTermNF s n msg env tm
+    = when !(logging s n) $ logTermNF' s n msg env tm
 
 export
 logGlue : {vars : _} ->
           {auto c : Ref Ctxt Defs} ->
-          (s : String) ->
-          {auto 0 _ : KnownTopic s} ->
+          LogTopic ->
           Nat -> Lazy String -> Env Term vars -> Glued vars -> Core ()
-logGlue str n msg env gtm
-    = when !(logging str n) $
+logGlue s n msg env gtm
+    = when !(logging s n) $
         do defs <- get Ctxt
            tm <- getTerm gtm
            tm' <- toFullNames tm
-           logString str n (msg ++ ": " ++ show tm')
+           logString s.topic n (msg ++ ": " ++ show tm')
 
 export
 logGlueNF : {vars : _} ->
             {auto c : Ref Ctxt Defs} ->
-            (s : String) ->
-            {auto 0 _ : KnownTopic s} ->
+            LogTopic ->
             Nat -> Lazy String -> Env Term vars -> Glued vars -> Core ()
-logGlueNF str n msg env gtm
-    = when !(logging str n) $
+logGlueNF s n msg env gtm
+    = when !(logging s n) $
         do defs <- get Ctxt
            tm <- getTerm gtm
            tmnf <- normaliseHoles defs env tm
            tm' <- toFullNames tmnf
-           logString str n (msg ++ ": " ++ show tm')
+           logString s.topic n (msg ++ ": " ++ show tm')
 
 export
 logEnv : {vars : _} ->
          {auto c : Ref Ctxt Defs} ->
-         (s : String) ->
-         {auto 0 _ : KnownTopic s} ->
+         LogTopic ->
          Nat -> String -> Env Term vars -> Core ()
-logEnv str n msg env
-    = when !(logging str n) $
-        do logString str n msg
+logEnv s n msg env
+    = when !(logging s n) $
+        do logString s.topic n msg
            dumpEnv env
 
   where
@@ -243,11 +236,11 @@ logEnv str n msg env
     dumpEnv : {vs : List Name} -> Env Term vs -> Core ()
     dumpEnv [] = pure ()
     dumpEnv {vs = x :: _} (Let _ c val ty :: bs)
-        = do logTermNF' str n (msg ++ ": let " ++ show x) bs val
-             logTermNF' str n (msg ++ ":" ++ show c ++ " " ++ show x) bs ty
+        = do logTermNF' s n (msg ++ ": let " ++ show x) bs val
+             logTermNF' s n (msg ++ ":" ++ show c ++ " " ++ show x) bs ty
              dumpEnv bs
     dumpEnv {vs = x :: _} (b :: bs)
-        = do logTermNF' str n (msg ++ ":" ++ show (multiplicity b) ++ " " ++
+        = do logTermNF' s n (msg ++ ":" ++ show (multiplicity b) ++ " " ++
                            show (piInfo b) ++ " " ++
                            show x) bs (binderType b)
              dumpEnv bs

--- a/src/Core/Options/Log.idr
+++ b/src/Core/Options/Log.idr
@@ -214,6 +214,16 @@ public export
 KnownTopic : String -> Type
 KnownTopic s = IsJust (lookup s knownTopics)
 
+public export
+record LogTopic where
+  constructor MkLogTopic
+  topic : String
+  {auto 0 known : KnownTopic topic}
+
+export
+fromString : (s : String) -> (0 _ : KnownTopic s) => LogTopic
+fromString = MkLogTopic
+
 ||| An individual log level is a pair of a list of non-empty strings and a number.
 ||| We keep the representation opaque to force users to call the smart constructor
 export
@@ -244,8 +254,8 @@ mkUnverifiedLogLevel ps = mkLogLevel' (Just (split (== '.') ps))
 ||| Like `mkUnverifiedLogLevel` but with a compile time check that
 ||| the passed string is a known topic.
 export
-mkLogLevel : (s : String) -> {auto 0 _ : KnownTopic s} -> Nat -> LogLevel
-mkLogLevel s = mkUnverifiedLogLevel s
+mkLogLevel : LogTopic -> Nat -> LogLevel
+mkLogLevel s = mkUnverifiedLogLevel s.topic
 
 ||| The unsafe constructor should only be used in places where the topic has already
 ||| been appropriately processed.

--- a/src/Core/Options/Log.idr
+++ b/src/Core/Options/Log.idr
@@ -211,8 +211,8 @@ helpTopics = show $ vcat $ map helpTopic knownTopics
       in vcat (title :: blurb)
 
 public export
-KnownTopic : String -> Type
-KnownTopic s = IsJust (lookup s knownTopics)
+data KnownTopic : String -> Type where
+  IsKnownTopic : IsJust (lookup s Log.knownTopics) => KnownTopic s
 
 public export
 record LogTopic where

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -1004,9 +1004,5 @@ getFn f = f
 -- Log message with a RawImp
 export
 logRaw : {auto c : Ref Ctxt Defs} ->
-         (s : String) ->
-         {auto 0 _ : KnownTopic s} ->
-         Nat -> Lazy String -> RawImp -> Core ()
-logRaw str n msg tm
-    = when !(logging str n) $
-        do logString str n (msg ++ ": " ++ show tm)
+         LogTopic -> Nat -> Lazy String -> RawImp -> Core ()
+logRaw s n msg tm = log s n $ msg ++ ": " ++ show tm


### PR DESCRIPTION
# Description

1. Added `LogTopic` type to avoid passing `KnownTopic` separately
2. `KnownTopic` made data to improve error output.
    Before: `Can't find an implementation for IsJust Nothing`.
    After: `Can't find an implementation for KnownTopic "invalid.topic"`.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

