### PR TITLE
[ test ] add regression test for codata unification infinite loop

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -73,6 +73,7 @@ Rodrigo Oliveira
 Rohit Grover
 Rui Barreiro
 Ruslan Feizerahmanov
+spikedoanz
 Sam Phillips
 Simon Chatterjee
 Stefan Höck

--- a/tests/idris2/reg/reg060/CoDataEta.idr
+++ b/tests/idris2/reg/reg060/CoDataEta.idr
@@ -1,0 +1,11 @@
+tabulate : (Nat -> a) -> Stream a
+tabulate f = f 0 :: tabulate (f . S)
+
+index : Stream a -> Nat -> a
+index (x :: _)  Z     = x
+index (_ :: xs) (S n) = index xs n
+
+lemma : (f : Nat -> Nat)
+        -> (k : Nat)
+        -> index (tabulate (f . S)) k = index (tabulate (\m => f (S m))) k
+lemma f k = Refl

--- a/tests/idris2/reg/reg060/expected
+++ b/tests/idris2/reg/reg060/expected
@@ -1,0 +1,1 @@
+1/1: Building CoDataEta (CoDataEta.idr)

--- a/tests/idris2/reg/reg060/run
+++ b/tests/idris2/reg/reg060/run
@@ -1,0 +1,11 @@
+. ../../../testutils.sh
+
+# This test must complete within 5 seconds.
+# Without the fix for codata unification, it would hang indefinitely
+# trying to unify eta-equivalent functions in codata context.
+timeout 5 $idris2 --no-banner --no-color --console-width 0 --check CoDataEta.idr
+
+if [ $? -eq 124 ]; then
+    echo "TIMEOUT: Unification hung (this indicates the bug is present)"
+    exit 1
+fi


### PR DESCRIPTION
## description

adds a regression test `idris2/reg/reg060` that reproduces the infinite loop from #3705 when unifying codata with eta-equivalent functions.

**note: this test currently fails/times out.** it documents the issue and will pass once #3705 is fixed.

## test details

- test `idris2/reg/reg060` reproduces the exact issue from #3705
- includes 5-second timeout to detect hangs
- currently expected to timeout/fail until the fix is implemented

run the test:
```bash
make test only=idris2/reg/reg060
```


## Self-check

<!-- /!\ Please delete sections that do not apply -->
- [x] This is my first time contributing, I've carefully read [`CONTRIBUTING.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTING.md)
      and I've updated [`CONTRIBUTORS.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTORS.md) with my name.

