### PR TITLE
Replace WithFC by alias for WithData

### DIFF
--- a/.github/workflows/ci-idris2-and-libs.yml
+++ b/.github/workflows/ci-idris2-and-libs.yml
@@ -281,6 +281,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install build dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y racket
           echo "$HOME/.idris2/bin" >> "$GITHUB_PATH"
       - name: Make bootstrap folder readonly

--- a/idris2api.ipkg
+++ b/idris2api.ipkg
@@ -105,6 +105,7 @@ modules =
     Core.Unify,
     Core.UnifyState,
     Core.Value,
+    Core.WithData,
 
     Core.SchemeEval.Builtins,
     Core.SchemeEval.Compile,
@@ -209,6 +210,8 @@ modules =
     Libraries.Data.UserNameMap,
     Libraries.Data.Version,
     Libraries.Data.WithDefault,
+    Libraries.Data.WithData,
+    Libraries.Data.Record,
 
     Libraries.System.Directory.Tree,
 

--- a/src/Core/Binary.idr
+++ b/src/Core/Binary.idr
@@ -29,7 +29,7 @@ import public Libraries.Utils.Binary
 ||| version number if you're changing the version more than once in the same day.
 export
 ttcVersion : Int
-ttcVersion = 2025_05_09_00
+ttcVersion = 2025_07_24_00
 
 export
 checkTTCVersion : String -> Int -> Int -> Core ()

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -817,7 +817,7 @@ HasNames Error where
   full gam (FailingDidNotFail fc) = pure (FailingDidNotFail fc)
   full gam (FailingWrongError fc x err) = FailingWrongError fc x <$> traverseList1 (full gam) err
   full gam (InType fc n err) = InType fc <$> full gam n <*> full gam err
-  full gam (InCon n err) = InCon <$> traverseFC (full gam) n <*> full gam err
+  full gam (InCon n err) = InCon <$> traverse (full gam) n <*> full gam err
   full gam (InLHS fc n err) = InLHS fc <$> full gam n <*> full gam err
   full gam (InRHS fc n err) = InRHS fc <$> full gam n <*> full gam err
   full gam (MaybeMisspelling err xs) = MaybeMisspelling <$> full gam err <*> pure xs
@@ -915,7 +915,7 @@ HasNames Error where
   resolved gam (FailingDidNotFail fc) = pure (FailingDidNotFail fc)
   resolved gam (FailingWrongError fc x err) = FailingWrongError fc x <$> traverseList1 (resolved gam) err
   resolved gam (InType fc n err) = InType fc <$> resolved gam n <*> resolved gam err
-  resolved gam (InCon n err) = InCon <$> traverseFC (resolved gam) n <*> resolved gam err
+  resolved gam (InCon n err) = InCon <$> traverse (resolved gam) n <*> resolved gam err
   resolved gam (InLHS fc n err) = InLHS fc <$> resolved gam n <*> resolved gam err
   resolved gam (InRHS fc n err) = InRHS fc <$> resolved gam n <*> resolved gam err
   resolved gam (MaybeMisspelling err xs) = MaybeMisspelling <$> resolved gam err <*> pure xs

--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -19,6 +19,9 @@ import Libraries.Data.WithData
 import public Data.IORef
 import System.File
 
+%hide Libraries.Data.Record.KeyVal.label
+%hide Libraries.Data.Record.LabelledValue.label
+
 %default covering
 
 public export

--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -3,6 +3,7 @@ module Core.Core
 import Core.Context.Context
 import Core.Env
 import Core.TT
+import public Core.WithData
 
 import Data.List1
 import Data.SnocList
@@ -13,6 +14,7 @@ import Libraries.Text.PrettyPrint.Prettyprinter
 import Libraries.Text.PrettyPrint.Prettyprinter.Util
 import Libraries.Text.PrettyPrint.Prettyprinter.Doc
 import Libraries.Data.Tap
+import Libraries.Data.WithData
 
 import public Data.IORef
 import System.File
@@ -858,8 +860,12 @@ namespace SnocList
   traverse_ f xs = traverse_' f (reverse xs)
 
 %inline export
+traverseData : (ty -> Core sy) -> WithData fs ty -> Core (WithData fs sy)
+traverseData f (MkWithData extra val) = MkWithData extra <$> f val
+
+%inline export
 traverseFC : (a -> Core b) -> WithFC a -> Core (WithFC b)
-traverseFC f (MkFCVal fc x) = MkFCVal fc <$> f x
+traverseFC = traverseData
 
 namespace PiInfo
   export

--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -862,13 +862,10 @@ namespace SnocList
   traverse_ : (a -> Core b) -> SnocList a -> Core ()
   traverse_ f xs = traverse_' f (reverse xs)
 
-%inline export
-traverseData : (ty -> Core sy) -> WithData fs ty -> Core (WithData fs sy)
-traverseData f (MkWithData extra val) = MkWithData extra <$> f val
-
-%inline export
-traverseFC : (a -> Core b) -> WithFC a -> Core (WithFC b)
-traverseFC = traverseData
+namespace WithData
+  %inline export
+  traverse : (ty -> Core sy) -> WithData fs ty -> Core (WithData fs sy)
+  traverse f (MkWithData extra val) = MkWithData extra <$> f val
 
 namespace PiInfo
   export

--- a/src/Core/FC.idr
+++ b/src/Core/FC.idr
@@ -77,46 +77,6 @@ NonEmptyFC : Type
 NonEmptyFC = (OriginDesc, FilePos, FilePos)
 
 ------------------------------------------------------------------------
-||| A wrapper for a value with a file context.
-public export
-record WithFC (ty : Type) where
-  constructor MkFCVal
-  fc : FC
-  val : ty
-
-||| Smart constructor for WithFC that uses EmptyFC as location
-%inline export
-NoFC : a -> WithFC a
-NoFC = MkFCVal EmptyFC
-
-%inline export
-mapFC : (a -> b) -> WithFC a -> WithFC b
-mapFC f (MkFCVal fc val) = MkFCVal fc (f val)
-
-%inline export
-distribFC : WithFC (List a) -> List (WithFC a)
-distribFC x = map (MkFCVal x.fc) x.val
-
-%inline export
-traverseFCMaybe : (a -> Maybe b) -> WithFC a -> Maybe (WithFC b)
-traverseFCMaybe f (MkFCVal fc val) = MkFCVal fc <$> f val
-
-||| An interface to extract the location of some data
-public export
-interface HasFC ty where
-  constructor MkHasLoc
-  (.getFC) : ty -> FC
-
-||| Anything with locations has a location
-export
-HasFC (WithFC ty) where
-  (.getFC) (MkFCVal f _) = f
-
-export
-setFC : FC -> WithFC a -> WithFC a
-setFC x = { fc := x }
-
-------------------------------------------------------------------------
 -- Conversion between NonEmptyFC and FC
 
 ||| NonEmptyFC always embeds into FC
