### PR TITLE
Allow `newSocket` to produce a value

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -338,7 +338,8 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 #### Network
 
 * Add a missing function parameter (the flag) in the C implementation of `idrnet_recv_bytes`
-* Merge callbacks in linear `newSocket` into one single, linear callback
+* Merge callbacks in linear `newSocket` into one single, linear callback,
+  and return a generic type from the callback
 
 #### Test
 

--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -339,7 +339,7 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 
 * Add a missing function parameter (the flag) in the C implementation of `idrnet_recv_bytes`
 * Merge callbacks in linear `newSocket` into one single, linear callback,
-  and return a generic type from the callback
+  and allow the callback to produce any value
 
 #### Test
 

--- a/libs/network/Control/Linear/Network.idr
+++ b/libs/network/Control/Linear/Network.idr
@@ -51,8 +51,8 @@ newSocket : LinearIO io
       => (fam  : SocketFamily)
       -> (ty   : SocketType)
       -> (pnum : ProtocolNumber)
-      -> (1 f : (1 sock : LEither (!* SocketError) (Socket Ready)) -> L io ())
-      -> L io ()
+      -> (1 f : (1 sock : LEither (!* SocketError) (Socket Ready)) -> L io a)
+      -> L io a
 newSocket fam ty pnum f
     = do Right rawsock <- socket fam ty pnum
                | Left err => f (Left $ MkBang err)


### PR DESCRIPTION
# Description

It's currently not possible to use a value produced by a socket, outside of `newSocket`. This fixes that.

I think I've got the linearity right - `L io` implies we can't return the `Socket` itself.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

