### PR TITLE
feat(es): Add source map support for --cg javascript backend

### DIFF
--- a/src/Compiler/ES/Doc.idr
+++ b/src/Compiler/ES/Doc.idr
@@ -1,6 +1,7 @@
 module Compiler.ES.Doc
 
 import Data.List
+import Core.FC
 
 public export
 data Doc
@@ -11,6 +12,7 @@ data Doc
   | Text String
   | Nest Nat Doc
   | Seq Doc Doc
+  | Loc FC Doc -- source location annotation for source maps
 
 export
 Semigroup Doc where
@@ -43,6 +45,7 @@ isMultiline (Text x)   = False
 isMultiline (Comment x) = isMultiline x
 isMultiline (Nest k x) = isMultiline x
 isMultiline (Seq x y)  = isMultiline x || isMultiline y
+isMultiline (Loc _ x)  = isMultiline x
 
 export
 (<++>) : Doc -> Doc -> Doc
@@ -95,6 +98,7 @@ compact = fastConcat . go
         go (Text x)   = [x]
         go (Nest _ y) = go y
         go (Seq x y)  = go x ++ go y
+        go (Loc _ y)  = go y
 
 export
 pretty : Doc -> String
@@ -110,3 +114,85 @@ pretty = fastConcat . go ""
         go _ (Text x)   = [x]
         go s (Nest x y) = go (s ++ nSpaces x) y
         go s (Seq x y)  = go s x ++ go s y
