### PR TITLE
replace binding symbol for autobind

### DIFF
--- a/docs/source/reference/operators.rst
+++ b/docs/source/reference/operators.rst
@@ -311,7 +311,7 @@ where the constructor for ``Pi`` takes terms on the left and lambdas on the righ
 We would like to use a custom operator to build values using ``VPi``, but its
 signature does not follow the pattern that ``typebind`` uses. Instead, we use
 ``autobind`` to tell the compiler that the type of the lambda must be inferred.
-For this we use ``:=`` instead of ``:``:
+For this we use ``<-`` instead of ``:``:
 
 .. code-block:: idris
 
@@ -322,19 +322,19 @@ For this we use ``:=`` instead of ``:``:
 
     sig : Value
     sig =
-        (fstTy := VStar) =>>
-        (sndTy := (_ := fstTy) =>> VStar) =>>
-        (val1 := fstTy) =>>
-        (val2 := sndTy `vapp` val1) =>>
+        (fstTy <- VStar) =>>
+        (sndTy <- (_ <- fstTy) =>> VStar) =>>
+        (val1 <- fstTy) =>>
+        (val2 <- sndTy `vapp` val1) =>>
         VSigma fstTy sndTy
 
 This new syntax is much closer to what the code is meant to look like for users
 accustomed to dependently-typed programming languages.
 
 More technically, any ``autobind`` operator is called with the syntax
-``(name := expr) op body`` and is desugared into ``expr op (\name : ? => body)``.
+``(name <- expr) op body`` and is desugared into ``expr op (\name : ? => body)``.
 If you want, or need, to give the type explicitly, you can still do so by using
-the full syntax: ``(name : type := expr) op body`` which is desugared into
+the full syntax: ``(name : type <- expr) op body`` which is desugared into
 ``expr op (\name : type => body)``.
 
 Like ``typebind``, ``autobind`` operators cannot be used as regular operators anymore

