### PR TITLE
ideMode: Add failing test for incorrectly generated prefix when calling :make-case in a `.lidr` file.

### DIFF
--- a/tests/ideMode/ideMode025/case.lidr
+++ b/tests/ideMode/ideMode025/case.lidr
@@ -1,0 +1,4 @@
+> foo : Nat -> Nat
+> foo x = ?foo_rhs
+>
+> -- Rest of file

--- a/tests/ideMode/ideMode025/expected
+++ b/tests/ideMode/ideMode025/expected
@@ -1,0 +1,14 @@
+000018(:protocol-version 2 1)
+0000dd(:output (:ok (:highlight-source ((((:filename "ideMode/ideMode025/case.lidr") (:start 0 0) (:end 0 3)) ((:name "foo") (:namespace "") (:decor :function) (:implicit :False) (:key "") (:doc-overview "") (:type "")))))) 1)
+000083(:output (:ok (:highlight-source ((((:filename "ideMode/ideMode025/case.lidr") (:start 0 4) (:end 0 5)) ((:decor :keyword)))))) 1)
+0000e6(:output (:ok (:highlight-source ((((:filename "ideMode/ideMode025/case.lidr") (:start 0 6) (:end 0 9)) ((:name "Nat") (:namespace "Prelude.Types") (:decor :type) (:implicit :False) (:key "") (:doc-overview "") (:type "")))))) 1)
+000085(:output (:ok (:highlight-source ((((:filename "ideMode/ideMode025/case.lidr") (:start 0 10) (:end 0 12)) ((:decor :keyword)))))) 1)
+0000e8(:output (:ok (:highlight-source ((((:filename "ideMode/ideMode025/case.lidr") (:start 0 13) (:end 0 16)) ((:name "Nat") (:namespace "Prelude.Types") (:decor :type) (:implicit :False) (:key "") (:doc-overview "") (:type "")))))) 1)
+0000e1(:output (:ok (:highlight-source ((((:filename "ideMode/ideMode025/case.lidr") (:start 1 0) (:end 1 3)) ((:name "foo") (:namespace "Main") (:decor :function) (:implicit :False) (:key "") (:doc-overview "") (:type "")))))) 1)
+0000d8(:output (:ok (:highlight-source ((((:filename "ideMode/ideMode025/case.lidr") (:start 1 4) (:end 1 5)) ((:name "x") (:namespace "") (:decor :bound) (:implicit :False) (:key "") (:doc-overview "") (:type "")))))) 1)
+000083(:output (:ok (:highlight-source ((((:filename "ideMode/ideMode025/case.lidr") (:start 1 6) (:end 1 7)) ((:decor :keyword)))))) 1)
+000084(:output (:ok (:highlight-source ((((:filename "ideMode/ideMode025/case.lidr") (:start 3 0) (:end 3 15)) ((:decor :comment)))))) 1)
+000015(:return (:ok ()) 1)
+000050(:return (:ok "> foo x = case _ of
+>              case_val => ?foo_rhs") 2)
+Alas the file is done, aborting

--- a/tests/ideMode/ideMode025/input
+++ b/tests/ideMode/ideMode025/input
@@ -1,0 +1,2 @@
+((:load-file "case.lidr") 1)
+((:make-case 2 "foo_rhs") 2)

--- a/tests/ideMode/ideMode025/run
+++ b/tests/ideMode/ideMode025/run
@@ -1,0 +1,3 @@
+. ../../testutils.sh
+
+idris2 --ide-mode < input


### PR DESCRIPTION

# This is failing test PR to demonstrate the issue. I hope someone will help with the fix :) 🙏🏻 

### Currently
when calling `make-case` in a `.lidr` file such as 

```
> foo : Nat -> Nat
> foo x = ?foo_rhs
```

Idris2 returns double ">" on first line
```
(:ok "> > foo x = case _ of\n>                case_val => ?foo_rhs")
```

### Expected:
Single ">" on the first line and correctly indented second line

```
(:ok "> foo x = case _ of\n>              case_val => ?foo_rhs")
```
This issue seems to be only in `ideMode` code as in `REPL` mode the output is generated correctly. See https://github.com/idris-lang/Idris2/blob/main/tests/idris2/literate/literate015/expected


Relates to https://github.com/idris-hackers/idris-mode/pull/644

# Description

<!-- Make your description as clear as possible for reviewers,
feel free to ask questions or bring attention to specific parts
of the code. Before submitting a large diff, ensure that this is
a change that we can accept by opening an issue first and discussing
the proposed change. -->

## Self-check

<!-- /!\ Please delete sections that do not apply -->
- [ ] This is my first time contributing, I've carefully read [`CONTRIBUTING.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTING.md)
      and I've updated [`CONTRIBUTORS.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTORS.md) with my name.
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)