@@ -201,10 +161,6 @@ export
 boundToFC' : OriginDesc -> Bounds -> FC
 boundToFC' mbModIdent b = MkFC mbModIdent (startBounds b) (endBounds b)
 
-export
-(.withFC) : (o : OriginDesc) => WithBounds t -> WithFC t
-x.withFC = MkFCVal x.toFC x.val
-
 ------------------------------------------------------------------------
 -- Predicates
 
@@ -274,8 +230,3 @@ Pretty Void FC where
   pretty (MkVirtualFC ident startPos endPos) = byShow ident <+> colon
                  <+> prettyPos startPos <+> pretty "--"
                  <+> prettyPos endPos
-
-export
-Eq a => Eq (WithFC a) where
-  a == b = a.fc == b.fc && a.val == b.val
-

--- a/src/Core/Reflect.idr
+++ b/src/Core/Reflect.idr
@@ -882,9 +882,9 @@ Reify a => Reify (WithFC a) where
 
 export
 Reflect a => Reflect (WithFC a) where
-  reflect fc defs lhs env (MkFCVal loc val)
-      = do loc' <- reflect fc defs lhs env loc
-           val' <- reflect fc defs lhs env val
+  reflect fc defs lhs env value
+      = do loc' <- reflect fc defs lhs env value.fc
+           val' <- reflect fc defs lhs env value.val
            appCon fc defs (reflectiontt "MkFCVal") [Erased fc Placeholder, loc', val']
 
 {-

--- a/src/Idris/Desugar/Mutual.idr
+++ b/src/Idris/Desugar/Mutual.idr
@@ -14,42 +14,42 @@ import Data.List1
 --       implementation headers (i.e. note their existence, but not the bodies)
 -- Everything else on the second pass
 getDecl : Pass -> PDecl-> Maybe PDecl
-getDecl p (MkFCVal fc $ PImplementation vis opts _ is cons n ps iname nusing ds)
-    = Just (MkFCVal fc $ PImplementation vis opts p is cons n ps iname nusing ds)
+getDecl p (MkWithData fc $ PImplementation vis opts _ is cons n ps iname nusing ds)
+    = Just (MkWithData fc $ PImplementation vis opts p is cons n ps iname nusing ds)
 
-getDecl p (MkFCVal fc $ PNamespace ns ds)
-    = Just (MkFCVal fc $ PNamespace ns (assert_total $ mapMaybe (getDecl p) ds))
+getDecl p (MkWithData fc $ PNamespace ns ds)
+    = Just (MkWithData fc $ PNamespace ns (assert_total $ mapMaybe (getDecl p) ds))
 
-getDecl AsType d@(MkFCVal _ $ PClaim _) = Just d
-getDecl AsType (MkFCVal fc $ PData doc vis mbtot (MkPData dfc tyn (Just tyc) _ _))
-    = Just (MkFCVal fc $ PData doc vis mbtot (MkPLater dfc tyn tyc))
-getDecl AsType d@(MkFCVal _ $ PInterface _ _ _ _ _ _ _ _) = Just d
-getDecl AsType (MkFCVal fc $ PRecord doc vis mbtot (MkPRecord n ps _ _ _))
-    = Just (MkFCVal fc $ PData doc vis mbtot (MkPLater fc n (mkRecType ps)))
+getDecl AsType d@(MkWithData _ $ PClaim _) = Just d
+getDecl AsType (MkWithData fc $ PData doc vis mbtot (MkPData dfc tyn (Just tyc) _ _))
+    = Just (MkWithData fc $ PData doc vis mbtot (MkPLater dfc tyn tyc))
+getDecl AsType d@(MkWithData _ $ PInterface _ _ _ _ _ _ _ _) = Just d
+getDecl AsType d@(MkWithData fc $ PRecord doc vis mbtot (MkPRecord n ps _ _ _))
+    = Just (MkWithData fc $ PData doc vis mbtot (MkPLater d.fc n (mkRecType ps)))
   where
     mkRecType : List PBinder -> PTerm
-    mkRecType [] = PType fc
+    mkRecType [] = PType d.fc
     mkRecType (MkPBinder p (MkBasicMultiBinder c (n ::: []) t) :: ts)
-      = PPi fc c p (Just n.val) t (mkRecType ts)
+      = PPi d.fc c p (Just n.val) t (mkRecType ts)
     mkRecType (MkPBinder p (MkBasicMultiBinder c (n ::: x :: xs) t) :: ts)
-      = PPi fc c p (Just n.val) t
+      = PPi d.fc c p (Just n.val) t
           (assert_total $ mkRecType (MkPBinder p (MkBasicMultiBinder c (x ::: xs) t) :: ts))
-getDecl AsType d@(MkFCVal _ $ PFixity _ ) = Just d
-getDecl AsType d@(MkFCVal _ $ PDirective _) = Just d
+getDecl AsType d@(MkWithData _ $ PFixity _ ) = Just d
+getDecl AsType d@(MkWithData _ $ PDirective _) = Just d
 getDecl AsType d = Nothing
 
-getDecl AsDef (MkFCVal _ $ PClaim _) = Nothing
-getDecl AsDef d@(MkFCVal _ $ PData _ _ _ (MkPLater _ _ _)) = Just d
-getDecl AsDef (MkFCVal _ $ PInterface _ _ _ _ _ _ _ _) = Nothing
-getDecl AsDef d@(MkFCVal _ $ PRecord _ _ _ (MkPRecordLater _ _)) = Just d
-getDecl AsDef (MkFCVal _ $ PFixity _ ) = Nothing
-getDecl AsDef (MkFCVal _ $ PDirective _) = Nothing
+getDecl AsDef (MkWithData _ $ PClaim _) = Nothing
+getDecl AsDef d@(MkWithData _ $ PData _ _ _ (MkPLater _ _ _)) = Just d
+getDecl AsDef (MkWithData _ $ PInterface _ _ _ _ _ _ _ _) = Nothing
+getDecl AsDef d@(MkWithData _ $ PRecord _ _ _ (MkPRecordLater _ _)) = Just d
+getDecl AsDef (MkWithData _ $ PFixity _ ) = Nothing
+getDecl AsDef (MkWithData _ $ PDirective _) = Nothing
 getDecl AsDef d = Just d
 
-getDecl p (MkFCVal fc $ PParameters ps pds)
-    = Just (MkFCVal fc $ PParameters ps (assert_total $ mapMaybe (getDecl p) pds))
-getDecl p (MkFCVal fc $ PUsing ps pds)
-    = Just (MkFCVal fc $ PUsing ps (assert_total $ mapMaybe (getDecl p) pds))
+getDecl p (MkWithData fc $ PParameters ps pds)
+    = Just (MkWithData fc $ PParameters ps (assert_total $ mapMaybe (getDecl p) pds))
+getDecl p (MkWithData fc $ PUsing ps pds)
+    = Just (MkWithData fc $ PUsing ps (assert_total $ mapMaybe (getDecl p) pds))
 
 getDecl Single d = Just d
 

--- a/src/Idris/Elab/Interface.idr
+++ b/src/Idris/Elab/Interface.idr
@@ -185,7 +185,7 @@ getMethToplevel {vars} env vis iname cname constraints allmeths params sig
          let ty_constr =
              substNames (toList vars) (map applyCon allmeths) sig.type
          ty_imp <- bindTypeNames EmptyFC [] (toList vars) (bindPs params $ bindIFace vfc ity ty_constr)
-         cn <- traverseFC inCurrentNS sig.name
+         cn <- traverse inCurrentNS sig.name
          let tydecl = IClaim (MkFCVal vfc $ MkIClaimData sig.count vis (if sig.isData then [Inline, Invertible]
                                             else [Inline])
                                       (MkImpTy vfc cn ty_imp))

--- a/src/Idris/Elab/Interface.idr
+++ b/src/Idris/Elab/Interface.idr
@@ -51,7 +51,7 @@ namePis i (IBindHere fc m ty) = IBindHere fc m (namePis i ty)
 namePis i ty = ty
 
 getSig : ImpDecl -> Maybe Signature
-getSig (IClaim (MkFCVal _ $ MkIClaimData c _ opts (MkImpTy fc n ty)))
+getSig (IClaim (MkWithData _ $ MkIClaimData c _ opts (MkImpTy fc n ty)))
     = Just $ MkSignature { count    = c
                          , flags    = opts
                          , name     = n

--- a/src/Idris/Pretty.idr
+++ b/src/Idris/Pretty.idr
@@ -185,16 +185,16 @@ mutual
   export
   Pretty IdrisSyntax IPTerm where
     prettyPrec d (PRef _ nm) = annotateM (kindAnn nm) $ cast $ prettyOp False nm.rawName
-    prettyPrec d (NewPi (MkFCVal fc (MkPBinderScope (MkPBinder Implicit bind) scope))) =
+    prettyPrec d (NewPi (MkWithData fc (MkPBinderScope (MkPBinder Implicit bind) scope))) =
       lcurly <+> pretty bind <+> rcurly <++> arrow <++> prettyPrec d scope
-    prettyPrec d (NewPi (MkFCVal fc (MkPBinderScope (MkPBinder Explicit bind) scope))) =
+    prettyPrec d (NewPi (MkWithData fc (MkPBinderScope (MkPBinder Explicit bind) scope))) =
       lparen <+> pretty bind <+> rparen <++> arrow <++> prettyPrec d scope
-    prettyPrec d (NewPi (MkFCVal fc (MkPBinderScope (MkPBinder AutoImplicit bind) scope))) =
+    prettyPrec d (NewPi (MkWithData fc (MkPBinderScope (MkPBinder AutoImplicit bind) scope))) =
       lcurly <+> auto_ <++> pretty bind <+> rcurly <++> arrow <++> prettyPrec d scope
-    prettyPrec d (NewPi (MkFCVal fc (MkPBinderScope (MkPBinder (DefImplicit x) bind) scope))) =
+    prettyPrec d (NewPi (MkWithData fc (MkPBinderScope (MkPBinder (DefImplicit x) bind) scope))) =
       lcurly <+> default_ <++> prettyPrec appPrec x
       <++> pretty bind <+> rcurly <++> arrow <++> prettyPrec d scope
-    prettyPrec d (Forall (MkFCVal fc (names, scope))) =
+    prettyPrec d (Forall (MkWithData fc (names, scope))) =
       parenthesise (d > startPrec) $ group $
         forall_ <++> commaSep (map (prettyBinder . val) (forget names)) <++> dot <++> pretty scope
     prettyPrec d (PPi _ rig Explicit Nothing arg ret) =
@@ -357,19 +357,19 @@ mutual
     prettyPrec d (PDotted _ p) = dot <+> prettyPrec d p
     prettyPrec d (PImplicit _) = "_"
     prettyPrec d (PInfer _) = annotate Hole $ "?"
-    prettyPrec d (POp _ (MkFCVal _ $ BindType nm left) op right) =
+    prettyPrec d (POp _ (MkWithData _ $ BindType nm left) op right) =
         group $ parens (prettyPrec d nm <++> ":" <++> pretty left)
            <++> prettyOp op.val.toName
            <++> pretty right
-    prettyPrec d (POp _ (MkFCVal _ $ BindExpr nm left) op right) =
+    prettyPrec d (POp _ (MkWithData _ $ BindExpr nm left) op right) =
         group $ parens (prettyPrec d nm <++> ":=" <++> pretty left)
            <++> prettyOp op.val.toName
            <++> pretty right
-    prettyPrec d (POp _ (MkFCVal _ $ BindExplicitType nm ty left) op right) =
+    prettyPrec d (POp _ (MkWithData _ $ BindExplicitType nm ty left) op right) =
         group $ parens (prettyPrec d nm <++> ":" <++> pretty ty <++> ":=" <++> pretty left)
            <++> prettyOp op.val.toName
            <++> pretty right
-    prettyPrec d (POp _ (MkFCVal _ $ NoBinder x) op y) =
+    prettyPrec d (POp _ (MkWithData _ $ NoBinder x) op y) =
       parenthesise (d >= App) $
         group $ pretty x
            <++> prettyOp op.val.toName

--- a/src/Idris/Pretty.idr
+++ b/src/Idris/Pretty.idr
@@ -182,18 +182,21 @@ mutual
       = prettyRig rig <++> commaSep (forget $ map (prettyBinder . val) names)
       <++> colon <++> pretty type
 
+  Pretty IdrisSyntax (PBinder' KindedName) where
+    prettyPrec d (MkPBinder Implicit bind) =
+      lcurly <+> pretty bind <+> rcurly
+    prettyPrec d (MkPBinder Explicit bind) =
+      lparen <+> pretty bind <+> rparen
+    prettyPrec d (MkPBinder AutoImplicit bind)  =
+      lcurly <+> auto_ <++> pretty bind <+> rcurly
+    prettyPrec d (MkPBinder (DefImplicit x) bind)  =
+      lcurly <+> default_ <++> prettyPrec appPrec x <+> rcurly
+
   export
   Pretty IdrisSyntax IPTerm where
     prettyPrec d (PRef _ nm) = annotateM (kindAnn nm) $ cast $ prettyOp False nm.rawName
-    prettyPrec d (NewPi (MkWithData fc (MkPBinderScope (MkPBinder Implicit bind) scope))) =
-      lcurly <+> pretty bind <+> rcurly <++> arrow <++> prettyPrec d scope
-    prettyPrec d (NewPi (MkWithData fc (MkPBinderScope (MkPBinder Explicit bind) scope))) =
-      lparen <+> pretty bind <+> rparen <++> arrow <++> prettyPrec d scope
-    prettyPrec d (NewPi (MkWithData fc (MkPBinderScope (MkPBinder AutoImplicit bind) scope))) =
-      lcurly <+> auto_ <++> pretty bind <+> rcurly <++> arrow <++> prettyPrec d scope
-    prettyPrec d (NewPi (MkWithData fc (MkPBinderScope (MkPBinder (DefImplicit x) bind) scope))) =
-      lcurly <+> default_ <++> prettyPrec appPrec x
-      <++> pretty bind <+> rcurly <++> arrow <++> prettyPrec d scope
+    prettyPrec d (NewPi (MkWithData fc (MkPBinderScope binder scope))) =
+      prettyPrec d binder <++> arrow <++> prettyPrec d scope
     prettyPrec d (Forall (MkWithData fc (names, scope))) =
       parenthesise (d > startPrec) $ group $
         forall_ <++> commaSep (map (prettyBinder . val) (forget names)) <++> dot <++> pretty scope

--- a/src/Idris/ProcessIdr.idr
+++ b/src/Idris/ProcessIdr.idr
@@ -80,9 +80,9 @@ processDecl : {auto c : Ref Ctxt Defs} ->
 -- Special cases to avoid treating these big blocks as units
 -- This should give us better error recovery (the whole block won't fail
 -- as soon as one of the definitions fails)
-processDecl (MkFCVal _ $ PNamespace ns ps)
+processDecl (MkWithData _ $ PNamespace ns ps)
     = withExtendedNS ns $ processDecls ps
-processDecl (MkFCVal _ $ PMutual ps)
+processDecl (MkWithData _ $ PMutual ps)
     = let (tys, defs) = splitMutual ps in
       processDecls (tys ++ defs)
 

--- a/src/Idris/Resugar.idr
+++ b/src/Idris/Resugar.idr
@@ -527,9 +527,9 @@ mutual
   toPDecl : {auto c : Ref Ctxt Defs} ->
             {auto s : Ref Syn SyntaxInfo} ->
             ImpDecl' KindedName -> Core (Maybe (PDecl' KindedName))
-  toPDecl (IClaim (MkFCVal fc $ MkIClaimData rig vis opts ty))
+  toPDecl (IClaim (MkWithData fc $ MkIClaimData rig vis opts ty))
       = do opts' <- traverse toPFnOpt opts
-           pure (Just (MkFCVal fc $ PClaim (MkPClaim rig vis opts' !(toPTypeDecl ty))))
+           pure (Just (MkWithData fc $ PClaim (MkPClaim rig vis opts' !(toPTypeDecl ty))))
   toPDecl (IData fc vis mbtot d)
       = pure (Just (MkFCVal fc $ PData "" vis mbtot !(toPData d)))
   toPDecl (IDef fc n cs)

--- a/src/Idris/Resugar.idr
+++ b/src/Idris/Resugar.idr
@@ -600,13 +600,13 @@ cleanPTerm ptm
     cleanNode (PRef fc nm)    =
       PRef fc <$> cleanKindedName nm
     cleanNode (POp fc abi op y) =
-      (\ op => POp fc abi op y) <$> traverseFC (traverseOp @{Functor.CORE} cleanKindedName) op
+      (\ op => POp fc abi op y) <$> traverse (traverseOp @{Functor.CORE} cleanKindedName) op
     cleanNode (PPrefixOp fc op x) =
-      (\ op => PPrefixOp fc op x) <$> traverseFC (traverseOp @{Functor.CORE} cleanKindedName) op
+      (\ op => PPrefixOp fc op x) <$> traverse (traverseOp @{Functor.CORE} cleanKindedName) op
     cleanNode (PSectionL fc op x) =
-      (\ op => PSectionL fc op x) <$> traverseFC (traverseOp @{Functor.CORE} cleanKindedName) op
+      (\ op => PSectionL fc op x) <$> traverse (traverseOp @{Functor.CORE} cleanKindedName) op
     cleanNode (PSectionR fc x op) =
-      PSectionR fc x <$> traverseFC (traverseOp @{Functor.CORE} cleanKindedName) op
+      PSectionR fc x <$> traverse (traverseOp @{Functor.CORE} cleanKindedName) op
     cleanNode (PPi fc rig vis (Just n) arg ret) =
       (\ n => PPi fc rig vis n arg ret) <$> (cleanBinderName vis n)
     cleanNode tm = pure tm

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -71,6 +71,8 @@ OpStr = OpStr' Name
 public export
 data HidingDirective = HideName Name
                      | HideFixity Fixity Name
+
+%hide Core.WithData.WithName
 -------------------------------------------------------------------------------
 -- With Name functor to carry name information with a payload
 public export
@@ -646,7 +648,7 @@ isStrLiteral (StrLiteral fc str) = Just (fc, str)
 
 export
 isPDef : PDecl -> Maybe (WithFC (List PClause))
-isPDef (MkFCVal fc (PDef cs)) = Just (MkFCVal fc cs)
+isPDef (MkWithData fc (PDef cs)) = Just (MkWithData fc cs)
 isPDef _ = Nothing
 
 
@@ -878,9 +880,9 @@ parameters {0 nm : Type} (toName : nm -> Name)
   showPBinder d (MkPBinder (DefImplicit x) bind) = "{default \{showPTerm x} \{ showBasicMultiBinder bind}}"
 
   showPTermPrec d (PRef _ n) = showPrec d (toName n)
-  showPTermPrec d (Forall (MkFCVal _ (names, scope)))
+  showPTermPrec d (Forall (MkWithData _ (names, scope)))
         = "forall " ++ concat (intersperse ", " (map (show . val) (forget names))) ++ " . " ++ showPTermPrec d scope
-  showPTermPrec d (NewPi (MkFCVal _ (MkPBinderScope binder scope)))
+  showPTermPrec d (NewPi (MkWithData _ (MkPBinderScope binder scope)))
         = showPBinder d binder ++ " -> "  ++ showPTermPrec d scope
   showPTermPrec d (PPi _ rig Explicit Nothing arg ret)
         = showPTermPrec d arg ++ " -> " ++ showPTermPrec d ret
@@ -961,13 +963,13 @@ parameters {0 nm : Type} (toName : nm -> Name)
   showPTermPrec d (PDotted _ p) = "." ++ showPTermPrec d p
   showPTermPrec _ (PImplicit _) = "_"
   showPTermPrec _ (PInfer _) = "?"
-  showPTermPrec d (POp _ (MkFCVal _ $ NoBinder left) op right)
+  showPTermPrec d (POp _ (MkWithData _ $ NoBinder left) op right)
         = showPTermPrec d left ++ " " ++ showOpPrec d op.val ++ " " ++ showPTermPrec d right
-  showPTermPrec d (POp _ (MkFCVal _ $ BindType nm left) op right)
+  showPTermPrec d (POp _ (MkWithData _ $ BindType nm left) op right)
         = "(" ++ showPTermPrec d nm ++ " : " ++ showPTermPrec d left ++ " " ++ showOpPrec d op.val ++ " " ++ showPTermPrec d right ++ ")"
-  showPTermPrec d (POp _ (MkFCVal _ $ BindExpr nm left) op right)
+  showPTermPrec d (POp _ (MkWithData _ $ BindExpr nm left) op right)
         = "(" ++ showPTermPrec d nm ++ " := " ++ showPTermPrec d left ++ " " ++ showOpPrec d op.val ++ " " ++ showPTermPrec d right ++ ")"
-  showPTermPrec d (POp _ (MkFCVal _ $ BindExplicitType nm ty left) op right)
+  showPTermPrec d (POp _ (MkWithData _ $ BindExplicitType nm ty left) op right)
         = "(" ++ showPTermPrec d nm ++ " : " ++ showPTermPrec d ty ++ ":=" ++ showPTermPrec d left ++ " " ++ showOpPrec d op.val ++ " " ++ showPTermPrec d right ++ ")"
   showPTermPrec d (PPrefixOp _ op x) = showOpPrec d op.val ++ showPTermPrec d x
   showPTermPrec d (PSectionL _ op x) = "(" ++ showOpPrec d op.val ++ " " ++ showPTermPrec d x ++ ")"

--- a/src/Idris/Syntax/Traversals.idr
+++ b/src/Idris/Syntax/Traversals.idr
@@ -18,9 +18,9 @@ mapPTermM f = goPTerm where
     goPTerm : PTerm' nm -> Core (PTerm' nm)
     goPTerm t@(PRef _ _) = f t
     goPTerm (NewPi x) =
-      NewPi <$> traverseFC goPBinderScope x
+      NewPi <$> traverse goPBinderScope x
     goPTerm (Forall x) =
-      Forall <$> traverseFC (\(a, b) => MkPair a <$> goPTerm b) x
+      Forall <$> traverse (\(a, b) => MkPair a <$> goPTerm b) x
     goPTerm (PPi fc x info z argTy retTy) =
       PPi fc x <$> goPiInfo info
                <*> pure z
@@ -46,7 +46,7 @@ mapPTermM f = goPTerm where
                <*> goPClauses xs
       >>= f
     goPTerm (PLocal fc xs scope) =
-      PLocal fc <$> traverse (traverseFC goPDecl) xs
+      PLocal fc <$> traverse (traverse goPDecl) xs
                 <*> goPTerm scope
       >>= f
     goPTerm (PUpdate fc xs) =
@@ -105,7 +105,7 @@ mapPTermM f = goPTerm where
     goPTerm t@(PInfer _) = f t
     goPTerm (POp fc bind op right) =
       POp fc
-          <$> traverseFC goOpBinder bind
+          <$> traverse goOpBinder bind
           <*> pure op
           <*> goPTerm right
       >>= f
@@ -227,8 +227,8 @@ mapPTermM f = goPTerm where
     goPDo (DoRewrite fc t) = DoRewrite fc <$> goPTerm t
 
     goPRecordDeclLet : PRecordDeclLet' nm -> Core (PRecordDeclLet' nm)
-    goPRecordDeclLet (RecordClaim x) = RecordClaim <$> traverseFC goPClaim x
-    goPRecordDeclLet (RecordClause x) = RecordClause <$> traverseFC goPClause x
+    goPRecordDeclLet (RecordClaim x) = RecordClaim <$> traverse goPClaim x
+    goPRecordDeclLet (RecordClause x) = RecordClause <$> traverse goPClause x
 
     goPClause : PClause' nm -> Core (PClause' nm)
     goPClause (MkPatClause fc lhs rhs wh) =
@@ -249,7 +249,7 @@ mapPTermM f = goPTerm where
     goPClaim : PClaimData' nm -> Core (PClaimData' nm)
     goPClaim (MkPClaim c v opts tdecl) =
       MkPClaim c v <$> goPFnOpts opts
-                   <*> traverseFC goPTypeDecl tdecl
+                   <*> traverse goPTypeDecl tdecl
 
     goPlainBinder : PlainBinder' nm -> Core (PlainBinder' nm)
     goPlainBinder = traverseWName f
@@ -402,7 +402,7 @@ mapPTermM f = goPTerm where
 
     goPDecls : List (PDecl' nm) -> Core (List (PDecl' nm))
     goPDecls []          = pure []
-    goPDecls (d :: ds) = (::) <$> traverseFC goPDecl d <*> goPDecls ds
+    goPDecls (d :: ds) = (::) <$> traverse goPDecl d <*> goPDecls ds
 
     goPFieldUpdates : List (PFieldUpdate' nm) -> Core (List (PFieldUpdate' nm))
     goPFieldUpdates []          = pure []
