### PR TITLE
Use field names when creating `EvalOpts`

### DIFF
--- a/src/Core/Value.idr
+++ b/src/Core/Value.idr
@@ -27,19 +27,55 @@ record EvalOpts where
 
 export
 defaultOpts : EvalOpts
-defaultOpts = MkEvalOpts False False True False False Nothing [] CBN
+defaultOpts = MkEvalOpts
+    { holesOnly = False
+    , argHolesOnly = False
+    , removeAs = True
+    , evalAll = False
+    , tcInline = False
+    , fuel = Nothing
+    , reduceLimit = []
+    , strategy = CBN
+    }
 
 export
 withHoles : EvalOpts
-withHoles = MkEvalOpts True True False False False Nothing [] CBN
+withHoles = MkEvalOpts
+    { holesOnly = True
+    , argHolesOnly = True
+    , removeAs = False
+    , evalAll = False
+    , tcInline = False
+    , fuel = Nothing
+    , reduceLimit = []
+    , strategy = CBN
+    }
 
 export
 withAll : EvalOpts
-withAll = MkEvalOpts False False True True False Nothing [] CBN
+withAll = MkEvalOpts
+    { holesOnly = False
+    , argHolesOnly = False
+    , removeAs = True
+    , evalAll = True
+    , tcInline = False
+    , fuel = Nothing
+    , reduceLimit = []
+    , strategy = CBN
+    }
 
 export
 withArgHoles : EvalOpts
-withArgHoles = MkEvalOpts False True False False False Nothing [] CBN
+withArgHoles = MkEvalOpts
+    { holesOnly = False
+    , argHolesOnly = True
+    , removeAs = False
+    , evalAll = False
+    , tcInline = False
+    , fuel = Nothing
+    , reduceLimit = []
+    , strategy = CBN
+    }
 
 export
 tcOnly : EvalOpts


### PR DESCRIPTION
This makes it more clear what all the booleans actually mean. Also, if a new field is added or the fields are reordered, then it's easier to not break everything.

<!-- Make your description as clear as possible for reviewers,
feel free to ask questions or bring attention to specific parts
of the code. Before submitting a large diff, ensure that this is
a change that we can accept by opening an issue first and discussing
the proposed change. -->

## Self-check

N/A
<!-- /!\ Please delete sections that do not apply -->

