### PR TITLE
Change idris-lang.org to www.idris-lang.org in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Documentation Status](https://readthedocs.org/projects/idris2/badge/?version=latest)](https://idris2.readthedocs.io/en/latest/?badge=latest)
 [![Build Status](https://github.com/idris-lang/Idris2/actions/workflows/ci-idris2-and-libs.yml/badge.svg?branch=main)](https://github.com/idris-lang/Idris2/actions/workflows/ci-idris2-and-libs.yml?query=branch%3Amain)
 
-[Idris 2](https://idris-lang.org/) is a purely functional programming language
+[Idris 2](https://www.idris-lang.org/) is a purely functional programming language
 with first class types.
 
 For installation instructions, see [INSTALL.md](INSTALL.md).

--- a/www/source/index.md
+++ b/www/source/index.md
@@ -50,7 +50,7 @@ keywords (`module`, `:`, `=`, `private`, etc.) and hopefully get helpful informa
 
 Here are links to the automatically generated documentation for the libraries shipped with the
 **bleeding edge** version of the compiler. The documentation for the latest **released** version
-is available on the [idris-lang.org](https://www.idris-lang.org/pages/documentation.html) site.
+is available on the [www.idris-lang.org](https://www.idris-lang.org/pages/documentation.html) site.
 
 #### [Prelude](https://idris-lang.github.io/Idris2/prelude)
 


### PR DESCRIPTION
The DNS records/github pages config for `idris-lang.org` seems to be wrong, so the wrong TLS certificate is served for `idris-lang.org`. Using `www.idris-lang.org` avoids this issue. Also `www.idris-lang.org` is the canonical domain, since `idris-lang.org` redirects to `www.idris-lang.org`.

The ideal solution would be to fix `idris-lang.org`, but I don't know how to do that, so in the mean time this will help avoid some confusion for new-comers.

## Self-check