@@ -410,7 +410,7 @@ mapPTermM f = goPTerm where
 
     goPFields : List (PField' nm) -> Core (List (PField' nm))
     goPFields []        = pure []
-    goPFields (f :: fs) = (::) <$> traverseFC goRecordField f <*> goPFields fs
+    goPFields (f :: fs) = (::) <$> traverse goRecordField f <*> goPFields fs
 
     goPFnOpts : List (PFnOpt' nm) -> Core (List (PFnOpt' nm))
     goPFnOpts []        = pure []
@@ -418,7 +418,7 @@ mapPTermM f = goPTerm where
 
     goPTypeDecls : List (PTypeDecl' nm) -> Core (List (PTypeDecl' nm))
     goPTypeDecls []        = pure []
-    goPTypeDecls (t :: ts) = (::) <$> traverseFC goPTypeDecl t <*> goPTypeDecls ts
+    goPTypeDecls (t :: ts) = (::) <$> traverse goPTypeDecl t <*> goPTypeDecls ts
 
 export
 mapPTerm : (PTerm' nm -> PTerm' nm) -> PTerm' nm -> PTerm' nm

--- a/src/Idris/Syntax/Traversals.idr
+++ b/src/Idris/Syntax/Traversals.idr
@@ -429,9 +429,9 @@ mapPTerm f = goPTerm where
     goPTerm : PTerm' nm -> PTerm' nm
     goPTerm t@(PRef _ _) = f t
     goPTerm (Forall binderScope)
