### PR TITLE
[ fix ] Remove type constructor tags

### DIFF
--- a/libs/base/Deriving/Common.idr
+++ b/libs/base/Deriving/Common.idr
@@ -46,11 +46,11 @@ wording : NameType -> String
 wording Bound = "a bound variable"
 wording Func = "a function name"
 wording (DataCon tag arity) = "a data constructor"
-wording (TyCon tag arity) = "a type constructor"
+wording (TyCon arity) = "a type constructor"
 
 isTypeCon : Elaboration m => FC -> Name -> m (List (Name, TTImp))
 isTypeCon fc ty = do
-    [(_, MkNameInfo (TyCon _ _))] <- getInfo ty
+    [(_, MkNameInfo (TyCon _))] <- getInfo ty
       | [] => failAt fc "\{show ty} out of scope"
       | [(_, MkNameInfo nt)] => failAt fc "\{show ty} is \{wording nt} rather than a type constructor"
       | _ => failAt fc "\{show ty} is ambiguous"

--- a/libs/base/Deriving/Common.idr
+++ b/libs/base/Deriving/Common.idr
@@ -46,11 +46,11 @@ wording : NameType -> String
 wording Bound = "a bound variable"
 wording Func = "a function name"
 wording (DataCon tag arity) = "a data constructor"
-wording (TyCon arity) = "a type constructor"
+wording (TyCon tag arity) = "a type constructor"
 
 isTypeCon : Elaboration m => FC -> Name -> m (List (Name, TTImp))
 isTypeCon fc ty = do
-    [(_, MkNameInfo (TyCon _))] <- getInfo ty
+    [(_, MkNameInfo (TyCon _ _))] <- getInfo ty
       | [] => failAt fc "\{show ty} out of scope"
       | [(_, MkNameInfo nt)] => failAt fc "\{show ty} is \{wording nt} rather than a type constructor"
       | _ => failAt fc "\{show ty} is ambiguous"

--- a/libs/base/Language/Reflection/TT.idr
+++ b/libs/base/Language/Reflection/TT.idr
@@ -108,7 +108,8 @@ data NameType : Type where
      Bound   : NameType
      Func    : NameType
      DataCon : (tag : Int) -> (arity : Nat) -> NameType
-     TyCon   : (arity : Nat) -> NameType
+     TyCon   : (tag : Int) -> (arity : Nat) -> NameType
+               -- TODO: remove type tag, it's is always 0
 
 %name NameType nty
 

--- a/libs/base/Language/Reflection/TT.idr
+++ b/libs/base/Language/Reflection/TT.idr
@@ -108,7 +108,7 @@ data NameType : Type where
      Bound   : NameType
      Func    : NameType
      DataCon : (tag : Int) -> (arity : Nat) -> NameType
-     TyCon   : (tag : Int) -> (arity : Nat) -> NameType
+     TyCon   : (arity : Nat) -> NameType
 
 %name NameType nty
 

--- a/src/Compiler/CompileExpr.idr
+++ b/src/Compiler/CompileExpr.idr
@@ -33,7 +33,7 @@ data Args
 ||| Extract the number of arguments from a term, or return that it's
 ||| a newtype by a given argument position
 numArgs : Defs -> Term vars -> Core Args
-numArgs defs (Ref _ (TyCon tag arity) n) = pure (Arity arity)
+numArgs defs (Ref _ (TyCon arity) n) = pure (Arity arity)
 numArgs defs (Ref _ _ n)
     = do Just gdef <- lookupCtxtExact n (gamma defs)
               | Nothing => pure (Arity 0)
@@ -167,7 +167,7 @@ toCExpTm n (Ref fc (DataCon tag arity) fn)
          cn <- getFullName fn
          fl <- dconFlag cn
          pure $ CCon fc cn fl (Just tag) []
-toCExpTm n (Ref fc (TyCon tag arity) fn)
+toCExpTm n (Ref fc (TyCon arity) fn)
     = pure $ CCon fc fn TYCON Nothing []
 toCExpTm n (Ref fc _ fn)
     = do full <- getFullName fn
@@ -470,7 +470,7 @@ nfToCFType _ (NBind fc _ (Pi _ _ _ ty) sc) False
          pure (CFFun sty tty)
 nfToCFType _ (NBind fc _ _ _) True
     = throw (GenericMsg fc "Function types not allowed in a foreign struct")
-nfToCFType _ (NTCon fc n_in _ _ args) s
+nfToCFType _ (NTCon fc n_in _ args) s
     = do defs <- get Ctxt
          n <- toFullNames n_in
          case !(getNArgs defs n $ map snd args) of
@@ -588,7 +588,7 @@ toCDef n _ _ (DCon tag arity pos)
                  EraseArgs ar erased => ar `minus` size erased
                  Arity ar => ar
          pure $ MkCon (Just tag) arity' nt
-toCDef n _ _ (TCon tag arity _ _ _ _ _ _)
+toCDef n _ _ (TCon arity _ _ _ _ _ _)
     = pure $ MkCon Nothing arity Nothing
 -- We do want to be able to compile these, but also report an error at run time
 -- (and, TODO: warn at compile time)

--- a/src/Core/AutoSearch.idr
+++ b/src/Core/AutoSearch.idr
@@ -400,11 +400,6 @@ searchName fc rigc defaults trying depth def top env target (n, ndef)
          when (isErased ty) $
             throw (CantSolveGoal fc (gamma defs) [] top Nothing)
 
-         let namety : NameType
-                 = case definition ndef of
-                        DCon tag arity _ => DataCon tag arity
-                        TCon arity _ _ _ _ _ _ => TyCon arity
-                        _ => Func
          nty <- nf defs env (embed ty)
          logNF "auto" 10 ("Searching Name " ++ show n) env nty
          (args, appTy) <- mkArgs fc rigc env nty
@@ -412,7 +407,7 @@ searchName fc rigc defaults trying depth def top env target (n, ndef)
          let [] = constraints ures
              | _ => throw (CantSolveGoal fc (gamma defs) Env.empty top Nothing)
          ispair <- isPairNF env nty defs
-         let candidate = apply fc (Ref fc namety n) (map metaApp args)
+         let candidate = apply fc (Ref fc (getDefNameType ndef) n) (map metaApp args)
          logTermNF "auto" 10 "Candidate " env candidate
          -- Work right to left, because later arguments may solve earlier
          -- dependencies by unification

--- a/src/Core/AutoSearch.idr
+++ b/src/Core/AutoSearch.idr
@@ -231,7 +231,7 @@ usableLocal loc defaults env (NApp fc (NMeta (PV _ _) _ _) args)
     = pure True
 usableLocal loc defaults env (NApp fc (NMeta _ _ _) args)
     = pure False
-usableLocal {vars} loc defaults env (NTCon _ n _ _ args)
+usableLocal {vars} loc defaults env (NTCon _ n _ args)
     = do sd <- getSearchData loc (not defaults) n
          usableLocalArg 0 (detArgs sd) (map snd args)
   -- usable if none of the determining arguments of the local's type are
@@ -324,7 +324,7 @@ searchLocalWith {vars} fc rigc defaults trying depth def top env (prf, ty) targe
               NF vars ->  -- local's type
               (target : NF vars) ->
               Core (Term vars)
-    findPos defs f nty@(NTCon pfc pn _ _ [(_, xty), (_, yty)]) target
+    findPos defs f nty@(NTCon pfc pn _ [(_, xty), (_, yty)]) target
         = tryUnifyUnambig (findDirect defs f nty target) $
              do fname <- maybe (throw (CantSolveGoal fc (gamma defs) Env.empty top Nothing))
                                pure
@@ -372,7 +372,7 @@ searchLocalVars fc rig defaults trying depth def top env target
 
 isPairNF : {auto c : Ref Ctxt Defs} ->
            Env Term vars -> NF vars -> Defs -> Core Bool
-isPairNF env (NTCon _ n _ _ _) defs
+isPairNF env (NTCon _ n _ _) defs
     = isPairType n
 isPairNF env (NBind fc b (Pi _ _ _ _) sc) defs
     = isPairNF env !(sc defs (toClosure defaultOpts env (Erased fc Placeholder))) defs
@@ -403,7 +403,7 @@ searchName fc rigc defaults trying depth def top env target (n, ndef)
          let namety : NameType
                  = case definition ndef of
                         DCon tag arity _ => DataCon tag arity
-                        TCon tag arity _ _ _ _ _ _ => TyCon tag arity
+                        TCon arity _ _ _ _ _ _ => TyCon arity
                         _ => Func
          nty <- nf defs env (embed ty)
          logNF "auto" 10 ("Searching Name " ++ show n) env nty
@@ -471,7 +471,7 @@ concreteDets {vars} fc defaults env top pos dets (arg :: args)
     concrete defs (NBind nfc x b sc) atTop
         = do scnf <- sc defs (toClosure defaultOpts env (Erased nfc Placeholder))
              concrete defs scnf False