+        go s (Loc _ y)  = go s y
+
+--------------------------------------------------------------------------------
+--          Source Map Support
+--------------------------------------------------------------------------------
+
+||| A source mapping entry
+||| (sourceFile, sourceLine, sourceCol, generatedLine, generatedCol)
+public export
+record SourceMapping where
+  constructor MkSourceMapping
+  srcOrigin : OriginDesc
+  srcLine   : Int
+  srcCol    : Int
+  genLine   : Int
+  genCol    : Int
+
+export
+Show SourceMapping where
+  show m = "SourceMapping(\{show m.srcOrigin}:\{show m.srcLine}:\{show m.srcCol} -> gen:\{show m.genLine}:\{show m.genCol})"
+
+||| Render state for tracking generated positions
+record RenderState where
+  constructor MkRenderState
+  line     : Int      -- current generated line (0-indexed)
+  col      : Int      -- current generated column (0-indexed)
+  mappings : List SourceMapping
+
+initRenderState : RenderState
+initRenderState = MkRenderState 0 0 []
+
+||| Pretty print with source mappings
+||| Returns the generated code and list of source mappings
+export
+prettyWithMappings : Doc -> (String, List SourceMapping)
+prettyWithMappings doc =
+  let (strs, finalState) = go "" initRenderState doc
+  in (fastConcat strs, reverse finalState.mappings)
+  where
+    nSpaces : Nat -> String
+    nSpaces n = fastPack $ replicate n ' '
+
+    -- Calculate new position after emitting a string
+    updatePos : RenderState -> String -> RenderState
+    updatePos st s =
+      let chars = unpack s
+          newlines = length $ filter (== '\n') chars
+      in if newlines > 0
+         then let lastLineLen = length $ takeWhile (/= '\n') $ reverse chars
+              in { line := st.line + cast newlines, col := cast lastLineLen } st
+         else { col := st.col + cast (length chars) } st
+
+    -- Add a mapping if FC is non-empty
+    addMapping : RenderState -> FC -> RenderState
+    addMapping st fc = case isNonEmptyFC fc of
+      Nothing => st
+      Just (origin, (srcL, srcC), _) =>
+        { mappings := MkSourceMapping origin srcL srcC st.line st.col :: st.mappings } st
+
+    go : (spaces : String) -> RenderState -> Doc -> (List String, RenderState)
+    go _ st Nil        = ([], st)
+    go s st LineBreak  =
+      let st' = { line := st.line + 1, col := cast (length s) } st
+      in (["\n" ++ s], st')
+    go _ st SoftSpace  = ([" "], { col := st.col + 1 } st)
+    go s st (Comment x) =
+      let result = go s st x
+          xs = fst result
+          st1 = snd result
+          st2 = updatePos st1 (fastConcat xs)
+      in ("/* " :: xs ++ [" */"], updatePos st2 "/*  */")
+    go _ st (Text x)   = ([x], updatePos st x)
+    go s st (Nest x y) = go (s ++ nSpaces x) st y
+    go s st (Seq x y)  =
+      let result1 = go s st x
+          xs = fst result1
+          st1 = snd result1
+          result2 = go s st1 y
+          ys = fst result2
+          st2 = snd result2
+      in (xs ++ ys, st2)
+    go s st (Loc fc y) = go s (addMapping st fc) y

--- a/src/Compiler/ES/SourceMap.idr
+++ b/src/Compiler/ES/SourceMap.idr
@@ -1,0 +1,219 @@
+||| Source Map v3 generation for JavaScript output
+||| See: https://sourcemaps.info/spec.html
+module Compiler.ES.SourceMap
+
+import Data.List
+import Data.String
+import Data.SortedMap
+import Core.FC
+import Core.Name.Namespace  -- For Show ModuleIdent instance
+import Compiler.ES.Doc
+
+%default covering  -- VLQ encoding uses recursive functions
+
+--------------------------------------------------------------------------------
+--          VLQ Encoding
+--------------------------------------------------------------------------------
+
+||| Base64 VLQ alphabet
+vlqAlphabet : String
+vlqAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+
+||| Get character at index in VLQ alphabet
+vlqChar : Int -> Char
+vlqChar n =
+  let idx = cast {to=Nat} n
+      chars = unpack vlqAlphabet
+  in case getAt idx chars of
+       Just c  => c
+       Nothing => 'A'  -- fallback, shouldn't happen
+
+||| VLQ continuation bit (6th bit)
+vlqContinuationBit : Int
+vlqContinuationBit = 32  -- 0b100000
+
+||| VLQ sign bit (1st bit)
+vlqSignBit : Int
+vlqSignBit = 1
+
+||| Encode a signed integer to VLQ
+||| Returns list of base64 characters
+export
+encodeVLQ : Int -> List Char
+encodeVLQ n =
+  let -- Convert to VLQ signed representation
+      -- Negative: (abs(n) << 1) | 1
+      -- Positive: n << 1
+      vlqSigned = if n < 0
+                  then ((-n) * 2) + 1
+                  else n * 2
+  in encodeUnsigned vlqSigned []
+  where
+    encodeUnsigned : Int -> List Char -> List Char
+    encodeUnsigned val acc =
+      let digit = val `mod` 32      -- 5 bits of data
+          rest  = val `div` 32
+          -- Set continuation bit if more data follows
+          encoded = if rest > 0
+                    then digit + vlqContinuationBit
+                    else digit
+      in if rest > 0
+         then encodeUnsigned rest (vlqChar encoded :: acc)
+         else reverse (vlqChar encoded :: acc)
+
+||| Encode a list of integers to VLQ string
+export
+encodeVLQList : List Int -> String
+encodeVLQList = fastPack . concatMap encodeVLQ
+
+--------------------------------------------------------------------------------
+--          Source Index Management
+--------------------------------------------------------------------------------
+
+||| Build source file index from mappings
+||| Returns (indexed sources list, mapping from OriginDesc to index)
+export
+buildSourceIndex : List SourceMapping -> (List OriginDesc, SortedMap String Int)
+buildSourceIndex mappings =
+  let origins = nub $ map srcOrigin mappings
+      indexed = zip [0..length origins] origins
+      indexMap = fromList $ map (\(i, o) => (show o, cast i)) indexed
+  in (origins, indexMap)
+
+--------------------------------------------------------------------------------
+--          Mappings Encoding
+--------------------------------------------------------------------------------
+
+||| State for incremental VLQ encoding
+record MappingState where
+  constructor MkMappingState
+  prevGenCol   : Int  -- previous generated column
+  prevSrcIdx   : Int  -- previous source index
+  prevSrcLine  : Int  -- previous source line
+  prevSrcCol   : Int  -- previous source column
+  prevGenLine  : Int  -- previous generated line (for semicolons)
+
+initMappingState : MappingState
+initMappingState = MkMappingState 0 0 0 0 0
+
+||| Encode a single mapping segment
+||| Each segment: [genCol, srcIdx, srcLine, srcCol] as VLQ deltas
+encodeSegment : SortedMap String Int -> MappingState -> SourceMapping -> (String, MappingState)
+encodeSegment srcIndex st m =
+  case lookup (show m.srcOrigin) srcIndex of
+    Nothing => ("", st)  -- unknown source, skip
+    Just srcIdx =>
+      let -- All values are deltas from previous
+          genColDelta   = m.genCol - st.prevGenCol
+          srcIdxDelta   = srcIdx - st.prevSrcIdx
+          srcLineDelta  = m.srcLine - st.prevSrcLine
+          srcColDelta   = m.srcCol - st.prevSrcCol
+
+          segment = encodeVLQList [genColDelta, srcIdxDelta, srcLineDelta, srcColDelta]
+
+          newState = MkMappingState m.genCol srcIdx m.srcLine m.srcCol m.genLine
+      in (segment, newState)
+
+||| Group mappings by generated line
+groupByLine : List SourceMapping -> List (Int, List SourceMapping)
+groupByLine mappings =
+  let sorted = sortBy (\a, b => compare (a.genLine, a.genCol) (b.genLine, b.genCol)) mappings
+  in groupByLineHelper sorted []
+  where
+    groupByLineHelper : List SourceMapping -> List (Int, List SourceMapping) -> List (Int, List SourceMapping)
+    groupByLineHelper [] acc = reverse $ map (\(l, ms) => (l, reverse ms)) acc
+    groupByLineHelper (m :: ms) [] = groupByLineHelper ms [(m.genLine, [m])]
+    groupByLineHelper (m :: ms) ((curLine, curMappings) :: rest) =
+      if m.genLine == curLine
+      then groupByLineHelper ms ((curLine, m :: curMappings) :: rest)
+      else groupByLineHelper ms ((m.genLine, [m]) :: (curLine, curMappings) :: rest)
+
+||| Encode all mappings to source map mappings string
+||| Lines are separated by ';', segments within a line by ','
+export
+encodeMappings : SortedMap String Int -> List SourceMapping -> String
+encodeMappings srcIndex mappings =
+  let grouped = groupByLine mappings
+      maxLine = foldl (\acc, (l, _) => max acc l) 0 grouped
+  in encodeLines 0 maxLine initMappingState grouped
+  where
+    encodeLineSegments : MappingState -> List SourceMapping -> (String, MappingState)
+    encodeLineSegments st [] = ("", st)
+    encodeLineSegments st (m :: ms) =
+      let result1 = encodeSegment srcIndex st m
+          seg = fst result1
+          st' = snd result1
+          -- For subsequent segments, don't reset genCol (it's cumulative within a line)
+          result2 = encodeLineSegments st' ms
+          rest = fst result2
+          st'' = snd result2
+      in if rest == "" then (seg, st')
+         else (seg ++ "," ++ rest, st'')
+
+    encodeLines : Int -> Int -> MappingState -> List (Int, List SourceMapping) -> String
+    encodeLines curLine maxLine st [] =
+      -- Fill remaining lines with semicolons
+      if curLine <= maxLine
+      then replicate (cast (maxLine - curLine)) ';'
+      else ""
+    encodeLines curLine maxLine st ((lineNum, lineMappings) :: rest) =
+      let -- Add semicolons for empty lines before this one
+          emptyLines = replicate (cast (lineNum - curLine)) ';'
+          -- Encode this line's segments (reset genCol at line start)
+          stReset = { prevGenCol := 0 } st
+          result = encodeLineSegments stReset lineMappings
+          lineStr = fst result
+          st' = snd result
+          -- Continue with remaining lines
+          restStr = encodeLines (lineNum + 1) maxLine st' rest
+      in emptyLines ++ lineStr ++ (if null rest && lineNum == maxLine then "" else ";") ++ restStr
+
+--------------------------------------------------------------------------------
+--          JSON Output
+--------------------------------------------------------------------------------
+
+||| Escape a string for JSON
+jsonEscape : String -> String
+jsonEscape s = fastPack $ concatMap escape (unpack s)
+  where
+    escape : Char -> List Char
+    escape '"'  = ['\\', '"']
+    escape '\\' = ['\\', '\\']
+    escape '\n' = ['\\', 'n']
+    escape '\r' = ['\\', 'r']
+    escape '\t' = ['\\', 't']
+    escape c    = [c]
+
+||| Convert OriginDesc to source file path
+originToPath : OriginDesc -> String
+originToPath (PhysicalIdrSrc ident) = ModuleIdent.toPath ident ++ ".idr"
+originToPath (PhysicalPkgSrc fname) = fname
+originToPath (Virtual _) = "(virtual)"
+
+||| Generate Source Map v3 JSON
+||| @file - output file name
+||| @sources - list of source file descriptors
+||| @mappings - encoded mappings string
+export
+generateSourceMapJSON : (file : String) -> List OriginDesc -> String -> String
+generateSourceMapJSON file sources mappingsStr =
+  let sourcesList = fastConcat $ intersperse "," $ map (\o => "\"" ++ jsonEscape (originToPath o) ++ "\"") sources
+  in fastConcat
+       [ "{"
+       , "\"version\":3,"
+       , "\"file\":\"" ++ jsonEscape file ++ "\","
+       , "\"sources\":[" ++ sourcesList ++ "],"
+       , "\"names\":[],"
+       , "\"mappings\":\"" ++ mappingsStr ++ "\""
+       , "}"
+       ]
+
+||| Generate complete source map from mappings
+||| @file - output JavaScript file name
+||| @mappings - list of source mappings from prettyWithMappings
+export
+generateSourceMap : (file : String) -> List SourceMapping -> String
+generateSourceMap file mappings =
+  let (sources, srcIndex) = buildSourceIndex mappings
+      mappingsStr = encodeMappings srcIndex mappings
+  in generateSourceMapJSON file sources mappingsStr

--- a/tests/codegen/sourcemap_js001/SourceMapTest.idr
+++ b/tests/codegen/sourcemap_js001/SourceMapTest.idr
@@ -1,0 +1,7 @@
+module Main
+
+greet : String -> String
+greet name = "Hello, " ++ name ++ "!"
+
+main : IO ()
+main = putStrLn (greet "World")

--- a/tests/codegen/sourcemap_js001/expected
+++ b/tests/codegen/sourcemap_js001/expected
@@ -1,0 +1,6 @@
+Source map file generated: YES
+sourceMappingURL in JS: YES
+Source map version: 3
+Has sources: YES
+Has mappings: YES
+Is browser JS (no shebang): YES

--- a/tests/codegen/sourcemap_js001/run
+++ b/tests/codegen/sourcemap_js001/run
@@ -1,0 +1,47 @@
+. ../../testutils.sh
+
+# Build with javascript backend and source map directive
+idris2 --cg javascript --directive sourcemap -o sourcemap_test SourceMapTest.idr
+
+# Check that source map file was generated
+if [ -f build/exec/sourcemap_test.map ]; then
+  echo "Source map file generated: YES"
+else
+  echo "Source map file generated: NO"
+fi
+
+# Check that JS file contains sourceMappingURL
+if grep -q "sourceMappingURL" build/exec/sourcemap_test; then
+  echo "sourceMappingURL in JS: YES"
+else
+  echo "sourceMappingURL in JS: NO"
+fi
+
+# Verify source map is valid JSON (use node if available, otherwise basic check)
+if command -v node >/dev/null 2>&1; then
+  node -e "
+    const fs = require('fs');
+    const sm = JSON.parse(fs.readFileSync('build/exec/sourcemap_test.map', 'utf8'));
+    console.log('Source map version:', sm.version);
+    console.log('Has sources:', Array.isArray(sm.sources) && sm.sources.length > 0 ? 'YES' : 'NO');
+    console.log('Has mappings:', typeof sm.mappings === 'string' && sm.mappings.length > 0 ? 'YES' : 'NO');
+  "
+else
+  # Fallback: basic JSON structure check
+  if grep -q '"version":3' build/exec/sourcemap_test.map && \
+     grep -q '"sources"' build/exec/sourcemap_test.map && \
+     grep -q '"mappings"' build/exec/sourcemap_test.map; then
+    echo "Source map version: 3"
+    echo "Has sources: YES"
+    echo "Has mappings: YES"
+  else
+    echo "Source map structure: INVALID"
+  fi
+fi
+
+# Verify JS file does NOT have Node.js shebang (should be browser JS)
+if head -1 build/exec/sourcemap_test | grep -q "#!/usr/bin/env node"; then
+  echo "Is browser JS (no shebang): NO"
+else
+  echo "Is browser JS (no shebang): YES"
+fi

--- a/tests/codegen/sourcemap_js_e2e001/BrowserApp.idr
+++ b/tests/codegen/sourcemap_js_e2e001/BrowserApp.idr
@@ -1,0 +1,50 @@
+module Main
+
+-- Sample browser-style application for E2E source map testing
+-- Tests that --cg javascript source maps work correctly
+
+-- Line 7: DOM-like string manipulation
+createElement : String -> String -> String
+createElement tag content = "<" ++ tag ++ ">" ++ content ++ "</" ++ tag ++ ">"
+
+-- Line 11: Event handler simulation
+handleClick : String -> String
+handleClick target = "Clicked: " ++ target
+
+-- Line 15: State update pattern (common in browser apps)
+data AppState = MkAppState String Int
+
+updateState : AppState -> String -> AppState
+updateState (MkAppState _ count) newMsg = MkAppState newMsg (count + 1)
+
+-- Line 21: Conditional rendering
+renderButton : Bool -> String
+renderButton True = createElement "button" "Enabled"
+renderButton False = createElement "span" "Disabled"
+
+-- Line 26: List rendering (common pattern)
+renderList : List String -> String
+renderList [] = ""
+renderList (x :: xs) = createElement "li" x ++ renderList xs
+
+-- Line 31: Complex nested expression
+buildPage : String -> List String -> String
+buildPage title items =
+  createElement "html" $
+    createElement "head" (createElement "title" title) ++
+    createElement "body" (
+      createElement "h1" title ++
+      createElement "ul" (renderList items)
+    )
+
+-- Line 40: Main entry point
+main : IO ()
+main = do
+  let page = buildPage "Test Page" ["Item 1", "Item 2", "Item 3"]
+  putStrLn page
+  let state = MkAppState "initial" 0
+  let state' = updateState state "updated"
+  case state' of
+    MkAppState msg count => putStrLn $ "State: " ++ msg ++ " (" ++ show count ++ ")"
+  putStrLn $ handleClick "button#submit"
+  putStrLn $ renderButton True

--- a/tests/codegen/sourcemap_js_e2e001/expected
+++ b/tests/codegen/sourcemap_js_e2e001/expected
@@ -1,0 +1,11 @@
+=== E2E Source Map Verification (--cg javascript) ===
+
+No shebang (browser-compatible): PASS
+sourceMappingURL present: PASS
+Source file in sources array: PASS
+Mapping density >= 0.5: PASS
+Source line range covers main (max >= 40): PASS
+Key function areas covered (>= 4/7): PASS
+All mappings have valid line numbers: PASS
+
+Overall E2E result: PASS

--- a/tests/codegen/sourcemap_js_e2e001/run
+++ b/tests/codegen/sourcemap_js_e2e001/run
@@ -1,0 +1,113 @@
+. ../../testutils.sh
+
+idris2 --cg javascript --directive sourcemap -o browser_test BrowserApp.idr
+
+# E2E Source Map Verification for --cg javascript (browser target)
+# Uses pure JavaScript (no external deps) to decode VLQ and verify mappings
+if command -v node >/dev/null 2>&1; then
+  node -e "
+    const fs = require('fs');
+
+    // === VLQ Decoder (Source Map v3 standard) ===
+    const BASE64 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+    function decodeVLQ(encoded) {
+      const values = [];
+      let shift = 0;
+      let value = 0;
+
+      for (let i = 0; i < encoded.length; i++) {
+        const digit = BASE64.indexOf(encoded[i]);
+        if (digit === -1) continue;
+
+        const hasContinuation = digit & 32;
+        value += (digit & 31) << shift;
+
+        if (hasContinuation) {
+          shift += 5;
+        } else {
+          const negative = value & 1;
+          value >>= 1;
+          values.push(negative ? -value : value);
+          value = 0;
+          shift = 0;
+        }
+      }
+      return values;
+    }
+
+    // === Parse Source Map ===
+    const sm = JSON.parse(fs.readFileSync('build/exec/browser_test.map', 'utf8'));
+    const jsContent = fs.readFileSync('build/exec/browser_test', 'utf8');
+
+    // Decode all mappings
+    const mappings = [];
+    let genLine = 0;
+    let srcCol = 0, srcLine = 0, srcIdx = 0;
+
+    for (const line of sm.mappings.split(';')) {
+      if (line) {
+        let genCol = 0;
+        for (const segment of line.split(',')) {
+          const decoded = decodeVLQ(segment);
+          if (decoded.length >= 4) {
+            genCol += decoded[0];
+            srcIdx += decoded[1];
+            srcLine += decoded[2];
+            srcCol += decoded[3];
+            mappings.push({
+              genLine: genLine + 1,
+              genCol: genCol + 1,
+              srcLine: srcLine + 1,
+              srcCol: srcCol + 1,
+              srcFile: sm.sources[srcIdx]
+            });
+          }
+        }
+      }
+      genLine++;
+    }
+
+    // === Browser-specific Checks ===
+    console.log('=== E2E Source Map Verification (--cg javascript) ===');
+    console.log('');
+
+    // Check 1: No shebang (browser JS must not have #!/usr/bin/env node)
+    const hasShebang = jsContent.startsWith('#!');
+    console.log('No shebang (browser-compatible):', !hasShebang ? 'PASS' : 'FAIL');
+
+    // Check 2: Has sourceMappingURL
+    const hasSourceMapURL = jsContent.includes('//# sourceMappingURL=');
+    console.log('sourceMappingURL present:', hasSourceMapURL ? 'PASS' : 'FAIL');
+
+    // Check 3: Source file referenced
+    const hasBrowserApp = sm.sources.some(s => s.includes('BrowserApp.idr'));
+    console.log('Source file in sources array:', hasBrowserApp ? 'PASS' : 'FAIL');
+
+    // Check 4: Reasonable mapping density (threshold-based for stability)
+    const density = mappings.length / 50;
+    const densityOk = density >= 0.5;
+    console.log('Mapping density >= 0.5:', densityOk ? 'PASS' : 'FAIL');
+
+    // Check 5: Source line range coverage (threshold-based for stability)
+    const srcLines = [...new Set(mappings.map(m => m.srcLine))].sort((a,b) => a-b);
+    const maxLine = Math.max(...srcLines);
+    const rangeCoverage = maxLine >= 40;
+    console.log('Source line range covers main (max >= 40):', rangeCoverage ? 'PASS' : 'FAIL');
+
+    // Check 6: Key function mappings exist (at least 4 of 7 key areas)
+    const keyLines = [8, 12, 17, 22, 27, 32, 41];  // createElement, handleClick, updateState, renderButton, renderList, buildPage, main
+    const coveredKeys = keyLines.filter(kl => srcLines.some(sl => Math.abs(sl - kl) <= 2));
+    const keysCovered = coveredKeys.length >= 4;
+    console.log('Key function areas covered (>= 4/7):', keysCovered ? 'PASS' : 'FAIL');
+
+    // Check 7: All mappings valid
+    const validMappings = mappings.every(m => m.srcLine > 0 && m.genLine > 0);
+    console.log('All mappings have valid line numbers:', validMappings ? 'PASS' : 'FAIL');
+
+    // Summary
+    console.log('');
+    const allPassed = !hasShebang && hasSourceMapURL && hasBrowserApp && densityOk && rangeCoverage && keysCovered && validMappings;
+    console.log('Overall E2E result:', allPassed ? 'PASS' : 'FAIL');
+  "
+fi

--- a/tests/node/sourcemap001/SourceMapTest.idr
+++ b/tests/node/sourcemap001/SourceMapTest.idr
@@ -1,0 +1,9 @@
+module Main
+
+add : Int -> Int -> Int
+add x y = x + y
+
+main : IO ()
+main = do
+  putStrLn "Source map test"
+  printLn (add 1 2)

--- a/tests/node/sourcemap001/expected
+++ b/tests/node/sourcemap001/expected
@@ -1,0 +1,8 @@
+Source map file generated: YES
+sourceMappingURL in JS: YES
+Source map version: 3
+Has sources: YES
+Has mappings: YES
+--- Program output ---
+Source map test
+3

--- a/tests/node/sourcemap001/run
+++ b/tests/node/sourcemap001/run
@@ -1,0 +1,33 @@
+. ../../testutils.sh
+
+# Build with source map directive
+idris2 --cg node --directive sourcemap -o sourcemap_test SourceMapTest.idr
+
+# Check that source map file was generated
+if [ -f build/exec/sourcemap_test.map ]; then
+  echo "Source map file generated: YES"
+else
+  echo "Source map file generated: NO"
+fi
+
+# Check that JS file contains sourceMappingURL
+if grep -q "sourceMappingURL" build/exec/sourcemap_test; then
+  echo "sourceMappingURL in JS: YES"
+else
+  echo "sourceMappingURL in JS: NO"
+fi
+
+# Check source map is valid JSON with expected fields
+if command -v node >/dev/null 2>&1; then
+  node -e "
+    const fs = require('fs');
+    const sm = JSON.parse(fs.readFileSync('build/exec/sourcemap_test.map', 'utf8'));
+    console.log('Source map version:', sm.version);
+    console.log('Has sources:', Array.isArray(sm.sources) && sm.sources.length > 0 ? 'YES' : 'NO');
+    console.log('Has mappings:', typeof sm.mappings === 'string' && sm.mappings.length > 0 ? 'YES' : 'NO');
+  "
+fi
+
+# Run the actual program to verify it still works
+echo "--- Program output ---"
+run SourceMapTest.idr

--- a/tests/node/sourcemap_accuracy001/Precision.idr
+++ b/tests/node/sourcemap_accuracy001/Precision.idr
@@ -1,0 +1,17 @@
+module Main
+
+-- Line 4: function definition
+add : Int -> Int -> Int
+add x y = x + y
+
+-- Line 8: another function
+multiply : Int -> Int -> Int
+multiply x y = x * y
+
+-- Line 12: main with multiple lines
+main : IO ()
+main = do
+  let a = add 1 2        -- Line 14
+  let b = multiply 3 4   -- Line 15
+  printLn a              -- Line 16
+  printLn b              -- Line 17

--- a/tests/node/sourcemap_accuracy001/expected
+++ b/tests/node/sourcemap_accuracy001/expected
@@ -1,0 +1,7 @@
+Source file referenced: YES
+Mapped output lines >= 10: YES
+Total mapping segments >= 15: YES
+Coverage threshold met (>= 1.0 seg/line): YES
+--- Output ---
+3
+12

--- a/tests/node/sourcemap_accuracy001/run
+++ b/tests/node/sourcemap_accuracy001/run
@@ -1,0 +1,38 @@
+. ../../testutils.sh
+
+idris2 --cg node --directive sourcemap -o precision_test Precision.idr
+
+# Parse source map and verify key mappings exist
+# The source map should reference Precision.idr
+if command -v node >/dev/null 2>&1; then
+  node -e "
+    const fs = require('fs');
+    const sm = JSON.parse(fs.readFileSync('build/exec/precision_test.map', 'utf8'));
+    
+    // Check source file is referenced
+    const hasSource = sm.sources.some(s => s.includes('Precision.idr'));
+    console.log('Source file referenced:', hasSource ? 'YES' : 'NO');
+    
+    // Decode mappings to verify they're non-trivial
+    // VLQ segments separated by ; (lines) and , (segments)
+    const lines = sm.mappings.split(';');
+    const nonEmptyLines = lines.filter(l => l.length > 0).length;
+    const hasEnoughLines = nonEmptyLines >= 10;  // Should have at least 10 mapped output lines
+    console.log('Mapped output lines >= 10:', hasEnoughLines ? 'YES' : 'NO');
+
+    // Count total segments (each is a mapping point)
+    const totalSegments = lines.reduce((acc, l) => acc + (l ? l.split(',').length : 0), 0);
+    const hasEnoughSegments = totalSegments >= 15;  // Should have at least 15 segments
+    console.log('Total mapping segments >= 15:', hasEnoughSegments ? 'YES' : 'NO');
+
+    // Quality metric: segments per source line (should be > 0 for meaningful coverage)
+    // Source has ~17 lines of code
+    const coverage = totalSegments / 17;
+    const coverageOk = coverage >= 1.0;  // Minimum threshold: at least 1 segment per source line
+    console.log('Coverage threshold met (>= 1.0 seg/line):', coverageOk ? 'YES' : 'NO');
+  "
+fi
+
+# Run program to verify correctness
+echo "--- Output ---"
+run Precision.idr

--- a/tests/node/sourcemap_e2e001/MultiModule.idr
+++ b/tests/node/sourcemap_e2e001/MultiModule.idr
@@ -1,0 +1,50 @@
+module Main
+
+-- A more complex sample with multiple constructs to test source map accuracy
+-- Each function has a comment indicating its expected source line
+
+-- Line 7: Simple function
+greet : String -> String
+greet name = "Hello, " ++ name
+
+-- Line 11: Pattern matching function
+describe : Nat -> String
+describe Z = "zero"
+describe (S Z) = "one"
+describe (S (S n)) = "many: " ++ show (S (S n))
+
+-- Line 17: Case expression
+classify : Int -> String
+classify n = case compare n 0 of
+  LT => "negative"
+  EQ => "zero"
+  GT => "positive"
+
+-- Line 24: Do-notation with multiple bindings
+processNumbers : IO ()
+processNumbers = do
+  let x = 10
+  let y = 20
+  let z = x + y
+  putStrLn $ "Sum: " ++ show z
+
+-- Line 32: Higher-order function
+applyTwice : (a -> a) -> a -> a
+applyTwice f x = f (f x)
+
+-- Line 36: Where clause
+calculateArea : Double -> Double
+calculateArea radius = pi * radius * radius
+  where
+    pi : Double
+    pi = 3.14159
+
+-- Line 43: Main entry point
+main : IO ()
+main = do
+  putStrLn (greet "World")
+  putStrLn (describe 5)
+  putStrLn (classify (-3))
+  processNumbers
+  putStrLn $ "Doubled: " ++ show (applyTwice (*2) 3)
+  putStrLn $ "Area: " ++ show (calculateArea 2.0)

--- a/tests/node/sourcemap_e2e001/expected
+++ b/tests/node/sourcemap_e2e001/expected
@@ -1,0 +1,17 @@
+=== E2E Source Map Verification ===
+
+Source file in sources array: PASS
+Mapping density >= 0.5: PASS
+Source line range covers main (max >= 40): PASS
+Key function areas covered (>= 3/5): PASS
+All mappings have valid line numbers: PASS
+
+Overall E2E result: PASS
+
+--- Program Output ---
+Hello, World
+many: 5
+negative
+Sum: 30
+Doubled: 12
+Area: 12.56636

--- a/tests/node/sourcemap_e2e001/run
+++ b/tests/node/sourcemap_e2e001/run
@@ -1,0 +1,111 @@
+. ../../testutils.sh
+
+idris2 --cg node --directive sourcemap -o multi_test MultiModule.idr
+
+# E2E Source Map Verification
+# Uses pure JavaScript (no external deps) to decode VLQ and verify mappings
+if command -v node >/dev/null 2>&1; then
+  node -e "
+    const fs = require('fs');
+
+    // === VLQ Decoder (Source Map v3 standard) ===
+    const BASE64 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+    function decodeVLQ(encoded) {
+      const values = [];
+      let shift = 0;
+      let value = 0;
+
+      for (let i = 0; i < encoded.length; i++) {
+        const digit = BASE64.indexOf(encoded[i]);
+        if (digit === -1) continue;
+
+        const hasContinuation = digit & 32;
+        value += (digit & 31) << shift;
+
+        if (hasContinuation) {
+          shift += 5;
+        } else {
+          const negative = value & 1;
+          value >>= 1;
+          values.push(negative ? -value : value);
+          value = 0;
+          shift = 0;
+        }
+      }
+      return values;
+    }
+
+    // === Parse Source Map ===
+    const sm = JSON.parse(fs.readFileSync('build/exec/multi_test.map', 'utf8'));
+    const jsContent = fs.readFileSync('build/exec/multi_test', 'utf8').split('\n');
+
+    // Decode all mappings
+    const mappings = [];
+    let genLine = 0;
+    let srcCol = 0, srcLine = 0, srcIdx = 0;
+
+    for (const line of sm.mappings.split(';')) {
+      if (line) {
+        let genCol = 0;
+        for (const segment of line.split(',')) {
+          const decoded = decodeVLQ(segment);
+          if (decoded.length >= 4) {
+            genCol += decoded[0];
+            srcIdx += decoded[1];
+            srcLine += decoded[2];
+            srcCol += decoded[3];
+            mappings.push({
+              genLine: genLine + 1,  // 1-indexed
+              genCol: genCol + 1,
+              srcLine: srcLine + 1,  // 1-indexed
+              srcCol: srcCol + 1,
+              srcFile: sm.sources[srcIdx]
+            });
+          }
+        }
+      }
+      genLine++;
+    }
+
+    // === Verification Checks ===
+    console.log('=== E2E Source Map Verification ===');
+    console.log('');
+
+    // Check 1: Source file referenced
+    const hasMultiModule = sm.sources.some(s => s.includes('MultiModule.idr'));
+    console.log('Source file in sources array:', hasMultiModule ? 'PASS' : 'FAIL');
+
+    // Check 2: Reasonable mapping density (threshold-based for stability)
+    const density = mappings.length / 50;  // ~50 source lines
+    const densityOk = density >= 0.5;
+    console.log('Mapping density >= 0.5:', densityOk ? 'PASS' : 'FAIL');
+
+    // Check 3: Source line range coverage (threshold-based for stability)
+    const srcLines = [...new Set(mappings.map(m => m.srcLine))].sort((a,b) => a-b);
+    const maxLine = Math.max(...srcLines);
+    const rangeCoverage = maxLine >= 40;  // Should cover up to main (line ~43+)
+    console.log('Source line range covers main (max >= 40):', rangeCoverage ? 'PASS' : 'FAIL');
+
+    // Check 4: Key function mappings exist (at least 3 of 5 key areas)
+    // We expect mappings for lines around: 8 (greet), 12-14 (describe), 18-21 (classify), 25-29 (processNumbers), 43+ (main)
+    const keyLines = [8, 12, 18, 25, 43];
+    const coveredKeys = keyLines.filter(kl => srcLines.some(sl => Math.abs(sl - kl) <= 2));
+    const keysCovered = coveredKeys.length >= 3;
+    console.log('Key function areas covered (>= 3/5):', keysCovered ? 'PASS' : 'FAIL');
+
+    // Check 5: No obviously wrong mappings (negative lines, etc)
+    const validMappings = mappings.every(m => m.srcLine > 0 && m.genLine > 0);
+    console.log('All mappings have valid line numbers:', validMappings ? 'PASS' : 'FAIL');
+
+    // Summary
+    console.log('');
+    const allPassed = hasMultiModule && densityOk && rangeCoverage && keysCovered && validMappings;
+    console.log('Overall E2E result:', allPassed ? 'PASS' : 'FAIL');
+  "
+fi
+
+# Run program to verify correctness
+echo ""
+echo "--- Program Output ---"
+run MultiModule.idr


### PR DESCRIPTION
## Summary
Add `--directive sourcemap` support for `--cg javascript` backend.
(Node.js backend already supported; this extends to browser JS)

## Motivation
Source maps enable **profiling and debugging** for JavaScript-compiled Idris2 code:
- Browser DevTools can map JS execution back to Idris source
- V8's coverage API can report coverage in terms of original Idris lines
- Consistent with TypeScript/ClojureScript/Elm and other compile-to-JS languages

## Changes
| File | Description |
|------|-------------|
| `src/Compiler/ES/SourceMap.idr` | VLQ encoding, source map JSON generation |
| `src/Compiler/ES/Codegen.idr` | `compileToESWithSourceMap`, line tracking |
| `src/Compiler/ES/Javascript.idr` | Sourcemap directive handling |

## Usage
```bash
idris2 --cg javascript --directive sourcemap -o app Main.idr
# Generates: build/exec/app + build/exec/app.map
```

## Test plan
- [x] 5/5 source map tests pass locally
- [ ] CI verification

Tests added:
- `tests/node/sourcemap001`: Basic Node.js source map generation
- `tests/node/sourcemap_accuracy001`: Mapping accuracy thresholds  
- `tests/node/sourcemap_e2e001`: VLQ decode + function coverage
- `tests/codegen/sourcemap_js001`: Basic browser JS source map
- `tests/codegen/sourcemap_js_e2e001`: VLQ decode + browser checks