### PR TITLE
[ refactor ] Make `Binary` argument auto in `TTC`

### DIFF
--- a/src/Compiler/Common.idr
+++ b/src/Compiler/Common.idr
@@ -145,12 +145,12 @@ getMinimalDef : ContextEntry -> Core (GlobalDef, Maybe (Namespace, Binary))
 getMinimalDef (Decoded def) = pure (def, Nothing)
 getMinimalDef (Coded ns bin)
     = do b <- newRef Bin bin
-         cdef <- fromBuf b
-         refsRList <- fromBuf b
+         cdef <- fromBuf
+         refsRList <- fromBuf
          let refsR = map fromList refsRList
-         fc <- fromBuf b
-         mul <- fromBuf b
-         name <- fromBuf b
+         fc <- fromBuf
+         mul <- fromBuf
+         name <- fromBuf
          let def
              = MkGlobalDef fc name (Erased fc Placeholder) [] [] [] [] mul
                            [] (specified Public) (MkTotality Unchecked IsCovering) False

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -194,48 +194,48 @@ writeTTCFile : (HasNames extra, TTC extra) =>
                Ref Bin Binary -> TTCFile extra -> Core ()
 writeTTCFile b file_in
       = do file <- toFullNames file_in
-           toBuf b "TT2"
-           toBuf @{Wasteful} b (version file)
-           toBuf b (totalReq file)
-           toBuf b (sourceHash file)
-           toBuf b (ifaceHash file)
-           toBuf b (importHashes file)
-           toBuf b (incData file)
-           toBuf b (imported file)
-           toBuf b (extraData file)
-           toBuf b (context file)
-           toBuf b (userHoles file)
-           toBuf b (autoHints file)
-           toBuf b (typeHints file)
-           toBuf b (nextVar file)
-           toBuf b (currentNS file)
-           toBuf b (nestedNS file)
-           toBuf b (pairnames file)
-           toBuf b (rewritenames file)
-           toBuf b (primnames file)
-           toBuf b (foreignImpl file)
-           toBuf b (namedirectives file)
-           toBuf b (cgdirectives file)
-           toBuf b (transforms file)
-           toBuf b (foreignExports file)
+           toBuf "TT2"
+           toBuf @{Wasteful} (version file)
+           toBuf (totalReq file)
+           toBuf (sourceHash file)
+           toBuf (ifaceHash file)
+           toBuf (importHashes file)
+           toBuf (incData file)
+           toBuf (imported file)
+           toBuf (extraData file)
+           toBuf (context file)
+           toBuf (userHoles file)
+           toBuf (autoHints file)
+           toBuf (typeHints file)
+           toBuf (nextVar file)
+           toBuf (currentNS file)
+           toBuf (nestedNS file)
+           toBuf (pairnames file)
+           toBuf (rewritenames file)
+           toBuf (primnames file)
+           toBuf (foreignImpl file)
+           toBuf (namedirectives file)
+           toBuf (cgdirectives file)
+           toBuf (transforms file)
+           toBuf (foreignExports file)
 
 readTTCFile : TTC extra =>
               {auto c : Ref Ctxt Defs} ->
               Bool -> String -> Maybe (Namespace) ->
               Ref Bin Binary -> Core (TTCFile extra)
 readTTCFile readall file as b
-      = do hdr <- fromBuf b
+      = do hdr <- fromBuf
            when (hdr /= "TT2") $
              corrupt ("TTC header in " ++ file ++ " " ++ show hdr)
-           ver <- fromBuf @{Wasteful} b
+           ver <- fromBuf @{Wasteful}
            checkTTCVersion file ver ttcVersion
-           totalReq <- fromBuf b
-           sourceFileHash <- fromBuf b
-           ifaceHash <- fromBuf b
-           importHashes <- fromBuf b
-           incData <- fromBuf b
-           imp <- fromBuf b
-           ex <- fromBuf b
+           totalReq <- fromBuf
+           sourceFileHash <- fromBuf
+           ifaceHash <- fromBuf
+           importHashes <- fromBuf
+           incData <- fromBuf
+           imp <- fromBuf
+           ex <- fromBuf
            if not readall
               then pure (MkTTCFile ver totalReq
                                    sourceFileHash ifaceHash importHashes
@@ -245,21 +245,21 @@ readTTCFile readall file as b
                                    (MkPrimNs Nothing Nothing Nothing Nothing Nothing Nothing Nothing)
                                    [] [] [] [] [] ex)
               else do
