### PR TITLE
[ fix ] Search do not use hints with erased types

### DIFF
--- a/src/Core/AutoSearch.idr
+++ b/src/Core/AutoSearch.idr
@@ -391,6 +391,9 @@ searchName fc rigc defaults trying depth def top env target (n, ndef)
             throw (CantSolveGoal fc (gamma defs) [] top Nothing)
 
          let ty = type ndef
+         when (isErased ty) $
+            throw (CantSolveGoal fc (gamma defs) [] top Nothing)
+
          let namety : NameType
                  = case definition ndef of
                         DCon tag arity _ => DataCon tag arity

--- a/src/Core/TT/Term.idr
+++ b/src/Core/TT/Term.idr
@@ -116,8 +116,7 @@ data Term : Scoped where
      TDelay : FC -> LazyReason -> (ty : Term vars) -> (arg : Term vars) -> Term vars
      TForce : FC -> LazyReason -> Term vars -> Term vars
      PrimVal : FC -> (c : Constant) -> Term vars
-     Erased : FC -> WhyErased (Term vars) -> -- True == impossible term, for coverage checker
-              Term vars
+     Erased : FC -> WhyErased (Term vars) -> Term vars
      TType : FC -> Name -> -- universe variable
              Term vars
 

--- a/src/Core/TTC.idr
+++ b/src/Core/TTC.idr
@@ -1117,7 +1117,7 @@ TTC GlobalDef where
            toBuf b (fullname gdef)
            toBuf b (map NameMap.toList (refersToM gdef))
            toBuf b (definition gdef)
-           when (isUserName (fullname gdef) || cwName (fullname gdef)) $
+           when (isUserName (fullname gdef)) $
               do toBuf b (type gdef)
                  toBuf b (eraseArgs gdef)
                  toBuf b (safeErase gdef)
@@ -1131,11 +1131,7 @@ TTC GlobalDef where
                  toBuf b (invertible gdef)
                  toBuf b (noCycles gdef)
                  toBuf b (sizeChange gdef)
-    where
-      cwName : Name -> Bool
-      cwName (CaseBlock _ _) = True
-      cwName (WithBlock _ _) = True
-      cwName _ = False
+
   fromBuf b
       = do cdef <- fromBuf b
            refsRList <- fromBuf b

--- a/tests/idris2/data/record023/Broken.idr
+++ b/tests/idris2/data/record023/Broken.idr
@@ -1,0 +1,9 @@
+module Broken
+
+export
+record VoidContainer where
+  theVoid : Void
+
+export
+getVoid : (p : VoidContainer) -> Void
+getVoid = theVoid

--- a/tests/idris2/data/record023/Main.idr
+++ b/tests/idris2/data/record023/Main.idr
@@ -1,0 +1,8 @@
+module Main
+
+import Broken
+
+%default total
+
+void : Void
+void = getVoid %search

--- a/tests/idris2/data/record023/expected
+++ b/tests/idris2/data/record023/expected
@@ -1,0 +1,12 @@
+1/2: Building Broken (Broken.idr)
+2/2: Building Main (Main.idr)
+Error: While processing right hand side of void. Can't find an implementation for VoidContainer.
+
+Main:8:16--8:23
+ 4 | 
+ 5 | %default total
+ 6 | 
+ 7 | void : Void
+ 8 | void = getVoid %search
+                    ^^^^^^^
+

--- a/tests/idris2/data/record023/run
+++ b/tests/idris2/data/record023/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check Main.idr

--- a/tests/idris2/reflection/reflection035/Broken.idr
+++ b/tests/idris2/reflection/reflection035/Broken.idr
@@ -1,0 +1,19 @@
+module Broken
+
+import Language.Reflection
+
+%default total
+
+%language ElabReflection
+
+decls : List Decl
+decls =
+  let con = MN "MkVoidContainer" 0
+   in [ IData EmptyFC (SpecifiedValue Export) Nothing $
+              MkData EmptyFC `{ VoidContainer } (Just `( Type )) []
+                     [ MkTy EmptyFC (NoFC con) `( Void -> VoidContainer ) ] ]
+
+%runElab declare decls
+
+export
+Uninhabited VoidContainer

--- a/tests/idris2/reflection/reflection035/Main.idr
+++ b/tests/idris2/reflection/reflection035/Main.idr
@@ -1,0 +1,11 @@
+module Main
+
+import Broken
+
+%default total
+
+broken : VoidContainer
+broken = %search
+
+void : Void
+void = uninhabited broken

--- a/tests/idris2/reflection/reflection035/expected
+++ b/tests/idris2/reflection/reflection035/expected
@@ -1,0 +1,12 @@
+1/2: Building Broken (Broken.idr)
+2/2: Building Main (Main.idr)
+Error: While processing right hand side of broken. Can't find an implementation for VoidContainer.
+
+Main:8:10--8:17
+ 4 | 
+ 5 | %default total
+ 6 | 
+ 7 | broken : VoidContainer
+ 8 | broken = %search
+              ^^^^^^^
+

--- a/tests/idris2/reflection/reflection035/run
+++ b/tests/idris2/reflection/reflection035/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check Main.idr


### PR DESCRIPTION
# Description

Issue #3532 provides a proof of false where `%search` finds a hint with erased types. I think we shouldn't use such hints, because we don't know the list of their arguments, and this can lead to errors.

Note that this PR does not fix [the main bug](https://github.com/idris-lang/Idris2/issues/3532#issuecomment-2801687000). It can still be [reproduced using the elaborator script](https://github.com/idris-lang/Idris2/issues/3532#issuecomment-2809461400).

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