-      = Forall (mapFC (mapSnd f) binderScope)
+      = Forall (mapData (mapSnd f) binderScope)
     goPTerm (NewPi binderScope)
-      = NewPi (mapFC goPBinderScope binderScope)
+      = NewPi (mapData goPBinderScope binderScope)
     goPTerm (PPi fc x info z argTy retTy)
       = f $ PPi fc x (goPiInfo info) z (goPTerm argTy) (goPTerm retTy)
     goPTerm (PLam fc x info z argTy scope)
@@ -441,7 +441,7 @@ mapPTerm f = goPTerm where
     goPTerm (PCase fc opts x xs)
       = f $ PCase fc (goPFnOpt <$>  opts) (goPTerm x) (goPClause <$> xs)
     goPTerm (PLocal fc xs scope)
-      = f $ PLocal fc (mapFC goPDecl <$> xs) (goPTerm scope)
+      = f $ PLocal fc (mapData goPDecl <$> xs) (goPTerm scope)
     goPTerm (PUpdate fc xs)
       = f $ PUpdate fc (goPFieldUpdate <$> xs)
     goPTerm (PApp fc x y)
@@ -464,7 +464,7 @@ mapPTerm f = goPTerm where
       = f $ PQuote fc $ goPTerm x
     goPTerm t@(PQuoteName _ _) = f t
     goPTerm (PQuoteDecl fc x)
