### PR TITLE
[ fix ] Early evaluation of external functions

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -194,6 +194,8 @@ This CHANGELOG describes the merged but unreleased changes. Please see [CHANGELO
   memoised. That is, once accessed, they are allowed to be not re-evaluated until garbage
   collector wipes them.
 
+* Fixed early external function evaluation in constant optimization.
+
 #### Racket
 
 * Fixed CSE soundness bug that caused delayed expressions to sometimes be eagerly

--- a/src/Compiler/Opts/ToplevelConstants.idr
+++ b/src/Compiler/Opts/ToplevelConstants.idr
@@ -99,6 +99,8 @@ checkNonPure : Ref SortTag SortST => (Name, FC, NamedDef) -> Core ()
 checkNonPure (n, _, MkNmError _) = update SortTag $ { nonconst $= insert n }
 checkNonPure (n, _, MkNmFun args (NmCrash _ _)) = update SortTag $ { nonconst $= insert n }
 checkNonPure (n, _, MkNmFun args (NmOp _ Crash _)) = update SortTag $ { nonconst $= insert n }
+-- Does not affect numeric primitives because this optimization only affects
+-- functions without runtime arguments
 checkNonPure (n, _, MkNmFun args (NmExtPrim _ _ _)) = update SortTag $ { nonconst $= insert n }
 checkNonPure (n, _, def) = do
   st <- get SortTag

--- a/tests/chez/reg002/Main.idr
+++ b/tests/chez/reg002/Main.idr
@@ -1,0 +1,11 @@
+import Data.So
+
+myVoid : (0 _ : Void) -> ()
+myVoid x = void x
+
+foo : (y: Bool) -> (0 p : So y) => ()
+foo False = myVoid (absurd p)
+foo True  = ()
+
+main : IO ()
+main = pure (foo True)

--- a/tests/chez/reg002/run
+++ b/tests/chez/reg002/run
@@ -1,0 +1,3 @@
+. ../../testutils.sh
+
+run Main.idr


### PR DESCRIPTION
# Description

The following program prints `Error: Executed 'void'` when run.

```idris
import Data.So

myVoid : (0 _ : Void) -> ()
myVoid x = void x

foo : (y: Bool) -> (0 p : So y) => ()
foo False = myVoid (absurd p)
foo True  = ()

main : IO ()
main = pure (foo True)
```

This happens because `myVoid` has no runtime arguments and gets evaluated too early due to [constant optimisation](https://github.com/idris-lang/Idris2/pull/2817). However, external functions may have side effects and therefore should not be treated as constants during optimisation.

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

