### PR TITLE
[ fix ] address an exception in building emacs related packages for Idris2 via Nix

### DIFF
--- a/nix/text-editor.nix
+++ b/nix/text-editor.nix
@@ -16,7 +16,7 @@ in rec {
       (idris2-mode :repo "redfish64/idris2-mode" :fetcher github)
     '';
   };
-  idris-emacs = emacsWithPackages [ idris2-mode ];
+  idris-emacs = emacs.pkgs.withPackages [ idris2-mode ];
   emacs-dev = makeEmacsWrapper "emacs-dev" idris-emacs init-file;
   emacs-with-idris = writeShellScriptBin "emacs-with-idris" ''
     export PATH=${idris2Pkg}/bin:$PATH


### PR DESCRIPTION
# Description

This addresses the following error when building emacs tooling via Nix:
```
error: 'emacsWithPackages' has been renamed to/replaced by 'emacs.pkgs.withPackages'
```

## Self-check

<!-- /!\ Please delete sections that do not apply -->
- [ ] This is my first time contributing, I've carefully read [`CONTRIBUTING.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTING.md)
      and I've updated [`CONTRIBUTORS.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTORS.md) with my name.
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)