-      = f $ PQuoteDecl fc (mapFC goPDecl <$> x)
+      = f $ PQuoteDecl fc (mapData goPDecl <$> x)
     goPTerm (PUnquote fc x)
       = f $ PUnquote fc $ goPTerm x
     goPTerm (PRunElab fc x)
@@ -478,7 +478,7 @@ mapPTerm f = goPTerm where
     goPTerm t@(PImplicit _) = f t
     goPTerm t@(PInfer _) = f t
     goPTerm (POp fc autoBindInfo opName z)
-      = f $ POp fc (mapFC (map f) autoBindInfo) opName (goPTerm z)
+      = f $ POp fc (mapData (map f) autoBindInfo) opName (goPTerm z)
     goPTerm (PPrefixOp fc x y)
       = f $ PPrefixOp fc x $ goPTerm y
     goPTerm (PSectionL fc x y)
@@ -543,7 +543,7 @@ mapPTerm f = goPTerm where
       = DoLet fc lhsFC n c (goPTerm t) (goPTerm scope)
     goPDo (DoLetPat fc pat t scope cls)
       = DoLetPat fc (goPTerm pat) (goPTerm t) (goPTerm scope) (goPClause <$> cls)
-    goPDo (DoLetLocal fc decls) = DoLetLocal fc $ mapFC goPDecl <$> decls
+    goPDo (DoLetLocal fc decls) = DoLetLocal fc $ mapData goPDecl <$> decls
     goPDo (DoRewrite fc t) = DoRewrite fc $ goPTerm t
 
     goPWithProblem : PWithProblem' nm -> PWithProblem' nm
