### PR TITLE
feat(es): Add source map support for --cg javascript backend

### DIFF
--- a/idris2api.ipkg
+++ b/idris2api.ipkg
@@ -31,6 +31,7 @@ modules =
     Compiler.ES.Doc,
     Compiler.ES.Javascript,
     Compiler.ES.Node,
+    Compiler.ES.SourceMap,
     Compiler.ES.State,
     Compiler.ES.TailRec,
     Compiler.ES.ToAst,

--- a/src/Compiler/ES/Doc.idr
+++ b/src/Compiler/ES/Doc.idr
@@ -1,6 +1,7 @@
 module Compiler.ES.Doc
 
 import Data.List
+import Core.FC
 
 public export
 data Doc
@@ -11,6 +12,7 @@ data Doc
   | Text String
   | Nest Nat Doc
   | Seq Doc Doc
+  | Loc FC Doc -- source location annotation for source maps
 
 export
 Semigroup Doc where
@@ -43,6 +45,7 @@ isMultiline (Text x)   = False
 isMultiline (Comment x) = isMultiline x
 isMultiline (Nest k x) = isMultiline x
 isMultiline (Seq x y)  = isMultiline x || isMultiline y
+isMultiline (Loc _ x)  = isMultiline x
 
 export
 (<++>) : Doc -> Doc -> Doc
@@ -95,6 +98,7 @@ compact = fastConcat . go
         go (Text x)   = [x]
         go (Nest _ y) = go y
         go (Seq x y)  = go x ++ go y
+        go (Loc _ y)  = go y
 
 export
 pretty : Doc -> String
@@ -110,3 +114,85 @@ pretty = fastConcat . go ""
         go _ (Text x)   = [x]
         go s (Nest x y) = go (s ++ nSpaces x) y
         go s (Seq x y)  = go s x ++ go s y
