### PR TITLE
Make `unrestricted` linear in the `(!*)`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ idris2docs_venv
 .\#*
 # VS Code
 .vscode/*
+# JetBrains IDEs
+.idea/
 
 # macOS
 .DS_Store

--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -292,6 +292,8 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 
 * Added `System.Concurrency.getThreadId` for the chez backend.
 
+* `unrestricted`, for unpacking a `!* a`, now uses its argument once
+
 #### Contrib
 
 * `Data.Vect.Views.Extra` was moved from `contrib` to `base`.

--- a/libs/linear/Data/Linear/Notation.idr
+++ b/libs/linear/Data/Linear/Notation.idr
@@ -21,6 +21,10 @@ public export
 export prefix 5 !*
 ||| Prefix notation for the linear unrestricted modality
 public export
-record (!*) (a : Type) where
-  constructor MkBang
-  unrestricted : a
+data (!*) : Type -> Type where
+  MkBang : (unrestricted : a) -> MkBang a
+
+||| Unpack an unrestricted value in a linear context
+public export
+unrestricted : !* a -@ a
+unrestricted (MkBang unr) = unr

--- a/libs/linear/Data/Linear/Notation.idr
+++ b/libs/linear/Data/Linear/Notation.idr
@@ -28,3 +28,10 @@ data (!*) : Type -> Type where
 public export
 unrestricted : !* a -@ a
 unrestricted (MkBang unr) = unr
+
+||| Unpack an unrestricted value in a linear context
+|||
+||| A postfix alias for function unrestricted.
+public export
+(.unrestricted) : !* a -@ a
+(.unrestricted) = unrestricted

--- a/libs/linear/Data/Linear/Notation.idr
+++ b/libs/linear/Data/Linear/Notation.idr
@@ -22,7 +22,7 @@ export prefix 5 !*
 ||| Prefix notation for the linear unrestricted modality
 public export
 data (!*) : Type -> Type where
-  MkBang : (unrestricted : a) -> MkBang a
+  MkBang : a -> !* a
 
 ||| Unpack an unrestricted value in a linear context
 public export


### PR DESCRIPTION
# Description

It seems only natural for `unrestricted` to be linear in  `(!*)` .

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