@@ -551,13 +551,13 @@ mapPTerm f = goPTerm where
 
     goPClause : PClause' nm -> PClause' nm
     goPClause (MkPatClause fc lhs rhs wh)
-      = MkPatClause fc (goPTerm lhs) (goPTerm rhs) (mapFC goPDecl <$> wh)
+      = MkPatClause fc (goPTerm lhs) (goPTerm rhs) (mapData goPDecl <$> wh)
     goPClause (MkWithClause fc lhs wps flags cls)
       = MkWithClause fc (goPTerm lhs) (goPWithProblem <$> wps) flags (goPClause <$> cls)
     goPClause (MkImpossible fc lhs) = MkImpossible fc $ goPTerm lhs
 
     goPClaim : PClaimData' nm -> PClaimData' nm
-    goPClaim (MkPClaim c v opts tdecl) = MkPClaim c v (goPFnOpt <$> opts) (mapFC goPTypeDecl tdecl)
+    goPClaim (MkPClaim c v opts tdecl) = MkPClaim c v (goPFnOpt <$> opts) (mapData goPTypeDecl tdecl)
 
     goPlainBinder : PlainBinder' nm -> PlainBinder' nm
     goPlainBinder = mapWName goPTerm
@@ -572,23 +572,23 @@ mapPTerm f = goPTerm where
     goPDecl (PDef cls) = PDef $ (map goPClause) cls
     goPDecl (PData doc v mbt d) = PData doc v mbt $ goPDataDecl d
     goPDecl (PParameters nts ps)
-      = PParameters (bimap (map goPlainBinder) (map goPBinder) nts) (mapFC goPDecl <$> ps)
+      = PParameters (bimap (map goPlainBinder) (map goPBinder) nts) (mapData goPDecl <$> ps)
     goPDecl (PUsing mnts ps)
-      = PUsing (goPairedPTerms mnts) (mapFC goPDecl <$> ps)
+      = PUsing (goPairedPTerms mnts) (mapData goPDecl <$> ps)
     goPDecl (PInterface v mnts n doc nrts ns mn ps)
-      = PInterface v (goPairedPTerms mnts) n doc (goBasicMultiBinder <$> nrts) ns mn (mapFC goPDecl <$> ps)
+      = PInterface v (goPairedPTerms mnts) n doc (goBasicMultiBinder <$> nrts) ns mn (mapData goPDecl <$> ps)
     goPDecl (PImplementation v opts p is cs n ts mn ns mps)
       = PImplementation v opts p (goImplicits is) (goPairedPTerms cs)
-           n (goPTerm <$> ts) mn ns (map (mapFC goPDecl <$>) mps)
+           n (goPTerm <$> ts) mn ns (map (mapData goPDecl <$>) mps)
     goPDecl (PRecord doc v tot (MkPRecord n nts opts mn fs))
       = PRecord doc v tot
-          (MkPRecord n (map goPBinder nts) opts mn (map (mapFC goRecordField) fs))
+          (MkPRecord n (map goPBinder nts) opts mn (map (mapData goRecordField) fs))
     goPDecl (PRecord doc v tot (MkPRecordLater n nts))
       = PRecord doc v tot (MkPRecordLater n (goPBinder <$> nts ))