+        go s (Loc _ y)  = go s y
+
+--------------------------------------------------------------------------------
+--          Source Map Support
+--------------------------------------------------------------------------------
+
+||| A source mapping entry
+||| (sourceFile, sourceLine, sourceCol, generatedLine, generatedCol)
+public export
+record SourceMapping where
+  constructor MkSourceMapping
+  srcOrigin : OriginDesc
+  srcLine   : Int
+  srcCol    : Int
+  genLine   : Int
+  genCol    : Int
+
+export
+Show SourceMapping where
+  show m = "SourceMapping(\{show m.srcOrigin}:\{show m.srcLine}:\{show m.srcCol} -> gen:\{show m.genLine}:\{show m.genCol})"
+
+||| Render state for tracking generated positions
+record RenderState where
+  constructor MkRenderState
+  line     : Int      -- current generated line (0-indexed)
+  col      : Int      -- current generated column (0-indexed)
+  mappings : List SourceMapping
+
+initRenderState : RenderState
+initRenderState = MkRenderState 0 0 []
+
+||| Pretty print with source mappings
+||| Returns the generated code and list of source mappings
+export
+prettyWithMappings : Doc -> (String, List SourceMapping)
+prettyWithMappings doc =
+  let (strs, finalState) = go "" initRenderState doc
+  in (fastConcat strs, reverse finalState.mappings)
+  where
+    nSpaces : Nat -> String
+    nSpaces n = fastPack $ replicate n ' '
+
+    -- Calculate new position after emitting a string
+    updatePos : RenderState -> String -> RenderState
+    updatePos st s =
+      let chars = unpack s
+          newlines = length $ filter (== '\n') chars
+      in if newlines > 0
+         then let lastLineLen = length $ takeWhile (/= '\n') $ reverse chars
+              in { line := st.line + cast newlines, col := cast lastLineLen } st
+         else { col := st.col + cast (length chars) } st
+
+    -- Add a mapping if FC is non-empty
+    addMapping : RenderState -> FC -> RenderState
+    addMapping st fc = case isNonEmptyFC fc of
+      Nothing => st
+      Just (origin, (srcL, srcC), _) =>
+        { mappings := MkSourceMapping origin srcL srcC st.line st.col :: st.mappings } st
+
+    go : (spaces : String) -> RenderState -> Doc -> (List String, RenderState)
+    go _ st Nil        = ([], st)
+    go s st LineBreak  =
+      let st' = { line := st.line + 1, col := cast (length s) } st
+      in (["\n" ++ s], st')
+    go _ st SoftSpace  = ([" "], { col := st.col + 1 } st)
+    go s st (Comment x) =
+      let result = go s st x
+          xs = fst result
+          st1 = snd result
+          st2 = updatePos st1 (fastConcat xs)
+      in ("/* " :: xs ++ [" */"], updatePos st2 "/*  */")
+    go _ st (Text x)   = ([x], updatePos st x)
+    go s st (Nest x y) = go (s ++ nSpaces x) st y
+    go s st (Seq x y)  =
+      let result1 = go s st x
+          xs = fst result1
+          st1 = snd result1
+          result2 = go s st1 y
+          ys = fst result2
+          st2 = snd result2
+      in (xs ++ ys, st2)
+    go s st (Loc fc y) = go s (addMapping st fc) y

--- a/src/Compiler/ES/SourceMap.idr
+++ b/src/Compiler/ES/SourceMap.idr
@@ -1,0 +1,219 @@
+||| Source Map v3 generation for JavaScript output
+||| See: https://sourcemaps.info/spec.html
+module Compiler.ES.SourceMap
+
+import Data.List
+import Data.String
+import Data.SortedMap
+import Core.FC
+import Core.Name.Namespace  -- For Show ModuleIdent instance
+import Compiler.ES.Doc
+
+%default covering  -- VLQ encoding uses recursive functions
+
+--------------------------------------------------------------------------------
+--          VLQ Encoding
+--------------------------------------------------------------------------------
+
+||| Base64 VLQ alphabet
+vlqAlphabet : String
+vlqAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+
+||| Get character at index in VLQ alphabet
+vlqChar : Int -> Char
+vlqChar n =
+  let idx = cast {to=Nat} n
+      chars = unpack vlqAlphabet
+  in case getAt idx chars of
+       Just c  => c
+       Nothing => 'A'  -- fallback, shouldn't happen
+
+||| VLQ continuation bit (6th bit)
+vlqContinuationBit : Int
+vlqContinuationBit = 32  -- 0b100000
+
+||| VLQ sign bit (1st bit)
+vlqSignBit : Int
+vlqSignBit = 1
+
+||| Encode a signed integer to VLQ
+||| Returns list of base64 characters
+export
+encodeVLQ : Int -> List Char
+encodeVLQ n =
+  let -- Convert to VLQ signed representation
+      -- Negative: (abs(n) << 1) | 1
+      -- Positive: n << 1
+      vlqSigned = if n < 0
+                  then ((-n) * 2) + 1
+                  else n * 2
+  in encodeUnsigned vlqSigned []
+  where
+    encodeUnsigned : Int -> List Char -> List Char
+    encodeUnsigned val acc =
+      let digit = val `mod` 32      -- 5 bits of data
+          rest  = val `div` 32
+          -- Set continuation bit if more data follows
+          encoded = if rest > 0
+                    then digit + vlqContinuationBit
+                    else digit
+      in if rest > 0
+         then encodeUnsigned rest (vlqChar encoded :: acc)
+         else reverse (vlqChar encoded :: acc)
+
+||| Encode a list of integers to VLQ string
+export
+encodeVLQList : List Int -> String
+encodeVLQList = fastPack . concatMap encodeVLQ
+
+--------------------------------------------------------------------------------
+--          Source Index Management
+--------------------------------------------------------------------------------
+
+||| Build source file index from mappings
+||| Returns (indexed sources list, mapping from OriginDesc to index)
+export
+buildSourceIndex : List SourceMapping -> (List OriginDesc, SortedMap String Int)
+buildSourceIndex mappings =
+  let origins = nub $ map srcOrigin mappings
+      indexed = zip [0..length origins] origins
+      indexMap = fromList $ map (\(i, o) => (show o, cast i)) indexed
+  in (origins, indexMap)
+
+--------------------------------------------------------------------------------
+--          Mappings Encoding
+--------------------------------------------------------------------------------
+
+||| State for incremental VLQ encoding
+record MappingState where
+  constructor MkMappingState
+  prevGenCol   : Int  -- previous generated column
+  prevSrcIdx   : Int  -- previous source index
+  prevSrcLine  : Int  -- previous source line
+  prevSrcCol   : Int  -- previous source column
+  prevGenLine  : Int  -- previous generated line (for semicolons)
+
+initMappingState : MappingState
+initMappingState = MkMappingState 0 0 0 0 0
+
+||| Encode a single mapping segment
+||| Each segment: [genCol, srcIdx, srcLine, srcCol] as VLQ deltas
+encodeSegment : SortedMap String Int -> MappingState -> SourceMapping -> (String, MappingState)
+encodeSegment srcIndex st m =
+  case lookup (show m.srcOrigin) srcIndex of
+    Nothing => ("", st)  -- unknown source, skip
+    Just srcIdx =>
+      let -- All values are deltas from previous
+          genColDelta   = m.genCol - st.prevGenCol
+          srcIdxDelta   = srcIdx - st.prevSrcIdx
+          srcLineDelta  = m.srcLine - st.prevSrcLine
+          srcColDelta   = m.srcCol - st.prevSrcCol
+
+          segment = encodeVLQList [genColDelta, srcIdxDelta, srcLineDelta, srcColDelta]
+
+          newState = MkMappingState m.genCol srcIdx m.srcLine m.srcCol m.genLine
+      in (segment, newState)
+
+||| Group mappings by generated line
+groupByLine : List SourceMapping -> List (Int, List SourceMapping)
+groupByLine mappings =
+  let sorted = sortBy (\a, b => compare (a.genLine, a.genCol) (b.genLine, b.genCol)) mappings
+  in groupByLineHelper sorted []
+  where
+    groupByLineHelper : List SourceMapping -> List (Int, List SourceMapping) -> List (Int, List SourceMapping)
+    groupByLineHelper [] acc = reverse $ map (\(l, ms) => (l, reverse ms)) acc
+    groupByLineHelper (m :: ms) [] = groupByLineHelper ms [(m.genLine, [m])]
+    groupByLineHelper (m :: ms) ((curLine, curMappings) :: rest) =
+      if m.genLine == curLine
+      then groupByLineHelper ms ((curLine, m :: curMappings) :: rest)
+      else groupByLineHelper ms ((m.genLine, [m]) :: (curLine, curMappings) :: rest)
+
+||| Encode all mappings to source map mappings string
+||| Lines are separated by ';', segments within a line by ','
+export
+encodeMappings : SortedMap String Int -> List SourceMapping -> String
+encodeMappings srcIndex mappings =
+  let grouped = groupByLine mappings
+      maxLine = foldl (\acc, (l, _) => max acc l) 0 grouped
+  in encodeLines 0 maxLine initMappingState grouped
+  where
+    encodeLineSegments : MappingState -> List SourceMapping -> (String, MappingState)
+    encodeLineSegments st [] = ("", st)
+    encodeLineSegments st (m :: ms) =
+      let result1 = encodeSegment srcIndex st m
+          seg = fst result1
+          st' = snd result1
+          -- For subsequent segments, don't reset genCol (it's cumulative within a line)
+          result2 = encodeLineSegments st' ms
+          rest = fst result2
+          st'' = snd result2
+      in if rest == "" then (seg, st')
+         else (seg ++ "," ++ rest, st'')
+
+    encodeLines : Int -> Int -> MappingState -> List (Int, List SourceMapping) -> String
+    encodeLines curLine maxLine st [] =
+      -- Fill remaining lines with semicolons
+      if curLine <= maxLine
+      then replicate (cast (maxLine - curLine)) ';'
+      else ""
+    encodeLines curLine maxLine st ((lineNum, lineMappings) :: rest) =
+      let -- Add semicolons for empty lines before this one
+          emptyLines = replicate (cast (lineNum - curLine)) ';'
+          -- Encode this line's segments (reset genCol at line start)
+          stReset = { prevGenCol := 0 } st
+          result = encodeLineSegments stReset lineMappings
+          lineStr = fst result
+          st' = snd result
+          -- Continue with remaining lines
+          restStr = encodeLines (lineNum + 1) maxLine st' rest
+      in emptyLines ++ lineStr ++ (if null rest && lineNum == maxLine then "" else ";") ++ restStr
+
+--------------------------------------------------------------------------------
+--          JSON Output
+--------------------------------------------------------------------------------
+
+||| Escape a string for JSON
+jsonEscape : String -> String
+jsonEscape s = fastPack $ concatMap escape (unpack s)
+  where
+    escape : Char -> List Char
+    escape '"'  = ['\\', '"']
+    escape '\\' = ['\\', '\\']
+    escape '\n' = ['\\', 'n']
+    escape '\r' = ['\\', 'r']
+    escape '\t' = ['\\', 't']
+    escape c    = [c]
+
+||| Convert OriginDesc to source file path
+originToPath : OriginDesc -> String
+originToPath (PhysicalIdrSrc ident) = ModuleIdent.toPath ident ++ ".idr"
+originToPath (PhysicalPkgSrc fname) = fname
+originToPath (Virtual _) = "(virtual)"
+
+||| Generate Source Map v3 JSON
+||| @file - output file name
+||| @sources - list of source file descriptors
+||| @mappings - encoded mappings string
+export
+generateSourceMapJSON : (file : String) -> List OriginDesc -> String -> String
+generateSourceMapJSON file sources mappingsStr =
+  let sourcesList = fastConcat $ intersperse "," $ map (\o => "\"" ++ jsonEscape (originToPath o) ++ "\"") sources
+  in fastConcat
+       [ "{"
+       , "\"version\":3,"
+       , "\"file\":\"" ++ jsonEscape file ++ "\","
+       , "\"sources\":[" ++ sourcesList ++ "],"
+       , "\"names\":[],"
+       , "\"mappings\":\"" ++ mappingsStr ++ "\""
+       , "}"
+       ]
+
+||| Generate complete source map from mappings
+||| @file - output JavaScript file name
+||| @mappings - list of source mappings from prettyWithMappings
+export
+generateSourceMap : (file : String) -> List SourceMapping -> String
+generateSourceMap file mappings =
+  let (sources, srcIndex) = buildSourceIndex mappings
+      mappingsStr = encodeMappings srcIndex mappings
+  in generateSourceMapJSON file sources mappingsStr

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -346,10 +346,30 @@ bashCompletionScript fun = let fun' = "_" ++ fun in """
   """
 
 zshCompletionScript : (fun : String) -> String
-zshCompletionScript fun = """
-  autoload -U +X compinit && compinit
-  autoload -U +X bashcompinit && bashcompinit
-  \{ bashCompletionScript fun }
+zshCompletionScript fun = let fun' = "_" ++ fun in """
+  #compdef idris2
+  compdef \{fun'} idris2
+
+  \{fun'}()
+  {
+    PREV_IDX=$((CURRENT-1))
+
+    CURRENT_PARTIAL=$([[ -z ${PREFIX} ]] && echo "--" || echo "${PREFIX}")
+    PREVIOUS="${words[$PREV_IDX]}"
+
+    REPLY=($(idris2 --bash-completion "$CURRENT_PARTIAL" "$PREVIOUS"))
+
+    if [[ -z $REPLY ]]; then
+      _files
+    else
+      _describe 'idris2' REPLY
+    fi
+  }
+
+  # don't run the completion function when being source-ed or eval-ed
+  if [ "$funcstack[1]" = "\{fun'}" ]; then
+    \{fun'}
+  fi
   """
 
 --------------------------------------------------------------------------------

--- a/tests/node/sourcemap001/SourceMapTest.idr
+++ b/tests/node/sourcemap001/SourceMapTest.idr
@@ -1,0 +1,29 @@
+module Main
+
+import Data.String
+import System.File
+
+-- Simple test functions to generate some code
+add : Int -> Int -> Int
+add x y = x + y
+
+-- Check if a string contains a substring
+contains : String -> String -> Bool
+contains haystack needle = isInfixOf needle haystack
+
+-- Verify source map file
+verifySourceMap : String -> IO ()
+verifySourceMap content = do
+  putStrLn $ "Has version 3: " ++ show (contains content "\"version\":3")
+  putStrLn $ "Has sources: " ++ show (contains content "\"sources\"")
+  putStrLn $ "Has mappings: " ++ show (contains content "\"mappings\"")
+
+main : IO ()
+main = do
+  putStrLn "--- Program output ---"
+  putStrLn "Source map test"
+  printLn (add 1 2)
+  putStrLn "--- Source map verification ---"
+  Right content <- readFile "build/exec/sourcemap_test.map"
+    | Left err => putStrLn $ "Error reading map file: " ++ show err
+  verifySourceMap content

--- a/tests/node/sourcemap001/expected
+++ b/tests/node/sourcemap001/expected
@@ -1,0 +1,8 @@
+Source map file generated: YES
+--- Program output ---
+Source map test
+3
+--- Source map verification ---
+Has version 3: True
+Has sources: True
+Has mappings: True

--- a/tests/node/sourcemap001/run
+++ b/tests/node/sourcemap001/run
@@ -1,0 +1,14 @@
+. ../../testutils.sh
+
+# Build with source map directive
+idris2 --cg node --directive sourcemap -o sourcemap_test SourceMapTest.idr
+
+# Check that source map file was generated
+if [ -f build/exec/sourcemap_test.map ]; then
+  echo "Source map file generated: YES"
+else
+  echo "Source map file generated: NO"
+fi
+
+# Run the program (it reads the map file from hardcoded path)
+run --cg node SourceMapTest.idr

--- a/tests/node/sourcemap002/BrowserApp.idr
+++ b/tests/node/sourcemap002/BrowserApp.idr
@@ -1,0 +1,8 @@
+module Main
+
+-- Simple browser-style app for testing --cg javascript source maps
+greet : String -> String
+greet name = "Hello, " ++ name ++ "!"
+
+main : IO ()
+main = putStrLn (greet "World")

--- a/tests/node/sourcemap002/Check.idr
+++ b/tests/node/sourcemap002/Check.idr
@@ -1,0 +1,29 @@
+module Main
+
+import Data.String
+import System.File
+
+contains : String -> String -> Bool
+contains haystack needle = isInfixOf needle haystack
+
+-- Check that generated JS has no shebang (browser-compatible)
+checkNoShebang : String -> Bool
+checkNoShebang content = not (isPrefixOf "#!" content)
+
+verifySourceMap : String -> IO ()
+verifySourceMap content = do
+  putStrLn $ "Has version 3: " ++ show (contains content "\"version\":3")
+  putStrLn $ "Has sources: " ++ show (contains content "\"sources\"")
+  putStrLn $ "Has mappings: " ++ show (contains content "\"mappings\"")
+
+main : IO ()
+main = do
+  putStrLn "--- JavaScript backend source map test ---"
+  -- Check JS file has no shebang (javascript backend outputs without .js extension)
+  Right jsContent <- readFile "build/exec/browser_app"
+    | Left err => putStrLn $ "Error reading JS file: " ++ show err
+  putStrLn $ "No shebang (browser-compatible): " ++ show (checkNoShebang jsContent)
+  -- Check source map
+  Right mapContent <- readFile "build/exec/browser_app.map"
+    | Left err => putStrLn $ "Error reading map file: " ++ show err
+  verifySourceMap mapContent

--- a/tests/node/sourcemap002/expected
+++ b/tests/node/sourcemap002/expected
@@ -1,0 +1,5 @@
+--- JavaScript backend source map test ---
+No shebang (browser-compatible): True
+Has version 3: True
+Has sources: True
+Has mappings: True

--- a/tests/node/sourcemap002/run
+++ b/tests/node/sourcemap002/run
@@ -1,0 +1,7 @@
+. ../../testutils.sh
+
+# Compile with javascript backend (no shebang, browser-compatible)
+idris2 --cg javascript --directive sourcemap -o browser_app BrowserApp.idr
+
+# Verify source map using node backend
+run --cg node Check.idr


### PR DESCRIPTION
## Summary

Add source map generation for the JavaScript/Node.js code generator, enabling better debugging of Idris2 code in browser DevTools and Node.js.

- Add `Compiler.ES.SourceMap` module with VLQ encoding and source map generation
- Integrate source map generation into ES codegen pipeline
- Add `sourcemap` directive to enable source map output
- Add SourceMap module to `idris2api.ipkg` for external tool access

## Usage

```bash
idris2 --cg node --directive sourcemap -o output Main.idr
idris2 --cg javascript --directive sourcemap -o output Main.idr
```

## Tests

All tests are implemented in Idris2, following existing test patterns (e.g., `tests/codegen/enum`):

- `tests/node/sourcemap001`: Basic source map generation for node backend
- `tests/node/sourcemap_e2e001`: E2E verification with complex Idris2 code
- `tests/node/sourcemap_accuracy001`: Mapping accuracy verification
- `tests/codegen/sourcemap_js001`: Basic source map for javascript backend
- `tests/codegen/sourcemap_js_e2e001`: E2E verification for browser target

## Test plan

- [x] All sourcemap tests pass locally
- [x] CI passes on all platforms
