### PR TITLE
Typo in typesfuns.rst

### DIFF
--- a/docs/source/tutorial/typesfuns.rst
+++ b/docs/source/tutorial/typesfuns.rst
@@ -580,10 +580,10 @@ to rely on the behaviour of a mutually defined function for something to typeche
 
   data Even : Nat -> Type where
     ZIsEven : Even Z
-    SOddIsEven : Odd n -> Even (S k)
+    SOddIsEven : Odd n -> Even (S n)
 
   data Odd : Nat -> Type where
-    SEvenIsOdd : Even n -> Odd (S k)
+    SEvenIsOdd : Even n -> Odd (S n)
 
 
 .. code-block:: idris


### PR DESCRIPTION
The example data constructors `SOddIsEven` and `SEvenIsOdd` had the wrong `Nat` identifier in the output type. Since this didn't match the identifier in the input type, there wasn't actually any relationship between the two. Changing `k` to `n` here makes sure that we can only construct `Even n` when `n` is even, and likewise for `Odd n`.