### PR TITLE
[ fix ] Process `PiInfo` in `convert` and `unify`

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -87,6 +87,8 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 
 * Elaborator scripts were made to be able to get pretty-printed resugared expressions.
 
+* Fixed unification and conversion of binders with different `PiInfo`.
+
 ### Compiler changes
 
 * The compiler now differentiates between "package search path" and "package

--- a/src/Core/Normalise/Convert.idr
+++ b/src/Core/Normalise/Convert.idr
@@ -319,6 +319,16 @@ mutual
           else pure False
   chkConvHead q i defs env _ _ = pure False
 
+  convPiInfo : {auto c : Ref Ctxt Defs} ->
+               {vars : _} ->
+               Ref QVar Int -> Bool -> Defs -> Env Term vars ->
+               PiInfo (Closure vars) -> PiInfo (Closure vars) -> Core Bool
+  convPiInfo q i defs env Implicit Implicit = pure True
+  convPiInfo q i defs env Explicit Explicit = pure True
+  convPiInfo q i defs env AutoImplicit AutoImplicit = pure True
+  convPiInfo q i defs env (DefImplicit x) (DefImplicit y) = convGen q i defs env x y
+  convPiInfo q i defs env _ _ = pure False
+
   convBinders : {auto c : Ref Ctxt Defs} ->
                 {vars : _} ->
                 Ref QVar Int -> Bool -> Defs -> Env Term vars ->
@@ -326,11 +336,13 @@ mutual
   convBinders q i defs env (Pi _ cx ix tx) (Pi _ cy iy ty)
       = if cx /= cy
            then pure False
-           else convGen q i defs env tx ty
+           else pure $ !(convPiInfo q i defs env ix iy)
+                    && !(convGen q i defs env tx ty)
   convBinders q i defs env (Lam _ cx ix tx) (Lam _ cy iy ty)
       = if cx /= cy
            then pure False
-           else convGen q i defs env tx ty
+           else pure $ !(convPiInfo q i defs env ix iy)
+                    && !(convGen q i defs env tx ty)
   convBinders q i defs env bx by = pure False
 
 

--- a/src/Core/Normalise/Convert.idr
+++ b/src/Core/Normalise/Convert.idr
@@ -333,18 +333,16 @@ mutual
                 {vars : _} ->
                 Ref QVar Int -> Bool -> Defs -> Env Term vars ->
                 Binder (Closure vars) -> Binder (Closure vars) -> Core Bool
-  convBinders q i defs env (Pi _ cx ix tx) (Pi _ cy iy ty)
-      = if cx /= cy
-           then pure False
-           else pure $ !(convPiInfo q i defs env ix iy)
-                    && !(convGen q i defs env tx ty)
-  convBinders q i defs env (Lam _ cx ix tx) (Lam _ cy iy ty)
-      = if cx /= cy
-           then pure False
-           else pure $ !(convPiInfo q i defs env ix iy)
-                    && !(convGen q i defs env tx ty)
-  convBinders q i defs env bx by = pure False
-
+  convBinders q i defs env bx by
+    = if sameBinders bx by && multiplicity bx == multiplicity by
+         then allM id [ convPiInfo q i defs env (piInfo bx) (piInfo by)
+                      , convGen q i defs env (binderType bx) (binderType by)]
+         else pure False
+    where
+      sameBinders : Binder (Closure vars) -> Binder (Closure vars) -> Bool
+      sameBinders (Pi {}) (Pi {}) = True
+      sameBinders (Lam {}) (Lam {}) = True
+      sameBinders _ _ = False
 
   export
   Convert NF where

--- a/src/Core/Normalise/Convert.idr
+++ b/src/Core/Normalise/Convert.idr
@@ -331,10 +331,7 @@ mutual
       = if cx /= cy
            then pure False
            else convGen q i defs env tx ty
-  convBinders q i defs env bx by
-      = if multiplicity bx /= multiplicity by
-           then pure False
-           else convGen q i defs env (binderType bx) (binderType by)
+  convBinders q i defs env bx by = pure False
 
 
   export

