### PR TITLE
Change List to List1 in ValidatedL doc comment

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -337,6 +337,9 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 * `prim__makeFuture` from `System.Future` is reimplemented as `%foreign` instead of
   using now removed `MakeFuture` primitive
 
+* The documentation for `Data.Validated.ValidatedL` has been corrected to reflect that
+  it uses a `List1` as an error accumulator, not a `List`.
+
 #### Network
 
 * Add a missing function parameter (the flag) in the C implementation of `idrnet_recv_bytes`

--- a/libs/contrib/Data/Validated.idr
+++ b/libs/contrib/Data/Validated.idr
@@ -146,7 +146,7 @@ public export
 
 --- Convenience representations ---
 
-||| Special case of `Validated` with a `List` as an error accumulator.
+||| Special case of `Validated` with a `List1` as an error accumulator.
 public export %inline
 ValidatedL : Type -> Type -> Type
 ValidatedL = Validated . List1


### PR DESCRIPTION
# Description

While I was using ValidatedL, I was confused for a few minutes about why it wouldn't work with a List and why List1 was being pulled in. That is, until I looked at the definition of ValidatedL. Hopefully this saves others a bit of their future time.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

