### PR TITLE
Unify binder data types using WithData

### DIFF
--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -875,6 +875,11 @@ namespace PiInfo
   traverse f AutoImplicit = pure AutoImplicit
   traverse f (DefImplicit t) = pure (DefImplicit !(f t))
 
+namespace PiBindData
+  export
+  traverse : (a -> Core b) -> PiBindData a -> Core (PiBindData b)
+  traverse f (MkPiBindData info boundType) = MkPiBindData <$> traverse f info <*> f boundType
+
 namespace Binder
   export
   traverse : (a -> Core b) -> Binder a -> Core (Binder b)

--- a/src/Core/Reflect.idr
+++ b/src/Core/Reflect.idr
@@ -757,24 +757,6 @@ Reflect t => Reflect (PiInfo t) where
       = do t' <- reflect fc defs lhs env t
            appCon fc defs (reflectiontt "DefImplicit") [Erased fc Placeholder, t']
 
--- export
--- Reify t => Reify (PiBindData t) where
---   reify defs val@(NDCon _ n _ _ [_, _, (_, info), (_, boundt)])
---       = case dropAllNS !(full (gamma defs) n) of
---              (UN (Basic "MkPair"))
---                => do info' <- reify defs !(evalClosure defs info)
---                      boundt' <- reify defs !(evalClosure defs boundt)
---                      pure (MkPiBindData info' boundt')
---              _ => cantReify val "PiBindData"
---   reify defs val = cantReify val "PiBindData"
---
--- export
--- Reflect t => Reflect (PiBindData t) where
---   reflect fc defs lhs env (MkPiBindData info type)
---       = do info' <- reflect fc defs lhs env info
---            type' <- reflect fc defs lhs env info
---            appCon fc defs (builtin "MkPair") [Erased fc Placeholder, Erased fc Placeholder, info', type']
-
 export
 Reify LazyReason where
   reify defs val@(NDCon _ n _ _ _)

--- a/src/Core/Reflect.idr
+++ b/src/Core/Reflect.idr
@@ -757,6 +757,24 @@ Reflect t => Reflect (PiInfo t) where
       = do t' <- reflect fc defs lhs env t
            appCon fc defs (reflectiontt "DefImplicit") [Erased fc Placeholder, t']
 
+-- export
+-- Reify t => Reify (PiBindData t) where
+--   reify defs val@(NDCon _ n _ _ [_, _, (_, info), (_, boundt)])
+--       = case dropAllNS !(full (gamma defs) n) of
+--              (UN (Basic "MkPair"))
+--                => do info' <- reify defs !(evalClosure defs info)
+--                      boundt' <- reify defs !(evalClosure defs boundt)
+--                      pure (MkPiBindData info' boundt')
+--              _ => cantReify val "PiBindData"
+--   reify defs val = cantReify val "PiBindData"
+--
+-- export
+-- Reflect t => Reflect (PiBindData t) where
+--   reflect fc defs lhs env (MkPiBindData info type)
+--       = do info' <- reflect fc defs lhs env info
+--            type' <- reflect fc defs lhs env info
+--            appCon fc defs (builtin "MkPair") [Erased fc Placeholder, Erased fc Placeholder, info', type']
+
 export
 Reify LazyReason where
   reify defs val@(NDCon _ n _ _ _)

--- a/src/Core/TTC.idr
+++ b/src/Core/TTC.idr
@@ -155,6 +155,16 @@ TTC t => TTC (PiInfo t) where
              _ => corrupt "PiInfo"
 
 export
+TTC t => TTC (PiBindData t) where
+  toBuf (MkPiBindData info ty)
+    = do toBuf info
+         toBuf ty
+  fromBuf
+    = do info <- fromBuf
+         ty <- fromBuf
+         pure (MkPiBindData info ty)
+
+export
 {fs : _} -> (ev : All (TTC . KeyVal.type) fs) => TTC (Record fs) where
   toBuf [] = tag 0
   toBuf {ev = _ :: _} ((lbl :- v) :: y)

--- a/src/Core/WithData.idr
+++ b/src/Core/WithData.idr
@@ -54,6 +54,10 @@ public export
 WithFC : Type -> Type
 WithFC = WithData [ FC' ]
 
+public export
+AddFC : Type -> Type
+AddFC = AddMetadata FC'
+
 ||| Obtain file context information from the metadata
 export
 (.fc) : {n : Nat} ->
@@ -110,6 +114,10 @@ public export
 Rig' : KeyVal
 Rig' = "rig" :-: RigCount
 
+public export
+WithRig : Type -> Type
+WithRig = AddMetadata Rig'
+
 ||| Obtain quantity information from the metadata
 export
 (.rig) : {n : Nat} ->
@@ -137,12 +145,7 @@ export
 ||| Attach name and file context information to a type
 public export
 WithName : Type -> Type
-WithName = WithData [ Name']
-
-||| Smart constructor to add a name and location to a type
-export
-MkWithName : WithFC Name -> ty -> WithName ty
-MkWithName x y = Mk [x] y
+WithName = AddMetadata Name'
 
 ||| the "tyname" label containing a `FCBind Name` for metadata records
 public export
@@ -161,6 +164,21 @@ export
 public export
 DocBindFC : Type -> Type
 DocBindFC = WithData [ Doc', Bind', FC' ]
+
+||| the "mname" label containing a `Maybe (WithFC Name)` for metadata records
+public export
+MName' : KeyVal
+MName' = "mname" :-: Maybe (WithFC Name)
+
+public export
+WithMName : Type -> Type
+WithMName = AddMetadata MName'
+
+export
+(.mName) : {n : Nat} ->
+            (inRange : NameInRange "mname" fields === Just (n, Maybe (WithFC Name))) =>
+            WithData fields a -> Maybe (WithFC Name)
+(.mName) = WithData.get "mname" @{inRange}
 
 ------------------------------------------------------------------------
 -- Default instances for metadata

--- a/src/Core/WithData.idr
+++ b/src/Core/WithData.idr
@@ -89,6 +89,10 @@ export
 (.withFC) : (o : OriginDesc) => WithBounds t -> WithFC t
 x.withFC = MkFCVal x.toFC x.val
 
+export
+(.addFC) : (o : OriginDesc) => WithBounds (WithData ls t) -> WithData (FC' :: ls) t
+(.addFC) x = x.toFC :+ x.val
+
 ------------------------------------------------------------------------------------------
 -- Helpers for documentation information
 ------------------------------------------------------------------------------------------
@@ -97,6 +101,10 @@ x.withFC = MkFCVal x.toFC x.val
 public export
 Doc' : KeyVal
 Doc' = "doc" :-: String
+
+public export
+WithDoc : Type -> Type
+WithDoc = AddMetadata Doc'
 
 ||| Obtain documentation information from the metadata
 export
@@ -179,6 +187,21 @@ export
             (inRange : NameInRange "mname" fields === Just (n, Maybe (WithFC Name))) =>
             WithData fields a -> Maybe (WithFC Name)
 (.mName) = WithData.get "mname" @{inRange}
+
+||| the "names" label containing a `List (WithFC Name)` for metadata records
+public export
+Names' : KeyVal
+Names' = "names" :-: List (WithFC Name)
+
+public export
+WithNames : Type -> Type
+WithNames = AddMetadata Names'
+
+export
+(.names) : {n : Nat} ->
+            (inRange : NameInRange "names" fields === Just (n, List (WithFC Name))) =>
+            WithData fields a -> List (WithFC Name)
+(.names) = WithData.get "names" @{inRange}
 
 ------------------------------------------------------------------------
 -- Default instances for metadata

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -1016,13 +1016,15 @@ mutual
                  {auto o : Ref ROpts REPLOpts} ->
                  List Name -> Namespace -> PField ->
                  Core (List IField)
-  desugarField ps ns field@(MkWithData _ $ MkRecordField doc rig p names ty)
+  desugarField ps ns field@(MkWithData _ $ MkRecordField doc rig names (MkPiBindData p ty))
       = flip Core.traverse names $ \n : Name => do
            addDocStringNS ns n doc
            addDocStringNS ns (toRF n) doc
            syn <- get Syn
-           pure (MkIField field.fc rig n $ MkPiBindData !(traverse (desugar AnyExpr ps) p )
-                          !(bindTypeNames field.fc (usingImpl syn) ps !(desugar AnyExpr ps ty)))
+           p' <- traverse (desugar AnyExpr ps) p
+           ty' <- bindTypeNames field.fc (usingImpl syn) ps !(desugar AnyExpr ps ty)
+           pure (MkIField field.fc rig n $ MkPiBindData p' ty')
+
         where
           toRF : Name -> Name
           toRF (UN (Basic n)) = UN (Field n)

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -1021,9 +1021,8 @@ mutual
            addDocStringNS ns n doc
            addDocStringNS ns (toRF n) doc
            syn <- get Syn
-           pure (MkIField field.fc rig !(traverse (desugar AnyExpr ps) p )
-                          n !(bindTypeNames field.fc (usingImpl syn)
-                          ps !(desugar AnyExpr ps ty)))
+           pure (MkIField field.fc rig n $ MkPiBindData !(traverse (desugar AnyExpr ps) p )
+                          !(bindTypeNames field.fc (usingImpl syn) ps !(desugar AnyExpr ps ty)))
         where
           toRF : Name -> Name
           toRF (UN (Basic n)) = UN (Field n)

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -1148,9 +1148,9 @@ mutual
                          (List1 PBinder) ->
                          Core (List1 (ImpParameter' RawImp))
         getArgs (Left params)
-          = traverseList1 (\(MkWithName n ty) => do
-              ty' <- desugar AnyExpr ps ty
-              pure (Mk [top, n] (MkPiBindData Explicit ty'))) params
+          = traverseList1 (\ty => do
+              ty' <- desugar AnyExpr ps ty.val
+              pure (Mk [top, ty.name] (MkPiBindData Explicit ty'))) params
         getArgs (Right params)
           = join <$> traverseList1 (\(MkPBinder info (MkBasicMultiBinder rig n ntm)) => do
               tm' <- desugar AnyExpr ps ntm

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -1017,13 +1017,13 @@ mutual
                  List Name -> Namespace -> PField ->
                  Core (List IField)
   desugarField ps ns field@(MkWithData _ $ MkRecordField doc rig names (MkPiBindData p ty))
-      = flip Core.traverse names $ \n : Name => do
-           addDocStringNS ns n doc
-           addDocStringNS ns (toRF n) doc
+      = flip Core.traverse names $ \n : WithFC Name => do
+           addDocStringNS ns n.val doc
+           addDocStringNS ns (toRF n.val) doc
            syn <- get Syn
            p' <- traverse (desugar AnyExpr ps) p
            ty' <- bindTypeNames field.fc (usingImpl syn) ps !(desugar AnyExpr ps ty)
-           pure (Mk [field.fc, rig, NoFC n] $ MkPiBindData p' ty')
+           pure (Mk [field.fc, rig, n] $ MkPiBindData p' ty')
 
         where
           toRF : Name -> Name
@@ -1298,7 +1298,7 @@ mutual
                          vis mbtot (MkImpRecord rec.fc tn paramsb opts conname (concat fields'))]
     where
       getfname : PField -> List Name
-      getfname x = x.val.names
+      getfname x = map val x.val.names
 
       mkConName : Name -> Name
       mkConName (NS ns (UN n))

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -1133,15 +1133,15 @@ mutual
       = do
            params' <- getArgs params
            let paramList = forget params'
-           pds' <- traverse (desugarDecl (ps ++ map fst paramList)) pds
+           let paramNames = map (\x => x.name.val) paramList
+           pds' <- traverse (desugarDecl (ps ++ paramNames)) pds
            -- Look for implicitly bindable names in the parameters
            pnames <- ifThenElse (not !isUnboundImplicits) (pure [])
              $ map concat
-             $ for (map (boundType . Builtin.snd . Builtin.snd) paramList)
-             $ findUniqueBindableNames pp.fc True (ps ++ map Builtin.fst paramList) []
+             $ for (map (boundType . val) paramList)
+             $ findUniqueBindableNames pp.fc True (ps ++ paramNames) []
 
-           let paramsb = map (\(n, rig, MkPiBindData info tm) =>
-                                 (n, rig, MkPiBindData info (doBind pnames tm))) params'
+           let paramsb = map {f = List1} (map {f = WithData _} (mapType (doBind pnames))) params'
            pure [IParameters pp.fc paramsb (concat pds')]
       where
         getArgs : Either (List1 PlainBinder)
@@ -1150,12 +1150,12 @@ mutual
         getArgs (Left params)
           = traverseList1 (\(MkWithName n ty) => do
               ty' <- desugar AnyExpr ps ty
-              pure (n.val, top, MkPiBindData Explicit ty')) params
+              pure (Mk [top, n] (MkPiBindData Explicit ty'))) params
         getArgs (Right params)
           = join <$> traverseList1 (\(MkPBinder info (MkBasicMultiBinder rig n ntm)) => do
               tm' <- desugar AnyExpr ps ntm
               i' <- traverse (desugar AnyExpr ps) info
-              let allbinders = map (\nn => (nn.val, rig, MkPiBindData i' tm')) n
+              let allbinders = map (\nn => Mk [rig, nn] (MkPiBindData i' tm')) n
               pure allbinders) params
 
   desugarDecl ps use@(MkWithData _ $ PUsing uimpls uds)
@@ -1217,10 +1217,10 @@ mutual
       = do opts <- traverse (desugarFnOpt ps) fnopts
            verifyTotalityModifiers impl.fc opts
 
-           is' <- for is $ \ (fc, c, n, bind) =>
+           is' <- for is $ traverse (\ bind =>
                      do tm' <- desugar AnyExpr ps bind.boundType
                         pi' <- mapDesugarPiInfo ps bind.info
-                        pure (fc, c, n, MkPiBindData pi' tm')
+                        pure (MkPiBindData pi' tm'))
            cons' <- for cons $ \ (n, tm) =>
                      do tm' <- desugar AnyExpr ps tm
                         pure (n, tm')
@@ -1233,8 +1233,8 @@ mutual
              $ findUniqueBindableNames impl.fc True ps []
 
            let paramsb = map (doBind bnames) params'
-           let isb = map (\ (info, r, n, bind) => (info, r, n, mapType (doBind bnames) bind)) is'
-           let consb = map (\(n, tm) => (n, doBind bnames tm)) cons'
+           let isb = map (map (mapType (doBind bnames))) is'
+           let consb = map (map (doBind bnames)) cons'
 
            body' <- maybe (pure Nothing)
                           (\b => do b' <- traverse (desugarDecl ps) b
@@ -1268,7 +1268,7 @@ mutual
            params' <- concat <$> traverse (\ (MkPBinder info (MkBasicMultiBinder rig names tm)) =>
                           do tm' <- desugar AnyExpr ps tm
                              p'  <- mapDesugarPiInfo ps info
-                             let allBinders = map (\nn => (nn.val, rig, MkPiBindData p' tm')) (forget names)
+                             let allBinders = map (\nm => Mk [rig, nm] (MkPiBindData p' tm')) (forget names)
                              pure allBinders)
                         params
            let _ = the (List ImpParameter) params'
@@ -1280,11 +1280,11 @@ mutual
            let bnames = if !isUnboundImplicits
                         then concatMap (findBindableNames True
                                          (ps ++ fnames ++ paramNames) [])
-                                       (map (\(_,_,b) => b.boundType) params')
+                                       (map (boundType . val) params')
                         else []
            let _ = the (List (String, String)) bnames
 
-           let paramsb = map (\ (n, c, bind) => (n, c, mapType (doBind bnames) bind)) params'
+           let paramsb = map (map (mapType (doBind bnames))) params'
            let _ = the (List ImpParameter) paramsb
            let recName = nameRoot tn
            fields' <- traverse (desugarField (ps ++ fnames ++ paramNames

--- a/src/Idris/Desugar.idr
+++ b/src/Idris/Desugar.idr
@@ -1023,7 +1023,7 @@ mutual
            syn <- get Syn
            p' <- traverse (desugar AnyExpr ps) p
            ty' <- bindTypeNames field.fc (usingImpl syn) ps !(desugar AnyExpr ps ty)
-           pure (MkIField field.fc rig n $ MkPiBindData p' ty')
+           pure (Mk [field.fc, rig, NoFC n] $ MkPiBindData p' ty')
 
         where
           toRF : Name -> Name

--- a/src/Idris/Desugar/Mutual.idr
+++ b/src/Idris/Desugar/Mutual.idr
@@ -2,6 +2,7 @@ module Idris.Desugar.Mutual
 
 import Idris.Syntax
 import Data.List1
+import TTImp.TTImp
 
 %default total
 

--- a/src/Idris/Elab/Implementation.idr
+++ b/src/Idris/Elab/Implementation.idr
@@ -49,10 +49,10 @@ bindConstraints fc p [] ty = ty
 bindConstraints fc p ((n, ty) :: rest) sc
     = IPi fc top p n ty (bindConstraints fc p rest sc)
 
-bindImpls : List (FC, RigCount, Name, PiInfo RawImp, RawImp) -> RawImp -> RawImp
+bindImpls : List (FC, ImpParameter' RawImp) -> RawImp -> RawImp
 bindImpls [] ty = ty
-bindImpls ((fc, r, n, p, ty) :: rest) sc
-    = IPi fc r p (Just n) ty (bindImpls rest sc)
+bindImpls ((fc, n, r, bind) :: rest) sc
+    = IPi fc r bind.info (Just n) bind.boundType (bindImpls rest sc)
 
 addDefaults : FC -> Name ->
               (params : List (Name, RawImp)) -> -- parameters have been specialised, use them!
@@ -122,7 +122,7 @@ elabImplementation : {vars : _} ->
                      {auto o : Ref ROpts REPLOpts} ->
                      FC -> Visibility -> List FnOpt -> Pass ->
                      Env Term vars -> NestedNames vars ->
-                     (implicits : List (FC, RigCount, Name, PiInfo RawImp, RawImp)) ->
+                     (implicits : List (FC, ImpParameter' RawImp)) ->
                      (constraints : List (Maybe Name, RawImp)) ->
                      Name ->
                      (ps : List RawImp) ->

--- a/src/Idris/Elab/Implementation.idr
+++ b/src/Idris/Elab/Implementation.idr
@@ -49,10 +49,10 @@ bindConstraints fc p [] ty = ty
 bindConstraints fc p ((n, ty) :: rest) sc
     = IPi fc top p n ty (bindConstraints fc p rest sc)
 
-bindImpls : List (FC, ImpParameter' RawImp) -> RawImp -> RawImp
+bindImpls : List (AddFC (ImpParameter' RawImp)) -> RawImp -> RawImp
 bindImpls [] ty = ty
-bindImpls ((fc, n, r, bind) :: rest) sc
-    = IPi fc r bind.info (Just n) bind.boundType (bindImpls rest sc)
+bindImpls (binder :: rest) sc
+    = IPi binder.fc binder.rig binder.val.info (Just binder.name.val) binder.val.boundType (bindImpls rest sc)
 
 addDefaults : FC -> Name ->
               (params : List (Name, RawImp)) -> -- parameters have been specialised, use them!
@@ -122,7 +122,7 @@ elabImplementation : {vars : _} ->
                      {auto o : Ref ROpts REPLOpts} ->
                      FC -> Visibility -> List FnOpt -> Pass ->
                      Env Term vars -> NestedNames vars ->
-                     (implicits : List (FC, ImpParameter' RawImp)) ->
+                     (implicits : List (AddFC (ImpParameter' RawImp))) ->
                      (constraints : List (Maybe Name, RawImp)) ->
                      Name ->
                      (ps : List RawImp) ->

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1747,7 +1747,7 @@ fieldDecl indents
                                        fatalLoc {c = True} b.bounds "Fields have to be named"))
                     decoratedSymbol fname ":"
                     ty <- typeExpr pdef fname indents
-                    pure (MkRecordField doc rig p (forget ns) ty))
+                    pure (MkRecordField doc rig (forget ns) (MkPiBindData p ty)))
              pure b.withFC
 
 parameters {auto fname : OriginDesc} {auto indents : IndentInfo}

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1192,7 +1192,7 @@ plainBinder : (fname : OriginDesc) => (indents : IndentInfo) => Rule PlainBinder
 plainBinder = do name <- fcBounds (decoratedSimpleBinderUName fname)
                  decoratedSymbol fname ":"
                  ty <- typeExpr pdef fname indents
-                 pure $ MkWithName name ty
+                 pure $ Mk [name] ty
 
 ||| A binder with multiple names and one type
 ||| BNF:

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1742,9 +1742,9 @@ fieldDecl indents
         = do b <- bounds (do
                     rig <- multiplicity fname
                     ns <- sepBy1 (decoratedSymbol fname ",")
-                            (decorate fname Function name
+                            (fcBounds (decorate fname Function name
                                <|> (do b <- bounds (symbol "_")
-                                       fatalLoc {c = True} b.bounds "Fields have to be named"))
+                                       fatalLoc {c = True} b.bounds "Fields have to be named")))
                     decoratedSymbol fname ":"
                     ty <- typeExpr pdef fname indents
                     pure (MkRecordField doc rig (forget ns) (MkPiBindData p ty)))

--- a/src/Idris/Resugar.idr
+++ b/src/Idris/Resugar.idr
@@ -491,7 +491,7 @@ mutual
              IField' KindedName -> Core (PField' KindedName)
   toPField field
       = do bind' <- traverse (toPTerm startPrec) field.val
-           pure (MkFCVal field.fc $ MkRecordField "" field.rig [field.name.val] bind')
+           pure (MkFCVal field.fc $ MkRecordField "" field.rig [field.name] bind')
 
   toPRecord : {auto c : Ref Ctxt Defs} ->
               {auto s : Ref Syn SyntaxInfo} ->

--- a/src/Idris/Resugar.idr
+++ b/src/Idris/Resugar.idr
@@ -490,9 +490,8 @@ mutual
              {auto s : Ref Syn SyntaxInfo} ->
              IField' KindedName -> Core (PField' KindedName)
   toPField (MkIField fc c n bind)
-      = do ty' <- toPTerm startPrec bind.boundType
-           p' <- traverse (toPTerm startPrec) bind.info
-           pure (MkFCVal fc $ MkRecordField "" c p' [n] ty')
+      = do bind' <- traverse (toPTerm startPrec) bind
+           pure (MkFCVal fc $ MkRecordField "" c [n] bind')
 
   toPRecord : {auto c : Ref Ctxt Defs} ->
               {auto s : Ref Syn SyntaxInfo} ->

--- a/src/Idris/Resugar.idr
+++ b/src/Idris/Resugar.idr
@@ -489,9 +489,9 @@ mutual
   toPField : {auto c : Ref Ctxt Defs} ->
              {auto s : Ref Syn SyntaxInfo} ->
              IField' KindedName -> Core (PField' KindedName)
-  toPField (MkIField fc c n bind)
-      = do bind' <- traverse (toPTerm startPrec) bind
-           pure (MkFCVal fc $ MkRecordField "" c [n] bind')
+  toPField field
+      = do bind' <- traverse (toPTerm startPrec) field.val
+           pure (MkFCVal field.fc $ MkRecordField "" field.rig [field.name.val] bind')
 
   toPRecord : {auto c : Ref Ctxt Defs} ->
               {auto s : Ref Syn SyntaxInfo} ->

--- a/src/Idris/Resugar.idr
+++ b/src/Idris/Resugar.idr
@@ -491,7 +491,7 @@ mutual
              IField' KindedName -> Core (PField' KindedName)
   toPField field
       = do bind' <- traverse (toPTerm startPrec) field.val
-           pure (MkFCVal field.fc $ MkRecordField "" field.rig [field.name] bind')
+           pure (Mk [field.fc , "", field.rig, [field.name]] bind')
 
   toPRecord : {auto c : Ref Ctxt Defs} ->
               {auto s : Ref Syn SyntaxInfo} ->

--- a/src/Idris/Resugar.idr
+++ b/src/Idris/Resugar.idr
@@ -489,9 +489,9 @@ mutual
   toPField : {auto c : Ref Ctxt Defs} ->
              {auto s : Ref Syn SyntaxInfo} ->
              IField' KindedName -> Core (PField' KindedName)
-  toPField (MkIField fc c p n ty)
-      = do ty' <- toPTerm startPrec ty
-           p' <- traverse (toPTerm startPrec) p
+  toPField (MkIField fc c n bind)
+      = do ty' <- toPTerm startPrec bind.boundType
+           p' <- traverse (toPTerm startPrec) bind.info
            pure (MkFCVal fc $ MkRecordField "" c p' [n] ty')
 
   toPRecord : {auto c : Ref Ctxt Defs} ->

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -499,9 +499,8 @@ mutual
     constructor MkRecordField
     doc : String
     rig : RigCount
-    piInfo : PiInfo (PTerm' nm)
     names : List Name -- See #3409
-    type : PTerm' nm
+    bind : PiBindData (PTerm' nm)
 
   public export
   PField : Type

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -476,14 +476,9 @@ mutual
        -- There is no nm on Directive
        ForeignImpl : Name -> List PTerm -> Directive
 
-
   public export
-  record RecordField' (nm : Type) where
-    constructor MkRecordField
-    doc : String
-    rig : RigCount
-    names : List (WithFC Name)
-    bind : PiBindData (PTerm' nm)
+  RecordField' : Type -> Type
+  RecordField' nm = WithDoc $ WithRig $ WithNames $ PiBindData (PTerm' nm)
 
   public export
   PField : Type
@@ -491,7 +486,7 @@ mutual
 
   public export
   PField' : Type -> Type
-  PField' nm = WithFC (RecordField' nm)
+  PField' nm = AddFC (RecordField' nm)
 
   public export
   0 PRecordDeclLet : Type

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -72,23 +72,6 @@ public export
 data HidingDirective = HideName Name
                      | HideFixity Fixity Name
 
-%hide Core.WithData.WithName
--------------------------------------------------------------------------------
--- With Name functor to carry name information with a payload
-public export
-record WithName (ty : Type) where
-  constructor MkWithName
-  name : WithFC Name
-  val : ty
-
-export
-mapWName : (ty -> sy) -> WithName ty -> WithName sy
-mapWName f = {val $= f}
-
-export
-traverseWName : (ty -> Core sy) -> WithName ty -> Core (WithName sy)
-traverseWName f (MkWithName name val) = MkWithName name <$> f val
-
 -------------------------------------------------------------------------------
 
 mutual

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -595,7 +595,7 @@ mutual
                     List (PDecl' nm) ->
                     PDeclNoFC' nm
        PImplementation : Visibility -> List PFnOpt -> Pass ->
-                         (implicits : List (FC, RigCount, Name, PiInfo (PTerm' nm), PTerm' nm)) ->
+                         (implicits : List (FC, ImpParameter' (PTerm' nm))) ->
                          (constraints : List (Maybe Name, PTerm' nm)) ->
                          Name ->
                          (params : List (PTerm' nm)) ->

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -337,7 +337,6 @@ mutual
   MkFullBinder : PiInfo (PTerm' nm) -> RigCount -> WithFC Name -> PTerm' nm -> PBinder' nm
   MkFullBinder info rig x y = MkPBinder info (MkBasicMultiBinder rig (singleton x) y)
 
-
   export
   getLoc : PDo' nm -> FC
   getLoc (DoExp fc _) = fc

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -482,7 +482,7 @@ mutual
     constructor MkRecordField
     doc : String
     rig : RigCount
-    names : List Name -- See #3409
+    names : List (WithFC Name)
     bind : PiBindData (PTerm' nm)
 
   public export

--- a/src/Idris/Syntax.idr
+++ b/src/Idris/Syntax.idr
@@ -595,7 +595,7 @@ mutual
                     List (PDecl' nm) ->
                     PDeclNoFC' nm
        PImplementation : Visibility -> List PFnOpt -> Pass ->
-                         (implicits : List (FC, ImpParameter' (PTerm' nm))) ->
+                         (implicits : List (AddFC (ImpParameter' (PTerm' nm)))) ->
                          (constraints : List (Maybe Name, PTerm' nm)) ->
                          Name ->
                          (params : List (PTerm' nm)) ->

--- a/src/Idris/Syntax/Traversals.idr
+++ b/src/Idris/Syntax/Traversals.idr
@@ -323,10 +323,8 @@ mapPTermM f = goPTerm where
     goPDataDecl (MkPLater fc n t) = MkPLater fc n <$> goPTerm t
 
     goRecordField : RecordField' nm -> Core (RecordField' nm)
-    goRecordField (MkRecordField doc c info n t) =
-      MkRecordField doc c <$> goPiInfo info
-                          <*> pure n
-                          <*> goPTerm t
+    goRecordField (MkRecordField doc c n bind) =
+      MkRecordField doc c n <$> traverse f bind
 
     goPiInfo : PiInfo (PTerm' nm) -> Core (PiInfo (PTerm' nm))
     goPiInfo (DefImplicit t) = DefImplicit <$> goPTerm t
@@ -618,8 +616,8 @@ mapPTerm f = goPTerm where
     goPRecordDeclLet (RecordClause clause) = RecordClause $ mapData goPClause clause
 
     goRecordField : RecordField' nm -> RecordField' nm
-    goRecordField (MkRecordField doc c info n t)
-      = MkRecordField doc c (goPiInfo info) n (goPTerm t)
+    goRecordField (MkRecordField doc c n bind)
+      = MkRecordField doc c n (map f bind)
 
     goPiInfo : PiInfo (PTerm' nm) -> PiInfo (PTerm' nm)
     goPiInfo (DefImplicit t) = DefImplicit $ goPTerm t

--- a/src/Idris/Syntax/Traversals.idr
+++ b/src/Idris/Syntax/Traversals.idr
@@ -363,11 +363,11 @@ mapPTermM f = goPTerm where
       (::) . (\ c => (a, b, c)) <$> goPTerm t
                                 <*> go3TupledPTerms ts
 
-    goImplicits : List (x, y, z, PiInfo (PTerm' nm), PTerm' nm) ->
-                      Core (List (x, y, z, PiInfo (PTerm' nm), PTerm' nm))
+    goImplicits : List (x, ImpParameter' (PTerm' nm)) ->
+                      Core (List (x, ImpParameter' (PTerm' nm)))
     goImplicits [] = pure []
-    goImplicits ((a, b, c, p, t) :: ts) =
-      ((::) . (a,b,c,)) <$> ((,) <$> goPiInfo p <*> goPTerm t)
+    goImplicits ((a, b, c, bind) :: ts) =
+      ((::) . (a,b,c,)) <$> traverse f bind
                         <*> goImplicits ts
 
     go4TupledPTerms : List (x, y, PiInfo (PTerm' nm), PTerm' nm) ->
@@ -640,9 +640,9 @@ mapPTerm f = goPTerm where
     go3TupledPTerms [] = []
     go3TupledPTerms ((a, b, t) :: ts) = (a, b, goPTerm t) :: go3TupledPTerms ts
 
-    goImplicits : List (x, y, z, PiInfo (PTerm' nm), PTerm' nm) -> List (x, y, z, PiInfo (PTerm' nm), PTerm' nm)
+    goImplicits : List (x, ImpParameter' (PTerm' nm)) -> List (x, ImpParameter' (PTerm' nm))
     goImplicits [] = []
-    goImplicits ((a, b, c, p, t) :: ts) = (a,b,c, goPiInfo p, goPTerm t) :: goImplicits ts
+    goImplicits ((a, b, c, t) :: ts) = (a,b,c, map f t) :: goImplicits ts
 
     go4TupledPTerms : List (x, y, PiInfo (PTerm' nm), PTerm' nm) ->
                       List (x, y, PiInfo (PTerm' nm), PTerm' nm)

--- a/src/Libraries/Data/WithData.idr
+++ b/src/Libraries/Data/WithData.idr
@@ -196,11 +196,10 @@ export
 (.drop) : WithData (l :: ls) a -> WithData ls a
 (.drop) = {metadata $= Record.tail }
 
-
 ||| WithData is functiorial in its payload
 export
-mapData : forall metadata. (a -> b) -> WithData metadata a -> WithData metadata b
-mapData f x = MkWithData x.metadata (f x.val)
+Functor (WithData metadata) where
+  map f x = MkWithData x.metadata (f x.val)
 
 ------------------------------------------------------------------------------------------------
 -- Default fields for records

--- a/src/Libraries/Data/WithData.idr
+++ b/src/Libraries/Data/WithData.idr
@@ -198,7 +198,7 @@ export
 
 ||| WithData is functiorial in its payload
 export
-Functor (WithData metadata) where
+Functor (WithData md) where
   map f x = MkWithData x.metadata (f x.val)
 
 ------------------------------------------------------------------------------------------------

--- a/src/TTImp/Elab/Local.idr
+++ b/src/TTImp/Elab/Local.idr
@@ -110,8 +110,8 @@ localHelper {vars} nest env nestdecls_in func
         = MkImpLater loc' (mapNestedName nest n) tycons
 
     updateFieldName : NestedNames vars -> IField -> IField
-    updateFieldName nest (MkIField fc rigc n bind)
-        = MkIField fc rigc (mapNestedName nest n) bind
+    updateFieldName nest field
+        = update "name" (map (mapNestedName nest)) field
 
     updateRecordName : NestedNames vars -> ImpRecord -> ImpRecord
     updateRecordName nest (MkImpRecord fc n params opts conName fields)

--- a/src/TTImp/Elab/Local.idr
+++ b/src/TTImp/Elab/Local.idr
@@ -110,8 +110,8 @@ localHelper {vars} nest env nestdecls_in func
         = MkImpLater loc' (mapNestedName nest n) tycons
 
     updateFieldName : NestedNames vars -> IField -> IField
-    updateFieldName nest (MkIField fc rigc piinfo n rawimp)
-        = MkIField fc rigc piinfo (mapNestedName nest n) rawimp
+    updateFieldName nest (MkIField fc rigc n bind)
+        = MkIField fc rigc (mapNestedName nest n) bind
 
     updateRecordName : NestedNames vars -> ImpRecord -> ImpRecord
     updateRecordName nest (MkImpRecord fc n params opts conName fields)

--- a/src/TTImp/Elab/Local.idr
+++ b/src/TTImp/Elab/Local.idr
@@ -100,7 +100,7 @@ localHelper {vars} nest env nestdecls_in func
     -- application of the nested name.
     updateTyName : NestedNames vars -> ImpTy -> ImpTy
     updateTyName nest (MkImpTy loc' n ty)
-        = MkImpTy loc' (mapData (mapNestedName nest) n) ty
+        = MkImpTy loc' (map (mapNestedName nest) n) ty
 
     updateDataName : NestedNames vars -> ImpData -> ImpData
     updateDataName nest (MkImpData loc' n tycons dopts dcons)
@@ -127,7 +127,7 @@ localHelper {vars} nest env nestdecls_in func
 
     updateName : NestedNames vars -> ImpDecl -> ImpDecl
     updateName nest (IClaim claim)
-         = IClaim $ mapData {type $= updateTyName nest} claim
+         = IClaim $ map {type $= updateTyName nest} claim
     updateName nest (IDef loc' n cs)
          = IDef loc' (mapNestedName nest n) cs
     updateName nest (IData loc' vis mbt d)
@@ -138,7 +138,7 @@ localHelper {vars} nest env nestdecls_in func
 
     setPublic : ImpDecl -> ImpDecl
     setPublic (IClaim claim)
-        = IClaim $ mapData {vis := Public} claim
+        = IClaim $ map {vis := Public} claim
     setPublic (IData fc _ mbt d) = IData fc (specified Public) mbt d
     setPublic (IRecord fc c _ mbt r) = IRecord fc c (specified Public) mbt r
     setPublic (IParameters fc ps decls)
@@ -149,7 +149,7 @@ localHelper {vars} nest env nestdecls_in func
 
     setErased : ImpDecl -> ImpDecl
     setErased (IClaim claim)
-        = IClaim $ mapData {rig := erased} claim
+        = IClaim $ map {rig := erased} claim
     setErased (IParameters fc ps decls)
         = IParameters fc ps (map setErased decls)
     setErased (INamespace fc ps decls)

--- a/src/TTImp/Elab/Quote.idr
+++ b/src/TTImp/Elab/Quote.idr
@@ -116,8 +116,8 @@ mutual
                     {auto u : Ref UST UState} ->
                     IField ->
                     Core IField
-  getUnquoteField (MkIField fc c p n ty)
-      = pure $ MkIField fc c p n !(getUnquote ty)
+  getUnquoteField (MkIField fc c n (MkPiBindData p ty))
+      = pure $ MkIField fc c n (MkPiBindData p !(getUnquote ty))
 
   getUnquoteRecord : {auto c : Ref Ctxt Defs} ->
                      {auto q : Ref Unq (List (Name, FC, RawImp))} ->

--- a/src/TTImp/Elab/Quote.idr
+++ b/src/TTImp/Elab/Quote.idr
@@ -128,9 +128,9 @@ mutual
       = pure $ MkImpRecord fc n !(traverse unqPair ps) opts cn
                            !(traverse getUnquoteField fs)
     where
-      unqPair : (Name, RigCount, PiInfo RawImp, RawImp) ->
-                Core (Name, RigCount, PiInfo RawImp, RawImp)
-      unqPair (n, c, p, t) = pure (n, c, p, !(getUnquote t))
+      unqPair : (Name, RigCount, PiBindData RawImp) ->
+                Core (Name, RigCount, PiBindData RawImp)
+      unqPair (n, c, MkPiBindData i t) = pure (n, c, MkPiBindData i !(getUnquote t))
 
   getUnquoteData : {auto c : Ref Ctxt Defs} ->
                    {auto q : Ref Unq (List (Name, FC, RawImp))} ->
@@ -159,8 +159,8 @@ mutual
                            !(traverseList1 unqTuple ps)
                            !(traverse getUnquoteDecl ds)
     where
-      unqTuple : (Name, RigCount, PiInfo RawImp, RawImp) -> Core (Name, RigCount, PiInfo RawImp, RawImp)
-      unqTuple (n, rig, i, t) = pure (n, rig, i, !(getUnquote t))
+      unqTuple : (Name, RigCount, PiBindData RawImp) -> Core (Name, RigCount, PiBindData RawImp)
+      unqTuple (n, rig, MkPiBindData i t) = pure (n, rig, MkPiBindData i !(getUnquote t))
   getUnquoteDecl (IRecord fc ns v mbt d)
       = pure $ IRecord fc ns v mbt !(getUnquoteRecord d)
   getUnquoteDecl (INamespace fc ns ds)

--- a/src/TTImp/Elab/Quote.idr
+++ b/src/TTImp/Elab/Quote.idr
@@ -111,14 +111,6 @@ mutual
                  Core ImpTy
   getUnquoteTy (MkImpTy fc n t) = pure $ MkImpTy fc n !(getUnquote t)
 
-  getUnquoteField : {auto c : Ref Ctxt Defs} ->
-                    {auto q : Ref Unq (List (Name, FC, RawImp))} ->
-                    {auto u : Ref UST UState} ->
-                    IField ->
-                    Core IField
-  getUnquoteField (MkIField fc c n (MkPiBindData p ty))
-      = pure $ MkIField fc c n (MkPiBindData p !(getUnquote ty))
-
   getUnquoteRecord : {auto c : Ref Ctxt Defs} ->
                      {auto q : Ref Unq (List (Name, FC, RawImp))} ->
                      {auto u : Ref UST UState} ->
@@ -127,7 +119,7 @@ mutual
   getUnquoteRecord (MkImpRecord fc n ps opts cn fs)
         -- unlike before, we are also unquoting the default value, maybe this is important?
       = pure $ MkImpRecord fc n !(traverse (traverse (traverse getUnquote)) ps) opts cn
-                           !(traverse getUnquoteField fs)
+                           !(traverse (traverse (traverse getUnquote)) fs)
 
   getUnquoteData : {auto c : Ref Ctxt Defs} ->
                    {auto q : Ref Unq (List (Name, FC, RawImp))} ->

--- a/src/TTImp/Parser.idr
+++ b/src/TTImp/Parser.idr
@@ -645,7 +645,7 @@ fieldDecl fname indents
              ty <- expr fname indents
              end <- location
              pure (map (\n => MkIField (MkFC fname start end)
-                                       linear p (UN $ Basic n) ty) (forget ns))
+                                       linear (UN $ Basic n) (MkPiBindData p ty)) (forget ns))
 
 recordDecl : OriginDesc -> IndentInfo -> Rule ImpDecl
 recordDecl fname indents

--- a/src/TTImp/Parser.idr
+++ b/src/TTImp/Parser.idr
@@ -645,12 +645,12 @@ fieldDecl fname indents
     fieldBody : PiInfo RawImp -> Rule (List IField)
     fieldBody p
         = do start <- location
-             ns <- sepBy1 (symbol ",") unqualifiedName
+             ns <- sepBy1 (symbol ",") (withFC unqualifiedName)
              symbol ":"
              ty <- expr fname indents
              end <- location
-             pure (map (\n => MkIField (MkFC fname start end)
-                                       linear (UN $ Basic n) (MkPiBindData p ty)) (forget ns))
+             pure (map (\n => Mk [MkFC fname start end, linear, map (UN . Basic) n]
+                                       (MkPiBindData p ty)) (forget ns))
 
 recordDecl : OriginDesc -> IndentInfo -> Rule ImpDecl
 recordDecl fname indents

--- a/src/TTImp/Parser.idr
+++ b/src/TTImp/Parser.idr
@@ -601,13 +601,13 @@ dataDecl fname indents
          end <- location
          pure (MkImpData (MkFC fname start end) n (Just ty) opts cs)
 
-recordParam : OriginDesc -> IndentInfo -> Rule (List (Name, RigCount, PiInfo RawImp, RawImp))
+recordParam : OriginDesc -> IndentInfo -> Rule (List (Name, RigCount, PiBindData RawImp))
 recordParam fname indents
     = do symbol "("
          start <- location
          params <- pibindListName fname start indents
          symbol ")"
-         pure $ map (\(c, n, tm) => (n, c, Explicit, tm)) params
+         pure $ map (\(c, n, tm) => (n, c, MkPiBindData Explicit tm)) params
   <|> do symbol "{"
          commit
          start <- location
@@ -619,11 +619,11 @@ recordParam fname indents
               <|> pure      Implicit)
          params <- pibindListName fname start indents
          symbol "}"
-         pure $ map (\(c, n, tm) => (n, c, info, tm)) params
+         pure $ map (\(c, n, tm) => (n, c, MkPiBindData info tm)) params
   <|> do start <- location
          n <- name
          end <- location
-         pure [(n, top, Explicit, Implicit (MkFC fname start end) False)]
+         pure [(n, top, MkPiBindData Explicit $ Implicit (MkFC fname start end) False)]
 
 fieldDecl : OriginDesc -> IndentInfo -> Rule (List IField)
 fieldDecl fname indents

--- a/src/TTImp/ProcessParams.idr
+++ b/src/TTImp/ProcessParams.idr
@@ -63,8 +63,8 @@ processParams {vars} {c} {m} {u} nest env fc ps ds
   where
     mkParamTy : List ImpParameter -> RawImp
     mkParamTy [] = IType fc
-    mkParamTy ((n, rig, binder) :: ps)
-       = IPi fc rig binder.info (Just n) binder.boundType (mkParamTy ps)
+    mkParamTy (binder :: ps)
+       = IPi fc binder.rig binder.val.info (Just binder.name.val) binder.val.boundType (mkParamTy ps)
 
     applyEnv : {vs : _} ->
                Env Term vs -> Name ->

--- a/src/TTImp/ProcessParams.idr
+++ b/src/TTImp/ProcessParams.idr
@@ -38,7 +38,7 @@ processParams : {vars : _} ->
                 {auto o : Ref ROpts REPLOpts} ->
                 NestedNames vars ->
                 Env Term vars ->
-                FC -> List (Name, RigCount, PiInfo RawImp, RawImp) -> List ImpDecl ->
+                FC -> List ImpParameter -> List ImpDecl ->
                 Core ()
 processParams {vars} {c} {m} {u} nest env fc ps ds
     = do -- Turn the parameters into a function type, (x : ps) -> Type,
@@ -61,10 +61,10 @@ processParams {vars} {c} {m} {u} nest env fc ps ds
          let nestBlock = { names $= (names' ++) } nest'
          traverse_ (processDecl [] nestBlock env') ds
   where
-    mkParamTy : List (Name, RigCount, PiInfo RawImp, RawImp) -> RawImp
+    mkParamTy : List ImpParameter -> RawImp
     mkParamTy [] = IType fc
-    mkParamTy ((n, rig, info, ty) :: ps)
-       = IPi fc rig info (Just n) ty (mkParamTy ps)
+    mkParamTy ((n, rig, binder) :: ps)
+       = IPi fc rig binder.info (Just n) binder.boundType (mkParamTy ps)
 
     applyEnv : {vs : _} ->
                Env Term vs -> Name ->

--- a/src/TTImp/ProcessRecord.idr
+++ b/src/TTImp/ProcessRecord.idr
@@ -98,11 +98,11 @@ elabRecord {vars} eopts fc env nest newns def_vis mbtot tn_in params0 opts conNa
         jname (n, _, t) = (EmptyFC, Just n, erased, MkPiBindData Implicit t.boundType)
 
     fname : IField -> Name
-    fname (MkIField fc c p n ty) = n
+    fname (MkIField fc c n _) = n
 
     farg : IField ->
            (FC, Maybe Name, RigCount, PiBindData RawImp)
-    farg (MkIField fc c p n ty) = (virtualiseFC fc, Just n, c, MkPiBindData p ty)
+    farg (MkIField fc c n bind) = (virtualiseFC fc, Just n, c, bind)
 
     mkTy : List (FC, Maybe Name, RigCount, PiBindData RawImp) ->
            RawImp -> RawImp

--- a/src/TTImp/Reflect.idr
+++ b/src/TTImp/Reflect.idr
@@ -732,7 +732,7 @@ mutual
         = do v' <- reflect fc defs lhs env field.fc
              w' <- reflect fc defs lhs env field.rig
              x' <- reflect fc defs lhs env field.val.info
-             y' <- reflect fc defs lhs env field.name
+             y' <- reflect fc defs lhs env field.name.val
              z' <- reflect fc defs lhs env field.val.boundType
              appCon fc defs (reflectionttimp "MkIField") [v', w', x', y', z']
 

--- a/src/TTImp/Reflect.idr
+++ b/src/TTImp/Reflect.idr
@@ -363,7 +363,7 @@ mutual
                           info <- reify defs !(evalClosure defs x)
                           name <- reify defs !(evalClosure defs y)
                           type <- reify defs !(evalClosure defs z)
-                          pure (MkIField fc rig name (MkPiBindData info type))
+                          pure (Mk [fc, rig, NoFC name] (MkPiBindData info type))
                _ => cantReify val "IField"
     reify defs val = cantReify val "IField"
 
@@ -728,12 +728,12 @@ mutual
 
   export
   Reflect IField where
-    reflect fc defs lhs env (MkIField v w name (MkPiBindData info type))
-        = do v' <- reflect fc defs lhs env v
-             w' <- reflect fc defs lhs env w
-             x' <- reflect fc defs lhs env info
-             y' <- reflect fc defs lhs env name
-             z' <- reflect fc defs lhs env type
+    reflect fc defs lhs env field -- Order matters to maintain compatibility with elab reflection
+        = do v' <- reflect fc defs lhs env field.fc
+             w' <- reflect fc defs lhs env field.rig
+             x' <- reflect fc defs lhs env field.val.info
+             y' <- reflect fc defs lhs env field.name
+             z' <- reflect fc defs lhs env field.val.boundType
              appCon fc defs (reflectionttimp "MkIField") [v', w', x', y', z']
 
   export

--- a/src/TTImp/Reflect.idr
+++ b/src/TTImp/Reflect.idr
@@ -378,7 +378,7 @@ mutual
                           y' <- reify defs !(evalClosure defs y)
                           z' <- reify defs !(evalClosure defs z)
                           a' <- reify defs !(evalClosure defs a)
-                          pure (MkImpRecord v' w' x' y' z' a')
+                          pure (MkImpRecord v' w' (map fromOldParams x') y' z' a')
                _ => cantReify val "Record"
     reify defs val = cantReify val "Record"
 
@@ -451,7 +451,7 @@ mutual
                     => do x' <- reify defs !(evalClosure defs x)
                           y' <- reify defs !(evalClosure defs y)
                           z' <- reify defs !(evalClosure defs z)
-                          pure (IParameters x' y' z')
+                          pure (IParameters x' (map fromOldParams y') z')
                (UN (Basic "IRecord"), [w,x,y,z,u])
                     => do w' <- reify defs !(evalClosure defs w)
                           x' <- reify defs !(evalClosure defs x)
@@ -741,7 +741,7 @@ mutual
     reflect fc defs lhs env (MkImpRecord v w x y z a)
         = do v' <- reflect fc defs lhs env v
              w' <- reflect fc defs lhs env w
-             x' <- reflect fc defs lhs env x
+             x' <- reflect fc defs lhs env (map toOldParams x)
              y' <- reflect fc defs lhs env y
              z' <- reflect fc defs lhs env z
              a' <- reflect fc defs lhs env a
@@ -800,7 +800,7 @@ mutual
              appCon fc defs (reflectionttimp "IDef") [x', y', z']
     reflect fc defs lhs env (IParameters x y z)
         = do x' <- reflect fc defs lhs env x
-             y' <- reflect fc defs lhs env y
+             y' <- reflect fc defs lhs env (map toOldParams y)
              z' <- reflect fc defs lhs env z
              appCon fc defs (reflectionttimp "IParameters") [x', y', z']
     reflect fc defs lhs env (IRecord w x y z u)

--- a/src/TTImp/Reflect.idr
+++ b/src/TTImp/Reflect.idr
@@ -358,12 +358,12 @@ mutual
     reify defs val@(NDCon _ n _ _ args)
         = case (dropAllNS !(full (gamma defs) n), map snd args) of
                (UN (Basic "MkIField"), [v,w,x,y,z])
-                    => do v' <- reify defs !(evalClosure defs v)
-                          w' <- reify defs !(evalClosure defs w)
-                          x' <- reify defs !(evalClosure defs x)
-                          y' <- reify defs !(evalClosure defs y)
-                          z' <- reify defs !(evalClosure defs z)
-                          pure (MkIField v' w' x' y' z')
+                    => do fc <- reify defs !(evalClosure defs v)
+                          rig <- reify defs !(evalClosure defs w)
+                          info <- reify defs !(evalClosure defs x)
+                          name <- reify defs !(evalClosure defs y)
+                          type <- reify defs !(evalClosure defs z)
+                          pure (MkIField fc rig name (MkPiBindData info type))
                _ => cantReify val "IField"
     reify defs val = cantReify val "IField"
 
@@ -728,12 +728,12 @@ mutual
 
   export
   Reflect IField where
-    reflect fc defs lhs env (MkIField v w x y z)
+    reflect fc defs lhs env (MkIField v w name (MkPiBindData info type))
         = do v' <- reflect fc defs lhs env v
              w' <- reflect fc defs lhs env w
-             x' <- reflect fc defs lhs env x
-             y' <- reflect fc defs lhs env y
-             z' <- reflect fc defs lhs env z
+             x' <- reflect fc defs lhs env info
+             y' <- reflect fc defs lhs env name
+             z' <- reflect fc defs lhs env type
              appCon fc defs (reflectionttimp "MkIField") [v', w', x', y', z']
 
   export

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -374,8 +374,7 @@ mutual
 
   public export
   data IField' : Type -> Type where
-       MkIField : FC -> RigCount -> PiInfo (RawImp' nm) ->
-                  (name : Name) -> (ty : RawImp' nm) ->
+       MkIField : FC -> RigCount -> (name : Name) -> PiBindData (RawImp' nm) ->
                   IField' nm
 
   %name IField' fld
@@ -384,11 +383,11 @@ mutual
   ImpParameter : Type
   ImpParameter = ImpParameter' Name
 
-  -- TODO: turn into a proper datatype
   public export
   ImpParameter' : Type -> Type
   ImpParameter' nm = (Name, RigCount, PiBindData (RawImp' nm))
 
+  -- old datatype for ImpParameter, used for elabreflection compatibility
   public export
   OldParameters' : Type -> Type
   OldParameters' nm = (Name, RigCount, PiInfo (RawImp' nm), RawImp' nm)
@@ -419,8 +418,8 @@ mutual
   export
   covering
   Show nm => Show (IField' nm) where
-    show (MkIField _ c Explicit n ty) = show n ++ " : " ++ show ty
-    show (MkIField _ c _ n ty) = "{" ++ show n ++ " : " ++ show ty ++ "}"
+    show (MkIField _ _ n (MkPiBindData Explicit ty)) = show n ++ " : " ++ show ty
+    show (MkIField _ _ n ty) = "{" ++ show n ++ " : " ++ show ty.boundType ++ "}"
 
   export
   covering
@@ -828,7 +827,7 @@ definedInBlock ns decls =
     getName (MkImpTy _ n _) = n.val
 
     getFieldName : IField -> Name
-    getFieldName (MkIField _ _ _ n _) = n
+    getFieldName (MkIField _ _ n _) = n
 
     expandNS : Namespace -> Name -> Name
     expandNS ns n

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -385,7 +385,7 @@ mutual
 
   public export
   ImpParameter' : Type -> Type
-  ImpParameter' nm = (Name, RigCount, PiBindData nm)
+  ImpParameter' nm = WithRig $ WithName $ PiBindData nm
 
   -- old datatype for ImpParameter, used for elabreflection compatibility
   public export
@@ -394,11 +394,15 @@ mutual
 
   public export
   toOldParams : ImpParameter' (RawImp' nm) -> OldParameters' nm
-  toOldParams (nm, rig, bind) = (nm, rig, bind.info, bind.boundType)
+  toOldParams bind = (bind.name.val, bind.rig, bind.val.info, bind.val.boundType)
 
   public export
   fromOldParams : OldParameters' nm -> ImpParameter' (RawImp' nm)
-  fromOldParams (nm, rig, info,type) = (nm, rig, MkPiBindData info type)
+  fromOldParams (nm, rig, info,type) = Mk [rig, NoFC nm] (MkPiBindData info type)
+
+  export
+  Show nm => Show (ImpParameter' nm) where
+    show x = "\{show x.rig}\{show x.name.val} \{show x.val.boundType}"
 
   public export
   ImpRecord : Type

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -381,11 +381,11 @@ mutual
 
   public export
   ImpParameter : Type
-  ImpParameter = ImpParameter' Name
+  ImpParameter = ImpParameter' (RawImp' Name)
 
   public export
   ImpParameter' : Type -> Type
-  ImpParameter' nm = (Name, RigCount, PiBindData (RawImp' nm))
+  ImpParameter' nm = (Name, RigCount, PiBindData nm)
 
   -- old datatype for ImpParameter, used for elabreflection compatibility
   public export
@@ -393,11 +393,11 @@ mutual
   OldParameters' nm = (Name, RigCount, PiInfo (RawImp' nm), RawImp' nm)
 
   public export
-  toOldParams : ImpParameter' nm -> OldParameters' nm
+  toOldParams : ImpParameter' (RawImp' nm) -> OldParameters' nm
   toOldParams (nm, rig, bind) = (nm, rig, bind.info, bind.boundType)
 
   public export
-  fromOldParams : OldParameters' nm -> ImpParameter' nm
+  fromOldParams : OldParameters' nm -> ImpParameter' (RawImp' nm)
   fromOldParams (nm, rig, info,type) = (nm, rig, MkPiBindData info type)
 
   public export
@@ -407,7 +407,7 @@ mutual
   public export
   data ImpRecord' : Type -> Type where
        MkImpRecord : FC -> (n : Name) ->
-                     (params : List (ImpParameter' nm)) ->
+                     (params : List (ImpParameter' (RawImp' nm))) ->
                      (opts : List DataOpt) ->
                      (conName : Name) ->
                      (fields : List (IField' nm)) ->
@@ -490,7 +490,7 @@ mutual
                Maybe TotalReq -> ImpData' nm -> ImpDecl' nm
        IDef : FC -> Name -> List (ImpClause' nm) -> ImpDecl' nm
        IParameters : FC ->
-                     List1 (ImpParameter' nm) ->
+                     List1 (ImpParameter' (RawImp' nm)) ->
                      List (ImpDecl' nm) -> ImpDecl' nm
        IRecord : FC ->
                  Maybe String -> -- nested namespace

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -387,7 +387,19 @@ mutual
   -- TODO: turn into a proper datatype
   public export
   ImpParameter' : Type -> Type
-  ImpParameter' nm = (Name, RigCount, PiInfo (RawImp' nm), RawImp' nm)
+  ImpParameter' nm = (Name, RigCount, PiBindData (RawImp' nm))
+
+  public export
+  OldParameters' : Type -> Type
+  OldParameters' nm = (Name, RigCount, PiInfo (RawImp' nm), RawImp' nm)
+
+  public export
+  toOldParams : ImpParameter' nm -> OldParameters' nm
+  toOldParams (nm, rig, bind) = (nm, rig, bind.info, bind.boundType)
+
+  public export
+  fromOldParams : OldParameters' nm -> ImpParameter' nm
+  fromOldParams (nm, rig, info,type) = (nm, rig, MkPiBindData info type)
 
   public export
   ImpRecord : Type

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -373,11 +373,8 @@ mutual
   IField = IField' Name
 
   public export
-  data IField' : Type -> Type where
-       MkIField : FC -> RigCount -> (name : Name) -> PiBindData (RawImp' nm) ->
-                  IField' nm
-
-  %name IField' fld
+  IField' : Type -> Type
+  IField' nm = AddFC $ ImpParameter' (RawImp' nm)
 
   public export
   ImpParameter : Type
@@ -422,8 +419,8 @@ mutual
   export
   covering
   Show nm => Show (IField' nm) where
-    show (MkIField _ _ n (MkPiBindData Explicit ty)) = show n ++ " : " ++ show ty
-    show (MkIField _ _ n ty) = "{" ++ show n ++ " : " ++ show ty.boundType ++ "}"
+    show f@(MkWithData _ (MkPiBindData Explicit ty)) = show f.name.val ++ " : " ++ show ty
+    show f@(MkWithData _ ty) = "{" ++ show f.name.val ++ " : " ++ show ty.boundType ++ "}"
 
   export
   covering
@@ -831,7 +828,7 @@ definedInBlock ns decls =
     getName (MkImpTy _ n _) = n.val
 
     getFieldName : IField -> Name
-    getFieldName (MkIField _ _ n _) = n
+    getFieldName f = f.name.val
 
     expandNS : Namespace -> Name -> Name
     expandNS ns n

--- a/src/TTImp/TTImp/Functor.idr
+++ b/src/TTImp/TTImp/Functor.idr
@@ -95,13 +95,13 @@ mutual
   export
   Functor ImpDecl' where
     map f (IClaim c)
-      = IClaim (mapData (map f) c)
+      = IClaim (map (map f) c)
     map f (IData fc vis mbtot dt)
       = IData fc vis mbtot (map f dt)
     map f (IDef fc nm cls)
       = IDef fc nm (map (map f) cls)
     map f (IParameters fc ps ds)
-      = IParameters fc (map (map  {f = ImpParameter'} (map f)) ps) (map (map f) ds)
+      = IParameters fc (map (map (map (map f))) ps) (map (map f) ds)
     map f (IRecord fc cs vis mbtot rec)
       = IRecord fc cs vis mbtot (map f rec)
     map f (IFail fc msg ds)
@@ -153,12 +153,8 @@ mutual
   export
   Functor ImpRecord' where
     map f (MkImpRecord fc n params opts conName fields)
-      = MkImpRecord fc n (map (map {f = ImpParameter'} (map f)) params)
+      = MkImpRecord fc n (map (map (map (map f))) params)
                     opts conName (map (map f) fields)
-
-  export
-  Functor ImpParameter' where
-    map f (nm, rig, bind) = (nm, rig, map f bind)
 
   export
   Functor IFieldUpdate' where

--- a/src/TTImp/TTImp/Functor.idr
+++ b/src/TTImp/TTImp/Functor.idr
@@ -147,8 +147,8 @@ mutual
 
   export
   Functor IField' where
-    map f (MkIField fc rig info n t)
-      = MkIField fc rig (map (map f) info) n (map f t)
+    map f (MkIField fc rig n bind)
+      = MkIField fc rig n (map (map f) bind)
 
   export
   Functor ImpRecord' where

--- a/src/TTImp/TTImp/Functor.idr
+++ b/src/TTImp/TTImp/Functor.idr
@@ -101,7 +101,7 @@ mutual
     map f (IDef fc nm cls)
       = IDef fc nm (map (map f) cls)
     map f (IParameters fc ps ds)
-      = IParameters fc (map (map  {f = ImpParameter'} f) ps) (map (map f) ds)
+      = IParameters fc (map (map  {f = ImpParameter'} (map f)) ps) (map (map f) ds)
     map f (IRecord fc cs vis mbtot rec)
       = IRecord fc cs vis mbtot (map f rec)
     map f (IFail fc msg ds)
@@ -153,12 +153,12 @@ mutual
   export
   Functor ImpRecord' where
     map f (MkImpRecord fc n params opts conName fields)
-      = MkImpRecord fc n (map (map {f = ImpParameter'} f) params)
+      = MkImpRecord fc n (map (map {f = ImpParameter'} (map f)) params)
                     opts conName (map (map f) fields)
 
   export
   Functor ImpParameter' where
-    map f (nm, rig, bind) = (nm, rig, map (map f) bind)
+    map f (nm, rig, bind) = (nm, rig, map f bind)
 
   export
   Functor IFieldUpdate' where

--- a/src/TTImp/TTImp/Functor.idr
+++ b/src/TTImp/TTImp/Functor.idr
@@ -158,7 +158,7 @@ mutual
 
   export
   Functor ImpParameter' where
-    map f (nm, rig, info, t) = (nm, rig, map (map f) info, map f t)
+    map f (nm, rig, bind) = (nm, rig, map (map f) bind)
 
   export
   Functor IFieldUpdate' where

--- a/src/TTImp/TTImp/Functor.idr
+++ b/src/TTImp/TTImp/Functor.idr
@@ -146,15 +146,10 @@ mutual
       = MkImpLater fc n (map f tycon)
 
   export
-  Functor IField' where
-    map f (MkIField fc rig n bind)
-      = MkIField fc rig n (map (map f) bind)
-
-  export
   Functor ImpRecord' where
     map f (MkImpRecord fc n params opts conName fields)
       = MkImpRecord fc n (map (map (map (map f))) params)
-                    opts conName (map (map f) fields)
+                    opts conName (map (map (map (map f))) fields)
 
   export
   Functor IFieldUpdate' where

--- a/src/TTImp/TTImp/TTC.idr
+++ b/src/TTImp/TTImp/TTC.idr
@@ -309,13 +309,13 @@ mutual
 
   export
   TTC IField where
-    toBuf (MkIField fc c p n ty)
-        = do toBuf fc; toBuf c; toBuf p; toBuf n; toBuf ty
+    toBuf (MkIField fc c n bind)
+        = do toBuf fc; toBuf c; toBuf n; toBuf bind
 
     fromBuf
-        = do fc <- fromBuf; c <- fromBuf; p <- fromBuf
-             n <- fromBuf; ty <- fromBuf
-             pure (MkIField fc c p n ty)
+        = do fc <- fromBuf; c <- fromBuf;
+             n <- fromBuf; bind <- fromBuf
+             pure (MkIField fc c n bind)
 
   export
   TTC ImpRecord where

--- a/src/TTImp/TTImp/TTC.idr
+++ b/src/TTImp/TTImp/TTC.idr
@@ -308,16 +308,6 @@ mutual
                _ => corrupt "ImpData"
 
   export
-  TTC IField where
-    toBuf (MkIField fc c n bind)
-        = do toBuf fc; toBuf c; toBuf n; toBuf bind
-
-    fromBuf
-        = do fc <- fromBuf; c <- fromBuf;
-             n <- fromBuf; bind <- fromBuf
-             pure (MkIField fc c n bind)
-
-  export
   TTC ImpRecord where
     toBuf (MkImpRecord fc n ps opts con fs)
         = do toBuf fc; toBuf n; toBuf ps; toBuf opts; toBuf con; toBuf fs

--- a/src/TTImp/TTImp/Traversals.idr
+++ b/src/TTImp/TTImp/Traversals.idr
@@ -59,7 +59,7 @@ parameters (f : RawImp' nm -> RawImp' nm)
   export
   mapImpRecord : ImpRecord' nm -> ImpRecord' nm
   mapImpRecord (MkImpRecord fc n params opts conName fields)
-    = MkImpRecord fc n (map (map $ map $ map mapTTImp) params) opts conName (map mapIField fields)
+    = MkImpRecord fc n (map (map (map mapTTImp)) params) opts conName (map mapIField fields)
 
 
   export

--- a/src/TTImp/TTImp/Traversals.idr
+++ b/src/TTImp/TTImp/Traversals.idr
@@ -59,7 +59,7 @@ parameters (f : RawImp' nm -> RawImp' nm)
   export
   mapImpRecord : ImpRecord' nm -> ImpRecord' nm
   mapImpRecord (MkImpRecord fc n params opts conName fields)
-    = MkImpRecord fc n (map (map $ map $ bimap mapPiInfo mapTTImp) params) opts conName (map mapIField fields)
+    = MkImpRecord fc n (map (map $ map $ map mapTTImp) params) opts conName (map mapIField fields)
 
 
   export

--- a/src/TTImp/TTImp/Traversals.idr
+++ b/src/TTImp/TTImp/Traversals.idr
@@ -54,7 +54,7 @@ parameters (f : RawImp' nm -> RawImp' nm)
 
   export
   mapIField : IField' nm -> IField' nm
-  mapIField (MkIField fc rig pinfo n t) = MkIField fc rig (mapPiInfo pinfo) n (mapTTImp t)
+  mapIField (MkIField fc rig n bind) = MkIField fc rig n (map f bind)
 
   export
   mapImpRecord : ImpRecord' nm -> ImpRecord' nm

--- a/src/TTImp/TTImp/Traversals.idr
+++ b/src/TTImp/TTImp/Traversals.idr
@@ -53,14 +53,10 @@ parameters (f : RawImp' nm -> RawImp' nm)
   mapImpData (MkImpLater fc n tycon) = MkImpLater fc n (mapTTImp tycon)
 
   export
-  mapIField : IField' nm -> IField' nm
-  mapIField (MkIField fc rig n bind) = MkIField fc rig n (map f bind)
-
-  export
   mapImpRecord : ImpRecord' nm -> ImpRecord' nm
   mapImpRecord (MkImpRecord fc n params opts conName fields)
-    = MkImpRecord fc n (map (map (map mapTTImp)) params) opts conName (map mapIField fields)
-
+    = MkImpRecord fc n (map (map (map mapTTImp)) params) opts conName
+        (map (map (map mapTTImp)) fields)
 
   export
   mapImpDecl : ImpDecl' nm -> ImpDecl' nm

--- a/src/TTImp/Utils.idr
+++ b/src/TTImp/Utils.idr
@@ -45,7 +45,7 @@ rawImpFromDecl decl = case decl of
     IPragma _ _ f => []
     ILog k => []
     IBuiltin _ _ _ => []
-  where getParamTy : ImpParameter' Name -> RawImp
+  where getParamTy : ImpParameter' RawImp -> RawImp
         getParamTy (_, _, binder) = binder.boundType
         getFromClause : ImpClause -> List RawImp
         getFromClause (PatClause fc1 lhs rhs) = [lhs, rhs]

--- a/src/TTImp/Utils.idr
+++ b/src/TTImp/Utils.idr
@@ -55,7 +55,7 @@ rawImpFromDecl decl = case decl of
         getFromPiInfo (DefImplicit x) = [x]
         getFromPiInfo _ = []
         getFromIField : IField -> List RawImp
-        getFromIField (MkIField fc x y z w) = getFromPiInfo y ++ [w]
+        getFromIField (MkIField fc x y z) = getFromPiInfo z.info ++ [z.boundType]
 
 
 -- Identify lower case names in argument position, which we can bind later.

--- a/src/TTImp/Utils.idr
+++ b/src/TTImp/Utils.idr
@@ -36,7 +36,7 @@ rawImpFromDecl decl = case decl of
     IDef fc1 y ys => getFromClause !ys
     IParameters fc1 ys zs => rawImpFromDecl !zs ++ map getParamTy (forget ys)
     IRecord fc1 y z _ (MkImpRecord fc n params opts conName fields) => do
-        binder <- map (snd . snd) params
+        binder <- map val params
         getFromPiInfo binder.info ++ [binder.boundType] ++ getFromIField !fields
     IFail fc1 msg zs => rawImpFromDecl !zs
     INamespace fc1 ys zs => rawImpFromDecl !zs
@@ -46,7 +46,7 @@ rawImpFromDecl decl = case decl of
     ILog k => []
     IBuiltin _ _ _ => []
   where getParamTy : ImpParameter' RawImp -> RawImp
-        getParamTy (_, _, binder) = binder.boundType
+        getParamTy binder = binder.val.boundType
         getFromClause : ImpClause -> List RawImp
         getFromClause (PatClause fc1 lhs rhs) = [lhs, rhs]
         getFromClause (WithClause fc1 lhs rig wval prf flags ys) = [wval, lhs] ++ getFromClause !ys
@@ -386,7 +386,7 @@ mutual
   substNamesDecl' : Bool -> List Name -> List (Name, RawImp ) ->
                    ImpDecl -> ImpDecl
   substNamesDecl' bvar bound ps (IClaim claim)
-      = IClaim $ mapData {type $= substNamesTy' bvar bound ps} claim
+      = IClaim $ map {type $= substNamesTy' bvar bound ps} claim
   substNamesDecl' bvar bound ps (IDef fc n cs)
       = IDef fc n (map (substNamesClause' bvar bound ps) cs)
   substNamesDecl' bvar bound ps (IData fc vis mbtot d)

--- a/src/TTImp/Utils.idr
+++ b/src/TTImp/Utils.idr
@@ -36,8 +36,8 @@ rawImpFromDecl decl = case decl of
     IDef fc1 y ys => getFromClause !ys
     IParameters fc1 ys zs => rawImpFromDecl !zs ++ map getParamTy (forget ys)
     IRecord fc1 y z _ (MkImpRecord fc n params opts conName fields) => do
-        (a, b) <- map (snd . snd) params
-        getFromPiInfo a ++ [b] ++ getFromIField !fields
+        binder <- map (snd . snd) params
+        getFromPiInfo binder.info ++ [binder.boundType] ++ getFromIField !fields
     IFail fc1 msg zs => rawImpFromDecl !zs
     INamespace fc1 ys zs => rawImpFromDecl !zs
     ITransform fc1 y z w => [z, w]
@@ -45,8 +45,8 @@ rawImpFromDecl decl = case decl of
     IPragma _ _ f => []
     ILog k => []
     IBuiltin _ _ _ => []
-  where getParamTy : (a, b, c, RawImp) -> RawImp
-        getParamTy (_, _, _, ty) = ty
+  where getParamTy : ImpParameter' Name -> RawImp
+        getParamTy (_, _, binder) = binder.boundType
         getFromClause : ImpClause -> List RawImp
         getFromClause (PatClause fc1 lhs rhs) = [lhs, rhs]
         getFromClause (WithClause fc1 lhs rig wval prf flags ys) = [wval, lhs] ++ getFromClause !ys

--- a/src/TTImp/Utils.idr
+++ b/src/TTImp/Utils.idr
@@ -55,7 +55,7 @@ rawImpFromDecl decl = case decl of
         getFromPiInfo (DefImplicit x) = [x]
         getFromPiInfo _ = []
         getFromIField : IField -> List RawImp
-        getFromIField (MkIField fc x y z) = getFromPiInfo z.info ++ [z.boundType]
+        getFromIField field = getFromPiInfo field.val.info ++ [field.val.boundType]
 
 
 -- Identify lower case names in argument position, which we can bind later.


### PR DESCRIPTION
# Description

This addresses a number of points from #3570 and #3409 namely:
- track location of names in binder with multiple names #3409
- Replace ImpParameter by its own data type using WithData #3570
- replace WithName by WithData #3570
- unify binder datatypes between syntax and TTImp via `PiBindData` (overdue)

We are starting to enjoy the benefits of `WithData` since we can now remove redundant TTC instances and have them properly behave using the default `WithData` instance. There is still some work to do around Reflect/reify instance but that should be resolved once we don't need to maintain backward compatibility with elab reflection.