### PR TITLE
[ chore ] Track PR #3665 in CHANGELOG_NEXT.md

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -10,3 +10,11 @@ should target this file (`CHANGELOG_NEXT`).
 ### Building/Packaging changes
 
 * Fix parsing of capitalised package names containing hyphens.
+
+### Backend changes
+
+#### RefC Backend
+
+* Fixed an issue to do with `alligned_alloc` not existing on older MacOS
+  versions, causing builds targeting PowerPC to fail (#3662).  For these
+  systems, the compiler will now use `posix_memalign`.


### PR DESCRIPTION
# Description

I'm aware updating the changelog is boring, but #3665 was both a fix and a compiler change, so as per the PR template, it should be tracked.
