### PR TITLE
[ libs ] Add rtrim to Data.String

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -48,3 +48,9 @@ should target this file (`CHANGELOG_NEXT`).
 * Fixed an issue to do with `alligned_alloc` not existing on older MacOS
   versions, causing builds targeting PowerPC to fail (#3662).  For these
   systems, the compiler will now use `posix_memalign`.
+
+### Library changes
+
+#### Base
+
+* Added `rtrim` to `Data.String`.

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -34,6 +34,7 @@ GhiOm
 Giuseppe Lomurno
 Guillaume Allais
 Hiroki Hattori
+Ilya Denisyev
 Ilya Rezvov
 Jacob Walters
 Jan de Muijnck-Hughes

--- a/idris2api.ipkg
+++ b/idris2api.ipkg
@@ -200,6 +200,7 @@ modules =
     Libraries.Data.SnocList.SizeOf,
     Libraries.Data.Span,
     Libraries.Data.SparseMatrix,
+    Libraries.Data.String,
     Libraries.Data.String.Builder,
     Libraries.Data.String.Extra,
     Libraries.Data.String.Iterator,

--- a/libs/base/Data/String.idr
+++ b/libs/base/Data/String.idr
@@ -166,10 +166,15 @@ ltrim str with (asList str)
   ltrim ""  | [] = ""
   ltrim str@_ | x :: xs = if isSpace x then ltrim _ | xs else str
 
+||| Trim whitespace on the right of the string
+public export
+rtrim : String -> String
+rtrim = reverse . ltrim . reverse
+
 ||| Trim whitespace on both sides of the string
 public export
 trim : String -> String
-trim = ltrim . reverse . ltrim . reverse
+trim = ltrim . rtrim
 
 ||| Splits the string into a part before the predicate
 ||| returns False and the rest of the string.

--- a/src/Idris/IDEMode/CaseSplit.idr
+++ b/src/Idris/IDEMode/CaseSplit.idr
@@ -26,6 +26,7 @@ import Data.List.Views
 import Data.SnocList
 import Libraries.Data.List.Extra
 import Data.String
+import Libraries.Data.String as L
 import System.File
 import Data.Fin
 
@@ -252,10 +253,6 @@ dropLast updChars with (snocList updChars)
   dropLast [] | Empty = []
   dropLast (xs ++ [x]) | (Snoc x xs rec) = xs
 
-||| Trim whitespace to the right of the string
-rtrim : String -> String
-rtrim = reverse . ltrim . reverse
-
 -- remove last paren
 dropLastParen : SnocList Char -> SnocList Char
 dropLastParen Lin = Lin
@@ -264,7 +261,7 @@ dropLastParen (cs :< c) = dropLastParen cs :< c
 
 ||| Drop the closing parenthesis and any indentation preceding it.
 parenTrim : String -> String
-parenTrim = rtrim . fastPack . cast . dropLastParen . cast . fastUnpack
+parenTrim = L.rtrim . fastPack . cast . dropLastParen . cast . fastUnpack
 
 ||| Drop the number of letters equal to the indentation level to align
 ||| just after the `of`.

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -69,6 +69,7 @@ import Libraries.Data.NameMap
 import Libraries.Data.PosMap
 import Data.Stream
 import Data.String
+import Libraries.Data.String as L
 import Libraries.Data.List.Extra
 import Libraries.Data.SparseMatrix
 import Libraries.Data.String.Extra
@@ -256,20 +257,17 @@ updateFile update
          coreLift_ $ writeFile f (unlines (update (lines content)))
          pure (DisplayEdit emptyDoc)
 
-rtrim : String -> String
-rtrim str = reverse (ltrim (reverse str))
-
 addClause : String -> Nat -> List String -> List String
-addClause c Z [] = rtrim c :: []
+addClause c Z [] = L.rtrim c :: []
 addClause c Z (x :: xs)
     = if all isSpace (unpack x)
-         then rtrim c :: x :: xs
+         then L.rtrim c :: x :: xs
          else x :: addClause c Z xs
 addClause c (S k) (x :: xs) = x :: addClause c k xs
 addClause c (S k) [] = [c]
 
 caseSplit : String -> Nat -> List String -> List String
-caseSplit c Z (x :: xs) = rtrim c :: xs
+caseSplit c Z (x :: xs) = L.rtrim c :: xs
 caseSplit c (S k) (x :: xs) = x :: caseSplit c k xs
 caseSplit c _ [] = [c]
 

--- a/src/Libraries/Data/String.idr
+++ b/src/Libraries/Data/String.idr
@@ -1,0 +1,15 @@
+module Libraries.Data.String
+
+import Data.String
+
+%default total
+
+-- Remove as soon as 0.9.0 is released,
+-- (together with its imports in Idris.IDEMode.CaseSplit and Idris.REPL)
+-- as rtrim is being moved to Data.String in base
+
+||| Trim whitespace on the right of the string
+public export
+rtrim : String -> String
+rtrim = reverse . ltrim . reverse
+


### PR DESCRIPTION
# Description

For some reason, `Data.String` has `ltrim` and `trim`, but not `rtrim`. This PR adds `rtrim` to the module and reimplements `trim` in terms of `ltrim` and `rtrim`.

## Self-check

<!-- /!\ Please delete sections that do not apply -->
- [x] This is my first time contributing, I've carefully read [`CONTRIBUTING.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTING.md)
      and I've updated [`CONTRIBUTORS.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTORS.md) with my name.
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)

