### PR TITLE
add proper zsh completion

### DIFF
--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -346,10 +346,30 @@ bashCompletionScript fun = let fun' = "_" ++ fun in """
   """
 
 zshCompletionScript : (fun : String) -> String
-zshCompletionScript fun = """
-  autoload -U +X compinit && compinit
-  autoload -U +X bashcompinit && bashcompinit
-  \{ bashCompletionScript fun }
+zshCompletionScript fun = let fun' = "_" ++ fun in """
+  #compdef idris2
+  compdef \{fun'} idris2
+
+  \{fun'}()
+  {
+    PREV_IDX=$((CURRENT-1))
+
+    CURRENT_PARTIAL=$([[ -z ${PREFIX} ]] && echo "--" || echo "${PREFIX}")
+    PREVIOUS="${words[$PREV_IDX]}"
+
+    REPLY=($(idris2 --bash-completion "$CURRENT_PARTIAL" "$PREVIOUS"))
+
+    if [[ -z $REPLY ]]; then
+      _files
+    else
+      _describe 'idris2' REPLY
+    fi
+  }
+
+  # don't run the completion function when being source-ed or eval-ed
+  if [ "$funcstack[1]" = "\{fun'}" ]; then
+    \{fun'}
+  fi
   """
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
# Description
Previously zsh shell completion was set up via the bash compatibility layer. This PR implements a proper zsh completion script. Initially this does not actually change any behavior, but it brings us much closer to taking advantage of some really nice zsh completion features like descriptions of completion options.

## Self-check

<!-- /!\ Please delete sections that do not apply -->
- [ ] This is my first time contributing, I've carefully read [`CONTRIBUTING.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTING.md)
      and I've updated [`CONTRIBUTORS.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTORS.md) with my name.
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)

