### PR TITLE
[ base ] Add default definitions for `zipWith3` and `unzipWith3`

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -304,6 +304,9 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
 
 * `unrestricted`, for unpacking a `!* a`, now uses its argument once
 
+* Added default definitions for `zipWith3` and `unzipWith3` in `Zippable`
+  interface.
+
 #### Contrib
 
 * `Data.Vect.Views.Extra` was moved from `contrib` to `base`.

--- a/libs/base/Data/Zippable.idr
+++ b/libs/base/Data/Zippable.idr
@@ -27,6 +27,7 @@ interface Zippable z where
   ||| @ z the parameterised type
   ||| @ func the function to combine elements with
   zipWith3 : (func : a -> b -> c -> d) -> z a -> z b -> z c -> z d
+  zipWith3 f = zipWith (uncurry f) .: zip
 
   ||| Combine three parameterised types into a parameterised type of triplets.
   ||| @ z the parameterised type
@@ -49,6 +50,7 @@ interface Zippable z where
   ||| @ z the parameterised type
   ||| @ func the function to split elements with
   unzipWith3 : (func : a -> (b, c, d)) -> z a -> (z b, z c, z d)
+  unzipWith3 = mapSnd unzip .: unzipWith
 
   ||| Split a parameterised type of triplets into a triplet of parameterised
   ||| types.


### PR DESCRIPTION
# Description


## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