-    concrete defs (NTCon nfc n t a args) atTop
+    concrete defs (NTCon nfc n a args) atTop
         = do sd <- getSearchData nfc False n
              let args' = NatSet.take (detArgs sd) args
              traverse_ (\ parg => do argnf <- evalClosure defs parg
@@ -497,7 +497,7 @@ checkConcreteDets : {vars : _} ->
                     Env Term vars -> (top : ClosedTerm) ->
                     NF vars ->
                     Core ()
-checkConcreteDets fc defaults env top (NTCon tfc tyn t a args)
+checkConcreteDets fc defaults env top (NTCon tfc tyn a args)
     = do defs <- get Ctxt
          if !(isPairType tyn)
             then case args of
@@ -543,14 +543,14 @@ searchType {vars} fc rigc defaults trying depth def checkdets top env target
          let trying' = target :: trying
          nty <- nf defs env target
          case nty of
-              NTCon tfc tyn t a args =>
+              NTCon tfc tyn a args =>
                   if a == length args
                      then do logNF "auto" 10 "Next target" env nty
                              sd <- getSearchData fc defaults tyn
                              -- Check determining arguments are okay for 'args'
                              when checkdets $
                                  checkConcreteDets fc defaults env top
-                                                   (NTCon tfc tyn t a args)
+                                                   (NTCon tfc tyn a args)
                              if defaults && checkdets
                                 then tryGroups Nothing nty (hintGroups sd)
                                 else tryUnifyUnambig

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -30,7 +30,7 @@ import public Libraries.Utils.Binary
 ||| version number if you're changing the version more than once in the same day.
 export
 ttcVersion : Int
-ttcVersion = 2025_08_06_00
+ttcVersion = 2025_08_08_00
 
 export
 checkTTCVersion : String -> Int -> Int -> Core ()

--- a/src/Core/Case/CaseBuilder.idr
+++ b/src/Core/Case/CaseBuilder.idr
@@ -824,7 +824,7 @@ sameType {ns} fc phase fn env (p :: xs)
 
     headEq : NF ns -> NF ns -> Phase -> Bool
     headEq (NBind _ _ (Pi _ _ _ _) _) (NBind _ _ (Pi _ _ _ _) _) _ = True
-    headEq (NTCon _ n _ _ _) (NTCon _ n' _ _ _) _ = n == n'
+    headEq (NTCon _ n _ _) (NTCon _ n' _ _) _ = n == n'
     headEq (NPrimVal _ c) (NPrimVal _ c') _ = c == c'
     headEq (NType _ _) (NType _ _) _ = True
     headEq (NApp _ (NRef _ n) _) (NApp _ (NRef _ n') _) RunTime = n == n'
@@ -1086,7 +1086,7 @@ export
 mkPat : {auto c : Ref Ctxt Defs} -> List Pat -> ClosedTerm -> ClosedTerm -> Core Pat
 mkPat [] orig (Ref fc Bound n) = pure $ PLoc fc n
 mkPat args orig (Ref fc (DataCon t a) n) = pure $ PCon fc n t a args
-mkPat args orig (Ref fc (TyCon t a) n) = pure $ PTyCon fc n a args
+mkPat args orig (Ref fc (TyCon a) n) = pure $ PTyCon fc n a args
 mkPat args orig (Ref fc Func n)
   = do prims <- getPrimitiveNames
        mtm <- normalisePrims (const True) isPConst True prims n args orig Env.empty

--- a/src/Core/Case/CaseTree.idr
+++ b/src/Core/Case/CaseTree.idr
@@ -276,7 +276,7 @@ mkTerm vars (PCon fc x tag arity xs)
     = apply fc (Ref fc (DataCon tag arity) x)
                (map (mkTerm vars) xs)
 mkTerm vars (PTyCon fc x arity xs)
-    = apply fc (Ref fc (TyCon 0 arity) x)
+    = apply fc (Ref fc (TyCon arity) x)
                (map (mkTerm vars) xs)
 mkTerm vars (PConst fc c) = PrimVal fc c
 mkTerm vars (PArrow fc x s t)

--- a/src/Core/Case/Util.idr
+++ b/src/Core/Case/Util.idr
@@ -22,9 +22,9 @@ export
 getCons : {auto c : Ref Ctxt Defs} ->
           {vars : _} ->
           Defs -> NF vars -> Core (List DataCon)
-getCons defs (NTCon _ tn _ _ _)
+getCons defs (NTCon _ tn _ _)
     = case !(lookupDefExact tn (gamma defs)) of
-           Just (TCon _ _ _ _ _ _ cons _) =>
+           Just (TCon _ _ _ _ _ cons _) =>
                 do cs' <- traverse addTy (fromMaybe [] cons)
                    pure (catMaybes cs')
            _ => throw (InternalError "Called `getCons` on something that is not a Type constructor")

--- a/src/Core/Context/Context.idr
+++ b/src/Core/Context/Context.idr
@@ -98,7 +98,7 @@ data Def : Type where
                -- that the value is inspected, to make sure external effects
                -- happen)
            Def -- data constructor
-    TCon : (tag : Int) -> (arity : Nat) ->
+    TCon : (arity : Nat) ->
            (parampos : NatSet) -> -- parameters
            (detpos : NatSet) -> -- determining arguments
            (flags : TypeFlags) -> -- should 'auto' implicits check
@@ -135,7 +135,7 @@ defNameType (ExternDef {}) = Just Func
 defNameType (ForeignDef {}) = Just Func
 defNameType (Builtin {}) = Just Func
 defNameType (DCon tag ar _) = Just (DataCon tag ar)
-defNameType (TCon tag ar _ _ _ _ _ _) = Just (TyCon tag ar)
+defNameType (TCon ar _ _ _ _ _ _) = Just (TyCon ar)
 defNameType (Hole {}) = Just Func
 defNameType (BySearch {}) = Nothing
 defNameType (Guess {}) = Nothing
@@ -155,8 +155,8 @@ Show Def where
   show (DCon t a nt)
       = "DataCon " ++ show t ++ " " ++ show a
            ++ maybe "" (\n => " (newtype by " ++ show n ++ ")") nt
-  show (TCon t a ps ds u ms cons det)
-      = "TyCon " ++ show t ++ " " ++ show a ++ " params: " ++ show ps ++
+  show (TCon a ps ds u ms cons det)
+      = "TyCon " ++ show a ++ " params: " ++ show ps ++
         " constructors: " ++ show cons ++
         " mutual with: " ++ show ms ++
         " detaggable by: " ++ show det

--- a/src/Core/Context/Context.idr
+++ b/src/Core/Context/Context.idr
@@ -330,6 +330,10 @@ record GlobalDef where
   schemeExpr : Maybe (SchemeMode, SchemeObj Write)
 
 export
+getDefNameType : GlobalDef -> NameType
+getDefNameType = fromMaybe Func . defNameType . definition
+
+export
 gDefKindedName : GlobalDef -> KindedName
 gDefKindedName def
   = let nm = fullname def in

--- a/src/Core/Context/Data.idr
+++ b/src/Core/Context/Data.idr
@@ -94,7 +94,6 @@ addData : {auto c : Ref Ctxt Defs} ->
           Scope -> Visibility -> Int -> DataDef -> Core Int
 addData vars vis tidx (MkData (MkCon dfc tyn arity tycon) datacons)
     = do defs <- get Ctxt
-         tag <- getNextTypeTag
          let allPos = NatSet.allLessThan arity
          -- In case there are no constructors, all the positions are parameter positions!
          let paramPositions = fromMaybe allPos !(paramPos (Resolved tidx) (map type datacons))
@@ -102,7 +101,7 @@ addData vars vis tidx (MkData (MkCon dfc tyn arity tycon) datacons)
             "Positions of parameters for datatype" ++ show tyn ++
             ": " ++ show paramPositions
          let tydef = newDef dfc tyn top vars tycon (specified vis)
-                            (TCon tag arity
+                            (TCon arity
                                   paramPositions
                                   allPos
                                   defaultFlags [] (Just $ map name datacons) Nothing)

--- a/src/Core/Context/Pretty.idr
+++ b/src/Core/Context/Pretty.idr
@@ -52,11 +52,10 @@ namespace Raw
           ([ "tag:" <++> byShow tag
            , "arity:" <++> byShow arity
            ] ++ maybe [] (\ n => ["newtype by:" <++> byShow n]) nt)
-  prettyDef (TCon tag arity ps ds u ms cons det) =
+  prettyDef (TCon arity ps ds u ms cons det) =
         let enum = hsep . punctuate "," in
         vcat $ header "Type constructor" :: map (indent 2)
-          ([ "tag:" <++> byShow tag
-           , "arity:" <++> byShow arity
+          ([ "arity:" <++> byShow arity
            , "parameter positions:" <++> byShow ps
            , "constructors:" <++> enum ((\ nm => annotate (Syntax $ DCon (Just nm)) (pretty0 nm)) <$> fromMaybe [] cons)
            ] ++ (("mutual with:" <++> enum (pretty0 <$> ms)) <$ guard (not $ null ms))
@@ -104,11 +103,10 @@ namespace Resugared
           ([ "tag:" <++> byShow tag
            , "arity:" <++> byShow arity
            ] ++ maybe [] (\ n => ["newtype by:" <++> byShow n]) nt)
-  prettyDef (TCon tag arity ps ds u ms cons det) = pure $
+  prettyDef (TCon arity ps ds u ms cons det) = pure $
         let enum = hsep . punctuate "," in
         vcat $ header "Type constructor" :: map (indent 2)
-          ([ "tag:" <++> byShow tag
-           , "arity:" <++> byShow arity
+          ([ "arity:" <++> byShow arity
            , "parameter positions:" <++> byShow ps
            , "constructors:" <++> enum ((\ nm => annotate (Syntax $ DCon (Just nm)) (pretty0 nm)) <$> fromMaybe [] cons)
            ] ++ (("mutual with:" <++> enum (pretty0 <$> ms)) <$ guard (not $ null ms))

--- a/src/Core/Coverage.idr
+++ b/src/Core/Coverage.idr
@@ -32,8 +32,8 @@ conflictMatch ((x, tm) :: ms) = conflictArgs x tm ms || conflictMatch ms
     clash : Term vars -> Term vars -> ClashResult
     clash (Ref _ (DataCon t _) _) (Ref _ (DataCon t' _) _)
         = if t /= t' then Distinct else Same
-    clash (Ref _ (TyCon t _) _) (Ref _ (TyCon t' _) _)
-        = if t /= t' then Distinct else Same
+    clash (Ref _ (TyCon _ _) n) (Ref _ (TyCon _ _) n')
+        = if n /= n' then Distinct else Same
     clash (PrimVal _ c) (PrimVal _ c') = if  c /= c' then Distinct else Same
     clash (Ref _ t _) (PrimVal _ _) = if isJust (isCon t) then Distinct else Incomparable
     clash (PrimVal _ _) (Ref _ t _) = if isJust (isCon t) then Distinct else Incomparable

--- a/src/Core/Coverage.idr
+++ b/src/Core/Coverage.idr
@@ -32,9 +32,9 @@ conflictMatch ((x, tm) :: ms) = conflictArgs x tm ms || conflictMatch ms
     clash : Term vars -> Term vars -> ClashResult
     clash (Ref _ (DataCon t _) _) (Ref _ (DataCon t' _) _)
         = if t /= t' then Distinct else Same
-    clash (Ref _ (TyCon _ _) n) (Ref _ (TyCon _ _) n')
+    clash (Ref _ (TyCon _) n) (Ref _ (TyCon _) n')
         = if n /= n' then Distinct else Same
-    clash (PrimVal _ c) (PrimVal _ c') = if  c /= c' then Distinct else Same
+    clash (PrimVal _ c) (PrimVal _ c') = if c /= c' then Distinct else Same
     clash (Ref _ t _) (PrimVal _ _) = if isJust (isCon t) then Distinct else Incomparable
     clash (PrimVal _ _) (Ref _ t _) = if isJust (isCon t) then Distinct else Incomparable
     clash (Ref _ t _) (TType _ _)   = if isJust (isCon t) then Distinct else Incomparable
@@ -124,7 +124,7 @@ conflict defs env nfty n
           = if t == t'
                then conflictArgs i (map snd args) (map snd args')
                else pure Nothing
-      conflictNF i (NTCon _ n t a args) (NTCon _ n' t' a' args')
+      conflictNF i (NTCon _ n a args) (NTCon _ n' a' args')
           = if n == n'
                then conflictArgs i (map snd args) (map snd args')
                else pure Nothing
@@ -140,14 +140,14 @@ export
 isEmpty : {vars : _} ->
           {auto c : Ref Ctxt Defs} ->
           Defs -> Env Term vars -> NF vars -> Core Bool
-isEmpty defs env (NTCon fc n t a args)
+isEmpty defs env (NTCon fc n a args)
   = do Just nty <- lookupDefExact n (gamma defs)
          | _ => pure False
        case nty of
-            TCon _ _ _ _ flags _ Nothing _ => pure False
-            TCon _ _ _ _ flags _ (Just cons) _
+            TCon _ _ _ flags _ Nothing _ => pure False
+            TCon _ _ _ flags _ (Just cons) _
                  => if not (external flags)
-                       then allM (conflict defs env (NTCon fc n t a args)) cons
+                       then allM (conflict defs env (NTCon fc n a args)) cons
                        else pure False
             _ => pure False
 isEmpty defs env _ = pure False

--- a/src/Core/Metadata.idr
+++ b/src/Core/Metadata.idr
@@ -31,7 +31,7 @@ nameDecoration nm nt
   nameTypeDecoration Bound         = Bound
   nameTypeDecoration Func          = Function
   nameTypeDecoration (DataCon _ _) = Data
-  nameTypeDecoration (TyCon _ _  ) = Typ
+  nameTypeDecoration (TyCon _)     = Typ
 
 
 public export

--- a/src/Core/Metadata.idr
+++ b/src/Core/Metadata.idr
@@ -28,10 +28,10 @@ nameDecoration nm nt
   where
 
   nameTypeDecoration : NameType -> Decoration
-  nameTypeDecoration Bound         = Bound
-  nameTypeDecoration Func          = Function
-  nameTypeDecoration (DataCon _ _) = Data
-  nameTypeDecoration (TyCon _)     = Typ
+  nameTypeDecoration Bound        = Bound
+  nameTypeDecoration Func         = Function
+  nameTypeDecoration (DataCon {}) = Data
+  nameTypeDecoration (TyCon {})   = Typ
 
 
 public export

--- a/src/Core/Normalise.idr
+++ b/src/Core/Normalise.idr
@@ -280,11 +280,11 @@ replace' {vars} tmpi defs env lhs parg tm
              pure $ applyStackWithFC
                         !(quote empty env (NDCon fc n t a []))
                         args'
-    repSub (NTCon fc n t a args)
+    repSub (NTCon fc n a args)
         = do args' <- traverse (traversePair repArg) args
              empty <- clearDefs defs
              pure $ applyStackWithFC
-                        !(quote empty env (NTCon fc n t a []))
+                        !(quote empty env (NTCon fc n a []))
                         args'
     repSub (NAs fc s a p)
         = do a' <- repSub a

--- a/src/Core/Normalise/Convert.idr
+++ b/src/Core/Normalise/Convert.idr
@@ -118,7 +118,7 @@ mutual
       quickConvArg _ (NBind{}) = True
       quickConvArg (NApp _ h _) (NApp _ h' _) = quickConvHead h h'
       quickConvArg (NDCon _ _ t _ _) (NDCon _ _ t' _ _) = t == t'
-      quickConvArg (NTCon _ n _ _ _) (NTCon _ n' _ _ _) = n == n'
+      quickConvArg (NTCon _ n _ _) (NTCon _ n' _ _) = n == n'
       quickConvArg (NAs _ _ _ t) (NAs _ _ _ t') = quickConvArg t t'
       quickConvArg (NDelayed _ _ t) (NDelayed _ _ t') = quickConvArg t t'
       quickConvArg (NDelay _ _ _ _) (NDelay _ _ _ _) = True
@@ -403,7 +403,7 @@ mutual
         = if tag == tag'
              then allConv q i defs env (map snd args) (map snd args')
              else pure False
-    convGen q i defs env (NTCon _ nm tag _ args) (NTCon _ nm' tag' _ args')
+    convGen q i defs env (NTCon _ nm _ args) (NTCon _ nm' _ args')
         = if nm == nm'
              then allConv q i defs env (map snd args) (map snd args')
              else pure False

--- a/src/Core/Normalise/Eval.idr
+++ b/src/Core/Normalise/Eval.idr
@@ -182,8 +182,8 @@ parameters (defs : Defs) (topopts : EvalOpts)
         = evalMeta env fc n i args (args' ++ stk)
     applyToStack env (NDCon fc n t a args) stk
         = pure $ NDCon fc n t a (args ++ stk)
-    applyToStack env (NTCon fc n t a args) stk
-        = pure $ NTCon fc n t a (args ++ stk)
+    applyToStack env (NTCon fc n a args) stk
+        = pure $ NTCon fc n a (args ++ stk)
     applyToStack env (NAs fc s p t) stk
        = if removeAs topopts
             then applyToStack env t stk
@@ -278,10 +278,10 @@ parameters (defs : Defs) (topopts : EvalOpts)
         = do -- logC "eval.ref.data" 50 $ do fn' <- toFullNames fn -- Can't use ! here, it gets lifted too far
              --                             pure $ "Found data constructor: " ++ show fn'
              pure $ NDCon fc fn tag arity stk
-    evalRef env meta fc (TyCon tag arity) fn stk def
+    evalRef env meta fc (TyCon arity) fn stk def
         = do -- logC "eval.ref.type" 50 $ do fn' <- toFullNames fn
              --                             pure $ "Found type constructor: " ++ show fn'
-             pure $ ntCon fc fn tag arity stk
+             pure $ ntCon fc fn arity stk
     evalRef env meta fc Bound fn stk def
         = do -- logC "eval.ref.bound" 50 $ do fn' <- toFullNames fn
              --                              pure $ "Found bound variable: " ++ show fn'
@@ -358,7 +358,7 @@ parameters (defs : Defs) (topopts : EvalOpts)
               then evalConAlt env loc opts fc stk args (map snd args') sc
               else pure NoMatch
     -- Type constructor matching, in typecase
-    tryAlt {more} env loc opts fc stk (NTCon _ nm tag' arity args') (ConCase nm' tag args sc)
+    tryAlt {more} env loc opts fc stk (NTCon _ nm arity args') (ConCase nm' tag args sc)
          = if nm == nm'
               then evalConAlt env loc opts fc stk args (map snd args') sc
               else pure NoMatch
@@ -399,7 +399,7 @@ parameters (defs : Defs) (topopts : EvalOpts)
       where
         concrete : NF free -> Bool
         concrete (NDCon _ _ _ _ _) = True
-        concrete (NTCon _ _ _ _ _) = True
+        concrete (NTCon _ _ _ _) = True
         concrete (NPrimVal _ _) = True
         concrete (NBind _ _ _ _) = True
         concrete (NType _ _) = True

--- a/src/Core/Normalise/Eval.idr
+++ b/src/Core/Normalise/Eval.idr
@@ -398,12 +398,12 @@ parameters (defs : Defs) (topopts : EvalOpts)
               else pure GotStuck
       where
         concrete : NF free -> Bool
-        concrete (NDCon _ _ _ _ _) = True
-        concrete (NTCon _ _ _ _) = True
-        concrete (NPrimVal _ _) = True
-        concrete (NBind _ _ _ _) = True
-        concrete (NType _ _) = True
-        concrete (NDelay _ _ _ _) = True
+        concrete (NDCon {}) = True
+        concrete (NTCon {}) = True
+        concrete (NPrimVal {}) = True
+        concrete (NBind {}) = True
+        concrete (NType {}) = True
+        concrete (NDelay {}) = True
         concrete _ = False
     tryAlt _ _ _ _ _ _ _ = pure GotStuck
 

--- a/src/Core/Normalise/Quote.idr
+++ b/src/Core/Normalise/Quote.idr
@@ -201,9 +201,9 @@ mutual
   quoteGenNF q opts defs bound env (NDCon fc n t ar args)
       = do args' <- quoteArgsWithFC q opts defs bound env args
            pure $ applyStackWithFC (Ref fc (DataCon t ar) n) args'
-  quoteGenNF q opts defs bound env (NTCon fc n t ar args)
+  quoteGenNF q opts defs bound env (NTCon fc n ar args)
       = do args' <- quoteArgsWithFC q opts defs bound env args
-           pure $ applyStackWithFC (Ref fc (TyCon t ar) n) args'
+           pure $ applyStackWithFC (Ref fc (TyCon ar) n) args'
   quoteGenNF q opts defs bound env (NAs fc s n pat)
       = do n' <- quoteGenNF q opts defs bound env n
            pat' <- quoteGenNF q opts defs bound env pat

--- a/src/Core/Primitives.idr
+++ b/src/Core/Primitives.idr
@@ -499,7 +499,7 @@ doubleCeiling = doubleOp ceiling
 -- Only reduce for concrete values
 believeMe : Vect 3 (NF vars) -> Maybe (NF vars)
 believeMe [_, _, val@(NDCon _ _ _ _ _)] = Just val
-believeMe [_, _, val@(NTCon _ _ _ _ _)] = Just val
+believeMe [_, _, val@(NTCon _ _ _ _)] = Just val
 believeMe [_, _, val@(NPrimVal _ _)] = Just val
 believeMe [_, _, NType fc u] = Just (NType fc u)
 believeMe [_, _, val] = Nothing

--- a/src/Core/Primitives.idr
+++ b/src/Core/Primitives.idr
@@ -498,9 +498,9 @@ doubleCeiling = doubleOp ceiling
 
 -- Only reduce for concrete values
 believeMe : Vect 3 (NF vars) -> Maybe (NF vars)
-believeMe [_, _, val@(NDCon _ _ _ _ _)] = Just val
-believeMe [_, _, val@(NTCon _ _ _ _)] = Just val
-believeMe [_, _, val@(NPrimVal _ _)] = Just val
+believeMe [_, _, val@(NDCon {})] = Just val
+believeMe [_, _, val@(NTCon {})] = Just val
+believeMe [_, _, val@(NPrimVal {})] = Just val
 believeMe [_, _, NType fc u] = Just (NType fc u)
 believeMe [_, _, val] = Nothing
 

--- a/src/Core/Reflect.idr
+++ b/src/Core/Reflect.idr
@@ -32,7 +32,7 @@ getCon : {vars : _} ->
 getCon fc defs n
     = case !(lookupDefExact n (gamma defs)) of
            Just (DCon t a _) => resolved (gamma defs) (Ref fc (DataCon t a) n)
-           Just (TCon t a _ _ _ _ _ _) => resolved (gamma defs) (Ref fc (TyCon t a) n)
+           Just (TCon a _ _ _ _ _ _) => resolved (gamma defs) (Ref fc (TyCon a) n)
            Just _ => resolved (gamma defs) (Ref fc Func n)
            _ => throw (UndefinedName fc n)
 
@@ -498,10 +498,9 @@ Reify NameType where
                   => do t' <- reify defs !(evalClosure defs t)
                         i' <- reify defs !(evalClosure defs i)
                         pure (DataCon t' i')
-             (UN (Basic "TyCon"), [(_, t),(_, i)])
-                  => do t' <- reify defs !(evalClosure defs t)
-                        i' <- reify defs !(evalClosure defs i)
-                        pure (TyCon t' i')
+             (UN (Basic "TyCon"), [(_, i)])
+                  => do i' <- reify defs !(evalClosure defs i)
+                        pure (TyCon i')
              _ => cantReify val "NameType"
   reify defs val = cantReify val "NameType"
 
@@ -513,10 +512,9 @@ Reflect NameType where
       = do t' <- reflect fc defs lhs env t
            i' <- reflect fc defs lhs env i
            appCon fc defs (reflectiontt "DataCon") [t', i']
-  reflect fc defs lhs env (TyCon t i)
-      = do t' <- reflect fc defs lhs env t
-           i' <- reflect fc defs lhs env i
-           appCon fc defs (reflectiontt "TyCon") [t', i']
+  reflect fc defs lhs env (TyCon i)
+      = do i' <- reflect fc defs lhs env i
+           appCon fc defs (reflectiontt "TyCon") [i']
 
 export
 Reify PrimType where

--- a/src/Core/Reflect.idr
+++ b/src/Core/Reflect.idr
@@ -514,7 +514,7 @@ Reflect NameType where
            appCon fc defs (reflectiontt "DataCon") [t', i']
   reflect fc defs lhs env (TyCon i)
       = do i' <- reflect fc defs lhs env i
-           appCon fc defs (reflectiontt "TyCon") [i']
+           appCon fc defs (reflectiontt "TyCon") [PrimVal fc (I 0), i']
 
 export
 Reify PrimType where

--- a/src/Core/SchemeEval/Compile.idr
+++ b/src/Core/SchemeEval/Compile.idr
@@ -200,11 +200,10 @@ compileStk svs stk (Ref fc (DataCon t a) name)
                        (toScheme !(toResolvedNames name) ::
                         toScheme fc :: stk)
          else pure $ unload (Apply (Var (schName name)) []) stk
-compileStk svs stk (Ref fc (TyCon t a) name)
+compileStk svs stk (Ref fc (TyCon a) name)
     = if length stk == a -- inline it if it's fully applied
          then pure $ Vector (-1)
-                       (IntegerVal (cast t) ::
-                        StringVal (show name) ::
+                       (StringVal (show name) ::
                         toScheme !(toResolvedNames name) ::
                         toScheme fc :: stk)
          else pure $ unload (Apply (Var (schName name)) []) stk
@@ -528,16 +527,14 @@ compileBody _ n (DCon tag arity newtypeArg)
     mkArgNs : Int -> Nat -> List Name
     mkArgNs i Z = []
     mkArgNs i (S k) = MN "arg" i :: mkArgNs (i+1) k
-compileBody _ n (TCon tag Z parampos detpos flags mutwith datacons detagabbleBy)
-    = pure $ Vector (-1) [IntegerVal (cast tag), StringVal (show n),
-                          toScheme n, toScheme emptyFC]
-compileBody _ n (TCon tag arity parampos detpos flags mutwith datacons detagabbleBy)
+compileBody _ n (TCon Z parampos detpos flags mutwith datacons detagabbleBy)
+    = pure $ Vector (-1) [StringVal (show n), toScheme n, toScheme emptyFC]
+compileBody _ n (TCon arity parampos detpos flags mutwith datacons detagabbleBy)
     = do let args = mkArgNs 0 arity
          argvs <- mkArgs args
          let body
                = Vector (-1)
-                        (IntegerVal (cast tag) ::
-                         StringVal (show n) ::
+                        (StringVal (show n) ::
                           toScheme n :: toScheme emptyFC ::
                             map (Var . schVarName) args)
          pure (bindArgs n argvs [] body)

--- a/src/Core/SchemeEval/Evaluate.idr
+++ b/src/Core/SchemeEval/Evaluate.idr
@@ -36,7 +36,7 @@ mutual
        SApp     : FC -> SHead vars -> List (Core (SNF vars)) -> SNF vars
        SDCon    : FC -> Name -> (tag : Int) -> (arity : Nat) ->
                   List (Core (SNF vars)) -> SNF vars
-       STCon    : FC -> Name -> (tag : Int) -> (arity : Nat) ->
+       STCon    : FC -> Name -> (arity : Nat) ->
                   List (Core (SNF vars)) -> SNF vars
        SDelayed : FC -> LazyReason -> SNF vars -> SNF vars
        SDelay   : FC -> LazyReason -> Core (SNF vars) -> Core (SNF vars) ->
@@ -172,12 +172,11 @@ mutual
            let argList = getArgList args_in
            args <- traverse (quote' svs) argList
            pure (apply emptyFC loc args)
-  quoteVector svs (-1) (_ :: tag_in :: strtag :: cname_in :: fc_in :: args_in) -- TyCon
-      = quoteOrInvalid cname_in $ \ cname =>
-        quoteOrInvalid {x = Integer} tag_in $ \ tag => do
+  quoteVector svs (-1) (_ :: strtag :: cname_in :: fc_in :: args_in) -- TyCon
+      = quoteOrInvalid cname_in $ \ cname => do
            let fc = emptyFC -- quoteFC fc_in
            args <- traverse (quote' svs) args_in
-           pure (apply fc (Ref fc (TyCon (cast tag) (length args)) cname)
+           pure (apply fc (Ref fc (TyCon (length args)) cname)
                            args)
   quoteVector svs (-15) [_, r_in, ty_in] -- Delayed
       = do ty <- quote' svs ty_in
@@ -413,12 +412,11 @@ mutual
                 | _ => invalidS
            let args' = map (snf' svs) (getArgList args_in)
            pure (SApp fc loc (args ++ args'))
-  snfVector svs (-1) (_ :: tag_in :: strtag :: cname_in :: fc_in :: args_in) -- TyCon
-      = quoteOrInvalidS cname_in $ \ cname =>
-        quoteOrInvalidS {x = Integer} tag_in $ \ tag => do
+  snfVector svs (-1) (_ :: strtag :: cname_in :: fc_in :: args_in) -- TyCon
+      = quoteOrInvalidS cname_in $ \ cname => do
            let fc = quoteFC fc_in
            let args = map (snf' svs) args_in
-           pure (STCon fc cname (cast tag) (length args) args)
+           pure (STCon fc cname (length args) args)
   snfVector svs (-15) [_, r_in, ty_in] -- Delayed
       = do ty <- snf' svs ty_in
            let r = quoteLazyReason r_in

--- a/src/Core/SchemeEval/Quote.idr
+++ b/src/Core/SchemeEval/Quote.idr
@@ -110,9 +110,9 @@ mutual
   quoteGen q bound env (SDCon fc n t ar args)
       = do args' <- quoteArgs q bound env args
            pure $ apply fc (Ref fc (DataCon t ar) n) args'
-  quoteGen q bound env (STCon fc n t ar args)
+  quoteGen q bound env (STCon fc n ar args)
       = do args' <- quoteArgs q bound env args
-           pure $ apply fc (Ref fc (TyCon t ar) n) args'
+           pure $ apply fc (Ref fc (TyCon ar) n) args'
   quoteGen q bound env (SDelayed fc r arg)
       = do argQ <- quoteGen q bound env arg
            pure (TDelayed fc r argQ)

--- a/src/Core/TT/Term.idr
+++ b/src/Core/TT/Term.idr
@@ -29,7 +29,7 @@ data NameType : Type where
      Bound   : NameType
      Func    : NameType
      DataCon : (tag : Int) -> (arity : Nat) -> NameType
-     TyCon   : (tag : Int) -> (arity : Nat) -> NameType
+     TyCon   : (arity : Nat) -> NameType
 
 %name NameType nt
 
@@ -39,12 +39,12 @@ Show NameType where
   showPrec d Bound = "Bound"
   showPrec d Func = "Func"
   showPrec d (DataCon tag ar) = showCon d "DataCon" $ showArg tag ++ showArg ar
-  showPrec d (TyCon tag ar) = showCon d "TyCon" $ showArg tag ++ showArg ar
+  showPrec d (TyCon ar) = showCon d "TyCon" $ showArg ar
 
 export
-isCon : NameType -> Maybe (Int, Nat)
-isCon (DataCon t a) = Just (t, a)
-isCon (TyCon t a) = Just (t, a)
+isCon : NameType -> Maybe Nat
+isCon (DataCon t a) = Just a
+isCon (TyCon a) = Just a
 isCon _ = Nothing
 
 -- Typechecked terms

--- a/src/Core/TTC.idr
+++ b/src/Core/TTC.idr
@@ -273,14 +273,14 @@ TTC NameType where
   toBuf Bound = tag 0
   toBuf Func = tag 1
   toBuf (DataCon t arity) = do tag 2; toBuf t; toBuf arity
-  toBuf (TyCon t arity) = do tag 3; toBuf t; toBuf arity
+  toBuf (TyCon arity) = do tag 3; toBuf arity
 
   fromBuf
       = case !getTag of
              0 => pure Bound
              1 => pure Func
              2 => do x <- fromBuf; y <- fromBuf; pure (DataCon x y)
-             3 => do x <- fromBuf; y <- fromBuf; pure (TyCon x y)
+             3 => do y <- fromBuf; pure (TyCon y)
              _ => corrupt "NameType"
 
 -- Assumption is that it was type safe when we wrote it out, so believe_me
@@ -1001,8 +1001,8 @@ TTC Def where
   toBuf (Builtin a)
       = throw (InternalError "Trying to serialise a Builtin")
   toBuf (DCon t arity nt) = do tag 4; toBuf t; toBuf arity; toBuf nt
-  toBuf (TCon t arity parampos detpos u ms datacons dets)
-      = do tag 5; toBuf t; toBuf arity; toBuf parampos
+  toBuf (TCon arity parampos detpos u ms datacons dets)
+      = do tag 5; toBuf arity; toBuf parampos
            toBuf detpos; toBuf u; toBuf ms; toBuf datacons
            toBuf dets
   toBuf (Hole locs p)
@@ -1030,12 +1030,12 @@ TTC Def where
                      pure (ForeignDef a cs)
              4 => do t <- fromBuf; a <- fromBuf; nt <- fromBuf
                      pure (DCon t a nt)
-             5 => do t <- fromBuf; a <- fromBuf
+             5 => do a <- fromBuf
                      ps <- fromBuf; dets <- fromBuf;
                      u <- fromBuf
                      ms <- fromBuf; cs <- fromBuf
                      detags <- fromBuf
-                     pure (TCon t a ps dets u ms cs detags)
+                     pure (TCon a ps dets u ms cs detags)
              6 => do l <- fromBuf
                      p <- fromBuf
                      pure (Hole l (holeInit p))

--- a/src/Core/Termination.idr
+++ b/src/Core/Termination.idr
@@ -113,7 +113,7 @@ checkTotal loc n_in
               Unchecked => do
                   mgdef <- lookupCtxtExact n (gamma defs)
                   case definition <$> mgdef of
-                       Just (TCon _ _ _ _ _ _ _ _)
+                       Just (TCon _ _ _ _ _ _ _)
                            => checkPositive loc n
                        _ => do whenJust (refersToM =<< mgdef) $ \ refs =>
                                  log "totality" 5 $ "  Mutually defined with:"

--- a/src/Core/Termination.idr
+++ b/src/Core/Termination.idr
@@ -113,7 +113,7 @@ checkTotal loc n_in
               Unchecked => do
                   mgdef <- lookupCtxtExact n (gamma defs)
                   case definition <$> mgdef of
-                       Just (TCon _ _ _ _ _ _ _)
+                       Just (TCon {})
                            => checkPositive loc n
                        _ => do whenJust (refersToM =<< mgdef) $ \ refs =>
                                  log "totality" 5 $ "  Mutually defined with:"

--- a/src/Core/Termination/CallGraph.idr
+++ b/src/Core/Termination/CallGraph.idr
@@ -213,8 +213,8 @@ mutual
     let (f, args) = getFnArgs t in
     let (g, args') = getFnArgs s in
     case f of
-      Ref _ (TyCon _) cn => case g of
-        Ref _ (TyCon _) cn' => if cn == cn'
+      Ref _ (TyCon {}) cn => case g of
+        Ref _ (TyCon {}) cn' => if cn == cn'
             then (Unknown /=) <$> sizeCompareProdConArgs fuel args' args
             else pure False
         _ => pure False

--- a/src/Core/Termination/CallGraph.idr
+++ b/src/Core/Termination/CallGraph.idr
@@ -213,8 +213,8 @@ mutual
     let (f, args) = getFnArgs t in
     let (g, args') = getFnArgs s in
     case f of
-      Ref _ (TyCon _ _) cn => case g of
-        Ref _ (TyCon _ _) cn' => if cn == cn'
+      Ref _ (TyCon _) cn => case g of
+        Ref _ (TyCon _) cn' => if cn == cn'
             then (Unknown /=) <$> sizeCompareProdConArgs fuel args' args
             else pure False
         _ => pure False

--- a/src/Core/Termination/Positivity.idr
+++ b/src/Core/Termination/Positivity.idr
@@ -35,7 +35,7 @@ nameIn defs tyns (NApp _ nh args)
            | True => pure False
          anyM (nameIn defs tyns)
            !(traverse (evalClosure defs . snd) args)
-nameIn defs tyns (NTCon _ n _ _ args)
+nameIn defs tyns (NTCon _ n _ args)
     = if n `elem` tyns
          then pure True
          else do args' <- traverse (evalClosure defs . snd) args
@@ -64,10 +64,10 @@ posArgs defs tyn (x :: xs)
 
 -- a tyn can only appear in the parameter positions of
 -- tc; report positivity failure if it appears anywhere else
-posArg defs tyns nf@(NTCon loc tc _ _ args) =
+posArg defs tyns nf@(NTCon loc tc _ args) =
   do logNF "totality.positivity" 50 "Found a type constructor" Env.empty nf
      testargs <- case !(lookupDefExact tc (gamma defs)) of
-                    Just (TCon _ _ params _ _ _ _ _) => do
+                    Just (TCon _ params _ _ _ _ _) => do
                          log "totality.positivity" 50 $
                            unwords [show tc, "has", show (size params), "parameters"]
                          pure $ NatSet.partition params (map snd args)
@@ -157,7 +157,7 @@ calcPositive loc n
     = do defs <- get Ctxt
          logC "totality.positivity" 6 $ do pure $ "Calculating positivity: " ++ show !(toFullNames n)
          case !(lookupDefTyExact n (gamma defs)) of
-              Just (TCon _ _ _ _ _ tns dcons _, ty) =>
+              Just (TCon _ _ _ _ tns dcons _, ty) =>
                   let dcons = fromMaybe [] dcons in
                   case !(totRefsIn defs ty) of
                        IsTerminating =>

--- a/src/Core/Unify.idr
+++ b/src/Core/Unify.idr
@@ -760,10 +760,10 @@ mutual
                  (margs' : List (Closure vars)) ->
                  NF vars ->
                  Core UnifyResult
-  unifyHoleApp swap mode loc env mname mref margs margs' (NTCon nfc n t a args')
+  unifyHoleApp swap mode loc env mname mref margs margs' (NTCon nfc n a args')
       = do defs <- get Ctxt
            mty <- lookupTyExact n (gamma defs)
-           unifyInvertible swap (lower mode) loc env mname mref margs margs' mty (NTCon nfc n t a) args'
+           unifyInvertible swap (lower mode) loc env mname mref margs margs' mty (NTCon nfc n a) args'
   unifyHoleApp swap mode loc env mname mref margs margs' (NDCon nfc n t a args')
       = do defs <- get Ctxt
            mty <- lookupTyExact n (gamma defs)
@@ -950,7 +950,7 @@ mutual
       = convertErrorS swap loc env (NApp xfc (NLocal rx x xp) args) y
   unifyApp swap mode loc env xfc (NLocal rx x xp) args y@(NDCon _ _ _ _ _)
       = convertErrorS swap loc env (NApp xfc (NLocal rx x xp) args) y
-  unifyApp swap mode loc env xfc (NLocal rx x xp) args y@(NTCon _ _ _ _ _)
+  unifyApp swap mode loc env xfc (NLocal rx x xp) args y@(NTCon _ _ _ _)
       = convertErrorS swap loc env (NApp xfc (NLocal rx x xp) args) y
   unifyApp swap mode loc env xfc (NLocal rx x xp) args y@(NPrimVal _ _)
       = convertErrorS swap loc env (NApp xfc (NLocal rx x xp) args) y
@@ -1189,7 +1189,7 @@ mutual
              else convertError loc env
                        (NDCon xfc x tagx ax xs)
                        (NDCon yfc y tagy ay ys)
-  unifyNoEta mode loc env (NTCon xfc x tagx ax xs) (NTCon yfc y tagy ay ys)
+  unifyNoEta mode loc env (NTCon xfc x ax xs) (NTCon yfc y ay ys)
    = do logC "unify" 20 $ do
           x <- toFullNames x
           y <- toFullNames y
@@ -1208,11 +1208,11 @@ mutual
              -- constraint. But before then, we need some way to decide
              -- what's injective...
              -- gallais: really? We don't mind being anticlassical do we?
---                then postpone True loc mode env (quote empty env (NTCon x tagx ax xs))
---                                           (quote empty env (NTCon y tagy ay ys))
+--                then postpone True loc mode env (quote empty env (NTCon x ax xs))
+--                                           (quote empty env (NTCon y ay ys))
            else convertError loc env
-                     (NTCon xfc x tagx ax xs)
-                     (NTCon yfc y tagy ay ys)
+                     (NTCon xfc x ax xs)
+                     (NTCon yfc y ay ys)
   unifyNoEta mode loc env (NDelayed xfc _ x) (NDelayed yfc _ y)
       = unify (lower mode) loc env x y
   unifyNoEta mode loc env (NDelay xfc _ xty x) (NDelay yfc _ yty y)

--- a/src/Idris/Doc/String.idr
+++ b/src/Idris/Doc/String.idr
@@ -422,7 +422,7 @@ getDocsForName fc n config
            PMDef _ _ _ _ _ => pure ( Nothing
                                    , catMaybes [ showTotal (totality d)
                                                , pure (showVisible (collapseDefault $ visibility d))])
-           TCon _ _ _ _ _ _ cons _ =>
+           TCon _ _ _ _ _ cons _ =>
              do let tot = catMaybes [ showTotal (totality d)
                                     , pure (showVisible (collapseDefault $ visibility d))]
                 cdocs <- traverse (getDConDoc <=< toFullNames) (fromMaybe [] cons)

--- a/src/TTImp/Elab/Ambiguity.idr
+++ b/src/TTImp/Elab/Ambiguity.idr
@@ -125,7 +125,7 @@ expandAmbigName mode nest env orig args (IVar fc x) exp
     wrapDot : Bool -> EState vars ->
               ElabMode -> Name -> List RawImp -> Def -> RawImp -> RawImp
     wrapDot _ _ _ _ _ (DCon _ _ _) tm = tm
-    wrapDot _ _ _ _ _ (TCon _ _ _ _ _ _ _ _) tm = tm
+    wrapDot _ _ _ _ _ (TCon _ _ _ _ _ _ _) tm = tm
     -- Leave primitive applications alone, because they'll be inlined
     -- before compiling the case tree
     wrapDot prim est (InLHS _) n' [arg] _ tm
@@ -224,7 +224,7 @@ mutual
   mightMatch defs target (NBind fc n (Pi _ _ _ _) sc)
       = mightMatchD defs target !(sc defs (toClosure defaultOpts Env.empty (Erased fc Placeholder)))
   mightMatch defs (NBind _ _ _ _) (NBind _ _ _ _) = pure Poly -- lambdas might match
-  mightMatch defs (NTCon _ n t a args) (NTCon _ n' t' a' args')
+  mightMatch defs (NTCon _ n a args) (NTCon _ n' a' args')
       = if n == n'
            then do amatch <- mightMatchArgs defs (map snd args) (map snd args')
                    if amatch then pure Concrete else pure NoMatch
@@ -266,7 +266,7 @@ couldBeFn defs ty _ = pure Poly
 couldBe : {auto c : Ref Ctxt Defs} ->
           {vars : _} ->
           Defs -> NF vars -> RawImp -> Core (Maybe (Bool, RawImp))
-couldBe {vars} defs ty@(NTCon _ n _ _ _) app
+couldBe {vars} defs ty@(NTCon _ n _ _) app
    = case !(couldBeFn {vars} defs ty (getFn app)) of
           Concrete => pure $ Just (True, app)
           Poly => pure $ Just (False, app)

--- a/src/TTImp/Elab/Ambiguity.idr
+++ b/src/TTImp/Elab/Ambiguity.idr
@@ -124,8 +124,8 @@ expandAmbigName mode nest env orig args (IVar fc x) exp
     -- If it's not a constructor application, dot it
     wrapDot : Bool -> EState vars ->
               ElabMode -> Name -> List RawImp -> Def -> RawImp -> RawImp
-    wrapDot _ _ _ _ _ (DCon _ _ _) tm = tm
-    wrapDot _ _ _ _ _ (TCon _ _ _ _ _ _ _) tm = tm
+    wrapDot _ _ _ _ _ (DCon {}) tm = tm
+    wrapDot _ _ _ _ _ (TCon {}) tm = tm
     -- Leave primitive applications alone, because they'll be inlined
     -- before compiling the case tree
     wrapDot prim est (InLHS _) n' [arg] _ tm

--- a/src/TTImp/Elab/App.idr
+++ b/src/TTImp/Elab/App.idr
@@ -389,12 +389,12 @@ mutual
       -- meta, shouldn't we delay the check instead of declaring the tm dotted?
       ||| Count the constructors of a fully applied concrete datatype
       countConstructors : NF vars -> Core (Maybe Nat)
-      countConstructors (NTCon _ tycName _ n args) =
+      countConstructors (NTCon _ tycName n args) =
         if length args == n
         then do defs <- get Ctxt
                 Just gdef <- lookupCtxtExact tycName (gamma defs)
                 | Nothing => pure Nothing
-                let (TCon _ _ _ _ _ _ datacons _) = gdef.definition
+                let (TCon _ _ _ _ _ datacons _) = gdef.definition
                 | _ => pure Nothing
                 pure (length <$> datacons)
         else pure Nothing
@@ -792,7 +792,7 @@ mutual
                | Nothing => pure res
          let (Ref _ t _, args) = getFnArgs (fst res)
                | _ => pure res
-         let Just (_, a) = isCon t
+         let Just a = isCon t
                | _ => pure res
          if a == length args
            then pure res

--- a/src/TTImp/Elab/App.idr
+++ b/src/TTImp/Elab/App.idr
@@ -79,7 +79,7 @@ getNameType elabMode rigc env fc x
                  when (not $ onLHS elabMode) $
                    checkDeprecation fc def
                  rigSafe (multiplicity def) rigc
-                 let nt = fromMaybe Func (defNameType $ definition def)
+                 let nt = getDefNameType def
 
                  log "ide-mode.highlight" 8
                      $ "getNameType is trying to add something for: "
@@ -126,7 +126,7 @@ getVarType elabMode rigc nest env fc x
                  case !(lookupCtxtExact n' (gamma defs)) of
                       Nothing => undefinedName fc n'
                       Just ndef =>
-                         let nt = fromMaybe Func (defNameType $ definition ndef)
+                         let nt = getDefNameType ndef
                              tm = tmf fc nt
                              tyenv = useVars (getArgs tm)
                                              (embed (type ndef)) in

--- a/src/TTImp/Elab/Case.idr
+++ b/src/TTImp/Elab/Case.idr
@@ -446,7 +446,7 @@ checkCase rig elabinfo nest env fc opts scr scrty_in alts exp
     getRetTy : Defs -> ClosedNF -> Core (Maybe (Name, ClosedNF))
     getRetTy defs (NBind fc _ (Pi _ _ _ _) sc)
         = getRetTy defs !(sc defs (toClosure defaultOpts Env.empty (Erased fc Placeholder)))
-    getRetTy defs (NTCon _ n _ arity _)
+    getRetTy defs (NTCon _ n arity _)
         = do Just ty <- lookupTyExact n (gamma defs)
                   | Nothing => pure Nothing
              pure (Just (n, !(nf defs Env.empty ty)))

--- a/src/TTImp/Elab/Check.idr
+++ b/src/TTImp/Elab/Check.idr
@@ -314,13 +314,13 @@ mustBePoly fc env tm ty = update EST { polyMetavars $= ((fc, env, tm, ty) :: ) }
 -- elaborating them, which might help us disambiguate things more easily.
 export
 concrete : Defs -> Env Term vars -> NF vars -> Core Bool
-concrete defs env (NBind fc _ (Pi _ _ _ _) sc)
+concrete defs env (NBind fc _ (Pi {}) sc)
     = do sc' <- sc defs (toClosure defaultOpts env (Erased fc Placeholder))
          concrete defs env sc'
-concrete defs env (NDCon _ _ _ _ _) = pure True
-concrete defs env (NTCon _ _ _ _) = pure True
-concrete defs env (NPrimVal _ _) = pure True
-concrete defs env (NType _ _) = pure True
+concrete defs env (NDCon {}) = pure True
+concrete defs env (NTCon {}) = pure True
+concrete defs env (NPrimVal {}) = pure True
+concrete defs env (NType {}) = pure True
 concrete defs env _ = pure False
 
 export

--- a/src/TTImp/Elab/Check.idr
+++ b/src/TTImp/Elab/Check.idr
@@ -318,7 +318,7 @@ concrete defs env (NBind fc _ (Pi _ _ _ _) sc)
     = do sc' <- sc defs (toClosure defaultOpts env (Erased fc Placeholder))
          concrete defs env sc'
 concrete defs env (NDCon _ _ _ _ _) = pure True
-concrete defs env (NTCon _ _ _ _ _) = pure True
+concrete defs env (NTCon _ _ _ _) = pure True
 concrete defs env (NPrimVal _ _) = pure True
 concrete defs env (NType _ _) = pure True
 concrete defs env _ = pure False

--- a/src/TTImp/Elab/Check.idr
+++ b/src/TTImp/Elab/Check.idr
@@ -465,7 +465,7 @@ searchVar fc rig depth def env nest n ty
              defs <- get Ctxt
              Just ndef <- lookupCtxtExact n' (gamma defs)
                  | Nothing => pure (vs ** (f, env'))
-             let nt = fromMaybe Func (defNameType $ definition ndef)
+             let nt = getDefNameType ndef
              let app = tmf fc nt
              let tyenv = useVars (getArgs app) (embed (type ndef))
              let binder = Let fc top (weakenNs (mkSizeOf vs) app)

--- a/src/TTImp/Elab/Delayed.idr
+++ b/src/TTImp/Elab/Delayed.idr
@@ -161,7 +161,7 @@ mutual
   mismatchNF : {auto c : Ref Ctxt Defs} ->
                {vars : _} ->
                Defs -> NF vars -> NF vars -> Core Bool
-  mismatchNF defs (NTCon _ xn xt _ xargs) (NTCon _ yn yt _ yargs)
+  mismatchNF defs (NTCon _ xn _ xargs) (NTCon _ yn _ yargs)
       = if xn /= yn
            then pure True
            else anyM (mismatch defs) (zipWith (curry $ mapHom snd) xargs yargs)
@@ -185,7 +185,7 @@ contra : {auto c : Ref Ctxt Defs} ->
          {vars : _} ->
          Defs -> NF vars -> NF vars -> Core Bool
 -- Unlike 'impossibleOK', any mismatch indicates an unrecoverable error
-contra defs (NTCon _ xn xt xa xargs) (NTCon _ yn yt ya yargs)
+contra defs (NTCon _ xn xa xargs) (NTCon _ yn ya yargs)
     = if xn /= yn
          then pure True
          else anyM (mismatch defs) (zipWith (curry $ mapHom snd) xargs yargs)

--- a/src/TTImp/Elab/Local.idr
+++ b/src/TTImp/Elab/Local.idr
@@ -202,7 +202,7 @@ checkCaseLocal {vars} rig elabinfo nest env fc uname iname args sc expty
     = do defs <- get Ctxt
          Just def <- lookupCtxtExact iname (gamma defs)
               | Nothing => check rig elabinfo nest env sc expty
-         let nt = fromMaybe Func (defNameType $ definition def)
+         let nt = getDefNameType def
          let name = Ref fc nt iname
          (app, args) <- getLocalTerm fc env name args
          log "elab.local" 5 $ "Updating case local " ++ show uname ++ " " ++ show args

--- a/src/TTImp/Elab/Quote.idr
+++ b/src/TTImp/Elab/Quote.idr
@@ -186,7 +186,7 @@ bindUnqs ((qvar, fc, esctm) :: qs) rig elabinfo nest env tm
          Just (idx, gdef) <- lookupCtxtExactI (reflectionttimp "TTImp") (gamma defs)
               | _ => throw (UndefinedName fc (reflectionttimp "TTImp"))
          (escv, escty) <- check rig elabinfo nest env esctm
-                                (Just (gnf env (Ref fc (TyCon 0 0)
+                                (Just (gnf env (Ref fc (TyCon 0)
                                            (Resolved idx))))
          sc <- bindUnqs qs rig elabinfo nest env tm
          pure (Bind fc qvar (Let fc (rigMult top rig) escv !(getTerm escty))

--- a/src/TTImp/Elab/Record.idr
+++ b/src/TTImp/Elab/Record.idr
@@ -24,7 +24,7 @@ import Libraries.Data.SortedSet
 %default covering
 
 getRecordType : Env Term vars -> NF vars -> Maybe Name
-getRecordType env (NTCon _ n _ _ _) = Just n
+getRecordType env (NTCon _ n _ _) = Just n
 getRecordType env _ = Nothing
 
 getNames : {auto c : Ref Ctxt Defs} -> Defs -> ClosedNF -> Core $ SortedSet Name
@@ -38,7 +38,7 @@ getNames defs (NApp _ hd args)
 getNames defs (NDCon _ _ _ _ args)
     = do eargs <- traverse (evalClosure defs . snd) args
          pure $ concat !(traverse (getNames defs) eargs)
-getNames defs (NTCon _ _ _ _ args)
+getNames defs (NTCon _ _ _ args)
   = do eargs <- traverse (evalClosure defs . snd) args
        pure $ concat !(traverse (getNames defs) eargs)
 getNames defs (NDelayed _ _ tm) = getNames defs tm
@@ -80,7 +80,7 @@ toRHS fc r = snd (toRHS' fc r)
 findConName : Defs -> Name -> Core (Maybe Name)
 findConName defs tyn
     = case !(lookupDefExact tyn (gamma defs)) of
-           Just (TCon _ _ _ _ _ _ (Just [con]) _) => pure (Just con)
+           Just (TCon _ _ _ _ _ (Just [con]) _) => pure (Just con)
            _ => pure Nothing
 
 findFieldsAndTypeArgs : {auto c : Ref Ctxt Defs} ->

--- a/src/TTImp/Elab/Rewrite.idr
+++ b/src/TTImp/Elab/Rewrite.idr
@@ -40,7 +40,7 @@ getRewriteTerms : {vars : _} ->
                   {auto c : Ref Ctxt Defs} ->
                   FC -> Defs -> NF vars -> Error ->
                   Core (NF vars, NF vars, NF vars)
-getRewriteTerms loc defs (NTCon nfc eq t a args) err
+getRewriteTerms loc defs (NTCon nfc eq a args) err
     = if !(isEqualTy eq)
          then case reverse $ map snd args of
                    (rhs :: lhs :: rhsty :: lhsty :: _) =>

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -49,7 +49,7 @@ lookupNameInfo n ctxt
   where
     getNameType : Def -> NameType
     getNameType (DCon t a _) = DataCon t a
-    getNameType (TCon t a _ _ _ _ _ _) = TyCon t a
+    getNameType (TCon a _ _ _ _ _ _) = TyCon a
     getNameType _ = Func
 
 Reflect NameInfo where
@@ -318,7 +318,7 @@ elabScript rig fc nest env script@(NDCon nfc nm t ar args) exp
     elabCon defs "GetCons" [n]
         = do n' <- evalClosure defs n
              cn <- reify defs n'
-             Just (TCon _ _ _ _ _ _ cons _) <-
+             Just (TCon _ _ _ _ _ cons _) <-
                      lookupDefExact cn (gamma defs)
                  | _ => failWith defs $ show cn ++ " is not a type"
              scriptRet $ fromMaybe [] cons

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -44,13 +44,8 @@ lookupNameInfo : Name -> Context -> Core (List (Name, NameInfo))
 lookupNameInfo n ctxt
     = do res <- lookupCtxtName n ctxt
          pure (map (\ (n, i, gd) =>
-                      (n, MkNameInfo { nametype = getNameType (definition gd) } ))
+                      (n, MkNameInfo { nametype = getDefNameType gd } ))
                    res)
-  where
-    getNameType : Def -> NameType
-    getNameType (DCon t a _) = DataCon t a
-    getNameType (TCon a _ _ _ _ _ _) = TyCon a
-    getNameType _ = Func
 
 Reflect NameInfo where
   reflect fc defs lhs env inf

--- a/src/TTImp/Elab/Term.idr
+++ b/src/TTImp/Elab/Term.idr
@@ -265,7 +265,7 @@ checkTerm rig elabinfo nest env (IWithUnambigNames fc ns rhs) exp
           case rns of
             [rn@(_, _, def)] =>
                 do whenJust (isConcreteFC nfc) $ \nfc => do
-                     let nt = fromMaybe Func (defNameType $ definition def)
+                     let nt = getDefNameType def
                      let decor = nameDecoration def.fullname nt
                      log "ide-mode.highlight" 7
                        $ "`with' unambiguous name is adding " ++ show decor ++ ": " ++ show def.fullname

--- a/src/TTImp/Elab/Utils.idr
+++ b/src/TTImp/Elab/Utils.idr
@@ -21,8 +21,8 @@ import Libraries.Data.List.Quantifiers.Extra as Lib
 
 detagSafe : {auto c : Ref Ctxt Defs} ->
             Defs -> ClosedNF -> Core Bool
-detagSafe defs (NTCon _ n _ _ args)
-    = do Just (TCon _ _ _ _ _ _ _ (Just detags)) <- lookupDefExact n (gamma defs)
+detagSafe defs (NTCon _ n _ args)
+    = do Just (TCon _ _ _ _ _ _ (Just detags)) <- lookupDefExact n (gamma defs)
               | _ => pure False
          args' <- traverse (evalClosure defs . snd) args
          pure $ NatSet.isEmpty detags || notErased 0 detags args'

--- a/src/TTImp/Impossible.idr
+++ b/src/TTImp/Impossible.idr
@@ -33,7 +33,7 @@ match nty (n, i, rty)
     sameRet _ (NErased _ _) = pure True
     sameRet (NApp _ _ _) _ = pure True
     sameRet (NErased _ _) _ = pure True
-    sameRet (NTCon _ n _ _ _) (NTCon _ n' _ _ _) = pure (n == n')
+    sameRet (NTCon _ n _ _) (NTCon _ n' _ _) = pure (n == n')
     sameRet (NPrimVal _ c) (NPrimVal _ c') = pure (c == c')
     sameRet (NType _ _) (NType _ _) = pure True
     sameRet nf (NBind fc _ (Pi _ _ _ _) sc)
@@ -143,7 +143,7 @@ mutual
            -- covered!
            let head = case definition gdef of
                         DCon t a _ => DataCon t a
-                        TCon t a _ _ _ _ _ _ => TyCon t a
+                        TCon a _ _ _ _ _ _ => TyCon a
                         _ => Func
            processArgs (Ref fc head (Resolved i)) tynf exps autos named
 

--- a/src/TTImp/Impossible.idr
+++ b/src/TTImp/Impossible.idr
@@ -141,11 +141,7 @@ mutual
            -- When `head` is `Func`, the pattern will be marked as forced and
            -- the coverage checker will considers that all the cases have been
            -- covered!
-           let head = case definition gdef of
-                        DCon t a _ => DataCon t a
-                        TCon a _ _ _ _ _ _ => TyCon a
-                        _ => Func
-           processArgs (Ref fc head (Resolved i)) tynf exps autos named
+           processArgs (Ref fc (getDefNameType gdef) (Resolved i)) tynf exps autos named
 
   mkTerm : {auto c : Ref Ctxt Defs} ->
            {auto q : Ref QVar Int} ->

--- a/src/TTImp/Interactive/CaseSplit.idr
+++ b/src/TTImp/Interactive/CaseSplit.idr
@@ -76,7 +76,7 @@ findTyName defs env n (Bind _ x b@(PVar _ c p ty) sc)
     = if n == x
          then do tynf <- nf defs env ty
                  case tynf of
-                      NTCon _ tyn _ _ _ => pure $ Just tyn
+                      NTCon _ tyn _ _ => pure $ Just tyn
                       _ => pure Nothing
          else findTyName defs (b :: env) n sc
 findTyName defs env n (Bind _ x b sc) = findTyName defs (b :: env) n sc
@@ -103,7 +103,7 @@ findCons n lhs
                       Nothing => pure (SplitFail (CantSplitThis n
                                          ("Can't find type of " ++ show n ++ " in LHS")))
                       Just tyn =>
-                          do Just (TCon _ _ _ _ _ _ cons _) <-
+                          do Just (TCon _ _ _ _ _ cons _) <-
                                       lookupDefExact tyn (gamma defs)
                                 | res => pure (SplitFail
                                             (CantSplitThis n

--- a/src/TTImp/Interactive/ExprSearch.idr
+++ b/src/TTImp/Interactive/ExprSearch.idr
@@ -291,11 +291,6 @@ searchName fc rigc opts hints env target topty (n, ndef)
          let ty = type ndef
          let True = usableName (fullname ndef)
              | _ => noResult
-         let namety : NameType
-                 = case definition ndef of
-                        DCon tag arity _ => DataCon tag arity
-                        TCon arity _ _ _ _ _ _ => TyCon arity
-                        _ => Func
          log "interaction.search" 5 $ "Trying " ++ show (fullname ndef)
          nty <- nf defs env (embed ty)
          (args, appTy) <- mkArgs fc rigc env nty
@@ -309,7 +304,7 @@ searchName fc rigc opts hints env target topty (n, ndef)
                    (filter explicit args)
          args' <- traverse (searchIfHole fc opts hints topty env)
                            args
-         mkCandidates fc (Ref fc namety n) [] args'
+         mkCandidates fc (Ref fc (getDefNameType ndef) n) [] args'
   where
     -- we can only use the name in a search result if it's a user writable
     -- name (so, no recursive with blocks or case blocks, for example)

--- a/src/TTImp/Interactive/ExprSearch.idr
+++ b/src/TTImp/Interactive/ExprSearch.idr
@@ -294,7 +294,7 @@ searchName fc rigc opts hints env target topty (n, ndef)
          let namety : NameType
                  = case definition ndef of
                         DCon tag arity _ => DataCon tag arity
-                        TCon tag arity _ _ _ _ _ _ => TyCon tag arity
+                        TCon arity _ _ _ _ _ _ => TyCon arity
                         _ => Func
          log "interaction.search" 5 $ "Trying " ++ show (fullname ndef)
          nty <- nf defs env (embed ty)
@@ -412,7 +412,7 @@ tryRecursive fc rig opts hints env ty topty rdata
                  Bool
       appsDiff (Ref _ (DataCon _ _) f) (Ref _ (DataCon _ _) f') args args'
          = f /= f' || any (uncurry argDiff) (zip args args')
-      appsDiff (Ref _ (TyCon _ _) f) (Ref _ (TyCon _ _) f') args args'
+      appsDiff (Ref _ (TyCon _) f) (Ref _ (TyCon _) f') args args'
          = f /= f' || any (uncurry argDiff) (zip args args')
       appsDiff (Ref _ _ f) (Ref _ _ f') args args'
          = f == f'
@@ -486,7 +486,7 @@ searchLocalWith {vars} fc nofn rig opts hints env ((p, pty) :: rest) ty topty
     findPos : Defs -> Term vars ->
               (Term vars -> Term vars) ->
               NF vars -> NF vars -> Core (Search (Term vars, ExprDefs))
-    findPos defs prf f x@(NTCon pfc pn _ _ [(fc1, xty), (fc2, yty)]) target
+    findPos defs prf f x@(NTCon pfc pn _ [(fc1, xty), (fc2, yty)]) target
         = getSuccessful fc rig opts False env ty topty
               [findDirect defs prf f x target,
                  (do fname <- maybe (throw (InternalError "No fst"))
@@ -611,7 +611,7 @@ tryIntermediateWith fc rig opts hints env ((p, pty) :: rest) ty topty
     matchable defs (NBind fc x (Pi _ _ _ _) sc)
         = matchable defs !(sc defs (toClosure defaultOpts env
                                               (Erased fc Placeholder)))
-    matchable defs (NTCon _ _ _ _ _) = pure True
+    matchable defs (NTCon _ _ _ _) = pure True
     matchable _ _ = pure False
 
     applyLocal : Defs -> Term vars ->
@@ -680,8 +680,8 @@ tryIntermediateRec fc rig opts hints env ty topty (Just rd)
     isSingleCon defs (NBind fc x (Pi _ _ _ _) sc)
         = isSingleCon defs !(sc defs (toClosure defaultOpts Env.empty
                                               (Erased fc Placeholder)))
-    isSingleCon defs (NTCon _ n _ _ _)
-        = do Just (TCon _ _ _ _ _ _ (Just [con]) _) <- lookupDefExact n (gamma defs)
+    isSingleCon defs (NTCon _ n _ _)
+        = do Just (TCon _ _ _ _ _ (Just [con]) _) <- lookupDefExact n (gamma defs)
                   | _ => pure False
              pure True
     isSingleCon _ _ = pure False
@@ -711,7 +711,7 @@ searchType {vars} fc rig opts hints env topty Z (Bind bfc n b@(Pi fc' c info ty)
                              (Bind bfc n' (Lam fc' c info ty) sc, ds)) scVal))]
 searchType fc rig opts hints env topty _ ty
     = case getFnArgs ty of
-           (Ref rfc (TyCon t ar) n, args) =>
+           (Ref rfc (TyCon ar) n, args) =>
                 do defs <- get Ctxt
                    if length args == ar
                      then do sd <- getSearchData fc False n

--- a/src/TTImp/Interactive/Intro.idr
+++ b/src/TTImp/Interactive/Intro.idr
@@ -51,7 +51,7 @@ parameters
     Just gdef <- lookupCtxtExact n (gamma defs)
       | _ => pure []
     -- for now we only handle types with a unique constructor
-    let TCon _ _ _ _ _ _ cs _ = definition gdef
+    let TCon _ _ _ _ _ cs _ = definition gdef
       | _ => pure []
     let gty = gnf env ty
     ics <- for (fromMaybe [] cs) $ \ cons => do
@@ -83,5 +83,5 @@ parameters
   -- interesting ones
   intro (Bind _ x (Pi _ rig Explicit ty) _) = pure <$> introLam x rig ty
   intro t = case getFnArgs t of
-    (Ref _ (TyCon _ ar) n, _) => introCon n t
+    (Ref _ (TyCon ar) n, _) => introCon n t
     _ => pure []

--- a/src/TTImp/Interactive/MakeLemma.idr
+++ b/src/TTImp/Interactive/MakeLemma.idr
@@ -29,7 +29,7 @@ hiddenName _ = False
 bindable : Nat -> Term vars -> Bool
 bindable p tm
     = case getFnArgs tm of
-           (Ref _ (TyCon _ _) n, args) => any (bindable p) args
+           (Ref _ (TyCon _) n, args) => any (bindable p) args
            (Ref _ (DataCon _ _) _, args) => any (bindable p) args
            (TDelayed _ _ t, args) => any (bindable p) (t :: args)
            (TDelay _ _ _ t, args) => any (bindable p) (t :: args)

--- a/src/TTImp/PartialEval.idr
+++ b/src/TTImp/PartialEval.idr
@@ -649,9 +649,9 @@ mutual
   quoteGenNF q defs bound env (NDCon fc n t ar args)
       = do args' <- quoteArgsWithFC q defs bound env args
            pure $ applyStackWithFC (Ref fc (DataCon t ar) n) args'
-  quoteGenNF q defs bound env (NTCon fc n t ar args)
+  quoteGenNF q defs bound env (NTCon fc n ar args)
       = do args' <- quoteArgsWithFC q defs bound env args
-           pure $ applyStackWithFC (Ref fc (TyCon t ar) n) args'
+           pure $ applyStackWithFC (Ref fc (TyCon ar) n) args'
   quoteGenNF q defs bound env (NAs fc s n pat)
       = do n' <- quoteGenNF q defs bound env n
            pat' <- quoteGenNF q defs bound env pat

--- a/src/TTImp/ProcessBuiltin.idr
+++ b/src/TTImp/ProcessBuiltin.idr
@@ -153,7 +153,7 @@ isNatural fc n = do
     defs <- get Ctxt
     Just gdef <- lookupCtxtExact n defs.gamma
         | Nothing => undefinedName EmptyFC n
-    let TCon _ _ _ _ _ _ cons _ = gdef.definition
+    let TCon _ _ _ _ _ cons _ = gdef.definition
         | _ => pure False
     consDefs <- getConsGDef fc (fromMaybe [] cons)
     pure $ all hasNatFlag consDefs
@@ -223,7 +223,7 @@ processBuiltinNatural fc name = do
         | ns => ambiguousName fc name $ (\(n, _, _) => n) <$> ns
     False <- isNatural fc n
         | True => pure ()
-    let TCon _ _ _ _ _ _ dcons _ = gdef.definition
+    let TCon _ _ _ _ _ dcons _ = gdef.definition
         | def => throw $ GenericMsg fc
             $ "Expected a type constructor, found " ++ showDefType def ++ "."
     cons <- getConsGDef fc (fromMaybe [] dcons)

--- a/src/TTImp/ProcessData.idr
+++ b/src/TTImp/ProcessData.idr
@@ -65,7 +65,7 @@ checkFamily loc cn tn env nf
     = checkRetType env nf $
          \case
            NType _ _ => throw $ BadDataConType loc cn tn
-           NTCon _ n' _ _ _ =>
+           NTCon _ n' _ _ =>
                  if tn == n'
                     then pure ()
                     else throw $ BadDataConType loc cn tn
@@ -143,7 +143,7 @@ getIndexPats tm
     getRetType defs t = pure t
 
     getPats : Defs -> ClosedNF -> Core (List ClosedNF)
-    getPats defs (NTCon fc _ _ _ args)
+    getPats defs (NTCon fc _ _ args)
         = do args' <- traverse (evalClosure defs . snd) args
              pure (toList args')
     getPats defs _ = pure [] -- Can't happen if we defined the type successfully!
@@ -174,7 +174,7 @@ getDetags fc tys
                        argsnf <- traverse (evalClosure defs . snd) args
                        args'nf <- traverse (evalClosure defs . snd) args'
                        disjointArgs argsnf args'nf
-      disjoint (NTCon _ n _ _ args) (NTCon _ n' _ _ args')
+      disjoint (NTCon _ n _ args) (NTCon _ n' _ args')
           = if n /= n'
                then pure True
                else do defs <- get Ctxt
@@ -271,7 +271,7 @@ firstArg (Bind _ _ (Pi _ c _ val) sc)
 firstArg tm = Nothing
 
 typeCon : Term vs -> Maybe Name
-typeCon (Ref _ (TyCon _ _) n) = Just n
+typeCon (Ref _ (TyCon _) n) = Just n
 typeCon (App _ fn _) = typeCon fn
 typeCon _ = Nothing
 
@@ -428,7 +428,7 @@ processData {vars} eopts nest env fc def_vis mbtot (MkImpLater dfc n_in ty_raw)
 
          -- Add the type constructor as a placeholder
          tidx <- addDef n (newDef fc n top vars fullty def_vis
-                          (TCon 0 arity NatSet.empty NatSet.empty defaultFlags [] Nothing Nothing))
+                          (TCon arity NatSet.empty NatSet.empty defaultFlags [] Nothing Nothing))
          addMutData (Resolved tidx)
          defs <- get Ctxt
          traverse_ (\n => setMutWith fc n (mutData defs)) (mutData defs)
@@ -501,7 +501,7 @@ processData {vars} eopts nest env fc def_vis mbtot (MkImpData dfc n_in mty_raw o
                       _ => pure $ mbtot <|> declTot
 
                     case definition ndef of
-                      TCon _ _ _ _ flags mw Nothing _ => case mfullty of
+                      TCon _ _ _ flags mw Nothing _ => case mfullty of
                         Nothing => pure (mw, vis, tot, type ndef)
                         Just fullty =>
                             do ok <- convert defs Env.empty fullty (type ndef)
@@ -518,7 +518,7 @@ processData {vars} eopts nest env fc def_vis mbtot (MkImpData dfc n_in mty_raw o
          -- Add the type constructor as a placeholder while checking
          -- data constructors
          tidx <- addDef n (newDef fc n linear vars fullty (specified vis)
-                          (TCon 0 arity NatSet.empty NatSet.empty defaultFlags [] Nothing Nothing))
+                          (TCon arity NatSet.empty NatSet.empty defaultFlags [] Nothing Nothing))
          case vis of
               Private => pure ()
               _ => do addHashWithNames n

--- a/src/TTImp/ProcessData.idr
+++ b/src/TTImp/ProcessData.idr
@@ -174,7 +174,7 @@ getDetags fc tys
                        argsnf <- traverse (evalClosure defs . snd) args
                        args'nf <- traverse (evalClosure defs . snd) args'
                        disjointArgs argsnf args'nf
-      disjoint (NTCon _ n _ _ args) (NDCon _ n' _ _ args')
+      disjoint (NTCon _ n _ _ args) (NTCon _ n' _ _ args')
           = if n /= n'
                then pure True
                else do defs <- get Ctxt

--- a/src/TTImp/ProcessDecls/Totality.idr
+++ b/src/TTImp/ProcessDecls/Totality.idr
@@ -24,7 +24,7 @@ checkTotalityOK n
          -- #524: need to check positivity even if we're not in a total context
          -- because a definition coming later may need to know it is positive
          case definition gdef of
-           (TCon _ _ _ _ _ _ _ _) => ignore $ checkPositive fc n
+           (TCon _ _ _ _ _ _ _) => ignore $ checkPositive fc n
            _ => pure ()
 
          -- Once that is done, we build up errors if necessary

--- a/src/TTImp/ProcessDecls/Totality.idr
+++ b/src/TTImp/ProcessDecls/Totality.idr
@@ -24,7 +24,7 @@ checkTotalityOK n
          -- #524: need to check positivity even if we're not in a total context
          -- because a definition coming later may need to know it is positive
          case definition gdef of
-           (TCon _ _ _ _ _ _ _) => ignore $ checkPositive fc n
+           (TCon {}) => ignore $ checkPositive fc n
            _ => pure ()
 
          -- Once that is done, we build up errors if necessary

--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -64,24 +64,24 @@ mutual
       = mismatchNF defs !(evalClosure defs x) !(evalClosure defs y)
 
   -- NPrimVal is apart from NDCon, NTCon, NBind, and NType
-  mismatchNF defs (NPrimVal _ _) (NDCon _ _ _ _ _) = pure True
-  mismatchNF defs (NDCon _ _ _ _ _) (NPrimVal _ _) = pure True
-  mismatchNF defs (NPrimVal _ _) (NBind _ _ _ _) = pure True
-  mismatchNF defs (NBind _ _ _ _) (NPrimVal _ _) = pure True
-  mismatchNF defs (NPrimVal _ _) (NTCon _ _ _ _) = pure True
-  mismatchNF defs (NTCon _ _ _ _) (NPrimVal _ _) = pure True
-  mismatchNF defs (NPrimVal _ _) (NType _ _) = pure True
-  mismatchNF defs (NType _ _) (NPrimVal _ _) = pure True
+  mismatchNF defs (NPrimVal {}) (NDCon {}) = pure True
+  mismatchNF defs (NDCon {}) (NPrimVal {}) = pure True
+  mismatchNF defs (NPrimVal {}) (NBind {}) = pure True
+  mismatchNF defs (NBind {}) (NPrimVal {}) = pure True
+  mismatchNF defs (NPrimVal {}) (NTCon {}) = pure True
+  mismatchNF defs (NTCon {}) (NPrimVal {}) = pure True
+  mismatchNF defs (NPrimVal {}) (NType {}) = pure True
+  mismatchNF defs (NType {}) (NPrimVal {}) = pure True
 
 -- NTCon is apart from NBind, and NType
-  mismatchNF defs (NTCon _ _ _ _) (NBind _ _ _ _) = pure True
-  mismatchNF defs (NBind _ _ _ _) (NTCon _ _ _ _) = pure True
-  mismatchNF defs (NTCon _ _ _ _) (NType _ _) = pure True
-  mismatchNF defs (NType _ _) (NTCon _ _ _ _) = pure True
+  mismatchNF defs (NTCon {}) (NBind {}) = pure True
+  mismatchNF defs (NBind {}) (NTCon {}) = pure True
+  mismatchNF defs (NTCon {}) (NType {}) = pure True
+  mismatchNF defs (NType {}) (NTCon {}) = pure True
 
 -- NBind is apart from NType
-  mismatchNF defs (NBind _ _ _ _) (NType _ _) = pure True
-  mismatchNF defs (NType _ _) (NBind _ _ _ _) = pure True
+  mismatchNF defs (NBind {}) (NType {}) = pure True
+  mismatchNF defs (NType {}) (NBind {}) = pure True
 
   mismatchNF _ _ _ = pure False
 
@@ -110,24 +110,24 @@ impossibleOK defs (NDCon _ _ xt _ xargs) (NDCon _ _ yt _ yargs)
 impossibleOK defs (NPrimVal _ x) (NPrimVal _ y) = pure (x /= y)
 
 -- NPrimVal is apart from NDCon, NTCon, NBind, and NType
-impossibleOK defs (NPrimVal _ _) (NDCon _ _ _ _ _) = pure True
-impossibleOK defs (NDCon _ _ _ _ _) (NPrimVal _ _) = pure True
-impossibleOK defs (NPrimVal _ _) (NBind _ _ _ _) = pure True
-impossibleOK defs (NBind _ _ _ _) (NPrimVal _ _) = pure True
-impossibleOK defs (NPrimVal _ _) (NTCon _ _ _ _) = pure True
-impossibleOK defs (NTCon _ _ _ _) (NPrimVal _ _) = pure True
-impossibleOK defs (NPrimVal _ _) (NType _ _) = pure True
-impossibleOK defs (NType _ _) (NPrimVal _ _) = pure True
+impossibleOK defs (NPrimVal {}) (NDCon {}) = pure True
+impossibleOK defs (NDCon {}) (NPrimVal {}) = pure True
+impossibleOK defs (NPrimVal {}) (NBind {}) = pure True
+impossibleOK defs (NBind {}) (NPrimVal {}) = pure True
+impossibleOK defs (NPrimVal {}) (NTCon {}) = pure True
+impossibleOK defs (NTCon {}) (NPrimVal {}) = pure True
+impossibleOK defs (NPrimVal {}) (NType {}) = pure True
+impossibleOK defs (NType {}) (NPrimVal {}) = pure True
 
 -- NTCon is apart from NBind, and NType
-impossibleOK defs (NTCon _ _ _ _) (NBind _ _ _ _) = pure True
-impossibleOK defs (NBind _ _ _ _) (NTCon _ _ _ _) = pure True
-impossibleOK defs (NTCon _ _ _ _) (NType _ _) = pure True
-impossibleOK defs (NType _ _) (NTCon _ _ _ _) = pure True
+impossibleOK defs (NTCon {}) (NBind {}) = pure True
+impossibleOK defs (NBind {}) (NTCon {}) = pure True
+impossibleOK defs (NTCon {}) (NType {}) = pure True
+impossibleOK defs (NType {}) (NTCon {}) = pure True
 
 -- NBind is apart from NType
-impossibleOK defs (NBind _ _ _ _) (NType _ _) = pure True
-impossibleOK defs (NType _ _) (NBind _ _ _ _) = pure True
+impossibleOK defs (NBind {}) (NType {}) = pure True
+impossibleOK defs (NType {}) (NBind {}) = pure True
 
 impossibleOK defs x y = pure False
 
@@ -165,17 +165,17 @@ recoverable defs (NTCon _ xn xa xargs) (NTCon _ yn ya yargs)
          then pure False
          else pure $ not !(anyM (mismatch defs) (zipWith (curry $ mapHom snd) xargs yargs))
 -- Type constructor vs. primitive type
-recoverable defs (NTCon _ _ _ _) (NPrimVal _ _) = pure False
-recoverable defs (NPrimVal _ _) (NTCon _ _ _ _) = pure False
+recoverable defs (NTCon {}) (NPrimVal {}) = pure False
+recoverable defs (NPrimVal {}) (NTCon {}) = pure False
 -- Type constructor vs. type
-recoverable defs (NTCon _ _ _ _) (NType _ _) = pure False
-recoverable defs (NType _ _) (NTCon _ _ _ _) = pure False
+recoverable defs (NTCon {}) (NType {}) = pure False
+recoverable defs (NType {}) (NTCon {}) = pure False
 -- Type constructor vs. binder
-recoverable defs (NTCon _ _ _ _) (NBind _ _ _ _) = pure False
-recoverable defs (NBind _ _ _ _) (NTCon _ _ _ _) = pure False
+recoverable defs (NTCon {}) (NBind {}) = pure False
+recoverable defs (NBind {}) (NTCon {}) = pure False
 
-recoverable defs (NTCon _ _ _ _) _ = pure True
-recoverable defs _ (NTCon _ _ _ _) = pure True
+recoverable defs (NTCon {}) _ = pure True
+recoverable defs _ (NTCon {}) = pure True
 
 -- DATA CONSTRUCTORS
 recoverable defs (NDCon _ _ xt _ xargs) (NDCon _ _ yt _ yargs)
@@ -183,11 +183,11 @@ recoverable defs (NDCon _ _ xt _ xargs) (NDCon _ _ yt _ yargs)
          then pure False
          else pure $ not !(anyM (mismatch defs) (zipWith (curry $ mapHom snd) xargs yargs))
 -- Data constructor vs. primitive constant
-recoverable defs (NDCon _ _ _ _ _) (NPrimVal _ _) = pure False
-recoverable defs (NPrimVal _ _) (NDCon _ _ _ _ _) = pure False
+recoverable defs (NDCon {}) (NPrimVal {}) = pure False
+recoverable defs (NPrimVal {}) (NDCon {}) = pure False
 
-recoverable defs (NDCon _ _ _ _ _) _ = pure True
-recoverable defs _ (NDCon _ _ _ _ _) = pure True
+recoverable defs (NDCon {}) _ = pure True
+recoverable defs _ (NDCon {}) = pure True
 
 -- FUNCTION CALLS
 recoverable defs (NApp _ (NRef _ f) fargs) (NApp _ (NRef _ g) gargs)
@@ -196,8 +196,8 @@ recoverable defs (NApp _ (NRef _ f) fargs) (NApp _ (NRef _ g) gargs)
 -- PRIMITIVES
 recoverable defs (NPrimVal _ x) (NPrimVal _ y) = pure (x == y)
 -- primitive vs. binder
-recoverable defs (NPrimVal _ _) (NBind _ _ _ _) = pure False
-recoverable defs (NBind _ _ _ _) (NPrimVal _ _) = pure False
+recoverable defs (NPrimVal {}) (NBind {}) = pure False
+recoverable defs (NBind {}) (NPrimVal {}) = pure False
 
 -- OTHERWISE: no
 recoverable defs x y = pure False

--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -50,7 +50,7 @@ mutual
   mismatchNF : {auto c : Ref Ctxt Defs} ->
                {vars : _} ->
                Defs -> NF vars -> NF vars -> Core Bool
-  mismatchNF defs (NTCon _ xn xt _ xargs) (NTCon _ yn yt _ yargs)
+  mismatchNF defs (NTCon _ xn _ xargs) (NTCon _ yn _ yargs)
       = if xn /= yn
            then pure True
            else anyM (mismatch defs) (zipWith (curry $ mapHom snd) xargs yargs)
@@ -68,16 +68,16 @@ mutual
   mismatchNF defs (NDCon _ _ _ _ _) (NPrimVal _ _) = pure True
   mismatchNF defs (NPrimVal _ _) (NBind _ _ _ _) = pure True
   mismatchNF defs (NBind _ _ _ _) (NPrimVal _ _) = pure True
-  mismatchNF defs (NPrimVal _ _) (NTCon _ _ _ _ _) = pure True
-  mismatchNF defs (NTCon _ _ _ _ _) (NPrimVal _ _) = pure True
+  mismatchNF defs (NPrimVal _ _) (NTCon _ _ _ _) = pure True
+  mismatchNF defs (NTCon _ _ _ _) (NPrimVal _ _) = pure True
   mismatchNF defs (NPrimVal _ _) (NType _ _) = pure True
   mismatchNF defs (NType _ _) (NPrimVal _ _) = pure True
 
 -- NTCon is apart from NBind, and NType
-  mismatchNF defs (NTCon _ _ _ _ _) (NBind _ _ _ _) = pure True
-  mismatchNF defs (NBind _ _ _ _) (NTCon _ _ _ _ _) = pure True
-  mismatchNF defs (NTCon _ _ _ _ _) (NType _ _) = pure True
-  mismatchNF defs (NType _ _) (NTCon _ _ _ _ _) = pure True
+  mismatchNF defs (NTCon _ _ _ _) (NBind _ _ _ _) = pure True
+  mismatchNF defs (NBind _ _ _ _) (NTCon _ _ _ _) = pure True
+  mismatchNF defs (NTCon _ _ _ _) (NType _ _) = pure True
+  mismatchNF defs (NType _ _) (NTCon _ _ _ _) = pure True
 
 -- NBind is apart from NType
   mismatchNF defs (NBind _ _ _ _) (NType _ _) = pure True
@@ -98,7 +98,7 @@ export
 impossibleOK : {auto c : Ref Ctxt Defs} ->
                {vars : _} ->
                Defs -> NF vars -> NF vars -> Core Bool
-impossibleOK defs (NTCon _ xn xt xa xargs) (NTCon _ yn yt ya yargs)
+impossibleOK defs (NTCon _ xn xa xargs) (NTCon _ yn ya yargs)
     = if xn /= yn
          then pure True
          else anyM (mismatch defs) (zipWith (curry $ mapHom snd) xargs yargs)
@@ -114,16 +114,16 @@ impossibleOK defs (NPrimVal _ _) (NDCon _ _ _ _ _) = pure True
 impossibleOK defs (NDCon _ _ _ _ _) (NPrimVal _ _) = pure True
 impossibleOK defs (NPrimVal _ _) (NBind _ _ _ _) = pure True
 impossibleOK defs (NBind _ _ _ _) (NPrimVal _ _) = pure True
-impossibleOK defs (NPrimVal _ _) (NTCon _ _ _ _ _) = pure True
-impossibleOK defs (NTCon _ _ _ _ _) (NPrimVal _ _) = pure True
+impossibleOK defs (NPrimVal _ _) (NTCon _ _ _ _) = pure True
+impossibleOK defs (NTCon _ _ _ _) (NPrimVal _ _) = pure True
 impossibleOK defs (NPrimVal _ _) (NType _ _) = pure True
 impossibleOK defs (NType _ _) (NPrimVal _ _) = pure True
 
 -- NTCon is apart from NBind, and NType
-impossibleOK defs (NTCon _ _ _ _ _) (NBind _ _ _ _) = pure True
-impossibleOK defs (NBind _ _ _ _) (NTCon _ _ _ _ _) = pure True
-impossibleOK defs (NTCon _ _ _ _ _) (NType _ _) = pure True
-impossibleOK defs (NType _ _) (NTCon _ _ _ _ _) = pure True
+impossibleOK defs (NTCon _ _ _ _) (NBind _ _ _ _) = pure True
+impossibleOK defs (NBind _ _ _ _) (NTCon _ _ _ _) = pure True
+impossibleOK defs (NTCon _ _ _ _) (NType _ _) = pure True
+impossibleOK defs (NType _ _) (NTCon _ _ _ _) = pure True
 
 -- NBind is apart from NType
 impossibleOK defs (NBind _ _ _ _) (NType _ _) = pure True
@@ -160,22 +160,22 @@ recoverable : {auto c : Ref Ctxt Defs} ->
 -- Unlike the above, any mismatch will do
 
 -- TYPE CONSTRUCTORS
-recoverable defs (NTCon _ xn xt xa xargs) (NTCon _ yn yt ya yargs)
+recoverable defs (NTCon _ xn xa xargs) (NTCon _ yn ya yargs)
     = if xn /= yn
          then pure False
          else pure $ not !(anyM (mismatch defs) (zipWith (curry $ mapHom snd) xargs yargs))
 -- Type constructor vs. primitive type
-recoverable defs (NTCon _ _ _ _ _) (NPrimVal _ _) = pure False
-recoverable defs (NPrimVal _ _) (NTCon _ _ _ _ _) = pure False
+recoverable defs (NTCon _ _ _ _) (NPrimVal _ _) = pure False
+recoverable defs (NPrimVal _ _) (NTCon _ _ _ _) = pure False
 -- Type constructor vs. type
-recoverable defs (NTCon _ _ _ _ _) (NType _ _) = pure False
-recoverable defs (NType _ _) (NTCon _ _ _ _ _) = pure False
+recoverable defs (NTCon _ _ _ _) (NType _ _) = pure False
+recoverable defs (NType _ _) (NTCon _ _ _ _) = pure False
 -- Type constructor vs. binder
-recoverable defs (NTCon _ _ _ _ _) (NBind _ _ _ _) = pure False
-recoverable defs (NBind _ _ _ _) (NTCon _ _ _ _ _) = pure False
+recoverable defs (NTCon _ _ _ _) (NBind _ _ _ _) = pure False
+recoverable defs (NBind _ _ _ _) (NTCon _ _ _ _) = pure False
 
-recoverable defs (NTCon _ _ _ _ _) _ = pure True
-recoverable defs _ (NTCon _ _ _ _ _) = pure True
+recoverable defs (NTCon _ _ _ _) _ = pure True
+recoverable defs _ (NTCon _ _ _ _) = pure True
 
 -- DATA CONSTRUCTORS
 recoverable defs (NDCon _ _ xt _ xargs) (NDCon _ _ yt _ yargs)
@@ -658,9 +658,9 @@ checkClause {vars} mult vis totreq hashit n opts nest env
       defs <- get Ctxt
 
       let eqName = NS builtinNS (UN $ Basic "Equal")
-      Just (TCon t ar _ _ _ _ _ _) <- lookupDefExact eqName (gamma defs)
+      Just (TCon ar _ _ _ _ _ _) <- lookupDefExact eqName (gamma defs)
         | _ => throw (InternalError "Cannot find builtin Equal")
-      let eqTyCon = Ref vfc (TyCon t ar) !(toResolvedNames eqName)
+      let eqTyCon = Ref vfc (TyCon ar) !(toResolvedNames eqName)
 
       let wargn : Name
           wargn = MN "warg" 0

--- a/src/TTImp/ProcessFnOpt.idr
+++ b/src/TTImp/ProcessFnOpt.idr
@@ -16,7 +16,7 @@ import Data.SnocList
 getRetTy : Defs -> ClosedNF -> Core Name
 getRetTy defs (NBind fc _ (Pi _ _ _ _) sc)
     = getRetTy defs !(sc defs (toClosure defaultOpts Env.empty (Erased fc Placeholder)))
-getRetTy defs (NTCon _ n _ _ _) = pure n
+getRetTy defs (NTCon _ n _ _) = pure n
 getRetTy defs ty
     = throw (GenericMsg (getLoc ty)
              "Can only add hints for concrete return types")
@@ -139,10 +139,10 @@ processFnOpt fc _ ndef (SpecArgs ns)
       getDeps inparam (NDCon _ n t a args) ns
           = do defs <- get Ctxt
                getDepsArgs False !(traverse (evalClosure defs . snd) args) ns
-      getDeps inparam (NTCon _ n t a args) ns
+      getDeps inparam (NTCon _ n a args) ns
           = do defs <- get Ctxt
                params <- case !(lookupDefExact n (gamma defs)) of
-                              Just (TCon _ _ ps _ _ _ _ _) => pure ps
+                              Just (TCon _ ps _ _ _ _ _) => pure ps
                               _ => pure NatSet.empty
                let (ps, ds) = NatSet.partition params (map snd args)
                ns' <- getDepsArgs True !(traverse (evalClosure defs) ps) ns

--- a/src/TTImp/ProcessType.idr
+++ b/src/TTImp/ProcessType.idr
@@ -107,7 +107,7 @@ findInferrable defs ty = fi 0 0 [] NatSet.empty ty
       findInf acc pos (NDCon _ _ _ _ args)
           = do args' <- traverse (evalClosure defs . snd) args
                findInfs acc pos args'
-      findInf acc pos (NTCon _ _ _ _ args)
+      findInf acc pos (NTCon _ _ _ args)
           = do args' <- traverse (evalClosure defs . snd) args
                findInfs acc pos args'
       findInf acc pos (NDelayed _ _ t) = findInf acc pos t

--- a/src/TTImp/Utils.idr
+++ b/src/TTImp/Utils.idr
@@ -592,7 +592,7 @@ getArgName defs x bound allvars ty
     findNamesM : NF vars -> Core (Maybe (List String))
     findNamesM (NBind _ x (Pi _ _ _ _) _)
         = pure (Just ["f", "g"])
-    findNamesM (NTCon _ n _ d [(_, v)]) = do
+    findNamesM (NTCon _ n d [(_, v)]) = do
           case dropNS !(full (gamma defs) n) of
             UN (Basic "List") =>
               do nf <- evalClosure defs v
@@ -610,7 +610,7 @@ getArgName defs x bound allvars ty
                    Nothing => namesFor n
                    Just ns => pure (Just (map ("s" ++) ns))
             _ => namesFor n
-    findNamesM (NTCon _ n _ _ _) = namesFor n
+    findNamesM (NTCon _ n _ _) = namesFor n
     findNamesM (NPrimVal fc c) = do
           let defaultPos = Just ["m", "n", "p", "q"]
           let defaultInts = Just ["i", "j", "k", "l"]

--- a/tests/base/deriving_traversable/expected
+++ b/tests/base/deriving_traversable/expected
@@ -65,7 +65,7 @@ LOG derive.traversable.clauses:1:
   traverseIVect : {0 m : _} -> {0 a, b : Type} -> {0 f : Type -> Type} -> Applicative f => (a -> f b) -> IVect {n = m} a -> f (IVect {n = m} b)
   traverseIVect f (MkIVect x2) = MkIVect <$> (traverse f x2)
 LOG derive.traversable.clauses:1: 
-  traverseEqMap : {0 key, eq : _} -> {0 a, b : Type} -> {0 f : Type -> Type} -> Applicative f => (a -> f b) -> EqMap key {{conArg:16433} = eq} a -> f (EqMap key {{conArg:16433} = eq} b)
+  traverseEqMap : {0 key, eq : _} -> {0 a, b : Type} -> {0 f : Type -> Type} -> Applicative f => (a -> f b) -> EqMap key {{conArg:1} = eq} a -> f (EqMap key {{conArg:1} = eq} b)
   traverseEqMap f (MkEqMap x3) = MkEqMap <$> (traverse (traverse f) x3)
 LOG derive.traversable.clauses:1: 
   traverseTree : {0 l : _} -> {0 a, b : Type} -> {0 f : Type -> Type} -> Applicative f => (a -> f b) -> Tree l a -> f (Tree l b)

--- a/tests/base/deriving_traversable/run
+++ b/tests/base/deriving_traversable/run
@@ -1,3 +1,3 @@
 . ../../testutils.sh
 
-check DeriveTraversable.idr
+check DeriveTraversable.idr | clean_names

--- a/tests/idris2/basic/basic074/erased.idr
+++ b/tests/idris2/basic/basic074/erased.idr
@@ -1,0 +1,9 @@
+data X : Type -> Type where
+  A : X ()
+  B : X Void
+
+f : (0 _ : X ()) -> ()
+f A = ()
+
+g : (0 _ : X Void) -> ()
+g B = ()

--- a/tests/idris2/basic/basic074/expected
+++ b/tests/idris2/basic/basic074/expected
@@ -1,0 +1,1 @@
+1/1: Building erased (erased.idr)

--- a/tests/idris2/basic/basic074/run
+++ b/tests/idris2/basic/basic074/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check erased.idr

--- a/tests/idris2/coverage/coverage023/Main.idr
+++ b/tests/idris2/coverage/coverage023/Main.idr
@@ -1,0 +1,7 @@
+-- Declared in separate modules because, at the time of writing the test, type
+-- constructors are compared by tags that are unique within a single module
+import X
+import Y
+
+Uninhabited (X === Y) where
+  uninhabited eq impossible

--- a/tests/idris2/coverage/coverage023/X.idr
+++ b/tests/idris2/coverage/coverage023/X.idr
@@ -1,0 +1,1 @@
+data X = MkX

--- a/tests/idris2/coverage/coverage023/Y.idr
+++ b/tests/idris2/coverage/coverage023/Y.idr
@@ -1,0 +1,1 @@
+data Y = MkY

--- a/tests/idris2/coverage/coverage023/expected
+++ b/tests/idris2/coverage/coverage023/expected
@@ -1,0 +1,3 @@
+1/3: Building X (X.idr)
+2/3: Building Y (Y.idr)
+3/3: Building Main (Main.idr)

--- a/tests/idris2/coverage/coverage023/run
+++ b/tests/idris2/coverage/coverage023/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check Main.idr

--- a/tests/idris2/reflection/reflection012/expected
+++ b/tests/idris2/reflection/reflection012/expected
@@ -1,3 +1,3 @@
 1/1: Building nameinfo (nameinfo.idr)
-Main> (TyCon 100 0, (DataCon 1 1, Func))
+Main> (TyCon 0, (DataCon 1 1, Func))
 Main> Bye for now!

--- a/tests/idris2/reflection/reflection012/expected
+++ b/tests/idris2/reflection/reflection012/expected
@@ -1,3 +1,3 @@
 1/1: Building nameinfo (nameinfo.idr)
-Main> (TyCon 0, (DataCon 1 1, Func))
+Main> (TyCon 0 0, (DataCon 1 1, Func))
 Main> Bye for now!

--- a/tests/idris2/reflection/reflection024/src/TypeProviders.idr
+++ b/tests/idris2/reflection/reflection024/src/TypeProviders.idr
@@ -44,7 +44,7 @@ saveRecordToSimpleJSON : LookupDir -> (path : String) -> (type : Name) -> Elab (
 saveRecordToSimpleJSON lk jsonPath type = do
   infos <- getInfo type
   let [(type, _)] = flip filter infos $ \case
-                      (name, MkNameInfo $ TyCon _ _) => True
+                      (name, MkNameInfo $ TyCon _) => True
                       _                              => False
     | [] => fail "Did not found any type matching \{show type}"
     | (_::_) => fail "Too many types matching \{show type}"

--- a/tests/idris2/reflection/reflection024/src/TypeProviders.idr
+++ b/tests/idris2/reflection/reflection024/src/TypeProviders.idr
@@ -44,7 +44,7 @@ saveRecordToSimpleJSON : LookupDir -> (path : String) -> (type : Name) -> Elab (
 saveRecordToSimpleJSON lk jsonPath type = do
   infos <- getInfo type
   let [(type, _)] = flip filter infos $ \case
-                      (name, MkNameInfo $ TyCon _) => True
+                      (name, MkNameInfo $ TyCon _ _) => True
                       _                              => False
     | [] => fail "Did not found any type matching \{show type}"
     | (_::_) => fail "Too many types matching \{show type}"

--- a/tests/idris2/repl/repl007/expected
+++ b/tests/idris2/repl/repl007/expected
@@ -1,6 +1,5 @@
 Main> Prelude.Basics.Bool
 Type constructor:
-  tag: 100
   arity: 0
   parameter positions: []
   constructors: Prelude.Basics.False, Prelude.Basics.True


### PR DESCRIPTION
# Description

Currently, the type constructor tag is always 100. In fact, they are not used. Therefore, I propose to remove them and also fix several related bugs.

Commits:
1. Fixed a bug that prevented the tag counter from increasing
2. Fixed irrefutable pattern with type in index
3. Fixed checking for emptiness of type with type in index. This is the only place where type constructors are compared by tags. But they are unique only within the module. Therefore, type constructors should be compared by name, as in all other places.
4. Type constructor tags have been removed because they are not suitable for comparison and are no longer used.
5. Remove some boilerplate.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

