### PR TITLE
Add `WithData` to generalise over `WithName` and `WithFC`

### DIFF
--- a/src/Core/WithData.idr
+++ b/src/Core/WithData.idr
@@ -1,0 +1,185 @@
+module Core.WithData
+
+import Core.Name
+import Core.FC
+import Core.TT
+import public Libraries.Data.WithData
+import Libraries.Text.Bounded
+
+------------------------------------------------------------------------------------------
+-- Helpers for binding information
+------------------------------------------------------------------------------------------
+
+||| The "bind" label containing binding information for metadata records
+public export
+Bind' : KeyVal
+Bind' = "bind" :-: BindingModifier
+
+||| Obtain binding information from the metadata
+export
+(.bind) :
+    {n : Nat} ->
+    (0 inRange : NameInRange "bind" fields === Just (n, BindingModifier)) =>
+    WithData fields a -> BindingModifier
+(.bind) = WithData.get "bind"
+
+------------------------------------------------------------------------------------------
+-- Totality information
+------------------------------------------------------------------------------------------
+
+||| The "totalReq" label containing totality information for metadata records
+public export
+Tot' : KeyVal
+Tot' = "totalReq" :-: Maybe TotalReq
+
+||| Obtain totality information from the metadata
+export
+(.totReq) :
+    {n : Nat} ->
+    (0 inRange : NameInRange "totalReq" fields === Just (n, Maybe TotalReq)) =>
+    WithData fields a -> Maybe TotalReq
+(.totReq) = WithData.get "totalReq"
+
+------------------------------------------------------------------------------------------
+-- Helpers for FC information
+------------------------------------------------------------------------------------------
+
+||| The "fc" label containing file context information for metadata records
+public export
+FC' : KeyVal
+FC' = "fc" :-: FC
+
+||| Attach FC information to a type
+public export
+WithFC : Type -> Type
+WithFC = WithData [ FC' ]
+
+||| Obtain file context information from the metadata
+export
+(.fc) : {n : Nat} ->
+        (inRange : NameInRange "fc" fields === Just (n, FC)) => WithData fields a -> FC
+(.fc) = WithData.get "fc"
+
+export
+setFC : {n : Nat} ->
+        (inRange : NameInRange "fc" fields === Just (n, FC)) => FC ->
+        WithData fields a -> WithData fields a
+setFC fc = WithData.set "fc" fc @{inRange}
+
+||| Attach binding and file context information to a type
+public export
+FCBind : Type -> Type
+FCBind = WithData [ Bind', FC' ]
+
+||| A wrapper for a value with a file context.
+public export
+MkFCVal : FC -> ty -> WithFC ty
+MkFCVal fc = Mk [fc]
+
+||| Smart constructor for WithFC that uses EmptyFC as location
+%inline export
+NoFC : a -> WithFC a
+NoFC = MkFCVal EmptyFC
+
+export
+(.withFC) : (o : OriginDesc) => WithBounds t -> WithFC t
+x.withFC = MkFCVal x.toFC x.val
+
+------------------------------------------------------------------------------------------
+-- Helpers for documentation information
+------------------------------------------------------------------------------------------
+
+||| The "doc" label containing documentation information for metadata records
+public export
+Doc' : KeyVal
+Doc' = "doc" :-: String
+
+||| Obtain documentation information from the metadata
+export
+(.doc) : {n : Nat} ->
+         (inRange : NameInRange "doc" fields === Just (n, String)) =>
+         WithData fields a -> String
+(.doc) = WithData.get "doc"
+
+------------------------------------------------------------------------------------------
+-- Helpers for quantity information
+------------------------------------------------------------------------------------------
+
+||| The "rig" label containing quantity information for metadata records
+public export
+Rig' : KeyVal
+Rig' = "rig" :-: RigCount
+
+||| Obtain documentation information from the metadata
+export
+(.rig) : {n : Nat} ->
+         (inRange : NameInRange "rig" fields === Just (n, RigCount)) =>
+         WithData fields a -> RigCount
+(.rig) = WithData.get "rig"
+
+------------------------------------------------------------------------------------------
+-- Helpers for name information
+------------------------------------------------------------------------------------------
+
+||| The "name" label containing a `Name` for metadata records
+public export
+Name' : KeyVal
+Name' = "name" :-: WithFC Name
+
+
+||| Extract the name out of the metadata.
+export
+(.name) : {n : Nat} ->
+          (inRange : NameInRange "name" fields === Just (n, WithFC Name)) =>
+          WithData fields a -> WithFC Name
+(.name) = WithData.get "name" @{inRange}
+
+||| Attach name and file context information to a type
+public export
+WithName : Type -> Type
+WithName = WithData [ Name']
+
+||| Smart constructor to add a name and location to a type
+export
+MkWithName : WithFC Name -> ty -> WithName ty
+MkWithName x y = Mk [x] y
+
+||| the "tyname" label containing a `FCBind Name` for metadata records
+public export
+TyName' : KeyVal
+TyName' = "tyname" :-: FCBind Name
+
+||| Extract the "tyname" value from the metadata record
+export
+(.tyName) : {n : Nat} ->
+            (inRange : NameInRange "tyname" fields === Just (n, FCBind Name)) =>
+            WithData fields a -> FCBind Name
+(.tyName) = WithData.get "tyname" @{inRange}
+
+
+||| Attach documentation, binding and location information to a type
+public export
+DocBindFC : Type -> Type
+DocBindFC = WithData [ Doc', Bind', FC' ]
+
+------------------------------------------------------------------------
+-- Default instances for metadata
+------------------------------------------------------------------------
+
+-- When location is unavailable, use `EmptyFC`
+export
+HasDefault FC where
+  defValue = EmptyFC
+
+-- When binding is not provided, the default is not binding
+export
+HasDefault BindingModifier where
+  defValue = NotBinding
+
+-- default doc string
+export
+HasDefault String where
+  defValue = ""
+
+------------------------------------------------------------------------
+

--- a/src/Core/WithData.idr
+++ b/src/Core/WithData.idr
@@ -110,7 +110,7 @@ public export
 Rig' : KeyVal
 Rig' = "rig" :-: RigCount
 
-||| Obtain documentation information from the metadata
+||| Obtain quantity information from the metadata
 export
 (.rig) : {n : Nat} ->
          (inRange : NameInRange "rig" fields === Just (n, RigCount)) =>

--- a/src/Libraries/Data/Record.idr
+++ b/src/Libraries/Data/Record.idr
@@ -1,0 +1,224 @@
+||| Modular records based on `All`
+module Libraries.Data.Record
+
+import public Data.List.Quantifiers
+import Data.Maybe
+import Data.List.Elem
+import Decidable.Equality
+import Data.DPair
+
+%hide Data.List.Quantifiers.Any.Any
+%hide Data.List.Quantifiers.Any.any
+
+export infixr 9 :-:
+export infix 9 :-
+export infixr 9 :+
+
+||| A type with a string-label for it. Used in `Record`
+|||
+||| ```idris example
+||| IntLabel : KeyVal
+||| IntLabel = "int" :-: Int
+||| ```
+public export
+record KeyVal where
+  constructor (:-:)
+  label : String
+  type : Type
+
+||| The value-constructor for `KeyVal`, essentially a pair of a label
+||| and a value that match the specification given by `KeyVal`
+|||
+||| ```idris example
+||| IntLabel : KeyVal
+||| IntLabel = "int" :-: Int
+|||
+||| intValue : LabelledValue IntLabel
+||| intValue = "int" :- 3
+||| ```
+public export
+record LabelledValue (kv : KeyVal) where
+  constructor (:-)
+  ||| The label matching the `KeyVal` spec, erased for performance reasons
+  0 label : String
+  ||| A proof that the label given matches the label in the specification
+  {auto 0 check : kv.label === label}
+  ||| A runtime value of the type given by the specification
+  value : kv.type
+
+||| Records are a list of of labelled values, their fields are given by a list of KeyVal
+||| Each element in the list describes a key
+|||
+||| ```idris example
+||| Spec : List KeyVal
+||| Spec = [ "username" :-: String, "amount" :-: Double ]
+|||
+||| recordValue : Record Spec
+||| recordValue = [ "username" :- "Alice", "amount" :- 3.14 ]
+||| ```
+public export
+Record : (fields : List KeyVal) -> Type
+Record = All LabelledValue
+
+||| Build a record from it's element values ignoring the labels
+|||
+||| ```idris example
+||| Spec : List KeyVal
+||| Spec = [ "username" :-: String, "amount" :-: Double ]
+|||
+||| recordValue : Record Spec
+||| recordValue = fromElems [ "Alice", 3.14 ]
+||| ```
+export
+fromElems : {fs : _} -> All KeyVal.type fs -> Record fs
+fromElems {fs = []} [] = []
+fromElems {fs = (l :-: t :: xs)} (x :: zs) = (l :- x) :: fromElems zs
+
+||| Obtain the tail of a list of predicates
+export
+tail : All p (x :: xs) -> All p xs
+tail (_ :: xs) = xs
+
+||| A procedue to find the type at the given index
+public export 0
+FindIndex : Nat -> List KeyVal -> Maybe Type
+FindIndex Z (x :: xs) = Just x.type
+FindIndex (S n) (x :: xs) = FindIndex n xs
+FindIndex _ _ = Nothing
+
+||| A procedure to find the index and type of a given label
+public export 0
+NameInRange : (key : String) -> List KeyVal -> Maybe (Nat, Type)
+NameInRange key [] = Nothing
+NameInRange key (x :: xs) = if (key == x.label)
+                               then Just (Z, x.type)
+                               else map (mapFst S) (NameInRange key xs)
+
+-- Convert a `NameInRange` proof to a `FindIndex` proof
+0
+IndexInRange : {fields : List KeyVal} ->
+               NameInRange key fields === Just (ix, ty) ->
+               FindIndex ix fields === Just ty
+IndexInRange {fields = []} prf = absurd prf
+IndexInRange {fields = ((label :-: type) :: xs)} {ty} prf with (key == label)
+  IndexInRange {fields = ((label :-: type) :: xs)} {ty} prf | False with (NameInRange key xs) proof p
+    IndexInRange {fields = ((label :-: type) :: xs)} {ty} prf | False | Nothing = absurd prf
+    IndexInRange {fields = ((label :-: type) :: xs)} {ty} Refl | False | (Just (x, ty))
+      = IndexInRange {fields = xs, key} p
+  IndexInRange {fields = ((label :-: type) :: xs)} {ty = type} Refl | True = Refl
+
+||| Add a label and a value to a record
+export
+add : (0 str : String) -> (_ : ty) -> Record fields -> Record (str :-: ty :: fields)
+add str val xs = (str :- val) :: xs
+
+absurd0 : (0 _ : t) -> Uninhabited t => a
+absurd0 x = void (uninhabited x)
+
+||| Obtain the value from a record at given index
+||| @ n The index at which we extract the value.
+||| @ out The type of the value at the index.
+||| @ inRange A proof that the field is in the record at the appropriate index with the appropriate type.
+export
+index : Record fields -> (n : Nat) -> (0 inRange : FindIndex n fields === Just out) => out
+index ((label :- val) :: y) 0 {inRange = Refl} = val
+index (x :: y) (S k) = index y k
+index [] 0 = absurd0 inRange
+index [] (S k) = absurd0 inRange
+
+||| Obtain the value from a record given its label.
+||| @ field The field for which we extract the value.
+||| @ n The index corresponding to the field given.
+||| @ out The type of the value at the given field.
+||| @ inRange A proof that the field is in the record at the appropriate index with the appropriate type.
+export
+get : (0 label : String) -> Record fields ->
+      {n : Nat} ->
+      (0 inRange : NameInRange label fields === Just (n, out)) => out
+get field rec = index rec n {inRange = IndexInRange inRange}
+
+||| Obtain the value from a record given its label and type.
+||| @ field The field for which we extract the value.
+||| @ out The type of the value at the given field.
+||| @ n The index corresponding to the field given.
+||| @ inRange A proof that the field is in the record at the appropriate index with the appropriate type.
+export
+get' : (0 label : String) -> (0 out : Type) -> Record fields ->
+       {n : Nat} ->
+       (0 inRange : NameInRange label fields === Just (n, out)) =>
+       out
+get' label type rec = get {n} label {out = type} rec {inRange = inRange}
+
+||| Remove a value from the list, used in the type of `removeAt`
+public export
+ListRemoveAt :
+    (fields : List KeyVal) -> (n : Nat) ->
+    (inRange : IsJust (FindIndex n fields)) => List KeyVal
+ListRemoveAt [] 0 = absurd inRange
+ListRemoveAt (x :: xs) 0 = xs
+ListRemoveAt [] (S k) = absurd inRange
+ListRemoveAt (x :: xs) (S k) = x :: ListRemoveAt xs k
+
+||| Remove the value at the given index.
+||| @ n The index we are removing.
+||| @ inRange A proof that the index is in range of the record spec.
+export
+removeAt :
+    (n : Nat) ->
+    (inRange : IsJust (FindIndex n fields)) =>
+    Record fields -> Record (ListRemoveAt fields n)
+removeAt 0 [] = absurd inRange
+removeAt 0 (x :: z) = z
+removeAt (S k) [] = absurd inRange
+removeAt (S k) (x :: xs) = x :: removeAt k xs
+
+||| Update the value at the given index.
+||| @ n The index we are removing.
+||| @ inRange A proof that the index is in range of the record spec.
+||| @ f The update function.
+export
+updateAt :
+    (n : Nat) ->
+    (0 inRange : (FindIndex n fields) === Just out) =>
+    (f : out -> out) ->
+    Record fields -> Record fields
+updateAt 0 f [] = absurd0 inRange
+updateAt 0 f ((label :- val) :: y) {inRange = Refl} = label :- f val :: y
+updateAt (S k) f [] = absurd0 inRange
+updateAt (S k) f (x :: y) = x :: updateAt k f y
+
+||| Update the value with the given label.
+||| @ field The label of the value we are updating.
+||| @ inRange A proof that the label is in the record at the appropriate index with the appropriate type.
+||| @ f The update function.
+export
+update :
+    (0 label : String) -> {n : Nat} ->
+    (0 inRange : NameInRange label fields === Just (n, out)) =>
+    (f : out -> out) ->
+    Record fields -> Record fields
+update field f rec = updateAt n {fields, out, inRange = IndexInRange inRange} f rec
+
+||| Override the value found at the given index.
+||| @ n The index we are removing.
+||| @ inRange A proof that the index is in range of the record spec.
+||| @ newVal The value that will replace the existing one.
+export
+setAt : (n : Nat) -> (inRange : FindIndex n fields === Just out) => (newVal : out) ->
+        Record fields -> Record fields
+setAt n newVal x = updateAt n (const newVal) x
+
+
+||| Override the value found at the given label.
+||| @ label The label of the value we are overriding.
+||| @ inRange A proof that the label is in the record at the appropriate index with the appropriate type.
+||| @ newVal The value that will replace the existing one.
+export
+set :
+    (0 label : String) -> {n : Nat} ->
+    (0 inRange : NameInRange label fields === Just (n, out)) =>
+    (newVal : out) ->
+    Record fields -> Record fields
+set field newVal rec = update field (const newVal) rec
+
+

--- a/src/Libraries/Data/WithData.idr
+++ b/src/Libraries/Data/WithData.idr
@@ -230,11 +230,17 @@ export
 Mk : {fs : _} -> All KeyVal.type fs -> a -> WithData fs a
 Mk x y = MkWithData (fromElems x) y
 
+||| Add a default value to an existing metadata record
+export
+AddDef :  (def : HasDefault ty) =>
+         WithData fl a -> WithData (lbl :-: ty :: fl) a
+AddDef x = (defValue @{def}) :+ x
+
 ||| Add a record of default values to an existing metadata record
 export
-AddDef : {fs : _} -> (values : All (HasDefault . KeyVal.type) fs) =>
+AddDefs : {fs : _} -> (values : All (HasDefault . KeyVal.type) fs) =>
          WithData fl a -> WithData (fs ++ fl) a
-AddDef x = fromDefault values :++ x
+AddDefs x = fromDefault values :++ x
 
 ------------------------------------------------------------------------------------------------
 -- WithData distributes with List and Maybe

--- a/src/Libraries/Data/WithData.idr
+++ b/src/Libraries/Data/WithData.idr
@@ -1,0 +1,269 @@
+||| The WithData module combines a record and an arbitrary payload. The intended use is to
+||| attach metadata to the payload.
+module Libraries.Data.WithData
+
+import public Data.List.Quantifiers
+import public Data.List
+import public Data.Maybe
+import public Libraries.Data.Record
+
+%hide Data.List.Quantifiers.Any.Any
+%hide Data.List.Quantifiers.Any.any
+
+||| A pair for a type and an attached record hosting metadata about that type
+|||
+||| Intended usage
+||| --------------
+||| Only ever put plain types in the metadata
+||| Do not add functors such as `List` or `PTerm`. The functor instance
+||| for `WithData` is only functorial on its payload and not the additional
+||| data.
+|||
+||| There is rarely any need to write down `WithData [ ... ] a` thanks to the
+||| `AddMetadata` type constructor.
+|||
+||| While possible, you are not meant to pattern match on values of this type
+||| to extract the main payload, you can use the `val` projection, and to access
+||| metadata fields you can use `get` and `getAt` functions that will automatically
+||| compute and extract the value out of the metadata record.
+|||
+||| Example usage
+||| -------------
+||| Given a value of type `value : WithData ["loc" :-: Location, "cached" :-: Bool] Term`
+||| we can access the `Term` by projecting our the underlying value:
+||| ```idris example
+||| termValue : Term
+||| termValue = value.val
+||| ```
+||| To access the metadata fields use `get` with the name of the field or `getAt` with
+||| the index of the field. For example "loc" is at index `0` therefore one can access
+||| it using `getAt 0`:
+||| ```idris example
+||| termLocation : Location
+||| termLocation = value `getAt` 0
+||| ```
+||| Similarly, we can obtain the "cached" field by giving its name directly
+||| ```idris example
+||| termCache : Bool
+||| termCache = value.get "cache"
+||| ```
+public export
+record WithData (additional : List KeyVal) (payload : Type) where
+  constructor MkWithData
+  metadata : Record additional
+  val : payload
+
+||| Add some metadata to a type given a label and a type for the metadata
+||| This function matches on the type and add it to the metadata record if it is alread a `WithData`
+|||
+||| example:
+||| ```idris example
+||| Term : Type
+|||
+||| RichTerm : Type
+||| RichTerm = AddMetadata ("loc" :-: Location) $ AddMetadata ("cached" :-: Bool) Term
+||| ```
+||| The example shows how to add the fields "loc" and "cached" to the type `Term` as metadata. Those
+||| fields can be accessed with `get` and `getAt` functions
+public export
+AddMetadata : KeyVal -> Type -> Type
+AddMetadata lbl (WithData ls a) = WithData (lbl :: ls) a
+AddMetadata lbl ty = WithData [lbl] ty
+
+||| Obtain the value of the metadata at the given index
+||| @ ix The index of the value we are extracting
+||| @ inRange A proof the index is in range of the metadata record
+export
+getAt : (ix : Nat) ->
+        (0 inRange : FindIndex ix fields === Just out) =>
+        WithData fields a -> out
+getAt ix rec = index rec.metadata ix
+
+||| Obtain the value out of the payload record given its label, same as `(.get)`
+||| @ label The label of the value we are extracting
+||| @ inRange A proof that the label is in the record at the appropriate index with the appropriate type.
+export
+get :
+    (0 label : String) ->
+    -- ^ The field we are accessing
+    {n : Nat} ->
+    -- ^ The index of the field, this can usually be infered
+    (0 inRange : NameInRange label fields === Just (n, out)) =>
+    -- ^ A proof that the field is in the record, its position matches the index `n` and the type at that location is `out`
+    WithData fields a ->
+    -- ^ The data from which we are extracting the field
+    out
+get label rec = Record.get label rec.metadata
+
+||| Obtain the value out of the payload record given its label, same as `get`.
+||| @ label The label of the value we are extracting.
+||| @ inRange A proof that the label is in the record at the appropriate index with the appropriate type.
+export
+(.get) :
+    WithData fields a ->
+    -- ^ The data from which we are extracting the field
+    (0 field : String) ->
+    -- ^ The field we are accessing
+    {n : Nat} ->
+    -- ^ The index of the field, this can usually be infered
+    (0 inRange : NameInRange field fields === Just (n, out)) =>
+    -- ^ A proof that the field is in the record, its position matches the index `n` and the type at that location is `out`
+    out
+(.get) rec field = Record.get field rec.metadata
+
+||| Update at the given index, updates cannot change the type of the field.
+||| @ ix The index at which we update the value.
+||| @ inRange A proof that the index is in range of the metadata record.
+||| @ f The update function.
+export
+updateAt :
+    (ix : Nat) ->
+    -- ^ The index selected for updating
+    (inRange : FindIndex ix fields === Just out) =>
+    -- ^ The proof that the index is in range
+    (f : out -> out) ->
+    -- ^ The update function.
+    WithData fields a -> WithData fields a
+updateAt ix f = {metadata $= updateAt ix f}
+
+||| Update the value with the given field name
+||| @ label The label of the value we are updating
+||| @ inRange A proof that the label is in the record at the appropriate index with the appropriate type.
+||| @ f The update function.
+export
+update :
+    (0 label : String) ->
+    -- ^ The field we want to update
+    {n : Nat} ->
+    -- ^ The index of the field, this can usually be infered
+    (0 inRange : NameInRange label fields === Just (n, out)) =>
+    -- ^ A proof that the field is in the record, its position matches the index `n` and the type at that location is `out`
+    (f : out -> out) ->
+    -- ^ The update function for the field
+    WithData fields a ->
+    -- ^ The data for which we are updating the field
+    WithData fields a
+update label f = {metadata $= update label f}
+
+||| Override the value at the given index.
+||| @ n The index at which we replace our value.
+||| @ inRange A proof that index is in range.
+||| @ newVal The new value remplacing the existing one.
+export
+setAt :
+    (n : Nat) ->
+    -- ^ The index at which we override our value
+    (inRange : FindIndex n ls === Just out) =>
+    -- ^ A proof that the index is in range
+    (newVal : out) ->
+    -- ^ The new value that is going to replace the old one
+    WithData ls a ->
+    -- ^ The data for which we are overriding a value
+    WithData ls a
+setAt n v = {metadata $= setAt n v}
+
+||| Override the value matching the given label
+||| @ label The label of the value we are overriding.
+||| @ inRange A proof that the label is in the record at the appropriate index with the appropriate type.
+||| @ newVal The new value remplacing the existing one.
+export
+set :
+    (0 label : String) -> {n : Nat} ->
+    (0 inRange : NameInRange label ls === Just (n, out)) =>
+    (newVal : out) ->
+    WithData ls a -> WithData ls a
+set label val = {metadata $= Record.set label val}
+
+
+||| Add a labelled value to the metadata
+export
+Add : (0 lbl : String) -> (_ : ty) -> a -> WithData [lbl :-: ty] a
+Add lbl ty x = MkWithData [ lbl :- ty ] x
+
+||| Add value the payload, ignore the label since it's given by the type
+export
+(:+) : ty -> WithData ls a -> WithData (lbl :-: ty :: ls) a
+val :+ x = MkWithData (add lbl val x.metadata) x.val
+
+export infixr 8 :++
+
+||| Add a record to the metadata
+export
+(:++) : Record ls -> WithData xs a -> WithData (ls ++ xs) a
+(:++) rec x = MkWithData (rec ++ x.metadata) x.val
+
+||| Drop the head element of the metadata
+export
+drop : WithData (l :: ls) a -> WithData ls a
+drop = {metadata $= Record.tail }
+
+||| Drop the head element of the metadata
+export
+(.drop) : WithData (l :: ls) a -> WithData ls a
+(.drop) = {metadata $= Record.tail }
+
+
+||| WithData is functiorial in its payload
+export
+mapData : forall metadata. (a -> b) -> WithData metadata a -> WithData metadata b
+mapData f x = MkWithData x.metadata (f x.val)
+
+------------------------------------------------------------------------------------------------
+-- Default fields for records
+------------------------------------------------------------------------------------------------
+
+||| An interface for default values, used to fill in missing values in metadata records
+public export
+interface HasDefault a | a where
+  defValue : a
+
+fromDefault : All (HasDefault . KeyVal.type) fs -> Record fs
+fromDefault [] = []
+fromDefault (_ :: y) = ? :- defValue :: fromDefault y
+
+||| Construct a payload filled with default values for its metadata
+export
+MkDef : {fs : _} -> a -> (values : All (HasDefault . KeyVal.type) fs) => WithData fs a
+MkDef x = MkWithData ((fromDefault values)) x
+
+||| Construct a value with metadata but ignore the labels
+export
+Mk : {fs : _} -> All KeyVal.type fs -> a -> WithData fs a
+Mk x y = MkWithData (fromElems x) y
+
+||| Add a record of default values to an existing metadata record
+export
+AddDef : {fs : _} -> (values : All (HasDefault . KeyVal.type) fs) =>
+         WithData fl a -> WithData (fs ++ fl) a
+AddDef x = fromDefault values :++ x
+
+------------------------------------------------------------------------------------------------
+-- WithData distributes with List and Maybe
+------------------------------------------------------------------------------------------------
+
+export
+distribData : WithData fs (List a) -> List (WithData fs a)
+distribData x = map (MkWithData x.metadata) x.val
+
+export
+distribDataMaybe : WithData fs (Maybe a) -> Maybe (WithData fs a)
+distribDataMaybe (MkWithData metadata Nothing) = Nothing
+distribDataMaybe (MkWithData metadata (Just x)) = Just (MkWithData metadata x)
+
+export
+traverseDataMaybe : (a -> Maybe b) -> WithData fs a -> Maybe (WithData fs b)
+traverseDataMaybe f x = MkWithData x.metadata <$> f x.val
+
+------------------------------------------------------------------------------------------------
+-- Interface implementations
+------------------------------------------------------------------------------------------------
+
+export
+(eq : All (Eq . KeyVal.type) fs) => Eq (Record fs) where
+  (==) [] [] = True
+  (==) {eq = e :: es} {fs = (f :: fs)} (x :: xs) (y :: ys) = x.value == y.value && xs == ys
+
+export
+(eq : All (Eq . KeyVal.type) fs) => Eq a => Eq (WithData fs a) where
+  x == y = x.val == y.val && x.metadata == y.metadata
+

--- a/src/Libraries/Data/WithData.idr
+++ b/src/Libraries/Data/WithData.idr
@@ -16,8 +16,7 @@ import public Libraries.Data.Record
 ||| --------------
 ||| Only ever put plain types in the metadata
 ||| Do not add functors such as `List` or `PTerm`. The functor instance
-||| for `WithData` is only functorial on its payload and not the additional
-||| data.
+||| for `WithData` is only functorial on its payload and not the metadata.
 |||
 ||| There is rarely any need to write down `WithData [ ... ] a` thanks to the
 ||| `AddMetadata` type constructor.
@@ -45,7 +44,7 @@ import public Libraries.Data.Record
 ||| Similarly, we can obtain the "cached" field by giving its name directly
 ||| ```idris example
 ||| termCache : Bool
-||| termCache = value.get "cache"
+||| termCache = value.get "cached"
 ||| ```
 public export
 record WithData (additional : List KeyVal) (payload : Type) where


### PR DESCRIPTION
# Description

This is the first step towards #3570 it adds three modules:

- `Libraries.Data.Record` a generic labelled record with runtime nat-indexing for performance
- `Libraries.Data.WithData` A datastructure to attach metadata to a type by means of a record
- `Core.WithData` A series of helpers for existing known metadata that the compiler already uses

This design addresses the goals set out by #3570 by allowing us to refactor a number of existing records into either `Record` or `WithData`. This refactoring, in turn, allows us to make changes to the metadata without changing the fundamental structure of the surrounding program, since most tree operations are metadata agnostic. 

Once we add the Reify and Reflect instances for those types, they will also remove the need to write bespoke versions for types that use them in their definitions.

Finally, it allows some data that is currently spread out to be appropriately related, removing the uncertainty about what a piece of data does, and self-documenting the code.


