### PR TITLE
[ ci ] Update `ci-bootstrap.yml`

### DIFF
--- a/.github/workflows/ci-bootstrap.yml
+++ b/.github/workflows/ci-bootstrap.yml
@@ -1,30 +1,23 @@
-######################################################################
-# Unlike the main yml file this uses the LTS version of chezscheme,
-# not the hirsute one. The main purpose is to make sure that
-# `make bootstrap` does not rely on `__collect_safe`.
-#
-# Note that we are *not* running on ubuntu-latest so this needs manual
-# upgrades if we want to jump on a newer github actions environment.
-######################################################################
+# Check bootstrap with the minimum supported Chez Scheme version.
 
 name: Bootstrap
 
+env:
+  MIN_CHEZ_VERSION: 9.5.1
+
 on:
   push:
-    paths:
+    paths: &paths
       - 'bootstrap/idris2_app/idris2.ss'
       - '.github/workflows/ci-bootstrap.yml'
   pull_request:
-    paths:
-      - 'bootstrap/idris2_app/idris2.ss'
-      - '.github/workflows/ci-bootstrap.yml'
+    paths: *paths
 
 jobs:
-
   initialise:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-      - name: Checkout Project
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           # for pull_request so we can do HEAD^2
@@ -45,19 +38,31 @@ jobs:
 
   bootstrap:
     needs: initialise
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: |
       !contains(needs.initialise.outputs.commit_message, '[ci: skip]')
     env:
       IDRIS2_CG: chez
       SCHEME: scheme
     steps:
-      - name: Checkout
+      - name: Checkout project
         uses: actions/checkout@v4
-      - name: Install build dependencies (LTS versions)
+
+      - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y chezscheme
-          echo "$HOME/.idris2/bin" >> "$GITHUB_PATH"
+          sudo apt-get install -y uuid-dev
+
+      - name: Build and Install Chez Scheme
+        run: |
+          git clone --depth 1 --branch "v${MIN_CHEZ_VERSION}" https://github.com/cisco/ChezScheme.git
+          cd ChezScheme
+          # Newer GCC reports maybe-uninitialized in Chez 9.5.1
+          ./configure --threads --disable-x11 CFLAGS=-Wno-error=maybe-uninitialized
+          make -j$(nproc)
+          sudo make install
+          cd ..
+          rm -rf ChezScheme
+
       - name: Build bootstrap
         run: make bootstrap

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,7 +43,10 @@ nix profile install github:idris-lang/Idris2
 The easiest way to install from source is via the existing generated Scheme
 code. The requirements are:
 
-- A Scheme compiler; either Chez Scheme (default), or Racket.
+- A Scheme compiler. One of
+  - Chez Scheme (default).\
+    Version `9.5.1` or newer; on Apple Silicon `10.0.0` or newer.
+  - Racket.
 - `bash`, `GNU make`, `gcc` or `clang`, `sha256sum` and `GMP`.  On Linux, you probably already
   have these.  On macOS and major BSD flavours, you can install them using a
   package manager: for instance, on macOS, you can install with the


### PR DESCRIPTION
# Description

[ci-bootstrap](https://github.com/idris-lang/Idris2/blob/main/.github/workflows/ci-bootstrap.yml) currently runs on the deprecated `ubuntu-20.04` runner, which [was retired some time ago](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/).

The original purpose of this job was to ensure we could build with older Chez Scheme versions from before support for `__collect_safe`. That check is no longer relevant: `__collect_safe` landed in Chez Scheme 9.5.1, and the same release introduced `collect-rendezvous` ([Chez release notes](https://cisco.github.io/ChezScheme/release_notes/v10.3.0/release_notes.html), 2.81 and 2.82), which Idris 2 now relies on.
https://github.com/idris-lang/Idris2/blob/b714fcaeaa7a91fae36ccee31bde250fa4858150/src/Compiler/Scheme/Chez.idr#L109

This PR updates the workflow to run on a supported runner and repurposes it to test bootstrapping against the minimum supported Chez Scheme version.