### PR TITLE
[ error ] check for similar names in let and where

### DIFF
--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -938,7 +938,7 @@ lookupOrAddAlias eopts nest env fc n [cl@(PatClause _ lhs _)]
                       | _ => pure Nothing
                     pure (Just (cand, vis, weight))
                 pure $ showSimilarNames (currentNS defs) n str $ catMaybes decls
-          | (x :: xs) => throw (MaybeMisspelling (NoDeclaration fc n) (x ::: xs))
+          | (x :: xs) => throw (MaybeMisspelling (NoDeclaration fc $ unnest n) (x ::: xs))
        --   3) declare an alias
        log "declare.def" 5 "Not a misspelling: go ahead and declare it!"
        processType eopts nest env fc top Public []
@@ -948,6 +948,10 @@ lookupOrAddAlias eopts nest env fc n [cl@(PatClause _ lhs _)]
        lookupCtxtExact n (gamma defs)
 
   where
+    unnest : Name -> Name
+    unnest (NS ns (Nested (outer,_) inner)) = inner
+    unnest nm = nm
+
     holeyType : List (FC, Name) -> RawImp
     holeyType [] = Implicit fc False
     holeyType ((xfc, x) :: xs)

--- a/tests/idris2/error/error034/LetError.idr
+++ b/tests/idris2/error/error034/LetError.idr
@@ -1,0 +1,5 @@
+blah : Nat
+blah =
+   let fox : ()
+       foo = ()
+   in 3

--- a/tests/idris2/error/error034/WhereError.idr
+++ b/tests/idris2/error/error034/WhereError.idr
@@ -1,0 +1,5 @@
+blah : Nat
+blah = 3
+    where
+        fox : ()
+        foo = ()

--- a/tests/idris2/error/error034/expected
+++ b/tests/idris2/error/error034/expected
@@ -1,0 +1,21 @@
+1/1: Building LetError (LetError.idr)
+Error: While processing right hand side of blah. No type declaration for foo.
+
+LetError:4:8--4:16
+ 1 | blah : Nat
+ 2 | blah =
+ 3 |    let fox : ()
+ 4 |        foo = ()
+            ^^^^^^^^
+Did you mean: fox?
+1/1: Building WhereError (WhereError.idr)
+Error: While processing right hand side of blah. No type declaration for foo.
+
+WhereError:5:9--5:17
+ 1 | blah : Nat
+ 2 | blah = 3
+ 3 |     where
+ 4 |         fox : ()
+ 5 |         foo = ()
+             ^^^^^^^^
+Did you mean: fox?

--- a/tests/idris2/error/error034/run
+++ b/tests/idris2/error/error034/run
@@ -1,0 +1,4 @@
+. ../../../testutils.sh
+
+check LetError.idr
+check WhereError.idr


### PR DESCRIPTION
# Description

At the top level of a file, we report an error for definitions that have no claim, if there is an unused claim with a similar name.  This PR updates this to also work for functions defined in `let` and `where`.

At the top level, the following code:
```idris
fox : ()
foo = ()
```
gives an error:
```
Error: No type declaration for Main.foo.

Main:2:1--2:9
 1 | fox : ()
 2 | foo = ()
     ^^^^^^^^
Did you mean: fox?
```
but inside a `let` or `where`, this doesn't happen:
```idris
blah : Nat
blah = 
   let fox : ()
       foo = ()
   in 3
```

After this change we get:
```
Error: While processing right hand side of blah. No type declaration for foo.

LetError:4:8--4:16
 1 | blah : Nat
 2 | blah =
 3 |    let fox : ()
 4 |        foo = ()
            ^^^^^^^^
Did you mean: fox?
```

