### PR TITLE
remove now-unneeded and no longer supported overrideSDK calls from Nix files

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719371271,
-        "narHash": "sha256-G3tm/ttP6PxnrrpCYIi4VBpJdGrwqr2pqRKuZlvTg2s=",
+        "lastModified": 1755542980,
+        "narHash": "sha256-vVlLAZSI27Ge7Cb6Vwhcwccd+reTLwa/KtrjyamM30I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "267d115a04e93a3487d3c2c26e3af5704a0144cc",
+        "rev": "54260f5b36f6136fc2f71629fb8d2c8c7158f140",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -68,7 +68,6 @@
           idris2ApiPkg = pkgs.callPackage ./nix/idris2Api.nix {
             inherit idris2Version buildIdris;
           };
-          stdenv' = with pkgs; if stdenv.isDarwin then overrideSDK stdenv "11.0" else stdenv;
         in {
           checks = import ./nix/test.nix {
             inherit (pkgs) system stdenv runCommand lib;
@@ -84,7 +83,7 @@
             inherit pkgs idris-emacs-src idris2Pkg;
           });
           inherit buildIdris;
-          devShells.default = pkgs.mkShell.override { stdenv = stdenv'; } {
+          devShells.default = pkgs.mkShell{
             packages = idris2Pkg.buildInputs;
           };
         };

--- a/nix/support.nix
+++ b/nix/support.nix
@@ -1,8 +1,5 @@
-{ stdenv, lib, overrideSDK, gmp, idris2Version }:
-let
-  stdenv' = if stdenv.isDarwin then overrideSDK stdenv "11.0" else stdenv;
-in
-stdenv'.mkDerivation rec {
+{ stdenv, lib, gmp, idris2Version }:
+stdenv.mkDerivation rec {
   pname = "libidris2_support";
   version = idris2Version;
 
@@ -18,7 +15,7 @@ stdenv'.mkDerivation rec {
 
   makeFlags = [
     "PREFIX=$(out)"
-  ] ++ lib.optional stdenv'.isDarwin "OS=";
+  ] ++ lib.optional stdenv.isDarwin "OS=";
 
   buildFlags = [ "support" ];
 


### PR DESCRIPTION
# Description

This addressed deprecation warnings and then later errors coming from Nixpkgs owing to use of an old helper that is no longer needed.

<!-- Make your description as clear as possible for reviewers,
feel free to ask questions or bring attention to specific parts
of the code. Before submitting a large diff, ensure that this is
a change that we can accept by opening an issue first and discussing
the proposed change. -->

## Self-check

<!-- /!\ Please delete sections that do not apply -->
- [ ] This is my first time contributing, I've carefully read [`CONTRIBUTING.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTING.md)
      and I've updated [`CONTRIBUTORS.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTORS.md) with my name.
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)