-                 defs <- fromBuf b
-                 uholes <- fromBuf b
-                 autohs <- fromBuf b
-                 typehs <- fromBuf b
-                 nextv <- fromBuf b
-                 cns <- fromBuf b
-                 nns <- fromBuf b
-                 pns <- fromBuf b
-                 rws <- fromBuf b
-                 prims <- fromBuf b
-                 foreignImpl <- fromBuf b
-                 nds <- fromBuf b
-                 cgds <- fromBuf b
-                 trans <- fromBuf b
-                 fexp <- fromBuf b
+                 defs <- fromBuf
+                 uholes <- fromBuf
+                 autohs <- fromBuf
+                 typehs <- fromBuf
+                 nextv <- fromBuf
+                 cns <- fromBuf
+                 nns <- fromBuf
+                 pns <- fromBuf
+                 rws <- fromBuf
+                 prims <- fromBuf
+                 foreignImpl <- fromBuf
+                 nds <- fromBuf
+                 cgds <- fromBuf
+                 trans <- fromBuf
+                 fexp <- fromBuf
                  pure (MkTTCFile ver totalReq
                                  sourceFileHash ifaceHash importHashes incData
                                  (map (replaceNS cns) defs) uholes
@@ -283,7 +283,7 @@ getSaveDefs modns (n :: ns) acc defs
          case definition gdef of
               Builtin _ => getSaveDefs modns ns acc defs
               _ => do bin <- initBinaryS 16384
-                      toBuf bin (trimNS modns !(full (gamma defs) gdef))
+                      toBuf (trimNS modns !(full (gamma defs) gdef))
                       b <- get Bin
                       getSaveDefs modns ns ((trimName (fullname gdef), b) :: acc) defs
   where
@@ -540,12 +540,12 @@ readFromTTC nestedns loc reexp fname modNS importAs
 export
 getTotalReq : String -> Ref Bin Binary -> Core TotalReq
 getTotalReq file b
-    = do hdr <- fromBuf {a = String} b
+    = do hdr <- fromBuf {a = String}
          when (hdr /= "TT2") $
            corrupt ("TTC header in " ++ file ++ " " ++ show hdr)
-         ver <- fromBuf @{Wasteful} b
+         ver <- fromBuf @{Wasteful}
          checkTTCVersion file ver ttcVersion
-         fromBuf b -- `totalReq`
+         fromBuf -- `totalReq`
 
 -- Implements a portion of @readTTCFile@. The fields must be read in order.
 -- This reads everything up to and including `interfaceHash`.
@@ -553,8 +553,8 @@ export
 getHashes : String -> Ref Bin Binary -> Core (Maybe String, Int)
 getHashes file b
     = do ignore $ getTotalReq file b
-         sourceFileHash <- fromBuf b
-         interfaceHash <- fromBuf b
+         sourceFileHash <- fromBuf
+         interfaceHash <- fromBuf
          pure (sourceFileHash, interfaceHash)
 
 -- Implements a portion of @readTTCFile@. The fields must be read in order.
@@ -563,7 +563,7 @@ getImportHashes : String -> Ref Bin Binary ->
                   Core (List (Namespace, Int))
 getImportHashes file b
     = do ignore $ getHashes file b
-         fromBuf b -- `importHashes`
+         fromBuf -- `importHashes`
 
 -- Implements a portion of @readTTCFile@. The fields must be read in order.
 -- This reads everything up to and including `incData`.
@@ -571,7 +571,7 @@ getIncData : String -> Ref Bin Binary ->
              Core (List (CG, String, List String))
 getIncData file b
     = do ignore $ getImportHashes file b
-         fromBuf b -- `incData`
+         fromBuf -- `incData`
 
 export
 readTotalReq : (fileName : String) -> -- file containing the module

--- a/src/Core/Context/TTC.idr
+++ b/src/Core/Context/TTC.idr
@@ -8,10 +8,10 @@ import Core.Context
 
 export
 TTC BuiltinType where
-    toBuf b BuiltinNatural = tag 0
-    toBuf b NaturalToInteger = tag 1
-    toBuf b IntegerToNatural = tag 2
-    fromBuf b = case !getTag of
+    toBuf BuiltinNatural = tag 0
+    toBuf NaturalToInteger = tag 1
+    toBuf IntegerToNatural = tag 2
+    fromBuf = case !getTag of
         0 => pure BuiltinNatural
         1 => pure NaturalToInteger
         2 => pure IntegerToNatural

--- a/src/Core/Metadata.idr
+++ b/src/Core/Metadata.idr
@@ -42,16 +42,16 @@ SemanticDecorations : Type
 SemanticDecorations = List ASemanticDecoration
 
 TTC Decoration where
-  toBuf b Typ       = tag 0
-  toBuf b Function  = tag 1
-  toBuf b Data      = tag 2
-  toBuf b Keyword   = tag 3
-  toBuf b Bound     = tag 4
-  toBuf b Namespace = tag 5
-  toBuf b Postulate = tag 6
-  toBuf b Module    = tag 7
-  toBuf b Comment   = tag 8
-  fromBuf b
+  toBuf Typ       = tag 0
+  toBuf Function  = tag 1
+  toBuf Data      = tag 2
+  toBuf Keyword   = tag 3
+  toBuf Bound     = tag 4
+  toBuf Namespace = tag 5
+  toBuf Postulate = tag 6
+  toBuf Module    = tag 7
+  toBuf Comment   = tag 8
+  fromBuf
     = case !getTag of
         0 => pure Typ
         1 => pure Function
@@ -168,27 +168,27 @@ export
 data MD : Type where
 
 TTC Metadata where
-  toBuf b m
-      = do toBuf b (lhsApps m)
-           toBuf b (names m)
-           toBuf b (tydecls m)
-           toBuf b (holeLHS m)
-           toBuf b (nameLocMap m)
-           toBuf b (sourceIdent m)
-           toBuf b (semanticHighlighting m)
-           toBuf b (semanticAliases m)
-           toBuf b (semanticDefaults m)
+  toBuf m
+      = do toBuf (lhsApps m)
+           toBuf (names m)
+           toBuf (tydecls m)
+           toBuf (holeLHS m)
+           toBuf (nameLocMap m)
+           toBuf (sourceIdent m)
+           toBuf (semanticHighlighting m)
+           toBuf (semanticAliases m)
+           toBuf (semanticDefaults m)
 
-  fromBuf b
-      = do apps <- fromBuf b
-           ns <- fromBuf b
-           tys <- fromBuf b
-           hlhs <- fromBuf b
-           dlocs <- fromBuf b
-           fname <- fromBuf b
-           semhl <- fromBuf b
-           semal <- fromBuf b
-           semdef <- fromBuf b
+  fromBuf
+      = do apps <- fromBuf
+           ns <- fromBuf
+           tys <- fromBuf
+           hlhs <- fromBuf
+           dlocs <- fromBuf
+           fname <- fromBuf
+           semhl <- fromBuf
+           semal <- fromBuf
+           semdef <- fromBuf
            pure (MkMetadata apps ns tys Nothing hlhs dlocs fname semhl semal semdef)
 
 export
@@ -365,17 +365,17 @@ record TTMFile where
   metadata : Metadata
 
 TTC TTMFile where
-  toBuf b file
-      = do toBuf b "TTM"
-           toBuf b (version file)
-           toBuf b (metadata file)
+  toBuf file
+      = do toBuf "TTM"
+           toBuf (version file)
+           toBuf (metadata file)
 
-  fromBuf b
-      = do hdr <- fromBuf b
+  fromBuf
+      = do hdr <- fromBuf
            when (hdr /= "TTM") $ corrupt "TTM header"
-           ver <- fromBuf b
+           ver <- fromBuf
            checkTTCVersion "" ver ttcVersion -- maybe change the interface to get the filename
-           md <- fromBuf b
+           md <- fromBuf
            pure (MkTTMFile ver md)
 
 HasNames Metadata where
@@ -434,7 +434,7 @@ writeToTTM fname
          buf <- initBinary
          meta <- get MD
          defs <- get Ctxt
-         toBuf buf (MkTTMFile ttcVersion !(full (gamma defs) meta))
+         toBuf (MkTTMFile ttcVersion !(full (gamma defs) meta))
          Right ok <- coreLift $ writeToFile fname !(get Bin)
              | Left err => throw (InternalError (fname ++ ": " ++ show err))
          pure ()
@@ -447,7 +447,7 @@ readFromTTM fname
     = do Right buf <- coreLift $ readFromFile fname
              | Left err => throw (InternalError (fname ++ ": " ++ show err))
          bin <- newRef Bin buf
-         ttm <- fromBuf bin
+         ttm <- fromBuf
          put MD (metadata ttm)
 
 ||| Read Metadata from given file
@@ -457,7 +457,7 @@ readMetadata fname
   = do Right buf <- coreLift $ readFromFile fname
              | Left err => throw (InternalError (fname ++ ": " ++ show err))
        bin <- newRef Bin buf
-       MkTTMFile _ md <- fromBuf bin
+       MkTTMFile _ md <- fromBuf
        pure md
 
 ||| Dump content of a .ttm file in human-readable format

--- a/src/Idris/Syntax/TTC.idr
+++ b/src/Idris/Syntax/TTC.idr
@@ -18,47 +18,47 @@ import Libraries.Data.StringMap
 
 export
 TTC Method where
-  toBuf b (MkMethod nm c treq ty)
-      = do toBuf b nm
-           toBuf b c
-           toBuf b treq
-           toBuf b ty
+  toBuf (MkMethod nm c treq ty)
+      = do toBuf nm
+           toBuf c
+           toBuf treq
+           toBuf ty
 
-  fromBuf b
-      = do nm <- fromBuf b
-           c <- fromBuf b
-           treq <- fromBuf b
-           ty <- fromBuf b
+  fromBuf
+      = do nm <- fromBuf
+           c <- fromBuf
+           treq <- fromBuf
+           ty <- fromBuf
            pure (MkMethod nm c treq ty)
 
 
 export
 TTC IFaceInfo where
-  toBuf b (MkIFaceInfo ic impps ps cs ms ds)
-      = do toBuf b ic
-           toBuf b impps
-           toBuf b ps
-           toBuf b cs
-           toBuf b ms
-           toBuf b ds
+  toBuf (MkIFaceInfo ic impps ps cs ms ds)
+      = do toBuf ic
+           toBuf impps
+           toBuf ps
+           toBuf cs
+           toBuf ms
+           toBuf ds
 
-  fromBuf b
-      = do ic <- fromBuf b
-           impps <- fromBuf b
-           ps <- fromBuf b
-           cs <- fromBuf b
-           ms <- fromBuf b
-           ds <- fromBuf b
+  fromBuf
+      = do ic <- fromBuf
+           impps <- fromBuf
+           ps <- fromBuf
+           cs <- fromBuf
+           ms <- fromBuf
+           ds <- fromBuf
            pure (MkIFaceInfo ic impps ps cs ms ds)
 
 export
 TTC Fixity where
-  toBuf b InfixL = tag 0
-  toBuf b InfixR = tag 1
-  toBuf b Infix = tag 2
-  toBuf b Prefix = tag 3
+  toBuf InfixL = tag 0
+  toBuf InfixR = tag 1
+  toBuf Infix = tag 2
+  toBuf Prefix = tag 3
 
-  fromBuf b
+  fromBuf
       = case !getTag of
              0 => pure InfixL
              1 => pure InfixR
@@ -68,25 +68,25 @@ TTC Fixity where
 
 export
 TTC Import where
-  toBuf b (MkImport loc reexport path nameAs)
-    = do toBuf b loc
-         toBuf b reexport
-         toBuf b path
-         toBuf b nameAs
+  toBuf (MkImport loc reexport path nameAs)
+    = do toBuf loc
+         toBuf reexport
+         toBuf path
+         toBuf nameAs
 
-  fromBuf b
-    = do loc <- fromBuf b
-         reexport <- fromBuf b
-         path <- fromBuf b
-         nameAs <- fromBuf b
+  fromBuf
+    = do loc <- fromBuf
+         reexport <- fromBuf
+         path <- fromBuf
+         nameAs <- fromBuf
          pure (MkImport loc reexport path nameAs)
 
 export
 TTC BindingModifier where
-  toBuf b NotBinding = tag 0
-  toBuf b Typebind = tag 1
-  toBuf b Autobind = tag 2
-  fromBuf b
+  toBuf NotBinding = tag 0
+  toBuf Typebind = tag 1
+  toBuf Autobind = tag 2
+  fromBuf
       = case !getTag of
              0 => pure NotBinding
              1 => pure Typebind
@@ -95,46 +95,46 @@ TTC BindingModifier where
 
 export
 TTC FixityInfo where
-  toBuf b fx
-      = do toBuf b fx.fc
-           toBuf b fx.vis
-           toBuf b fx.bindingInfo
-           toBuf b fx.fix
-           toBuf b fx.precedence
-  fromBuf b
-      = do fc <- fromBuf b
-           vis <- fromBuf b
-           binding <- fromBuf b
-           fix <- fromBuf b
-           prec <- fromBuf b
+  toBuf fx
+      = do toBuf fx.fc
+           toBuf fx.vis
+           toBuf fx.bindingInfo
+           toBuf fx.fix
+           toBuf fx.precedence
+  fromBuf
+      = do fc <- fromBuf
+           vis <- fromBuf
+           binding <- fromBuf
+           fix <- fromBuf
+           prec <- fromBuf
            pure $ MkFixityInfo fc vis binding fix prec
 
 
 export
 TTC SyntaxInfo where
-  toBuf b syn
-      = do toBuf b (ANameMap.toList (fixities syn))
-           toBuf b (filter (\n => elemBy (==) (fst n) (saveMod syn))
+  toBuf syn
+      = do toBuf (ANameMap.toList (fixities syn))
+           toBuf (filter (\n => elemBy (==) (fst n) (saveMod syn))
                            (SortedMap.toList $ modDocstrings syn))
-           toBuf b (filter (\n => elemBy (==) (fst n) (saveMod syn))
+           toBuf (filter (\n => elemBy (==) (fst n) (saveMod syn))
                            (SortedMap.toList $ modDocexports syn))
-           toBuf b (filter (\n => fst n `elem` saveIFaces syn)
+           toBuf (filter (\n => fst n `elem` saveIFaces syn)
                            (ANameMap.toList (ifaces syn)))
-           toBuf b (filter (\n => isJust (lookup (fst n) (saveDocstrings syn)))
+           toBuf (filter (\n => isJust (lookup (fst n) (saveDocstrings syn)))
                            (ANameMap.toList (defDocstrings syn)))
-           toBuf b (bracketholes syn)
-           toBuf b (startExpr syn)
-           toBuf b (holeNames syn)
+           toBuf (bracketholes syn)
+           toBuf (startExpr syn)
+           toBuf (holeNames syn)
 
-  fromBuf b
-      = do fix <- fromBuf b
-           moddstr <- fromBuf b
-           modexpts <- fromBuf b
-           ifs <- fromBuf b
-           defdstrs <- fromBuf b
-           bhs <- fromBuf b
-           start <- fromBuf b
-           hnames <- fromBuf b
+  fromBuf
+      = do fix <- fromBuf
+           moddstr <- fromBuf
+           modexpts <- fromBuf
+           ifs <- fromBuf
+           defdstrs <- fromBuf
+           bhs <- fromBuf
+           start <- fromBuf
+           hnames <- fromBuf
            pure $ MkSyntax (fromList fix)
                    [] (fromList moddstr) (fromList modexpts)
                    [] (fromList ifs)

--- a/src/TTImp/TTImp/TTC.idr
+++ b/src/TTImp/TTImp/TTC.idr
@@ -15,203 +15,203 @@ import Libraries.Data.WithDefault
 mutual
   export
   TTC RawImp where
-    toBuf b (IVar fc n) = do tag 0; toBuf b fc; toBuf b n
-    toBuf b (IPi fc r p n argTy retTy)
-        = do tag 1; toBuf b fc; toBuf b r; toBuf b p; toBuf b n
-             toBuf b argTy; toBuf b retTy
-    toBuf b (ILam fc r p n argTy scope)
-        = do tag 2; toBuf b fc; toBuf b r; toBuf b p; toBuf b n;
-             toBuf b argTy; toBuf b scope
-    toBuf b (ILet fc lhsFC r n nTy nVal scope)
-        = do tag 3; toBuf b fc; toBuf b lhsFC; toBuf b r; toBuf b n;
-             toBuf b nTy; toBuf b nVal; toBuf b scope
-    toBuf b (ICase fc opts y ty xs)
-        = do tag 4; toBuf b fc; toBuf b opts; toBuf b y; toBuf b ty; toBuf b xs
-    toBuf b (ILocal fc xs sc)
-        = do tag 5; toBuf b fc; toBuf b xs; toBuf b sc
-    toBuf b (ICaseLocal fc _ _ _ sc)
-        = toBuf b sc
-    toBuf b (IUpdate fc fs rec)
-        = do tag 6; toBuf b fc; toBuf b fs; toBuf b rec
-    toBuf b (IApp fc fn arg)
-        = do tag 7; toBuf b fc; toBuf b fn; toBuf b arg
-    toBuf b (INamedApp fc fn y arg)
-        = do tag 8; toBuf b fc; toBuf b fn; toBuf b y; toBuf b arg
-    toBuf b (IWithApp fc fn arg)
-        = do tag 9; toBuf b fc; toBuf b fn; toBuf b arg
-    toBuf b (ISearch fc depth)
-        = do tag 10; toBuf b fc; toBuf b depth
-    toBuf b (IAlternative fc y xs)
-        = do tag 11; toBuf b fc; toBuf b y; toBuf b xs
-    toBuf b (IRewrite fc x y)
-        = do tag 12; toBuf b fc; toBuf b x; toBuf b y
-    toBuf b (ICoerced fc y)
-        = do tag 13; toBuf b fc; toBuf b y
+    toBuf (IVar fc n) = do tag 0; toBuf fc; toBuf n
+    toBuf (IPi fc r p n argTy retTy)
+        = do tag 1; toBuf fc; toBuf r; toBuf p; toBuf n
+             toBuf argTy; toBuf retTy
+    toBuf (ILam fc r p n argTy scope)
+        = do tag 2; toBuf fc; toBuf r; toBuf p; toBuf n;
+             toBuf argTy; toBuf scope
+    toBuf (ILet fc lhsFC r n nTy nVal scope)
+        = do tag 3; toBuf fc; toBuf lhsFC; toBuf r; toBuf n;
+             toBuf nTy; toBuf nVal; toBuf scope
+    toBuf (ICase fc opts y ty xs)
+        = do tag 4; toBuf fc; toBuf opts; toBuf y; toBuf ty; toBuf xs
+    toBuf (ILocal fc xs sc)
+        = do tag 5; toBuf fc; toBuf xs; toBuf sc
+    toBuf (ICaseLocal fc _ _ _ sc)
+        = toBuf sc
+    toBuf (IUpdate fc fs rec)
+        = do tag 6; toBuf fc; toBuf fs; toBuf rec
+    toBuf (IApp fc fn arg)
+        = do tag 7; toBuf fc; toBuf fn; toBuf arg
+    toBuf (INamedApp fc fn y arg)
+        = do tag 8; toBuf fc; toBuf fn; toBuf y; toBuf arg
+    toBuf (IWithApp fc fn arg)
+        = do tag 9; toBuf fc; toBuf fn; toBuf arg
+    toBuf (ISearch fc depth)
+        = do tag 10; toBuf fc; toBuf depth
+    toBuf (IAlternative fc y xs)
+        = do tag 11; toBuf fc; toBuf y; toBuf xs
+    toBuf (IRewrite fc x y)
+        = do tag 12; toBuf fc; toBuf x; toBuf y
+    toBuf (ICoerced fc y)
+        = do tag 13; toBuf fc; toBuf y
 
-    toBuf b (IBindHere fc m y)
-        = do tag 14; toBuf b fc; toBuf b m; toBuf b y
-    toBuf b (IBindVar fc y)
-        = do tag 15; toBuf b fc; toBuf b y
-    toBuf b (IAs fc nameFC s y pattern)
-        = do tag 16; toBuf b fc; toBuf b nameFC; toBuf b s; toBuf b y;
-             toBuf b pattern
-    toBuf b (IMustUnify fc r pattern)
+    toBuf (IBindHere fc m y)
+        = do tag 14; toBuf fc; toBuf m; toBuf y
+    toBuf (IBindVar fc y)
+        = do tag 15; toBuf fc; toBuf y
+    toBuf (IAs fc nameFC s y pattern)
+        = do tag 16; toBuf fc; toBuf nameFC; toBuf s; toBuf y;
+             toBuf pattern
+    toBuf (IMustUnify fc r pattern)
         -- No need to record 'r', it's for type errors only
-        = do tag 17; toBuf b fc; toBuf b pattern
+        = do tag 17; toBuf fc; toBuf pattern
 
-    toBuf b (IDelayed fc r y)
-        = do tag 18; toBuf b fc; toBuf b r; toBuf b y
-    toBuf b (IDelay fc t)
-        = do tag 19; toBuf b fc; toBuf b t
-    toBuf b (IForce fc t)
-        = do tag 20; toBuf b fc; toBuf b t
+    toBuf (IDelayed fc r y)
+        = do tag 18; toBuf fc; toBuf r; toBuf y
+    toBuf (IDelay fc t)
+        = do tag 19; toBuf fc; toBuf t
+    toBuf (IForce fc t)
+        = do tag 20; toBuf fc; toBuf t
 
-    toBuf b (IQuote fc t)
-        = do tag 21; toBuf b fc; toBuf b t
-    toBuf b (IQuoteName fc t)
-        = do tag 22; toBuf b fc; toBuf b t
-    toBuf b (IQuoteDecl fc t)
-        = do tag 23; toBuf b fc; toBuf b t
-    toBuf b (IUnquote fc t)
-        = do tag 24; toBuf b fc; toBuf b t
-    toBuf b (IRunElab fc re t)
-        = do tag 25; toBuf b fc; toBuf b re; toBuf b t
+    toBuf (IQuote fc t)
+        = do tag 21; toBuf fc; toBuf t
+    toBuf (IQuoteName fc t)
+        = do tag 22; toBuf fc; toBuf t
+    toBuf (IQuoteDecl fc t)
+        = do tag 23; toBuf fc; toBuf t
+    toBuf (IUnquote fc t)
+        = do tag 24; toBuf fc; toBuf t
+    toBuf (IRunElab fc re t)
+        = do tag 25; toBuf fc; toBuf re; toBuf t
 
-    toBuf b (IPrimVal fc y)
-        = do tag 26; toBuf b fc; toBuf b y
-    toBuf b (IType fc)
-        = do tag 27; toBuf b fc
-    toBuf b (IHole fc y)
-        = do tag 28; toBuf b fc; toBuf b y
-    toBuf b (IUnifyLog fc lvl x) = toBuf b x
+    toBuf (IPrimVal fc y)
+        = do tag 26; toBuf fc; toBuf y
+    toBuf (IType fc)
+        = do tag 27; toBuf fc
+    toBuf (IHole fc y)
+        = do tag 28; toBuf fc; toBuf y
+    toBuf (IUnifyLog fc lvl x) = toBuf x
 
-    toBuf b (Implicit fc i)
-        = do tag 29; toBuf b fc; toBuf b i
-    toBuf b (IWithUnambigNames fc ns rhs)
-        = do tag 30; toBuf b fc; toBuf b ns; toBuf b rhs
-    toBuf b (IAutoApp fc fn arg)
-        = do tag 31; toBuf b fc; toBuf b fn; toBuf b arg
+    toBuf (Implicit fc i)
+        = do tag 29; toBuf fc; toBuf i
+    toBuf (IWithUnambigNames fc ns rhs)
+        = do tag 30; toBuf fc; toBuf ns; toBuf rhs
+    toBuf (IAutoApp fc fn arg)
+        = do tag 31; toBuf fc; toBuf fn; toBuf arg
 
-    fromBuf b
+    fromBuf
         = case !getTag of
-               0 => do fc <- fromBuf b; n <- fromBuf b;
+               0 => do fc <- fromBuf; n <- fromBuf;
                        pure (IVar fc n)
-               1 => do fc <- fromBuf b;
-                       r <- fromBuf b; p <- fromBuf b;
-                       n <- fromBuf b
-                       argTy <- fromBuf b; retTy <- fromBuf b
+               1 => do fc <- fromBuf;
+                       r <- fromBuf; p <- fromBuf;
+                       n <- fromBuf
+                       argTy <- fromBuf; retTy <- fromBuf
                        pure (IPi fc r p n argTy retTy)
-               2 => do fc <- fromBuf b;
-                       r <- fromBuf b; p <- fromBuf b; n <- fromBuf b
-                       argTy <- fromBuf b; scope <- fromBuf b
+               2 => do fc <- fromBuf;
+                       r <- fromBuf; p <- fromBuf; n <- fromBuf
+                       argTy <- fromBuf; scope <- fromBuf
                        pure (ILam fc r p n argTy scope)
-               3 => do fc <- fromBuf b;
-                       lhsFC <- fromBuf b;
-                       r <- fromBuf b; n <- fromBuf b
-                       nTy <- fromBuf b; nVal <- fromBuf b
-                       scope <- fromBuf b
+               3 => do fc <- fromBuf;
+                       lhsFC <- fromBuf;
+                       r <- fromBuf; n <- fromBuf
+                       nTy <- fromBuf; nVal <- fromBuf
+                       scope <- fromBuf
                        pure (ILet fc lhsFC r n nTy nVal scope)
-               4 => do fc <- fromBuf b; opts <- fromBuf b; y <- fromBuf b;
-                       ty <- fromBuf b; xs <- fromBuf b
+               4 => do fc <- fromBuf; opts <- fromBuf; y <- fromBuf;
+                       ty <- fromBuf; xs <- fromBuf
                        pure (ICase fc opts y ty xs)
-               5 => do fc <- fromBuf b;
-                       xs <- fromBuf b; sc <- fromBuf b
+               5 => do fc <- fromBuf;
+                       xs <- fromBuf; sc <- fromBuf
                        pure (ILocal fc xs sc)
-               6 => do fc <- fromBuf b; fs <- fromBuf b
-                       rec <- fromBuf b
+               6 => do fc <- fromBuf; fs <- fromBuf
+                       rec <- fromBuf
                        pure (IUpdate fc fs rec)
-               7 => do fc <- fromBuf b; fn <- fromBuf b
-                       arg <- fromBuf b
+               7 => do fc <- fromBuf; fn <- fromBuf
+                       arg <- fromBuf
                        pure (IApp fc fn arg)
-               8 => do fc <- fromBuf b; fn <- fromBuf b
-                       y <- fromBuf b; arg <- fromBuf b
+               8 => do fc <- fromBuf; fn <- fromBuf
+                       y <- fromBuf; arg <- fromBuf
                        pure (INamedApp fc fn y arg)
-               9 => do fc <- fromBuf b; fn <- fromBuf b
-                       arg <- fromBuf b
+               9 => do fc <- fromBuf; fn <- fromBuf
+                       arg <- fromBuf
                        pure (IWithApp fc fn arg)
-               10 => do fc <- fromBuf b; depth <- fromBuf b
+               10 => do fc <- fromBuf; depth <- fromBuf
                         pure (ISearch fc depth)
-               11 => do fc <- fromBuf b; y <- fromBuf b
-                        xs <- fromBuf b
+               11 => do fc <- fromBuf; y <- fromBuf
+                        xs <- fromBuf
                         pure (IAlternative fc y xs)
-               12 => do fc <- fromBuf b; x <- fromBuf b; y <- fromBuf b
+               12 => do fc <- fromBuf; x <- fromBuf; y <- fromBuf
                         pure (IRewrite fc x y)
-               13 => do fc <- fromBuf b; y <- fromBuf b
+               13 => do fc <- fromBuf; y <- fromBuf
                         pure (ICoerced fc y)
-               14 => do fc <- fromBuf b; m <- fromBuf b; y <- fromBuf b
+               14 => do fc <- fromBuf; m <- fromBuf; y <- fromBuf
                         pure (IBindHere fc m y)
-               15 => do fc <- fromBuf b; y <- fromBuf b
+               15 => do fc <- fromBuf; y <- fromBuf
                         pure (IBindVar fc y)
-               16 => do fc <- fromBuf b; nameFC <- fromBuf b
-                        side <- fromBuf b;
-                        y <- fromBuf b; pattern <- fromBuf b
+               16 => do fc <- fromBuf; nameFC <- fromBuf
+                        side <- fromBuf;
+                        y <- fromBuf; pattern <- fromBuf
                         pure (IAs fc nameFC side y pattern)
-               17 => do fc <- fromBuf b
-                        pattern <- fromBuf b
+               17 => do fc <- fromBuf
+                        pattern <- fromBuf
                         pure (IMustUnify fc UnknownDot pattern)
 
-               18 => do fc <- fromBuf b; r <- fromBuf b
-                        y <- fromBuf b
+               18 => do fc <- fromBuf; r <- fromBuf
+                        y <- fromBuf
                         pure (IDelayed fc r y)
-               19 => do fc <- fromBuf b; y <- fromBuf b
+               19 => do fc <- fromBuf; y <- fromBuf
                         pure (IDelay fc y)
-               20 => do fc <- fromBuf b; y <- fromBuf b
+               20 => do fc <- fromBuf; y <- fromBuf
                         pure (IForce fc y)
 
-               21 => do fc <- fromBuf b; y <- fromBuf b
+               21 => do fc <- fromBuf; y <- fromBuf
                         pure (IQuote fc y)
-               22 => do fc <- fromBuf b; y <- fromBuf b
+               22 => do fc <- fromBuf; y <- fromBuf
                         pure (IQuoteName fc y)
-               23 => do fc <- fromBuf b; y <- fromBuf b
+               23 => do fc <- fromBuf; y <- fromBuf
                         pure (IQuoteDecl fc y)
-               24 => do fc <- fromBuf b; y <- fromBuf b
+               24 => do fc <- fromBuf; y <- fromBuf
                         pure (IUnquote fc y)
-               25 => do fc <- fromBuf b; re <- fromBuf b; y <- fromBuf b
+               25 => do fc <- fromBuf; re <- fromBuf; y <- fromBuf
                         pure (IRunElab fc re y)
 
-               26 => do fc <- fromBuf b; y <- fromBuf b
+               26 => do fc <- fromBuf; y <- fromBuf
                         pure (IPrimVal fc y)
-               27 => do fc <- fromBuf b
+               27 => do fc <- fromBuf
                         pure (IType fc)
-               28 => do fc <- fromBuf b; y <- fromBuf b
+               28 => do fc <- fromBuf; y <- fromBuf
                         pure (IHole fc y)
-               29 => do fc <- fromBuf b
-                        i <- fromBuf b
+               29 => do fc <- fromBuf
+                        i <- fromBuf
                         pure (Implicit fc i)
-               30 => do fc <- fromBuf b
-                        ns <- fromBuf b
-                        rhs <- fromBuf b
+               30 => do fc <- fromBuf
+                        ns <- fromBuf
+                        rhs <- fromBuf
                         pure (IWithUnambigNames fc ns rhs)
-               31 => do fc <- fromBuf b; fn <- fromBuf b
-                        arg <- fromBuf b
+               31 => do fc <- fromBuf; fn <- fromBuf
+                        arg <- fromBuf
                         pure (IAutoApp fc fn arg)
                _ => corrupt "RawImp"
 
   export
   TTC IFieldUpdate where
-    toBuf b (ISetField p val)
-        = do tag 0; toBuf b p; toBuf b val
-    toBuf b (ISetFieldApp p val)
-        = do tag 1; toBuf b p; toBuf b val
+    toBuf (ISetField p val)
+        = do tag 0; toBuf p; toBuf val
+    toBuf (ISetFieldApp p val)
+        = do tag 1; toBuf p; toBuf val
 
-    fromBuf b
+    fromBuf
         = case !getTag of
-               0 => do p <- fromBuf b; val <- fromBuf b
+               0 => do p <- fromBuf; val <- fromBuf
                        pure (ISetField p val)
-               1 => do p <- fromBuf b; val <- fromBuf b
+               1 => do p <- fromBuf; val <- fromBuf
                        pure (ISetFieldApp p val)
                _ => corrupt "IFieldUpdate"
 
   export
   TTC BindMode where
-    toBuf b (PI r) = do tag 0; toBuf b r
-    toBuf b PATTERN = tag 1
-    toBuf b NONE = tag 2
-    toBuf b COVERAGE = tag 3
+    toBuf (PI r) = do tag 0; toBuf r
+    toBuf PATTERN = tag 1
+    toBuf NONE = tag 2
+    toBuf COVERAGE = tag 3
 
-    fromBuf b
+    fromBuf
         = case !getTag of
-               0 => do x <- fromBuf b
+               0 => do x <- fromBuf
                        pure (PI x)
                1 => pure PATTERN
                2 => pure NONE
@@ -220,67 +220,67 @@ mutual
 
   export
   TTC AltType where
-    toBuf b FirstSuccess = tag 0
-    toBuf b Unique = tag 1
-    toBuf b (UniqueDefault x) = do tag 2; toBuf b x
+    toBuf FirstSuccess = tag 0
+    toBuf Unique = tag 1
+    toBuf (UniqueDefault x) = do tag 2; toBuf x
 
-    fromBuf b
+    fromBuf
         = case !getTag of
                0 => pure FirstSuccess
                1 => pure Unique
-               2 => do x <- fromBuf b
+               2 => do x <- fromBuf
                        pure (UniqueDefault x)
                _ => corrupt "AltType"
 
   export
   TTC ImpTy where
-    toBuf b (MkImpTy fc n ty)
-        = do toBuf b fc;  toBuf b n; toBuf b ty
-    fromBuf b
-        = do fc <- fromBuf b; n <- fromBuf b; ty <- fromBuf b
+    toBuf (MkImpTy fc n ty)
+        = do toBuf fc;  toBuf n; toBuf ty
+    fromBuf
+        = do fc <- fromBuf; n <- fromBuf; ty <- fromBuf
              pure (MkImpTy fc n ty)
 
   export
   TTC ImpClause where
-    toBuf b (PatClause fc lhs rhs)
-        = do tag 0; toBuf b fc; toBuf b lhs; toBuf b rhs
-    toBuf b (ImpossibleClause fc lhs)
-        = do tag 1; toBuf b fc; toBuf b lhs
-    toBuf b (WithClause fc lhs rig wval prf flags cs)
+    toBuf (PatClause fc lhs rhs)
+        = do tag 0; toBuf fc; toBuf lhs; toBuf rhs
+    toBuf (ImpossibleClause fc lhs)
+        = do tag 1; toBuf fc; toBuf lhs
+    toBuf (WithClause fc lhs rig wval prf flags cs)
         = do tag 2
-             toBuf b fc
-             toBuf b lhs
-             toBuf b rig
-             toBuf b wval
-             toBuf b prf
-             toBuf b cs
+             toBuf fc
+             toBuf lhs
+             toBuf rig
+             toBuf wval
+             toBuf prf
+             toBuf cs
 
-    fromBuf b
+    fromBuf
         = case !getTag of
-               0 => do fc <- fromBuf b; lhs <- fromBuf b;
-                       rhs <- fromBuf b
+               0 => do fc <- fromBuf; lhs <- fromBuf;
+                       rhs <- fromBuf
                        pure (PatClause fc lhs rhs)
-               1 => do fc <- fromBuf b; lhs <- fromBuf b;
+               1 => do fc <- fromBuf; lhs <- fromBuf;
                        pure (ImpossibleClause fc lhs)
-               2 => do fc <- fromBuf b; lhs <- fromBuf b;
-                       rig <- fromBuf b; wval <- fromBuf b;
-                       prf <- fromBuf b;
-                       cs <- fromBuf b
+               2 => do fc <- fromBuf; lhs <- fromBuf;
+                       rig <- fromBuf; wval <- fromBuf;
+                       prf <- fromBuf;
+                       cs <- fromBuf
                        pure (WithClause fc lhs rig wval prf [] cs)
                _ => corrupt "ImpClause"
 
   export
   TTC DataOpt where
-    toBuf b (SearchBy ns)
-        = do tag 0; toBuf b ns
-    toBuf b NoHints = tag 1
-    toBuf b UniqueSearch = tag 2
-    toBuf b External = tag 3
-    toBuf b NoNewtype = tag 4
+    toBuf (SearchBy ns)
+        = do tag 0; toBuf ns
+    toBuf NoHints = tag 1
+    toBuf UniqueSearch = tag 2
+    toBuf External = tag 3
+    toBuf NoNewtype = tag 4
 
-    fromBuf b
+    fromBuf
         = case !getTag of
-               0 => do ns <- fromBuf b
+               0 => do ns <- fromBuf
                        pure (SearchBy ns)
                1 => pure NoHints
                2 => pure UniqueSearch
@@ -290,148 +290,148 @@ mutual
 
   export
   TTC ImpData where
-    toBuf b (MkImpData fc n tycon opts cons)
-        = do tag 0; toBuf b fc; toBuf b n; toBuf b tycon; toBuf b opts
-             toBuf b cons
-    toBuf b (MkImpLater fc n tycon)
-        = do tag 1; toBuf b fc; toBuf b n; toBuf b tycon
+    toBuf (MkImpData fc n tycon opts cons)
+        = do tag 0; toBuf fc; toBuf n; toBuf tycon; toBuf opts
+             toBuf cons
+    toBuf (MkImpLater fc n tycon)
+        = do tag 1; toBuf fc; toBuf n; toBuf tycon
 
-    fromBuf b
+    fromBuf
         = case !getTag of
-               0 => do fc <- fromBuf b; n <- fromBuf b;
-                       tycon <- fromBuf b; opts <- fromBuf b
-                       cons <- fromBuf b
+               0 => do fc <- fromBuf; n <- fromBuf;
+                       tycon <- fromBuf; opts <- fromBuf
+                       cons <- fromBuf
                        pure (MkImpData fc n tycon opts cons)
-               1 => do fc <- fromBuf b; n <- fromBuf b;
-                       tycon <- fromBuf b
+               1 => do fc <- fromBuf; n <- fromBuf;
+                       tycon <- fromBuf
                        pure (MkImpLater fc n tycon)
                _ => corrupt "ImpData"
 
   export
   TTC IField where
-    toBuf b (MkIField fc c p n ty)
-        = do toBuf b fc; toBuf b c; toBuf b p; toBuf b n; toBuf b ty
+    toBuf (MkIField fc c p n ty)
+        = do toBuf fc; toBuf c; toBuf p; toBuf n; toBuf ty
 
-    fromBuf b
-        = do fc <- fromBuf b; c <- fromBuf b; p <- fromBuf b
-             n <- fromBuf b; ty <- fromBuf b
+    fromBuf
+        = do fc <- fromBuf; c <- fromBuf; p <- fromBuf
+             n <- fromBuf; ty <- fromBuf
              pure (MkIField fc c p n ty)
 
   export
   TTC ImpRecord where
-    toBuf b (MkImpRecord fc n ps opts con fs)
-        = do toBuf b fc; toBuf b n; toBuf b ps; toBuf b opts; toBuf b con; toBuf b fs
+    toBuf (MkImpRecord fc n ps opts con fs)
+        = do toBuf fc; toBuf n; toBuf ps; toBuf opts; toBuf con; toBuf fs
 
-    fromBuf b
-        = do fc <- fromBuf b; n <- fromBuf b; ps <- fromBuf b
-             opts <- fromBuf b; con <- fromBuf b; fs <- fromBuf b
+    fromBuf
+        = do fc <- fromBuf; n <- fromBuf; ps <- fromBuf
+             opts <- fromBuf; con <- fromBuf; fs <- fromBuf
              pure (MkImpRecord fc n ps opts con fs)
 
   export
   TTC FnOpt where
-    toBuf b Inline = tag 0
-    toBuf b (Hint t) = do tag 1; toBuf b t
-    toBuf b (GlobalHint t) = do tag 2; toBuf b t
-    toBuf b ExternFn = tag 3
-    toBuf b (ForeignFn cs) = do tag 4; toBuf b cs
-    toBuf b Invertible = tag 5
-    toBuf b (Totality Total) = tag 6
-    toBuf b (Totality CoveringOnly) = tag 7
-    toBuf b (Totality PartialOK) = tag 8
-    toBuf b Macro = tag 9
-    toBuf b (SpecArgs ns) = do tag 10; toBuf b ns
-    toBuf b TCInline = tag 11
-    toBuf b NoInline = tag 12
-    toBuf b Unsafe = tag 13
-    toBuf b Deprecate = tag 14
-    toBuf b (ForeignExport cs) = do tag 15; toBuf b cs
+    toBuf Inline = tag 0
+    toBuf (Hint t) = do tag 1; toBuf t
+    toBuf (GlobalHint t) = do tag 2; toBuf t
+    toBuf ExternFn = tag 3
+    toBuf (ForeignFn cs) = do tag 4; toBuf cs
+    toBuf Invertible = tag 5
+    toBuf (Totality Total) = tag 6
+    toBuf (Totality CoveringOnly) = tag 7
+    toBuf (Totality PartialOK) = tag 8
+    toBuf Macro = tag 9
+    toBuf (SpecArgs ns) = do tag 10; toBuf ns
+    toBuf TCInline = tag 11
+    toBuf NoInline = tag 12
+    toBuf Unsafe = tag 13
+    toBuf Deprecate = tag 14
+    toBuf (ForeignExport cs) = do tag 15; toBuf cs
 
-    fromBuf b
+    fromBuf
         = case !getTag of
                0 => pure Inline
-               1 => do t <- fromBuf b; pure (Hint t)
-               2 => do t <- fromBuf b; pure (GlobalHint t)
+               1 => do t <- fromBuf; pure (Hint t)
+               2 => do t <- fromBuf; pure (GlobalHint t)
                3 => pure ExternFn
-               4 => do cs <- fromBuf b; pure (ForeignFn cs)
+               4 => do cs <- fromBuf; pure (ForeignFn cs)
                5 => pure Invertible
                6 => pure (Totality Total)
                7 => pure (Totality CoveringOnly)
                8 => pure (Totality PartialOK)
                9 => pure Macro
-               10 => do ns <- fromBuf b; pure (SpecArgs ns)
+               10 => do ns <- fromBuf; pure (SpecArgs ns)
                11 => pure TCInline
                12 => pure NoInline
                13 => pure Unsafe
                14 => pure Deprecate
-               15 => do cs <- fromBuf b; pure (ForeignExport cs)
+               15 => do cs <- fromBuf; pure (ForeignExport cs)
                _ => corrupt "FnOpt"
 
   export
   TTC (IClaimData Name) where
-    toBuf b (MkIClaimData rig vis opts type)
-        = do toBuf b rig; toBuf b vis; toBuf b opts; toBuf b type
-    fromBuf b
-        = do rig <- fromBuf b
-             vis <- fromBuf b
-             opts <- fromBuf b
-             type <- fromBuf b
+    toBuf (MkIClaimData rig vis opts type)
+        = do toBuf rig; toBuf vis; toBuf opts; toBuf type
+    fromBuf
+        = do rig <- fromBuf
+             vis <- fromBuf
+             opts <- fromBuf
+             type <- fromBuf
              pure $ MkIClaimData rig vis opts type
 
   export
   TTC ImpDecl where
-    toBuf b (IClaim claim)
-        = do tag 0; toBuf b claim
-    toBuf b (IData fc vis mbtot d)
-        = do tag 1; toBuf b fc; toBuf b vis; toBuf b mbtot; toBuf b d
-    toBuf b (IDef fc n xs)
-        = do tag 2; toBuf b fc; toBuf b n; toBuf b xs
-    toBuf b (IParameters fc vis d)
-        = do tag 3; toBuf b fc; toBuf b vis; toBuf b d
-    toBuf b (IRecord fc ns vis mbtot r)
-        = do tag 4; toBuf b fc; toBuf b ns; toBuf b vis; toBuf b mbtot; toBuf b r
-    toBuf b (INamespace fc xs ds)
-        = do tag 5; toBuf b fc; toBuf b xs; toBuf b ds
-    toBuf b (ITransform fc n lhs rhs)
-        = do tag 6; toBuf b fc; toBuf b n; toBuf b lhs; toBuf b rhs
-    toBuf b (IRunElabDecl fc tm)
-        = do tag 7; toBuf b fc; toBuf b tm
-    toBuf b (IPragma _ _ f) = throw (InternalError "Can't write Pragma")
-    toBuf b (ILog n)
-        = do tag 8; toBuf b n
-    toBuf b (IBuiltin fc type name)
-        = do tag 9; toBuf b fc; toBuf b type; toBuf b name
-    toBuf b (IFail _ _ _)
+    toBuf (IClaim claim)
+        = do tag 0; toBuf claim
+    toBuf (IData fc vis mbtot d)
+        = do tag 1; toBuf fc; toBuf vis; toBuf mbtot; toBuf d
+    toBuf (IDef fc n xs)
+        = do tag 2; toBuf fc; toBuf n; toBuf xs
+    toBuf (IParameters fc vis d)
+        = do tag 3; toBuf fc; toBuf vis; toBuf d
+    toBuf (IRecord fc ns vis mbtot r)
+        = do tag 4; toBuf fc; toBuf ns; toBuf vis; toBuf mbtot; toBuf r
+    toBuf (INamespace fc xs ds)
+        = do tag 5; toBuf fc; toBuf xs; toBuf ds
+    toBuf (ITransform fc n lhs rhs)
+        = do tag 6; toBuf fc; toBuf n; toBuf lhs; toBuf rhs
+    toBuf (IRunElabDecl fc tm)
+        = do tag 7; toBuf fc; toBuf tm
+    toBuf (IPragma _ _ f) = throw (InternalError "Can't write Pragma")
+    toBuf (ILog n)
+        = do tag 8; toBuf n
+    toBuf (IBuiltin fc type name)
+        = do tag 9; toBuf fc; toBuf type; toBuf name
+    toBuf (IFail _ _ _)
         = pure ()
 
-    fromBuf b
+    fromBuf
         = case !getTag of
-               0 => do claimData <- fromBuf b
+               0 => do claimData <- fromBuf
                        pure (IClaim claimData)
-               1 => do fc <- fromBuf b; vis <- fromBuf b
-                       mbtot <- fromBuf b; d <- fromBuf b
+               1 => do fc <- fromBuf; vis <- fromBuf
+                       mbtot <- fromBuf; d <- fromBuf
                        pure (IData fc vis mbtot d)
-               2 => do fc <- fromBuf b; n <- fromBuf b
-                       xs <- fromBuf b
+               2 => do fc <- fromBuf; n <- fromBuf
+                       xs <- fromBuf
                        pure (IDef fc n xs)
-               3 => do fc <- fromBuf b; vis <- fromBuf b
-                       d <- fromBuf b
+               3 => do fc <- fromBuf; vis <- fromBuf
+                       d <- fromBuf
                        pure (IParameters fc vis d)
-               4 => do fc <- fromBuf b; ns <- fromBuf b;
-                       vis <- fromBuf b; mbtot <- fromBuf b;
-                       r <- fromBuf b
+               4 => do fc <- fromBuf; ns <- fromBuf;
+                       vis <- fromBuf; mbtot <- fromBuf;
+                       r <- fromBuf
                        pure (IRecord fc ns vis mbtot r)
-               5 => do fc <- fromBuf b; xs <- fromBuf b
-                       ds <- fromBuf b
+               5 => do fc <- fromBuf; xs <- fromBuf
+                       ds <- fromBuf
                        pure (INamespace fc xs ds)
-               6 => do fc <- fromBuf b; n <- fromBuf b
-                       lhs <- fromBuf b; rhs <- fromBuf b
+               6 => do fc <- fromBuf; n <- fromBuf
+                       lhs <- fromBuf; rhs <- fromBuf
                        pure (ITransform fc n lhs rhs)
-               7 => do fc <- fromBuf b; tm <- fromBuf b
+               7 => do fc <- fromBuf; tm <- fromBuf
                        pure (IRunElabDecl fc tm)
-               8 => do n <- fromBuf b
+               8 => do n <- fromBuf
                        pure (ILog n)
-               9 => do fc <- fromBuf b
-                       type <- fromBuf b
-                       name <- fromBuf b
+               9 => do fc <- fromBuf
+                       type <- fromBuf
+                       name <- fromBuf
                        pure (IBuiltin fc type name)
                _ => corrupt "ImpDecl"


### PR DESCRIPTION
# Description

In Yaffle, `Ref Bin Binary` is passed implicitly, reducing boilerplate slightly. I suggest adopting the same approach in Idris.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

