### PR TITLE
[ fix ] stuck elaboration in parser library.

### DIFF
--- a/libs/contrib/Text/Parser.idr
+++ b/libs/contrib/Text/Parser.idr
@@ -1,7 +1,7 @@
 module Text.Parser
 
 import Data.Bool
-import Data.Nat
+import public Data.Nat
 import public Data.List1
 
 import public Text.Parser.Core


### PR DESCRIPTION
The type of the `Text.Parser` function `count` requires access to the `min` function of `Data.Nat`. If `Data.Nat` has not been imported in your parser module, then usages of `count` will fail to elaborate correctly.

Thus, one can see errors of the form:

```
Error: While processing right hand side of header. Can't solve constraint
between: isSucc (min (between 1 6)) || Delay ?c2 and True.
```

This fix makes the import of `Data.Nat` public.

# Description

<!-- Make your description as clear as possible for reviewers,
feel free to ask questions or bring attention to specific parts
of the code. Before submitting a large diff, ensure that this is
a change that we can accept by opening an issue first and discussing
the proposed change. -->



