### PR TITLE
[ ci ] add 45 minute timeout to jobs running tests

### DIFF
--- a/.github/workflows/ci-idris2-and-libs.yml
+++ b/.github/workflows/ci-idris2-and-libs.yml
@@ -197,6 +197,7 @@ jobs:
   windows-bootstrap-chez:
     needs: [initialise, quick-check]
     runs-on: windows-latest
+    timeout-minutes: 45
     if: |
       !contains(needs.initialise.outputs.commit_message, '[ci:')
       || contains(needs.initialise.outputs.commit_message, '[ci: windows]')
@@ -301,6 +302,7 @@ jobs:
   ubuntu-self-host-chez:
     needs: ubuntu-bootstrap-chez
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     env:
       IDRIS2_CG: chez
       SCHEME: scheme
@@ -326,6 +328,7 @@ jobs:
   macos-self-host-chez:
     needs: macos-bootstrap-chez
     runs-on: macos-latest
+    timeout-minutes: 45
     env:
       SCHEME: chez
     steps:
@@ -381,6 +384,7 @@ jobs:
   ubuntu-self-host-previous-version:
     needs: [initialise, quick-check]
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     if: |
       !contains(needs.initialise.outputs.commit_message, '[ci:')
       || contains(needs.initialise.outputs.commit_message, '[ci: ubuntu]')


### PR DESCRIPTION
# Description

We're having some CI runs freezing up during tests and being killed after five hours. This has occurred a few times in `macos-self-host-chez` and in `windows-bootstrap-chez`.  I don't have a root cause, but suspect a bug in chez or possibly the test runner is causing a deadlock. I see that there is some history of deadlocks on these platforms in the chez bug tracker.

As a workaround, I've added a 45 minute timeout to the jobs that run tests. The typically run in about half that time.  They will still fail when there is a deadlock, but will fail in 45 minutes instead of 5 hours.
