### PR TITLE
docs: added note about valid operators

### DIFF
--- a/docs/source/reference/operators.rst
+++ b/docs/source/reference/operators.rst
@@ -339,3 +339,16 @@ the full syntax: ``(name : type := expr) op body`` which is desugared into
 
 Like ``typebind``, ``autobind`` operators cannot be used as regular operators anymore
 , additionally an ``autobind`` operator cannot use the ``typebind`` syntax either.
+
+
+.. note::
+    Operators may only contain the following charecters: ``:``, ``!``, ``#``, ``$``, ``%``, ``&``, ``*``, ``+``, ``.``, ``/``, ``<``, ``=``, ``>``, ``?``, ``@``, ``\``, ``^``, ``|``, ``-``, and ``~`` .
+    
+    In addition, it may *not* be one of these symbols ``%``, ``\``, ``:``, ``=``, ``:=``, ``$=``, ``|``, ``|||``, ``<-``, ``->``, ``=>``, ``?``, ``!``, ``&``, ``**``, ``..``, ``~``, ``@``.
+
+.. note::
+
+    While not strictly part of the syntax, the symbols defined in Prelude should be mentioned, those being:
+    ``.``, ``.:``, ``|>``, ``<|``, ``||``, ``&&``, ``::``, ``:<``
+    ``==``, ``/=``, ``<``, ``<=``, ``>``, ``>=``
+    <+>``, ``<$>``, ``<*>``, ``<$``, ``$>``, ``<*>``, ``<*``, ``*>``, ``<|>``, ``>>=``, ``=<<``, ``>>``, ``>=>``, ``<=<``, ``+``, ``*``, ``-``, ``/``, ``$``, ``++``, ``#``, ``===``, ``~=~``


### PR DESCRIPTION
# Description

Added small note in the operators documentation describing all valid syntax

## Self-check

<!-- /!\ Please delete sections that do not apply -->
- [X] This is my first time contributing, I've carefully read [`CONTRIBUTING.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTING.md)
      and I've updated [`CONTRIBUTORS.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTORS.md) with my name.
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)