-    goPDecl (PFail msg ps) = PFail msg $ mapFC goPDecl <$> ps
-    goPDecl (PMutual ps) = PMutual $ map (mapFC goPDecl) ps
+    goPDecl (PFail msg ps) = PFail msg $ mapData goPDecl <$> ps
+    goPDecl (PMutual ps) = PMutual $ map (mapData goPDecl) ps
     goPDecl (PFixity p) = PFixity p
-    goPDecl (PNamespace strs ps) = PNamespace strs $ mapFC goPDecl <$> ps
+    goPDecl (PNamespace strs ps) = PNamespace strs $ mapData goPDecl <$> ps
     goPDecl (PTransform n a b) = PTransform n (goPTerm a) (goPTerm b)
     goPDecl (PRunElabDecl a) = PRunElabDecl $ goPTerm a
     goPDecl (PDirective d) = PDirective d
@@ -610,12 +610,12 @@ mapPTerm f = goPTerm where
 
     goPDataDecl : PDataDecl' nm -> PDataDecl' nm
     goPDataDecl (MkPData fc n t opts tdecls)
-      = MkPData fc n (map goPTerm t) opts (mapFC goPTypeDecl <$> tdecls)
+      = MkPData fc n (map goPTerm t) opts (mapData goPTypeDecl <$> tdecls)
     goPDataDecl (MkPLater fc n t) = MkPLater fc n $ goPTerm t
 
     goPRecordDeclLet : PRecordDeclLet' nm -> PRecordDeclLet' nm
-    goPRecordDeclLet (RecordClaim claim) = RecordClaim $ mapFC goPClaim claim
-    goPRecordDeclLet (RecordClause clause) = RecordClause $ mapFC goPClause clause
+    goPRecordDeclLet (RecordClaim claim) = RecordClaim $ mapData goPClaim claim
+    goPRecordDeclLet (RecordClause clause) = RecordClause $ mapData goPClause clause
 
     goRecordField : RecordField' nm -> RecordField' nm
     goRecordField (MkRecordField doc c info n t)

--- a/src/Libraries/Data/WithData.idr
+++ b/src/Libraries/Data/WithData.idr
@@ -186,11 +186,6 @@ val :+ x = MkWithData (add lbl val x.metadata) x.val
 
 export infixr 8 :++
 
-||| Add a record to the metadata
-export
-(:++) : Record ls -> WithData xs a -> WithData (ls ++ xs) a
-(:++) rec x = MkWithData (rec ++ x.metadata) x.val
-
 ||| Drop the head element of the metadata
 export
 drop : WithData (l :: ls) a -> WithData ls a
@@ -235,12 +230,6 @@ export
 AddDef :  (def : HasDefault ty) =>
          WithData fl a -> WithData (lbl :-: ty :: fl) a
 AddDef x = (defValue @{def}) :+ x
-
-||| Add a record of default values to an existing metadata record
-export
-AddDefs : {fs : _} -> (values : All (HasDefault . KeyVal.type) fs) =>
-         WithData fl a -> WithData (fs ++ fl) a
-AddDefs x = fromDefault values :++ x
 
 ------------------------------------------------------------------------------------------------
 -- WithData distributes with List and Maybe