--- a/src/TTImp/ProcessData.idr
+++ b/src/TTImp/ProcessData.idr
@@ -506,7 +506,7 @@ processData {vars} eopts nest env fc def_vis mbtot (MkImpData dfc n_in mty_raw o
                                if ok then pure (mw, vis, tot, fullty)
                                      else do logTermNF "declare.data" 1 "Previous" [] (type ndef)
                                              logTermNF "declare.data" 1 "Now" [] fullty
-                                             throw (AlreadyDefined fc n)
+                                             throw (CantConvert fc (gamma defs) [] (type ndef) fullty)
                       _ => throw (AlreadyDefined fc n)
 
          logTermNF "declare.data" 5 ("data " ++ show n) [] fullty

--- a/tests/idris2/basic/basic073/DefaultHole.idr
+++ b/tests/idris2/basic/basic073/DefaultHole.idr
@@ -1,0 +1,8 @@
+foo : (Nat -> {default 42 _ : Nat} -> Nat) -> Nat
+foo f = f 0
+
+bar : Nat
+bar = foo baz
+  where
+  baz : Nat -> {default ? y : Nat} -> Nat
+  baz x = x + y

--- a/tests/idris2/basic/basic073/expected
+++ b/tests/idris2/basic/basic073/expected
@@ -1,0 +1,1 @@
+1/1: Building DefaultHole (DefaultHole.idr)

--- a/tests/idris2/basic/basic073/run
+++ b/tests/idris2/basic/basic073/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check DefaultHole.idr

--- a/tests/idris2/data/data006/ConvertPiInfo.idr
+++ b/tests/idris2/data/data006/ConvertPiInfo.idr
@@ -1,0 +1,51 @@
+--------------
+-- Explicit --
+--------------
+
+data EI : Type -> Type
+data EI : {_ : Type} -> Type where
+
+data EA : Type -> Type
+data EA : {auto _ : Type} -> Type where
+
+data ED : Type -> Type
+data ED : {default Int _ : Type} -> Type where
+
+--------------
+-- Implicit --
+--------------
+
+data IE : {_ : Type} -> Type
+data IE : Type -> Type where
+
+data IA : {_ : Type} -> Type
+data IA : {auto _ : Type} -> Type where
+
+data ID : {_ : Type} -> Type
+data ID : {default Int _ : Type} -> Type where
+
+----------
+-- Auto --
+----------
+
+data AE : {auto _ : Type} -> Type
+data AE : Type -> Type where
+
+data AI : {auto _ : Type} -> Type
+data AI : {_ : Type} -> Type where
+
+data AD : {auto _ : Type} -> Type
+data AD : {default Int _ : Type} -> Type where
+
+-------------
+-- Default --
+-------------
+
+data DE : {default Int _ : Type} -> Type
+data DE : Type -> Type where
+
+data DI : {default Int _ : Type} -> Type
+data DI : {_ : Type} -> Type where
+
+data DA : {default Int _ : Type} -> Type
+data DA : {auto _ : Type} -> Type where

--- a/tests/idris2/data/data006/expected
+++ b/tests/idris2/data/data006/expected
@@ -1,0 +1,121 @@
+1/1: Building ConvertPiInfo (ConvertPiInfo.idr)
+Error: Main.EI is already defined.
+
+ConvertPiInfo:6:1--6:35
+ 2 | -- Explicit --
+ 3 | --------------
+ 4 | 
+ 5 | data EI : Type -> Type
+ 6 | data EI : {_ : Type} -> Type where
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Error: Main.EA is already defined.
+
+ConvertPiInfo:9:1--9:40
+ 5 | data EI : Type -> Type
+ 6 | data EI : {_ : Type} -> Type where
+ 7 | 
+ 8 | data EA : Type -> Type
+ 9 | data EA : {auto _ : Type} -> Type where
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Error: Main.ED is already defined.
+
+ConvertPiInfo:12:1--12:47
+ 08 | data EA : Type -> Type
+ 09 | data EA : {auto _ : Type} -> Type where
+ 10 | 
+ 11 | data ED : Type -> Type
+ 12 | data ED : {default Int _ : Type} -> Type where
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Error: Main.IE is already defined.
+
+ConvertPiInfo:19:1--19:29
+ 15 | -- Implicit --
+ 16 | --------------
+ 17 | 
+ 18 | data IE : {_ : Type} -> Type
+ 19 | data IE : Type -> Type where
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Error: Main.IA is already defined.
+
+ConvertPiInfo:22:1--22:40
+ 18 | data IE : {_ : Type} -> Type
+ 19 | data IE : Type -> Type where
+ 20 | 
+ 21 | data IA : {_ : Type} -> Type
+ 22 | data IA : {auto _ : Type} -> Type where
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Error: Main.ID is already defined.
+
+ConvertPiInfo:25:1--25:47
+ 21 | data IA : {_ : Type} -> Type
+ 22 | data IA : {auto _ : Type} -> Type where
+ 23 | 
+ 24 | data ID : {_ : Type} -> Type
+ 25 | data ID : {default Int _ : Type} -> Type where
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Error: Main.AE is already defined.
+
+ConvertPiInfo:32:1--32:29
+ 28 | -- Auto --
+ 29 | ----------
+ 30 | 
+ 31 | data AE : {auto _ : Type} -> Type
+ 32 | data AE : Type -> Type where
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Error: Main.AI is already defined.
+
+ConvertPiInfo:35:1--35:35
+ 31 | data AE : {auto _ : Type} -> Type
+ 32 | data AE : Type -> Type where
+ 33 | 
+ 34 | data AI : {auto _ : Type} -> Type
+ 35 | data AI : {_ : Type} -> Type where
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Error: Main.AD is already defined.
+
+ConvertPiInfo:38:1--38:47
+ 34 | data AI : {auto _ : Type} -> Type
+ 35 | data AI : {_ : Type} -> Type where
+ 36 | 
+ 37 | data AD : {auto _ : Type} -> Type
+ 38 | data AD : {default Int _ : Type} -> Type where
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Error: Main.DE is already defined.
+
+ConvertPiInfo:45:1--45:29
+ 41 | -- Default --
+ 42 | -------------
+ 43 | 
+ 44 | data DE : {default Int _ : Type} -> Type
+ 45 | data DE : Type -> Type where
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Error: Main.DI is already defined.
+
+ConvertPiInfo:48:1--48:35
+ 44 | data DE : {default Int _ : Type} -> Type
+ 45 | data DE : Type -> Type where
+ 46 | 
+ 47 | data DI : {default Int _ : Type} -> Type
+ 48 | data DI : {_ : Type} -> Type where
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Error: Main.DA is already defined.
+
+ConvertPiInfo:51:1--51:40
+ 47 | data DI : {default Int _ : Type} -> Type
+ 48 | data DI : {_ : Type} -> Type where
+ 49 | 
+ 50 | data DA : {default Int _ : Type} -> Type
+ 51 | data DA : {auto _ : Type} -> Type where
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+

--- a/tests/idris2/data/data006/expected
+++ b/tests/idris2/data/data006/expected
@@ -1,5 +1,5 @@
 1/1: Building ConvertPiInfo (ConvertPiInfo.idr)
-Error: Main.EI is already defined.
+Error: Mismatch between: Type -> Type and Type.
 
 ConvertPiInfo:6:1--6:35
  2 | -- Explicit --
@@ -9,7 +9,7 @@ ConvertPiInfo:6:1--6:35
  6 | data EI : {_ : Type} -> Type where
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Error: Main.EA is already defined.
+Error: Mismatch between: Type -> Type and Type => Type.
 
 ConvertPiInfo:9:1--9:40
  5 | data EI : Type -> Type
@@ -19,7 +19,7 @@ ConvertPiInfo:9:1--9:40
  9 | data EA : {auto _ : Type} -> Type where
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Error: Main.ED is already defined.
+Error: Mismatch between: Type -> Type and {default Int _ : Type} -> Type.
 
 ConvertPiInfo:12:1--12:47
  08 | data EA : Type -> Type
@@ -29,7 +29,7 @@ ConvertPiInfo:12:1--12:47
  12 | data ED : {default Int _ : Type} -> Type where
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Error: Main.IE is already defined.
+Error: Mismatch between: Type and Type -> Type.
 
 ConvertPiInfo:19:1--19:29
  15 | -- Implicit --
@@ -39,7 +39,7 @@ ConvertPiInfo:19:1--19:29
  19 | data IE : Type -> Type where
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Error: Main.IA is already defined.
+Error: Mismatch between: Type and Type => Type.
 
 ConvertPiInfo:22:1--22:40
  18 | data IE : {_ : Type} -> Type
@@ -49,7 +49,7 @@ ConvertPiInfo:22:1--22:40
  22 | data IA : {auto _ : Type} -> Type where
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Error: Main.ID is already defined.
+Error: Mismatch between: Type and {default Int _ : Type} -> Type.
 
 ConvertPiInfo:25:1--25:47
  21 | data IA : {_ : Type} -> Type
@@ -59,7 +59,7 @@ ConvertPiInfo:25:1--25:47
  25 | data ID : {default Int _ : Type} -> Type where
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Error: Main.AE is already defined.
+Error: Mismatch between: Type => Type and Type -> Type.
 
 ConvertPiInfo:32:1--32:29
  28 | -- Auto --
@@ -69,7 +69,7 @@ ConvertPiInfo:32:1--32:29
  32 | data AE : Type -> Type where
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Error: Main.AI is already defined.
+Error: Mismatch between: Type => Type and Type.
 
 ConvertPiInfo:35:1--35:35
  31 | data AE : {auto _ : Type} -> Type
@@ -79,7 +79,7 @@ ConvertPiInfo:35:1--35:35
  35 | data AI : {_ : Type} -> Type where
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Error: Main.AD is already defined.
+Error: Mismatch between: Type => Type and {default Int _ : Type} -> Type.
 
 ConvertPiInfo:38:1--38:47
  34 | data AI : {auto _ : Type} -> Type
@@ -89,7 +89,7 @@ ConvertPiInfo:38:1--38:47
  38 | data AD : {default Int _ : Type} -> Type where
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Error: Main.DE is already defined.
+Error: Mismatch between: {default Int _ : Type} -> Type and Type -> Type.
 
 ConvertPiInfo:45:1--45:29
  41 | -- Default --
@@ -99,7 +99,7 @@ ConvertPiInfo:45:1--45:29
  45 | data DE : Type -> Type where
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Error: Main.DI is already defined.
+Error: Mismatch between: {default Int _ : Type} -> Type and Type.
 
 ConvertPiInfo:48:1--48:35
  44 | data DE : {default Int _ : Type} -> Type
@@ -109,7 +109,7 @@ ConvertPiInfo:48:1--48:35
  48 | data DI : {_ : Type} -> Type where
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Error: Main.DA is already defined.
+Error: Mismatch between: {default Int _ : Type} -> Type and Type => Type.
 
 ConvertPiInfo:51:1--51:40
  47 | data DI : {default Int _ : Type} -> Type

--- a/tests/idris2/data/data006/run
+++ b/tests/idris2/data/data006/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check ConvertPiInfo.idr

--- a/tests/idris2/error/error033/Examples.idr
+++ b/tests/idris2/error/error033/Examples.idr
@@ -1,0 +1,12 @@
+pls : Int -> {_ : Int} -> Int
+pls = (+)
+
+higherOrder : (Int -> {_ : Int} -> Int) -> ()
+higherOrder _ = ()
+
+foo : ()
+foo = higherOrder (+)
+
+maybePls : Maybe Int -> Maybe Int -> Maybe Int
+maybePls x y = pure {f=Maybe} pls <*> x <*> y
+

--- a/tests/idris2/error/error033/UnifyPiInfo.idr
+++ b/tests/idris2/error/error033/UnifyPiInfo.idr
@@ -1,0 +1,76 @@
+--------------
+-- Explicit --
+--------------
+
+namespace EI
+  f : Type -> Type -> Type
+  g : Type -> {_ : Type} -> Type
+  g = f
+
+namespace EA
+  f : Type -> Type -> Type
+  g : Type -> {auto _ : Type} -> Type
+  g = f
+
+namespace ED
+  f : Type -> Type -> Type
+  g : Type -> {default Int _ : Type} -> Type
+  g = f
+
+--------------
+-- Implicit --
+--------------
+
+namespace IE
+  f : Type -> {_ : Type} -> Type
+  g : Type -> Type -> Type
+  g = f
+
+namespace IA
+  f : Type -> {_ : Type} -> Type
+  g : Type -> {auto _ : Type} -> Type
+  g = f
+
+namespace ID
+  f : Type -> {_ : Type} -> Type
+  g : Type -> {default Int _ : Type} -> Type
+  g = f
+
+----------
+-- Auto --
+----------
+
+namespace AE
+  f : Type -> {auto _ : Type} -> Type
+  g : Type -> Type -> Type
+  g = f
+
+namespace AI
+  f : Type -> {auto _ : Type} -> Type
+  g : Type -> {_ : Type} -> Type
+  g = f
+
+namespace AD
+  f : Type -> {auto _ : Type} -> Type
+  g : Type -> {default Int _ : Type} -> Type
+  g = f
+
+-------------
+-- Default --
+-------------
+
+namespace DE
+  f : Type -> {default Int _ : Type} -> Type
+  g : Type -> Type -> Type
+  g = f
+
+namespace DI
+  f : Type -> {default Int _ : Type} -> Type
+  g : Type -> {_ : Type} -> Type
+  g = f
+
+namespace DA
+  f : Type -> {default Int _ : Type} -> Type
+  g : Type -> {auto _ : Type} -> Type
+  g = f
+

--- a/tests/idris2/error/error033/expected
+++ b/tests/idris2/error/error033/expected
@@ -1,0 +1,213 @@
+1/1: Building UnifyPiInfo (UnifyPiInfo.idr)
+Error: While processing right hand side of g. When unifying:
+    Type -> Type -> Type
+and:
+    Type -> Type
+Mismatch between: Type -> Type and Type.
+
+UnifyPiInfo:8:7--8:8
+ 4 | 
+ 5 | namespace EI
+ 6 |   f : Type -> Type -> Type
+ 7 |   g : Type -> {_ : Type} -> Type
+ 8 |   g = f
+           ^
+
+Error: While processing right hand side of g. When unifying:
+    Type -> Type -> Type
+and:
+    Type -> Type => Type
+Mismatch between: Type -> Type and Type => Type.
+
+UnifyPiInfo:13:7--13:8
+ 09 | 
+ 10 | namespace EA
+ 11 |   f : Type -> Type -> Type
+ 12 |   g : Type -> {auto _ : Type} -> Type
+ 13 |   g = f
+            ^
+
+Error: While processing right hand side of g. When unifying:
+    Type -> Type -> Type
+and:
+    Type -> {default Int _ : Type} -> Type
+Mismatch between: Type -> Type and {default Int _ : Type} -> Type.
+
+UnifyPiInfo:18:7--18:8
+ 14 | 
+ 15 | namespace ED
+ 16 |   f : Type -> Type -> Type
+ 17 |   g : Type -> {default Int _ : Type} -> Type
+ 18 |   g = f
+            ^
+
+Error: While processing right hand side of g. When unifying:
+    Type -> Type
+and:
+    Type -> Type -> Type
+Mismatch between: Type and Type -> Type.
+
+UnifyPiInfo:27:7--27:8
+ 23 | 
+ 24 | namespace IE
+ 25 |   f : Type -> {_ : Type} -> Type
+ 26 |   g : Type -> Type -> Type
+ 27 |   g = f
+            ^
+
+Error: While processing right hand side of g. When unifying:
+    Type -> Type
+and:
+    Type -> Type => Type
+Mismatch between: Type and Type => Type.
+
+UnifyPiInfo:32:7--32:8
+ 28 | 
+ 29 | namespace IA
+ 30 |   f : Type -> {_ : Type} -> Type
+ 31 |   g : Type -> {auto _ : Type} -> Type
+ 32 |   g = f
+            ^
+
+Error: While processing right hand side of g. When unifying:
+    Type -> Type
+and:
+    Type -> {default Int _ : Type} -> Type
+Mismatch between: Type and {default Int _ : Type} -> Type.
+
+UnifyPiInfo:37:7--37:8
+ 33 | 
+ 34 | namespace ID
+ 35 |   f : Type -> {_ : Type} -> Type
+ 36 |   g : Type -> {default Int _ : Type} -> Type
+ 37 |   g = f
+            ^
+
+Error: While processing right hand side of g. When unifying:
+    Type -> Type => Type
+and:
+    Type -> Type -> Type
+Mismatch between: Type => Type and Type -> Type.
+
+UnifyPiInfo:46:7--46:8
+ 42 | 
+ 43 | namespace AE
+ 44 |   f : Type -> {auto _ : Type} -> Type
+ 45 |   g : Type -> Type -> Type
+ 46 |   g = f
+            ^
+
+Error: While processing right hand side of g. When unifying:
+    Type -> Type => Type
+and:
+    Type -> Type
+Mismatch between: Type => Type and Type.
+
+UnifyPiInfo:51:7--51:8
+ 47 | 
+ 48 | namespace AI
+ 49 |   f : Type -> {auto _ : Type} -> Type
+ 50 |   g : Type -> {_ : Type} -> Type
+ 51 |   g = f
+            ^
+
+Error: While processing right hand side of g. When unifying:
+    Type -> Type => Type
+and:
+    Type -> {default Int _ : Type} -> Type
+Mismatch between: Type => Type and {default Int _ : Type} -> Type.
+
+UnifyPiInfo:56:7--56:8
+ 52 | 
+ 53 | namespace AD
+ 54 |   f : Type -> {auto _ : Type} -> Type
+ 55 |   g : Type -> {default Int _ : Type} -> Type
+ 56 |   g = f
+            ^
+
+Error: While processing right hand side of g. When unifying:
+    Type -> {default Int _ : Type} -> Type
+and:
+    Type -> Type -> Type
+Mismatch between: {default Int _ : Type} -> Type and Type -> Type.
+
+UnifyPiInfo:65:7--65:8
+ 61 | 
+ 62 | namespace DE
+ 63 |   f : Type -> {default Int _ : Type} -> Type
+ 64 |   g : Type -> Type -> Type
+ 65 |   g = f
+            ^
+
+Error: While processing right hand side of g. When unifying:
+    Type -> {default Int _ : Type} -> Type
+and:
+    Type -> Type
+Mismatch between: {default Int _ : Type} -> Type and Type.
+
+UnifyPiInfo:70:7--70:8
+ 66 | 
+ 67 | namespace DI
+ 68 |   f : Type -> {default Int _ : Type} -> Type
+ 69 |   g : Type -> {_ : Type} -> Type
+ 70 |   g = f
+            ^
+
+Error: While processing right hand side of g. When unifying:
+    Type -> {default Int _ : Type} -> Type
+and:
+    Type -> Type => Type
+Mismatch between: {default Int _ : Type} -> Type and Type => Type.
+
+UnifyPiInfo:75:7--75:8
+ 71 | 
+ 72 | namespace DA
+ 73 |   f : Type -> {default Int _ : Type} -> Type
+ 74 |   g : Type -> {auto _ : Type} -> Type
+ 75 |   g = f
+            ^
+
+1/1: Building Examples (Examples.idr)
+Error: While processing right hand side of pls. When unifying:
+    Int -> Int -> Int
+and:
+    Int -> Int
+Mismatch between: Int -> Int and Int.
+
+Examples:2:7--2:10
+ 1 | pls : Int -> {_ : Int} -> Int
+ 2 | pls = (+)
+           ^^^
+
+Error: While processing right hand side of foo. When unifying:
+    Int -> Int -> Int
+and:
+    Int -> Int
+Mismatch between: Int -> Int and Int.
+
+Examples:8:19--8:22
+ 4 | higherOrder : (Int -> {_ : Int} -> Int) -> ()
+ 5 | higherOrder _ = ()
+ 6 | 
+ 7 | foo : ()
+ 8 | foo = higherOrder (+)
+                       ^^^
+
+Error: While processing right hand side of maybePls. When unifying:
+    Maybe Int
+and:
+    Maybe Int
+When unifying:
+    Maybe Int
+and:
+    Maybe (Int -> ?b)
+Mismatch between: Int and Int -> ?b.
+
+Examples:11:16--11:46
+ 07 | foo : ()
+ 08 | foo = higherOrder (+)
+ 09 | 
+ 10 | maybePls : Maybe Int -> Maybe Int -> Maybe Int
+ 11 | maybePls x y = pure {f=Maybe} pls <*> x <*> y
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+

--- a/tests/idris2/error/error033/run
+++ b/tests/idris2/error/error033/run
@@ -1,0 +1,4 @@
+. ../../../testutils.sh
+
+check UnifyPiInfo.idr
+check Examples.idr


### PR DESCRIPTION
# Description

Now `convert` and `unify` do not compare `PiInfo`. As a result, the following code compiles successfully:

```idris
data X : Type -> Type

data X : Type => Type where
```

```idris
plus : Int -> {n : Int} -> Int
plus = (+)
```

This PR adds `PiInfo` processing to both functions. Also, due to unification, it allows resolve metavariables in default values (see [DefaultHole.idr](https://github.com/idris-lang/Idris2/pull/3541/files#diff-77829a94397b1b4f0ba98e4da1584596dc448465f9873fdde00fef1dc43b4401)). 

In additional to this, I changed `AlreadyDefined` to `CantConvert` when data is declared and defined with different types.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