--- a/src/Idris/Error.idr
+++ b/src/Idris/Error.idr
@@ -634,7 +634,7 @@ perrorRaw (OperatorBindingMismatch fc {print=p} expected actual opName rhs candi
        <+> line <+> !(ploc fc)
        <+> "Explanation: regular, typebind and autobind operators all use a slightly different"
        <++> "syntax, typebind looks like this: '(name : type)" <++> infixOpName
-       <++> "expr', autobind looks like this: '(name := expr)" <++> infixOpName
+       <++> "expr', autobind looks like this: '(name <- expr)" <++> infixOpName
        <++> "expr'."
        <+> line <+> line
        <+> "Possible solutions:" <+> line
@@ -677,7 +677,7 @@ perrorRaw (OperatorBindingMismatch fc {print=p} expected actual opName rhs candi
                     NotBinding =>
                        printE actual.getLhs <++> infixOpName <++> printE rhs
                     Autobind =>
-                       parens (maybe "_" printE actual.getBoundPat <++> ":="
+                       parens (maybe "_" printE actual.getBoundPat <++> "<-"
                                <++> printE actual.getLhs)
                        <++> infixOpName <++> printE rhs
                     Typebind =>

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -327,15 +327,15 @@ mutual
         pure (map (\ n => (boundToFC fname n, n.val)) $ forget ns)
 
   -- The different kinds of operator bindings `x : ty` for typebind
-  -- x := e and x : ty := e for autobind
+  -- x <- e and x : ty <- e for autobind
   opBinderTypes : OriginDesc -> IndentInfo -> WithBounds PTerm -> Rule (OperatorLHSInfo PTerm)
   opBinderTypes fname indents boundName =
            do decoratedSymbol fname ":"
               ty <- typeExpr pdef fname indents
-              decoratedSymbol fname ":="
+              decoratedSymbol fname "<-"
               exp <- expr pdef fname indents
               pure (BindExplicitType boundName.val ty exp)
-       <|> do decoratedSymbol fname ":="
+       <|> do decoratedSymbol fname "<-"
               exp <- expr pdef fname indents
               pure (BindExpr boundName.val exp)
        <|> do decoratedSymbol fname ":"

--- a/src/Idris/Pretty.idr
+++ b/src/Idris/Pretty.idr
@@ -365,11 +365,11 @@ mutual
            <++> prettyOp op.val.toName
            <++> pretty right
     prettyPrec d (POp _ (MkWithData _ $ BindExpr nm left) op right) =
-        group $ parens (prettyPrec d nm <++> ":=" <++> pretty left)
+        group $ parens (prettyPrec d nm <++> "<-" <++> pretty left)
            <++> prettyOp op.val.toName
            <++> pretty right
     prettyPrec d (POp _ (MkWithData _ $ BindExplicitType nm ty left) op right) =
-        group $ parens (prettyPrec d nm <++> ":" <++> pretty ty <++> ":=" <++> pretty left)
+        group $ parens (prettyPrec d nm <++> ":" <++> pretty ty <++> "<-" <++> pretty left)
            <++> prettyOp op.val.toName
            <++> pretty right
     prettyPrec d (POp _ (MkWithData _ $ NoBinder x) op y) =

--- a/tests/idris2/operators/operators001/Test.idr
+++ b/tests/idris2/operators/operators001/Test.idr
@@ -55,10 +55,10 @@ MyLet : (val) -> (val -> rest) -> rest
 MyLet arg fn = fn arg
 
 program : Nat
-program = (n := 3) `MyLet` 2 + n
+program = (n <- 3) `MyLet` 2 + n
 
 program2 : Nat
-program2 = (n : Nat := 3) `MyLet` 2 + n
+program2 = (n : Nat <- 3) `MyLet` 2 + n
 
 private typebind infixr 0 |>
 

--- a/tests/idris2/operators/operators002/Errors.idr
+++ b/tests/idris2/operators/operators002/Errors.idr
@@ -5,5 +5,5 @@ private typebind infixr 0 =@
 (=@) a f = (1 x : a) -> f x
 
 data S : {ty : Type} -> (x : ty) -> Type where
-  MkS : (x := ty) =@ S x
+  MkS : (x <- ty) =@ S x
 

--- a/tests/idris2/operators/operators002/Errors5.idr
+++ b/tests/idris2/operators/operators002/Errors5.idr
@@ -7,4 +7,4 @@ private infixr 0 =@
 
 
 data S : {ty : Type} -> (x : ty) -> Type where
-  MkS : (x := ty) =@ S x
+  MkS : (x <- ty) =@ S x

--- a/tests/idris2/operators/operators002/LinImport.idr
+++ b/tests/idris2/operators/operators002/LinImport.idr
@@ -5,5 +5,5 @@ import Lin
 (=@) a f = (1 x : a) -> f x
 
 data S : {ty : Type} -> (x : ty) -> Type where
-  MkS : (x := ty) =@ S x
+  MkS : (x <- ty) =@ S x
 

--- a/tests/idris2/operators/operators002/expected
+++ b/tests/idris2/operators/operators002/expected
@@ -6,9 +6,9 @@ Errors:8:19--8:21
  5 | (=@) a f = (1 x : a) -> f x
  6 | 
  7 | data S : {ty : Type} -> (x : ty) -> Type where
- 8 |   MkS : (x := ty) =@ S x
+ 8 |   MkS : (x <- ty) =@ S x
                        ^^
-Explanation: regular, typebind and autobind operators all use a slightly different syntax, typebind looks like this: '(name : type) =@ expr', autobind looks like this: '(name := expr) =@ expr'.
+Explanation: regular, typebind and autobind operators all use a slightly different syntax, typebind looks like this: '(name : type) =@ expr', autobind looks like this: '(name <- expr) =@ expr'.
 
 Possible solutions:
  - Write the expression using typebind syntax: '(x : ty) =@ S x'.
@@ -24,10 +24,10 @@ Errors2:7:29--7:31
  6 | 
  7 | wrongId : {0 a : Type} -> a =@ a
                                  ^^
-Explanation: regular, typebind and autobind operators all use a slightly different syntax, typebind looks like this: '(name : type) =@ expr', autobind looks like this: '(name := expr) =@ expr'.
+Explanation: regular, typebind and autobind operators all use a slightly different syntax, typebind looks like this: '(name : type) =@ expr', autobind looks like this: '(name <- expr) =@ expr'.
 
 Possible solutions:
- - Write the expression using autobind syntax: '(_ := a) =@ a'.
+ - Write the expression using autobind syntax: '(_ <- a) =@ a'.
  - Change the fixity defined at Errors2:2:18--2:29 to 'private infixr 0 =@'.
  - Hide or remove the fixity at Errors2:2:18--2:29 and import a module that exports a compatible fixity.
 1/1: Building Errors3 (Errors3.idr)
@@ -40,7 +40,7 @@ Errors3:7:29--7:31
  6 | 
  7 | wrongId : {0 a : Type} -> a =@ a
                                  ^^
-Explanation: regular, typebind and autobind operators all use a slightly different syntax, typebind looks like this: '(name : type) =@ expr', autobind looks like this: '(name := expr) =@ expr'.
+Explanation: regular, typebind and autobind operators all use a slightly different syntax, typebind looks like this: '(name : type) =@ expr', autobind looks like this: '(name <- expr) =@ expr'.
 
 Possible solutions:
  - Write the expression using typebind syntax: '(_ : a) =@ a'.
@@ -56,7 +56,7 @@ Errors4:9:18--9:20
  8 | data S : {ty : Type} -> (x : ty) -> Type where
  9 |   MkS : (x : ty) =@ S x
                       ^^
-Explanation: regular, typebind and autobind operators all use a slightly different syntax, typebind looks like this: '(name : type) =@ expr', autobind looks like this: '(name := expr) =@ expr'.
+Explanation: regular, typebind and autobind operators all use a slightly different syntax, typebind looks like this: '(name : type) =@ expr', autobind looks like this: '(name <- expr) =@ expr'.
 
 Possible solutions:
  - Write the expression using regular syntax: 'ty =@ S x'.
@@ -70,9 +70,9 @@ Errors5:10:19--10:21
  07 | 
  08 | 
  09 | data S : {ty : Type} -> (x : ty) -> Type where
- 10 |   MkS : (x := ty) =@ S x
+ 10 |   MkS : (x <- ty) =@ S x
                         ^^
-Explanation: regular, typebind and autobind operators all use a slightly different syntax, typebind looks like this: '(name : type) =@ expr', autobind looks like this: '(name := expr) =@ expr'.
+Explanation: regular, typebind and autobind operators all use a slightly different syntax, typebind looks like this: '(name : type) =@ expr', autobind looks like this: '(name <- expr) =@ expr'.
 
 Possible solutions:
  - Write the expression using regular syntax: 'ty =@ S x'.
@@ -87,9 +87,9 @@ LinImport:8:19--8:21
  5 | (=@) a f = (1 x : a) -> f x
  6 | 
  7 | data S : {ty : Type} -> (x : ty) -> Type where
- 8 |   MkS : (x := ty) =@ S x
+ 8 |   MkS : (x <- ty) =@ S x
                        ^^
-Explanation: regular, typebind and autobind operators all use a slightly different syntax, typebind looks like this: '(name : type) =@ expr', autobind looks like this: '(name := expr) =@ expr'.
+Explanation: regular, typebind and autobind operators all use a slightly different syntax, typebind looks like this: '(name : type) =@ expr', autobind looks like this: '(name <- expr) =@ expr'.
 
 Possible solutions:
  - Write the expression using typebind syntax: '(x : ty) =@ S x'.

--- a/tests/idris2/operators/operators005/Test.idr
+++ b/tests/idris2/operators/operators005/Test.idr
@@ -13,7 +13,7 @@ const : Type -> Type -> Container
 const a b = (_ : a) :- b
 
 test : Maybe (List Double)
-test = (_ := ["1", "two", "3"]) `for` Just 3
+test = (_ <- ["1", "two", "3"]) `for` Just 3
 
 test2 : Maybe (List Double)
-test2 = (_ : String := ["1", "two", "3"]) `for` Just 3
+test2 = (_ : String <- ["1", "two", "3"]) `for` Just 3

--- a/tests/idris2/operators/operators006/Test.idr
+++ b/tests/idris2/operators/operators006/Test.idr
@@ -7,4 +7,4 @@ bind : Monad m => m a -> (a -> m b) -> m b
 bind = (>>=)
 
 both : Maybe (Nat, Nat) -> Maybe Nat
-both m = (MkPair x y := m) `bind` Just (x + y)
+both m = (MkPair x y <- m) `bind` Just (x + y)

--- a/tests/idris2/operators/operators007/Test.idr
+++ b/tests/idris2/operators/operators007/Test.idr
@@ -7,4 +7,4 @@ private autobind infixr 0 >>
 (>>) = (>>=)
 
 both : Maybe (Nat, Nat) -> Maybe Nat
-both m = (MkPair x y := m) >>= Just (x + y)
+both m = (MkPair x y <- m) >>= Just (x + y)

--- a/tests/idris2/operators/operators007/Test2.idr
+++ b/tests/idris2/operators/operators007/Test2.idr
@@ -11,4 +11,4 @@ private autobind infixr 0 >=
 (>=) = (>>=)
 
 both : Maybe (Nat, Nat) -> Maybe Nat
-both m = (MkPair x y := m) >>= Just (x + y)
+both m = (MkPair x y <- m) >>= Just (x + y)

--- a/tests/idris2/operators/operators007/expected
+++ b/tests/idris2/operators/operators007/expected
@@ -6,9 +6,9 @@ Test:10:28--10:31
  07 | (>>) = (>>=)
  08 | 
  09 | both : Maybe (Nat, Nat) -> Maybe Nat
- 10 | both m = (MkPair x y := m) >>= Just (x + y)
+ 10 | both m = (MkPair x y <- m) >>= Just (x + y)
                                  ^^^
-Explanation: regular, typebind and autobind operators all use a slightly different syntax, typebind looks like this: '(name : type) >>= expr', autobind looks like this: '(name := expr) >>= expr'.
+Explanation: regular, typebind and autobind operators all use a slightly different syntax, typebind looks like this: '(name : type) >>= expr', autobind looks like this: '(name <- expr) >>= expr'.
 
 Possible solutions:
  - Write the expression using regular syntax: 'm >>= Just (x + y)'.
@@ -23,9 +23,9 @@ Test2:14:28--14:31
  11 | (>=) = (>>=)
  12 | 
  13 | both : Maybe (Nat, Nat) -> Maybe Nat
- 14 | both m = (MkPair x y := m) >>= Just (x + y)
+ 14 | both m = (MkPair x y <- m) >>= Just (x + y)
                                  ^^^
-Explanation: regular, typebind and autobind operators all use a slightly different syntax, typebind looks like this: '(name : type) >>= expr', autobind looks like this: '(name := expr) >>= expr'.
+Explanation: regular, typebind and autobind operators all use a slightly different syntax, typebind looks like this: '(name : type) >>= expr', autobind looks like this: '(name <- expr) >>= expr'.
 
 Possible solutions:
  - Write the expression using regular syntax: 'm >>= Just (x + y)'.


### PR DESCRIPTION
# Description

fine print of #3582 

## Self-check

- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)


(There is actually no changelog changes to make since there has not been a release since the previous implementation of binding operators)