--- a/src/TTImp/Elab/Local.idr
+++ b/src/TTImp/Elab/Local.idr
@@ -100,7 +100,7 @@ localHelper {vars} nest env nestdecls_in func
     -- application of the nested name.
     updateTyName : NestedNames vars -> ImpTy -> ImpTy
     updateTyName nest (MkImpTy loc' n ty)
-        = MkImpTy loc' (mapFC (mapNestedName nest) n) ty
+        = MkImpTy loc' (mapData (mapNestedName nest) n) ty
 
     updateDataName : NestedNames vars -> ImpData -> ImpData
     updateDataName nest (MkImpData loc' n tycons dopts dcons)
@@ -127,7 +127,7 @@ localHelper {vars} nest env nestdecls_in func
 
     updateName : NestedNames vars -> ImpDecl -> ImpDecl
     updateName nest (IClaim claim)
-         = IClaim $ mapFC {type $= updateTyName nest} claim
+         = IClaim $ mapData {type $= updateTyName nest} claim
     updateName nest (IDef loc' n cs)
          = IDef loc' (mapNestedName nest n) cs
     updateName nest (IData loc' vis mbt d)
@@ -138,7 +138,7 @@ localHelper {vars} nest env nestdecls_in func
 
     setPublic : ImpDecl -> ImpDecl
     setPublic (IClaim claim)
-        = IClaim $ mapFC {vis := Public} claim
+        = IClaim $ mapData {vis := Public} claim
     setPublic (IData fc _ mbt d) = IData fc (specified Public) mbt d
     setPublic (IRecord fc c _ mbt r) = IRecord fc c (specified Public) mbt r
     setPublic (IParameters fc ps decls)
@@ -149,7 +149,7 @@ localHelper {vars} nest env nestdecls_in func
 
     setErased : ImpDecl -> ImpDecl
     setErased (IClaim claim)
-        = IClaim $ mapFC {rig := erased} claim
+        = IClaim $ mapData {rig := erased} claim
     setErased (IParameters fc ps decls)
         = IParameters fc ps (map setErased decls)
     setErased (INamespace fc ps decls)

--- a/src/TTImp/Elab/Quote.idr
+++ b/src/TTImp/Elab/Quote.idr
@@ -148,8 +148,8 @@ mutual
                    {auto u : Ref UST UState} ->
                    ImpDecl ->
                    Core ImpDecl
-  getUnquoteDecl (IClaim (MkFCVal fc (MkIClaimData c v opts ty)))
-      = pure $ IClaim (MkFCVal fc (MkIClaimData c v opts !(getUnquoteTy ty)))
+  getUnquoteDecl (IClaim (MkWithData fc (MkIClaimData c v opts ty)))
+      = pure $ IClaim (MkWithData fc (MkIClaimData c v opts !(getUnquoteTy ty)))
   getUnquoteDecl (IData fc v mbt d)
       = pure $ IData fc v mbt !(getUnquoteData d)
   getUnquoteDecl (IDef fc v d)

--- a/src/TTImp/Parser.idr
+++ b/src/TTImp/Parser.idr
@@ -528,7 +528,7 @@ mutual
            ws <- nonEmptyBlock (clause (S withArgs) fname)
            end <- location
            let fc = MkFC fname start end
-           pure (!(getFn lhs), WithClause fc lhs rig wval prf [] (forget $ map snd ws))
+           pure (MkPair !(getFn lhs) $ WithClause fc lhs rig wval prf [] (forget $ map snd ws))
 
     <|> do keyword "impossible"
            atEnd indents

--- a/src/TTImp/ProcessDecls.idr
+++ b/src/TTImp/ProcessDecls.idr
@@ -118,8 +118,8 @@ process : {vars : _} ->
           {auto o : Ref ROpts REPLOpts} ->
           List ElabOpt ->
           NestedNames vars -> Env Term vars -> ImpDecl -> Core ()
-process eopts nest env (IClaim (MkFCVal fc (MkIClaimData rig vis opts ty)))
-    = processType eopts nest env fc rig vis opts ty
+process eopts nest env (IClaim dat@(MkWithData fc (MkIClaimData rig vis opts ty)))
+    = processType eopts nest env dat.fc rig vis opts ty
 process eopts nest env (IData fc vis mbtot ddef)
     = processData eopts nest env fc vis mbtot ddef
 process eopts nest env (IDef fc fname def)
@@ -186,9 +186,9 @@ processTTImpDecls {vars} nest env decls
 
     -- bind implicits to make raw TTImp source a bit friendlier
     bindNames : ImpDecl -> Core ImpDecl
-    bindNames (IClaim (MkFCVal fc (MkIClaimData c vis opts (MkImpTy tfc n ty))))
-        = do ty' <- bindTypeNames fc [] (toList vars) ty
-             pure (IClaim (MkFCVal fc (MkIClaimData c vis opts (MkImpTy tfc n ty'))))
+    bindNames (IClaim dat@(MkWithData fc (MkIClaimData c vis opts (MkImpTy tfc n ty))))
+        = do ty' <- bindTypeNames dat.fc [] (toList vars) ty
+             pure (IClaim (MkWithData fc (MkIClaimData c vis opts (MkImpTy tfc n ty'))))
     bindNames (IData fc vis mbtot d)
         = do d' <- bindDataNames d
              pure (IData fc vis mbtot d')

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -504,7 +504,7 @@ mutual
   export
   covering
   Show nm => Show (ImpDecl' nm) where
-    show (IClaim (MkFCVal _ $ MkIClaimData c _ opts ty))
+    show (IClaim (MkWithData _ $ MkIClaimData c _ opts ty))
         = show opts ++ " " ++ show c ++ " " ++ show ty
     show (IData _ _ _ d) = show d
     show (IDef _ n cs) = "(%def " ++ show n ++ " " ++ show cs ++ ")"

--- a/src/TTImp/TTImp/Functor.idr
+++ b/src/TTImp/TTImp/Functor.idr
@@ -1,6 +1,7 @@
 module TTImp.TTImp.Functor
 
 import Core.TT
+import Core.WithData
 import TTImp.TTImp
 
 %default covering
@@ -94,7 +95,7 @@ mutual
   export
   Functor ImpDecl' where
     map f (IClaim c)
-      = IClaim (mapFC (map f) c)
+      = IClaim (mapData (map f) c)
     map f (IData fc vis mbtot dt)
       = IData fc vis mbtot (map f dt)
     map f (IDef fc nm cls)

--- a/src/TTImp/TTImp/Traversals.idr
+++ b/src/TTImp/TTImp/Traversals.idr
@@ -2,6 +2,7 @@ module TTImp.TTImp.Traversals
 
 import Core.TT
 import TTImp.TTImp
+import Core.WithData
 
 %default total
 
@@ -63,8 +64,8 @@ parameters (f : RawImp' nm -> RawImp' nm)
 
   export
   mapImpDecl : ImpDecl' nm -> ImpDecl' nm
-  mapImpDecl (IClaim (MkFCVal fc (MkIClaimData rig vis opts ty)))
-    = IClaim (MkFCVal fc (MkIClaimData rig vis (map mapFnOpt opts) (mapImpTy ty)))
+  mapImpDecl (IClaim (MkWithData fc (MkIClaimData rig vis opts ty)))
+    = IClaim (MkWithData fc (MkIClaimData rig vis (map mapFnOpt opts) (mapImpTy ty)))
   mapImpDecl (IData fc vis mtreq dat) = IData fc vis mtreq (mapImpData dat)
   mapImpDecl (IDef fc n cls) = IDef fc n (map mapImpClause cls)
   mapImpDecl (IParameters fc params xs) = IParameters fc params (assert_total $ map mapImpDecl xs)

--- a/src/TTImp/Utils.idr
+++ b/src/TTImp/Utils.idr
@@ -29,7 +29,7 @@ genUniqueStr xs x = if x `elem` xs then genUniqueStr xs (x ++ "'") else x
 -- Used in findBindableNames{,Quot}
 rawImpFromDecl : ImpDecl -> List RawImp
 rawImpFromDecl decl = case decl of
-    IClaim (MkFCVal fc1 $ MkIClaimData y z ys ty) => [ty.type]
+    IClaim (MkWithData fc1 $ MkIClaimData y z ys ty) => [ty.type]
     IData fc1 y _ (MkImpData fc2 n tycon opts datacons)
         => maybe id (::) tycon $ map type datacons
     IData fc1 y _ (MkImpLater fc2 n tycon) => [tycon]
@@ -386,7 +386,7 @@ mutual
   substNamesDecl' : Bool -> List Name -> List (Name, RawImp ) ->
                    ImpDecl -> ImpDecl
   substNamesDecl' bvar bound ps (IClaim claim)
-      = IClaim $ mapFC {type $= substNamesTy' bvar bound ps} claim
+      = IClaim $ mapData {type $= substNamesTy' bvar bound ps} claim
   substNamesDecl' bvar bound ps (IDef fc n cs)
       = IDef fc n (map (substNamesClause' bvar bound ps) cs)
   substNamesDecl' bvar bound ps (IData fc vis mbtot d)
@@ -475,7 +475,7 @@ mutual
 
   substLocTy : FC -> ImpTy -> ImpTy
   substLocTy fc' (MkImpTy fc n ty)
-      = MkImpTy fc' ({fc := fc'} n) (substLoc fc' ty)
+      = MkImpTy fc' (set "fc" fc' n) (substLoc fc' ty)
 
   substLocData : FC -> ImpData -> ImpData
   substLocData fc' (MkImpData fc n con opts dcons)
@@ -485,7 +485,7 @@ mutual
       = MkImpLater fc' n (substLoc fc' con)
 
   substLocDecl : FC -> ImpDecl -> ImpDecl
-  substLocDecl fc' (IClaim (MkFCVal _ $ MkIClaimData r vis opts td))
+  substLocDecl fc' (IClaim (MkWithData _ $ MkIClaimData r vis opts td))
       = IClaim (MkFCVal fc' $ MkIClaimData r vis opts (substLocTy fc' td))
   substLocDecl fc' (IDef fc n cs)
       = IDef fc' n (map (substLocClause fc') cs)


### PR DESCRIPTION
# Description

This change is part of #3570 

The goal is to gradually replace all constructor that tie meta-data to nodes with uses of `WithData` such that one can easily add metadata without changing the trees


