### PR TITLE
[ ci ] Add 45 minute timeout to `nix-bootstrap-chez`

### DIFF
--- a/.github/workflows/ci-idris2-and-libs.yml
+++ b/.github/workflows/ci-idris2-and-libs.yml
@@ -249,6 +249,7 @@ jobs:
   nix-bootstrap-chez:
     needs: [initialise, quick-check]
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     if: |
       (!contains(needs.initialise.outputs.commit_message, '[ci:')
       || contains(needs.initialise.outputs.commit_message, '[ci: nix]')


### PR DESCRIPTION
# Description

PR #3504 missed the `nix-bootstrap-chez` that runs the tests

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

