### PR TITLE
Get pattern matching on pi types to compile with refc

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -176,6 +176,10 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 * Constant `String`, `Int64`, `Bits64` and `Double` values are allocated statically as
   immortal and shared.
 
+* A constant string for the representation of Pi type constructor is defined in
+  the support library. Code that creates or pattern-matches on Pi types at
+  runtime will now build instead of being rejected by the C compiler.
+
 #### Chez
 
 * Fixed CSE soundness bug that caused delayed expressions to sometimes be eagerly

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -35,6 +35,7 @@ Hiroki Hattori
 Ilya Rezvov
 Jacob Walters
 Jan de Muijnck-Hughes
+Jason Manuel
 Jeetu
 Jens Petersen
 Joel Berkeley

--- a/support/refc/prim.c
+++ b/support/refc/prim.c
@@ -233,3 +233,4 @@ char const idris2_constr_Double[] = "Double";
 char const idris2_constr_Integer[] = "Integer";
 char const idris2_constr_Char[] = "Char";
 char const idris2_constr_String[] = "String";
+char const idris2_constr____gt[] = "->";

--- a/support/refc/prim.h
+++ b/support/refc/prim.h
@@ -65,3 +65,4 @@ extern char const idris2_constr_Double[];
 extern char const idris2_constr_Integer[];
 extern char const idris2_constr_Char[];
 extern char const idris2_constr_String[];
+extern char const idris2_constr____gt[];

--- a/tests/node/node004/.gitignore
+++ b/tests/node/node004/.gitignore
@@ -1,0 +1,1 @@
+test.buf

--- a/tests/node/node017/.gitignore
+++ b/tests/node/node017/.gitignore
@@ -1,0 +1,1 @@
+testdir/

--- a/tests/node/node018/.gitignore
+++ b/tests/node/node018/.gitignore
@@ -1,0 +1,1 @@
+testout.txt

--- a/tests/refc/piTypecase001/Test.idr
+++ b/tests/refc/piTypecase001/Test.idr
@@ -1,0 +1,12 @@
+module Test
+
+typeof : Type -> String
+typeof (_ -> _) = "->"
+typeof _ = "Other"
+
+main : IO ()
+main = do
+    putStrLn $ typeof (Int -> Int)
+    putStrLn $ typeof (Nat -> Int)
+    putStrLn $ typeof Nat
+    putStrLn $ typeof Int

--- a/tests/refc/piTypecase001/expected
+++ b/tests/refc/piTypecase001/expected
@@ -1,0 +1,4 @@
+->
+->
+Other
+Other

--- a/tests/refc/piTypecase001/run
+++ b/tests/refc/piTypecase001/run
@@ -1,0 +1,4 @@
+. ../../testutils.sh
+
+idris2 --cg refc -o refc_typecase Test.idr
+./build/exec/refc_typecase


### PR DESCRIPTION
# Description
This pull request introduces changes to fix support for Pi type constructors in the RefC runtime and includes updates to tests and supporting files. The most notable changes include defining a constant string for Pi type representation, adding test cases to verify this functionality, and updating `.gitignore` files for some of the Node backend tests.

### Runtime and Library Enhancements:
* Added a constant string `idris2_constr____gt` (`"->"`) in the RefC support library to represent Pi type constructors. This ensures that code involving Pi types can now compile successfully. (`support/refc/prim.c`, `support/refc/prim.h`) [[1]](diffhunk://#diff-2423aedfcc69b49c9088332a7302217f6bee57d5708269249a8134ec1563f9f0R236) [[2]](diffhunk://#diff-e31bd75810a67651c461e5fc744c3c4e3bfeeb4992552308f445f427ebb7af2bR68)
* Documented the addition of Pi type constructor support to RefC in the `CHANGELOG_NEXT.md` file. (`CHANGELOG_NEXT.md`)

### Testing Updates:
* Added a new test case (`tests/refc/piTypecase001`) to verify the handling of Pi type constructors. This includes the test source file (`Test.idr`), expected output, and a script to run the test. (`tests/refc/piTypecase001`) [[1]](diffhunk://#diff-2238241ac25886e8875f00cd3e2fc09024aece0339e29b8f57ccfee229682ca0R1-R12) [[2]](diffhunk://#diff-8218a139526a55632922631cfd2733de61875e8d4a0ee9fd52c704a139f07c90R1-R4) [[3]](diffhunk://#diff-bc945248ef5409d252f2f540434b3e7e52353204e93163743a3ade8f4cf33fc9R1-R4)
* Updated `.gitignore` files for various test directories to exclude generated files (`test.buf`, `testdir/`, `testout.txt`). (`tests/node/node004/.gitignore`, `tests/node/node017/.gitignore`, `tests/node/node018/.gitignore`) [[1]](diffhunk://#diff-7313fdfb30778b701cf229296484e95b9947b7bbe00362d374fcda752d42c137R1) [[2]](diffhunk://#diff-eee43f179bb7195c966e0967112123bb944a3b970ed0cee18b912b0f2dda6a4dR1) [[3]](diffhunk://#diff-a490ac1288a537a4b0f058dcd94d0b87a74c7e1ce6058a933c6d62331b661f17R1)

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

