### PR TITLE
[ fix ] Remove trailing whitespaces in errors

### DIFF
--- a/src/Libraries/Text/PrettyPrint/Prettyprinter/Doc.idr
+++ b/src/Libraries/Text/PrettyPrint/Prettyprinter/Doc.idr
@@ -137,6 +137,8 @@ export infixr 6 <++>
 ||| Concatenates two documents with a space in between.
 export
 (<++>) : Doc ann -> Doc ann -> Doc ann
+Empty <++> y = y
+x <++> Empty = x
 x <++> y = x <+> Chara ' ' <+> y
 
 ||| The empty document behaves like `pretty ""`, so it has a height of 1.

--- a/tests/chez/chez006/expected
+++ b/tests/chez/chez006/expected
@@ -19,7 +19,7 @@ Error: While processing left hand side of strangeId. Can't match on Nat (Erased 
 TypeCase2:5:14--5:17
  1 | data Bar = MkBar
  2 | data Baz = MkBaz
- 3 | 
+ 3 |
  4 | strangeId : a -> a
  5 | strangeId {a=Nat} x = x+1
                   ^^^
@@ -29,7 +29,7 @@ Error: While processing left hand side of foo. Can't match on Nat (Erased argume
 TypeCase2:9:5--9:8
  5 | strangeId {a=Nat} x = x+1
  6 | strangeId x = x
- 7 | 
+ 7 |
  8 | foo : (0 x : Type) -> String
  9 | foo Nat = "Nat"
          ^^^

--- a/tests/idris2/basic/basic003/expected
+++ b/tests/idris2/basic/basic003/expected
@@ -8,7 +8,7 @@ Error: While processing right hand side of keepUnique. Ambiguous elaboration. Po
 Ambig2:26:21--26:27
  22 |   export
  23 |   fromList : List a -> Set a
- 24 | 
+ 24 |
  25 | keepUnique : List b -> List b
  26 | keepUnique {b} xs = toList (fromList xs)
                           ^^^^^^

--- a/tests/idris2/basic/basic014/expected
+++ b/tests/idris2/basic/basic014/expected
@@ -3,7 +3,7 @@ Error: While processing right hand side of wrongCommutes. Rewriting by m + k = k
 
 Rewrite:15:25--15:57
  11 | plusCommutes (S k) m = rewrite plusCommutes k m in sym (plusnSm m k)
- 12 | 
+ 12 |
  13 | wrongCommutes : (n, m : Nat) -> n + m = m + n
  14 | wrongCommutes Z m = sym (plusnZ m)
  15 | wrongCommutes (S k) m = rewrite plusCommutes m k in ?bar
@@ -13,7 +13,7 @@ Error: While processing right hand side of wrongCommutes2. Nat is not a rewrite 
 
 Rewrite:19:26--19:43
  15 | wrongCommutes (S k) m = rewrite plusCommutes m k in ?bar
- 16 | 
+ 16 |
  17 | wrongCommutes2 : (n, m : Nat) -> n + m = m + n
  18 | wrongCommutes2 Z m = sym (plusnZ m)
  19 | wrongCommutes2 (S k) m = rewrite m in ?bar

--- a/tests/idris2/basic/basic016/expected
+++ b/tests/idris2/basic/basic016/expected
@@ -8,7 +8,7 @@ Mismatch between: Nat and Integer.
 Eta:14:10--14:14
  10 | etaGood3: (f : a -> b) -> f = (\x => f x)
  11 | etaGood3 f = Refl
- 12 | 
+ 12 |
  13 | etaBad : MkTest = (\x : Nat => \y => MkTest ? ?)
  14 | etaBad = Refl
                ^^^^
@@ -34,7 +34,7 @@ Mismatch between: a and Nat.
 Eta2:5:44--5:48
  1 | test : Builtin.Equal S (\x : a => S ?)
  2 | test = Refl
- 3 | 
+ 3 |
  4 | test2 : ?
  5 | test2 = {a : _} -> the (S = \x : a => S _) Refl
                                                 ^^^^

--- a/tests/idris2/basic/basic018/expected
+++ b/tests/idris2/basic/basic018/expected
@@ -4,7 +4,7 @@ Error: While processing right hand side of bar. Can't find an implementation for
 Fin:34:7--34:8
  30 | foo : Fin 5
  31 | foo = 3
- 32 | 
+ 32 |
  33 | bar : Fin 5
  34 | bar = 8
             ^

--- a/tests/idris2/basic/basic022/expected
+++ b/tests/idris2/basic/basic022/expected
@@ -4,7 +4,7 @@ Error: While processing left hand side of bad. Can't match on False (Erased argu
 Erase:5:5--5:10
  1 | myReplace : forall p . (0 rule : x = y) -> (1 val : p y) -> p x
  2 | myReplace Refl prf = prf
- 3 | 
+ 3 |
  4 | bad : (0 x : Bool) -> Bool
  5 | bad False = True
          ^^^^^
@@ -13,7 +13,7 @@ Error: While processing left hand side of minusBad. Can't match on LeZ (Erased a
 
 Erase:19:18--19:21
  15 | minus (S k) (S j) (LeS p) = minus k j p
- 16 | 
+ 16 |
  17 | -- y is used in the run time case tree, so erasure not okay
  18 | minusBad : (x : Nat) -> (0 y : Nat) -> (0 prf : LT y x) -> Nat
  19 | minusBad (S k) Z LeZ = S k

--- a/tests/idris2/basic/basic030/expected
+++ b/tests/idris2/basic/basic030/expected
@@ -7,7 +7,7 @@ Mismatch between: Nat -> MyN and MyN.
 
 arity:4:16--4:21
  1 | data MyN = MkN Nat Nat
- 2 | 
+ 2 |
  3 | foo : Nat -> Nat -> Nat
  4 | foo x y = case MkN x of
                     ^^^^^

--- a/tests/idris2/basic/basic031/expected
+++ b/tests/idris2/basic/basic031/expected
@@ -3,7 +3,7 @@ Error: While processing left hand side of nameOf. Can't match on Bool (Erased ar
 
 erased:7:17--7:21
  3 |   MyJust : a -> MyMaybe a
- 4 | 
+ 4 |
  5 | -- Should fail since type argument is deleted
  6 | nameOf : Type -> String
  7 | nameOf (MyMaybe Bool) = "MyMaybe Bool"

--- a/tests/idris2/basic/basic033/expected
+++ b/tests/idris2/basic/basic033/expected
@@ -4,7 +4,7 @@ Error: While processing type of len'. Undefined name xs.
 unboundimps:18:11--18:13
  14 | -- xs and its indices
  15 | len : forall xs . Env xs -> Nat
- 16 | 
+ 16 |
  17 | -- neither of these are fine
  18 | len': Env xs -> Nat
                 ^^
@@ -13,7 +13,7 @@ Error: While processing type of append'. Undefined name n.
 
 unboundimps:19:16--19:17
  15 | len : forall xs . Env xs -> Nat
- 16 | 
+ 16 |
  17 | -- neither of these are fine
  18 | len': Env xs -> Nat
  19 | append' : Vect n a -> Vect m a -> Vect (n + m) a

--- a/tests/idris2/basic/basic034/expected
+++ b/tests/idris2/basic/basic034/expected
@@ -7,7 +7,7 @@ Mismatch between: Int and String.
 
 lets:22:39--22:40
  18 |          pure (x' + y')
- 19 | 
+ 19 |
  20 | dolet2 : Maybe Int -> Maybe Int -> Maybe Int
  21 | dolet2 x y
  22 |     = do let Just x' : Maybe String = x

--- a/tests/idris2/basic/basic041/expected
+++ b/tests/idris2/basic/basic041/expected
@@ -3,7 +3,7 @@ Error: While processing right hand side of test. Undefined name B.A.(>>).
 
 QDo:27:10--27:11
  23 |     a >> f = a >>= const f
- 24 | 
+ 24 |
  25 | test : Nat
  26 | test = B.A.do
  27 |          5

--- a/tests/idris2/basic/basic049/expected
+++ b/tests/idris2/basic/basic049/expected
@@ -4,7 +4,7 @@ You may be unintentionally shadowing the associated global definitions:
   a is shadowing Main.R1.R1.a
 
 Fld:68:11--68:20
- 64 | 
+ 64 |
  65 |   public export
  66 |   record R2 where
  67 |     constructor MkR
@@ -17,8 +17,8 @@ You may be unintentionally shadowing the associated global definitions:
 
 Fld:86:3--86:37
  82 |                                              -- constructor)
- 83 | 
- 84 | 
+ 83 |
+ 84 |
  85 | data MyDataImpl : a -> Type where            -- implementation of MyData
  86 |   MkMyData : (x : a) -> MyDataImpl x
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -38,7 +38,7 @@ You may be unintentionally shadowing the associated global definitions:
 Fld:112:1--112:40
  108 | Show' String where
  109 |    show' = id
- 110 | 
+ 110 |
  111 | %hint
  112 | showMaybe' : Show' a => Show' (Maybe a)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -51,7 +51,7 @@ You may be unintentionally shadowing the associated global definitions:
 Fld:141:3--141:57
  137 | setName : String -> OrdinaryDog -> OrdinaryDog
  138 | setName name' = {name := name'}
- 139 | 
+ 139 |
  140 | data Three : Type -> Type -> Type -> Type where
  141 |   MkThree : (x : a) -> (y : b) -> (z : c) -> Three a b c
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -62,10 +62,10 @@ You may be unintentionally shadowing the associated global definitions:
   b is shadowing Main.Other.b
 
 Fld:143:1--143:74
- 139 | 
+ 139 |
  140 | data Three : Type -> Type -> Type -> Type where
  141 |   MkThree : (x : a) -> (y : b) -> (z : c) -> Three a b c
- 142 | 
+ 142 |
  143 | mapSetMap : (a -> a') -> b' -> (c -> c') -> Three a b c -> Three a' b' c'
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -73,9 +73,9 @@ Warning: You may be unintentionally shadowing the following local bindings:
   a
 
 Fld:154:1--154:70
- 150 | 
+ 150 |
  151 | --------- Applications in presence of duplicate names ----------
- 152 | 
+ 152 |
  153 | -- Duplicate names are ok and treated sequentially
  154 | testDuplicateNames : {auto a : String} -> {auto a : String} -> String
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -107,7 +107,7 @@ Warning: You may be unintentionally shadowing the following local bindings:
 
 Fld:181:1--181:74
  177 | sameNamesOk {a {- = a-}, a = b} = (a, b)
- 178 | 
+ 178 |
  179 | -- All arguments are named and are of different `plicities`. Binds occur sequentially.
  180 | -- Arguments are renamed on LHS
  181 | eachArgType : (a : String) -> {a : String} -> {auto a : String} -> String
@@ -121,7 +121,7 @@ Fld:219:15--219:21
  215 | dontCare2 : (x : Nat) -> Nat -> Nat -> Nat -> (y : Nat) -> x + y = y + x
  216 | dontCare2 {} = plusCommutative {}
  217 | -- dontCare2 _ _ _ _ _ = plusCommutative _ _
- 218 | 
+ 218 |
  219 | data Tree a = Leaf a | Node (Tree a) a (Tree a)
                      ^^^^^^
 
@@ -133,7 +133,7 @@ Fld:219:24--219:48
  215 | dontCare2 : (x : Nat) -> Nat -> Nat -> Nat -> (y : Nat) -> x + y = y + x
  216 | dontCare2 {} = plusCommutative {}
  217 | -- dontCare2 _ _ _ _ _ = plusCommutative _ _
- 218 | 
+ 218 |
  219 | data Tree a = Leaf a | Node (Tree a) a (Tree a)
                               ^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -143,9 +143,9 @@ You may be unintentionally shadowing the associated global definitions:
 
 Fld:221:1--221:24
  217 | -- dontCare2 _ _ _ _ _ = plusCommutative _ _
- 218 | 
+ 218 |
  219 | data Tree a = Leaf a | Node (Tree a) a (Tree a)
- 220 | 
+ 220 |
  221 | isNode : Tree a -> Bool
        ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -162,10 +162,10 @@ You may be unintentionally shadowing the associated global definitions:
   a is shadowing Main.R2.R2.a, Main.R1.R1.a
 
 Fld:228:1--228:43
- 224 | 
+ 224 |
  225 | data IsNode : Tree a -> Type where
  226 |   Is : IsNode (Node {})
- 227 | 
+ 227 |
  228 | decIsNode : (x : Tree a) -> Dec (IsNode x)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -176,7 +176,7 @@ Error: While processing right hand side of r2_shouldNotTypecheck1. Ambiguous ela
 Fld:74:26--74:29
  70 | r1 : R1 -- explicit fields access
  71 | r1 = MkR {field = "string"}
- 72 | 
+ 72 |
  73 | r2_shouldNotTypecheck1 : ?
  74 | r2_shouldNotTypecheck1 = MkR {field = the Nat 22} -- fail, impossible to disambiguate
                                ^^^

--- a/tests/idris2/basic/basic070/expected
+++ b/tests/idris2/basic/basic070/expected
@@ -5,7 +5,7 @@ Error: While processing right hand side of fee. Undefined name y.
 Issue2782:9:7--9:8
  5 |       y = 1
  6 |   in y
- 7 | 
+ 7 |
  8 | fee : Integer
  9 | fee = y
            ^

--- a/tests/idris2/basic/basic072/expected
+++ b/tests/idris2/basic/basic072/expected
@@ -2,7 +2,7 @@
 Error: While processing right hand side of test2. Trying to use linear name x in non-linear context.
 
 Issue3327:11:11--11:12
- 07 | 
+ 07 |
  08 | test2 : IO ()
  09 | test2 = do
  10 |   1 x : Nat <- foo
@@ -12,7 +12,7 @@ Issue3327:11:11--11:12
 Error: While processing right hand side of test3. x is not accessible in this context.
 
 Issue3327:16:11--16:12
- 12 | 
+ 12 |
  13 | test3 : IO ()
  14 | test3 = do
  15 |   0 x : Nat <- foo
@@ -22,7 +22,7 @@ Issue3327:16:11--16:12
 Error: While processing right hand side of test4. Trying to use linear name x in non-linear context.
 
 Issue3327:21:11--21:12
- 17 | 
+ 17 |
  18 | test4 : IO ()
  19 | test4 = do
  20 |   1 x <- foo
@@ -32,7 +32,7 @@ Issue3327:21:11--21:12
 Error: While processing right hand side of test5. x is not accessible in this context.
 
 Issue3327:26:11--26:12
- 22 | 
+ 22 |
  23 | test5 : IO ()
  24 | test5 = do
  25 |   0 x <- foo

--- a/tests/idris2/builtin/builtin002/expected
+++ b/tests/idris2/builtin/builtin002/expected
@@ -5,7 +5,7 @@ Test:6:1--6:23
  2 | data MyNat
  3 |     = S MyNat MyNat
  4 |     | Z
- 5 | 
+ 5 |
  6 | %builtin Natural MyNat
      ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/idris2/builtin/builtin004/expected
+++ b/tests/idris2/builtin/builtin004/expected
@@ -5,7 +5,7 @@ Test:6:1--6:23
  2 | data MyNat
  3 |     = S (Inf MyNat)
  4 |     | Z
- 5 | 
+ 5 |
  6 | %builtin Natural MyNat
      ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/idris2/builtin/builtin006/expected
+++ b/tests/idris2/builtin/builtin006/expected
@@ -5,7 +5,7 @@ Test:9:1--9:35
  5 | natToInt : MyNat -> Integer
  6 | natToInt Z = 0
  7 | natToInt (S k _) = 1 + natToInt k
- 8 | 
+ 8 |
  9 | %builtin NaturalToInteger natToInt
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/idris2/builtin/builtin008/expected
+++ b/tests/idris2/builtin/builtin008/expected
@@ -5,7 +5,7 @@ Test:11:1--11:39
  07 | finToInteger : {k : _} -> Fin k -> Integer
  08 | finToInteger FZ = 0
  09 | finToInteger (FS k) = 1 + finToInteger k
- 10 | 
+ 10 |
  11 | %builtin NaturalToInteger finToInteger
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/idris2/builtin/builtin010/expected
+++ b/tests/idris2/builtin/builtin010/expected
@@ -5,17 +5,17 @@ Test:20:1--20:37
  16 | natToMyNat : Nat -> MyNat
  17 | natToMyNat Z = Z
  18 | natToMyNat (S k) = S $ natToMyNat k
- 19 | 
+ 19 |
  20 | %builtin IntegerToNatural natToMyNat
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Error: Return type is not a 'Nat'-like type
 
 Test:25:1--25:42
- 21 | 
+ 21 |
  22 | integerToNotNat : Integer -> Maybe String
  23 | integerToNotNat x = Just "Boo"
- 24 | 
+ 24 |
  25 | %builtin IntegerToNatural integerToNotNat
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/idris2/casetree/casetree001/expected
+++ b/tests/idris2/casetree/casetree001/expected
@@ -4,7 +4,7 @@ Error: While processing left hand side of fail. Can't match on S (Under-applied 
 
 IsS:31:14--31:15
  27 | --              ^ forced by Refl
- 28 | 
+ 28 |
  29 | -- If you don't: too bad!
  30 | fail : IsS s -> s === S
  31 | fail (Indeed S eq) = eq

--- a/tests/idris2/casetree/casetree002/expected
+++ b/tests/idris2/casetree/casetree002/expected
@@ -2,7 +2,7 @@
 Warning: Unreachable clause: extraDefault _
 
 DefaultCases:12:1--12:15
- 08 | 
+ 08 |
  09 | extraDefault : MyBit -> Int
  10 | extraDefault A = 1
  11 | extraDefault B = 2
@@ -13,7 +13,7 @@ Warning: Unreachable clause: earlyDefault A
 
 DefaultCases:20:1--20:15
  16 | usefulDefault _ = 2
- 17 | 
+ 17 |
  18 | earlyDefault : MyBit -> Int
  19 | earlyDefault _ = 1
  20 | earlyDefault A = 2
@@ -44,7 +44,7 @@ Warning: Unreachable clause: g3 _
 
 Issue1079:5:1--5:5
  1 | %default total
- 2 | 
+ 2 |
  3 | g3 : (Nat, Nat) -> Nat
  4 | g3 (x, y) = x
  5 | g3 _ = 6
@@ -56,7 +56,7 @@ Warning: Unreachable clause: case _ of
   }
 
 Issue1079:12:7--12:18
- 08 | 
+ 08 |
  09 | h3 : Monad m => m Nat
  10 | h3 = do
  11 |   (x, y) <- f

--- a/tests/idris2/coverage/coverage001/expected
+++ b/tests/idris2/coverage/coverage001/expected
@@ -9,7 +9,7 @@ Error: zip [] [] is not a valid impossible case.
 Vect2:8:1--8:21
  4 |      Nil  : Vect Z a
  5 |      (::) : a -> Vect k a -> Vect (S k) a
- 6 | 
+ 6 |
  7 | zip : Vect n a -> Vect n b -> Vect n (a, b)
  8 | zip [] [] impossible
      ^^^^^^^^^^^^^^^^^^^^
@@ -20,7 +20,7 @@ Warning: Vect3:9:8--9:9:Z does not match expected type
 Vect3:9:8--9:9
  5 |      Nil  : Vect Z a
  6 |      (::) : a -> Vect k a -> Vect (S k) a
- 7 | 
+ 7 |
  8 | zip : Vect n a -> Vect n b -> Vect n (a, b)
  9 | zip [] Z impossible
             ^

--- a/tests/idris2/coverage/coverage003/expected
+++ b/tests/idris2/coverage/coverage003/expected
@@ -4,7 +4,7 @@ Error: While processing left hand side of badBar. Can't match on 0 as it must ha
 Cover:16:8--16:9
  12 | cty Nat (S _) = S Z
  13 | cty _ x = S (S Z)
- 14 | 
+ 14 |
  15 | badBar : a -> Nat
  16 | badBar Z = Z
              ^

--- a/tests/idris2/coverage/coverage004/expected
+++ b/tests/idris2/coverage/coverage004/expected
@@ -2,7 +2,7 @@
 Error: While processing left hand side of bad. Can't match on Just 0 as it must have a polymorphic type.
 
 Cover:14:6--14:12
- 10 | 
+ 10 |
  11 | bad : a -> Foo a -> Bool
  12 | bad Z IsNat = False
  13 | bad True IsBool = True

--- a/tests/idris2/coverage/coverage007/expected
+++ b/tests/idris2/coverage/coverage007/expected
@@ -4,7 +4,7 @@ Error: badeq x y p is not a valid impossible case.
 eq:27:1--27:23
  23 | eqL2 : (xs : List a) -> (x :: xs = x :: y :: xs) -> Nat
  24 | eqL2 xs p impossible
- 25 | 
+ 25 |
  26 | badeq : (x : Nat) -> (y : Nat) -> (S (S x) = S y) -> Nat
  27 | badeq x y p impossible
       ^^^^^^^^^^^^^^^^^^^^^^
@@ -14,7 +14,7 @@ Error: badeqL xs ys p is not a valid impossible case.
 eq:30:1--30:26
  26 | badeq : (x : Nat) -> (y : Nat) -> (S (S x) = S y) -> Nat
  27 | badeq x y p impossible
- 28 | 
+ 28 |
  29 | badeqL : (xs : List a) -> (ys : List a) -> (x :: xs = x :: y :: ys) -> Nat
  30 | badeqL xs ys p impossible
       ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/idris2/coverage/coverage010/expected
+++ b/tests/idris2/coverage/coverage010/expected
@@ -2,10 +2,10 @@
 Error: main is not covering.
 
 casetot:12:1--12:13
- 08 | 
+ 08 |
  09 | ints : Vect 4 Int
  10 | ints = [1, 2, 3, 4]
- 11 | 
+ 11 |
  12 | main : IO ()
       ^^^^^^^^^^^^
 

--- a/tests/idris2/coverage/coverage012/expected
+++ b/tests/idris2/coverage/coverage012/expected
@@ -3,7 +3,7 @@ Error: zeroImpossible is not covering.
 
 Issue899:3:1--3:46
  1 | %default total
- 2 | 
+ 2 |
  3 | zeroImpossible : (k : Nat) -> k === Z -> Void
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -17,7 +17,7 @@ Issue484:10:1--10:41
  06 | getType Vrai = Unit
  07 | getType Faux = Unit
  08 | getType Indef = Void
- 09 | 
+ 09 |
  10 | swap : (t : Three) -> getType t -> Three
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/idris2/coverage/coverage013/expected
+++ b/tests/idris2/coverage/coverage013/expected
@@ -2,9 +2,9 @@
 Error: test8 eq is not a valid impossible case.
 
 Issue1022:25:1--25:20
- 21 | 
+ 21 |
  22 | -- The following ones are actually possible
- 23 | 
+ 23 |
  24 | test8 : Not (a = Type)
  25 | test8 eq impossible
       ^^^^^^^^^^^^^^^^^^^
@@ -14,7 +14,7 @@ Error: test9 eq is not a valid impossible case.
 Issue1022:28:1--28:20
  24 | test8 : Not (a = Type)
  25 | test8 eq impossible
- 26 | 
+ 26 |
  27 | test9 : Not (a = 'a')
  28 | test9 eq impossible
       ^^^^^^^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ Error: test10 eq is not a valid impossible case.
 Issue1022:31:1--31:21
  27 | test9 : Not (a = 'a')
  28 | test9 eq impossible
- 29 | 
+ 29 |
  30 | test10 : Not (a = Nat)
  31 | test10 eq impossible
       ^^^^^^^^^^^^^^^^^^^^
@@ -34,7 +34,7 @@ Error: test11 eq is not a valid impossible case.
 Issue1022:34:1--34:21
  30 | test10 : Not (a = Nat)
  31 | test10 eq impossible
- 32 | 
+ 32 |
  33 | test11 : Not (3 = a)
  34 | test11 eq impossible
       ^^^^^^^^^^^^^^^^^^^^
@@ -43,9 +43,9 @@ Issue1022:34:1--34:21
 Error: test8 Refl is not a valid impossible case.
 
 Issue1022-Refl:25:1--25:22
- 21 | 
+ 21 |
  22 | -- The following ones are actually possible
- 23 | 
+ 23 |
  24 | test8 : Not (a = Type)
  25 | test8 Refl impossible
       ^^^^^^^^^^^^^^^^^^^^^
@@ -55,7 +55,7 @@ Error: test9 Refl is not a valid impossible case.
 Issue1022-Refl:28:1--28:22
  24 | test8 : Not (a = Type)
  25 | test8 Refl impossible
- 26 | 
+ 26 |
  27 | test9 : Not (a = 'a')
  28 | test9 Refl impossible
       ^^^^^^^^^^^^^^^^^^^^^
@@ -65,7 +65,7 @@ Error: test10 Refl is not a valid impossible case.
 Issue1022-Refl:31:1--31:23
  27 | test9 : Not (a = 'a')
  28 | test9 Refl impossible
- 29 | 
+ 29 |
  30 | test10 : Not (a = Nat)
  31 | test10 Refl impossible
       ^^^^^^^^^^^^^^^^^^^^^^
@@ -75,7 +75,7 @@ Error: test11 Refl is not a valid impossible case.
 Issue1022-Refl:34:1--34:23
  30 | test10 : Not (a = Nat)
  31 | test10 Refl impossible
- 32 | 
+ 32 |
  33 | test11 : Not (3 = a)
  34 | test11 Refl impossible
       ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/idris2/coverage/coverage014/expected
+++ b/tests/idris2/coverage/coverage014/expected
@@ -4,8 +4,8 @@ Can't solve constraint between: ?_ ++ [?_] and ?x :: ?xs.
 
 Issue794:15:7--15:17
  11 | empty Empty impossible
- 12 | 
- 13 | 
+ 12 |
+ 13 |
  14 | snoc : SnocList (x :: xs) -> a
  15 | snoc (Snoc _ _ _) impossible
             ^^^^^^^^^^
@@ -16,7 +16,7 @@ Issue794:10:1--10:32
  06 |      Empty : SnocList []
  07 |      Snoc : (x : a) -> (xs : List a) ->
  08 |             (rec : SnocList xs) -> SnocList (xs ++ [x])
- 09 | 
+ 09 |
  10 | empty : SnocList (x :: xs) -> a
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/idris2/coverage/coverage015/expected
+++ b/tests/idris2/coverage/coverage015/expected
@@ -3,7 +3,7 @@ Error: test is not covering.
 
 Issue1169:3:1--3:26
  1 | %default total
- 2 | 
+ 2 |
  3 | test : (String, ()) -> ()
      ^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -13,10 +13,10 @@ Missing cases:
 Error: test' is not covering.
 
 Issue1169:6:1--6:24
- 2 | 
+ 2 |
  3 | test : (String, ()) -> ()
  4 | test ("a", ()) = ()
- 5 | 
+ 5 |
  6 | test' : (Int, ()) -> ()
      ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -26,10 +26,10 @@ Missing cases:
 Error: test'' is not covering.
 
 Issue1169:9:1--9:22
- 5 | 
+ 5 |
  6 | test' : (Int, ()) -> ()
  7 | test' (1, ()) = ()
- 8 | 
+ 8 |
  9 | test'' : Type -> Type
      ^^^^^^^^^^^^^^^^^^^^^
 
@@ -44,7 +44,7 @@ You may be unintentionally shadowing the associated global definitions:
 Issue1366:30:3--30:33
  26 |   uninhabited (Z _) impossible
  27 |   uninhabited (S _) impossible
- 28 | 
+ 28 |
  29 | data Funny : (a : Type) -> (f : Type -> Type) -> Type where
  30 |   A : List a -> f a -> Funny a f
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -55,7 +55,7 @@ You may be unintentionally shadowing the associated global definitions:
 
 Issue1366:31:3--31:16
  27 |   uninhabited (S _) impossible
- 28 | 
+ 28 |
  29 | data Funny : (a : Type) -> (f : Type -> Type) -> Type where
  30 |   A : List a -> f a -> Funny a f
  31 |   B : Funny a f
@@ -69,7 +69,7 @@ Issue1366:33:1--33:45
  29 | data Funny : (a : Type) -> (f : Type -> Type) -> Type where
  30 |   A : List a -> f a -> Funny a f
  31 |   B : Funny a f
- 32 | 
+ 32 |
  33 | decode : NS [[List a, f a], []] -> Funny a f
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -79,7 +79,7 @@ Issue1366:33:1--33:45
  29 | data Funny : (a : Type) -> (f : Type -> Type) -> Type where
  30 |   A : List a -> f a -> Funny a f
  31 |   B : Funny a f
- 32 | 
+ 32 |
  33 | decode : NS [[List a, f a], []] -> Funny a f
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/idris2/coverage/coverage016/expected
+++ b/tests/idris2/coverage/coverage016/expected
@@ -3,7 +3,7 @@ Error: While processing left hand side of test. Can't match on \x => True (Not a
 
 Issue633:4:1--4:18
  1 | %default total
- 2 | 
+ 2 |
  3 | test : (f : () -> Bool) -> f () = True
  4 | test (\x => True) = Refl
      ^^^^^^^^^^^^^^^^^

--- a/tests/idris2/coverage/coverage021/expected
+++ b/tests/idris2/coverage/coverage021/expected
@@ -4,7 +4,7 @@ Warning: Issue2250a:15:5--15:9:Refl does not match expected type
 Issue2250a:15:5--15:9
  11 | Ex1 : 3 `LessThanOrEqualTo` 5
  12 | Ex1 = Choose 2
- 13 | 
+ 13 |
  14 | Bug : Not (3 `LessThanOrEqualTo` 5)
  15 | Bug Refl impossible
           ^^^^
@@ -12,10 +12,10 @@ Issue2250a:15:5--15:9
 Error: Bug is not covering.
 
 Issue2250a:14:1--14:36
- 10 | 
+ 10 |
  11 | Ex1 : 3 `LessThanOrEqualTo` 5
  12 | Ex1 = Choose 2
- 13 | 
+ 13 |
  14 | Bug : Not (3 `LessThanOrEqualTo` 5)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -25,10 +25,10 @@ Missing cases:
 Error: Yikes is not covering.
 
 Issue2250a:17:1--17:13
- 13 | 
+ 13 |
  14 | Bug : Not (3 `LessThanOrEqualTo` 5)
  15 | Bug Refl impossible
- 16 | 
+ 16 |
  17 | Yikes : Void
       ^^^^^^^^^^^^
 
@@ -37,9 +37,9 @@ Calls non covering function Main.Bug
 Warning: Issue2250b:6:3--6:4:Z does not match expected type
 
 Issue2250b:6:3--6:4
- 2 | 
+ 2 |
  3 | %default total
- 4 | 
+ 4 |
  5 | f : n `LTE` m -> Void
  6 | f Z impossible
        ^
@@ -48,9 +48,9 @@ Error: f is not covering.
 
 Issue2250b:5:1--5:22
  1 | import Data.Nat
- 2 | 
+ 2 |
  3 | %default total
- 4 | 
+ 4 |
  5 | f : n `LTE` m -> Void
      ^^^^^^^^^^^^^^^^^^^^^
 
@@ -63,7 +63,7 @@ Issue2250b:9:1--9:9
  5 | f : n `LTE` m -> Void
  6 | f Z impossible
  7 | f (LTESucc x) = f x
- 8 | 
+ 8 |
  9 | x : Void
      ^^^^^^^^
 
@@ -73,7 +73,7 @@ Warning: Issue2250c:4:3--4:5:MkUnit does not match expected type
 
 Issue2250c:4:3--4:5
  1 | %default total
- 2 | 
+ 2 |
  3 | g : Not Bool
  4 | g () impossible
        ^^
@@ -81,10 +81,10 @@ Issue2250c:4:3--4:5
 Error: f is not covering.
 
 Issue2250c:6:1--6:9
- 2 | 
+ 2 |
  3 | g : Not Bool
  4 | g () impossible
- 5 | 
+ 5 |
  6 | f : Void
      ^^^^^^^^
 
@@ -93,7 +93,7 @@ Error: g is not covering.
 
 Issue2250c:3:1--3:13
  1 | %default total
- 2 | 
+ 2 |
  3 | g : Not Bool
      ^^^^^^^^^^^^
 
@@ -106,7 +106,7 @@ Warning: Issue3276:20:23--20:27:Refl does not match expected type
 Issue3276:20:23--20:27
  16 | prf1 : Digit 51
  17 | prf1 = MkDigit 51
- 18 | 
+ 18 |
  19 | dis0 : Digit 51 -> Void
  20 | dis0 (MkDigit _ {prf1=Refl}) impossible
                             ^^^^
@@ -114,10 +114,10 @@ Issue3276:20:23--20:27
 Error: dis0 is not covering.
 
 Issue3276:19:1--19:24
- 15 | 
+ 15 |
  16 | prf1 : Digit 51
  17 | prf1 = MkDigit 51
- 18 | 
+ 18 |
  19 | dis0 : Digit 51 -> Void
       ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -130,7 +130,7 @@ Warning: Visibility:8:6--8:7:Z does not match expected type
 Visibility:8:6--8:7
  4 |     data Foo : Type where
  5 |         MkFoo : Foo
- 6 | 
+ 6 |
  7 | boom : Foo -> Void
  8 | boom Z impossible
           ^
@@ -141,7 +141,7 @@ Visibility:7:1--7:19
  3 |     export
  4 |     data Foo : Type where
  5 |         MkFoo : Foo
- 6 | 
+ 6 |
  7 | boom : Foo -> Void
      ^^^^^^^^^^^^^^^^^^
 
@@ -161,7 +161,7 @@ Head:4:6--4:8
 Warning: Head:9:7--9:8:Z does not match expected type
 
 Head:9:7--9:8
- 5 | 
+ 5 |
  6 | total
  7 | head' : List a -> a
  8 | head' (x :: xs) = x

--- a/tests/idris2/coverage/coverage024/expected
+++ b/tests/idris2/coverage/coverage024/expected
@@ -4,7 +4,7 @@ Error: boom is not covering.
 Issue2690:4:1--4:12
  1 | trythis : (mb : Maybe Bool) -> mb === Just True -> Void
  2 | trythis Nothing ab = absurd ab
- 3 | 
+ 3 |
  4 | boom : Void
      ^^^^^^^^^^^
 

--- a/tests/idris2/coverage/coverage025/expected
+++ b/tests/idris2/coverage/coverage025/expected
@@ -5,7 +5,7 @@ ErasedBind:14:1--14:12
  10 | g : (a : Type) -> ErasedBind a -> Maybe Void
  11 | g (a -> b) e = Just (f e)
  12 | g _ _ = Nothing
- 13 | 
+ 13 |
  14 | boom : Void
       ^^^^^^^^^^^
 
@@ -16,7 +16,7 @@ ErasedBind:7:1--7:50
  3 | data ErasedBind : Type -> Type where
  4 |   Impossible : Void => ErasedBind a
  5 |   Erased     : forall b. ErasedBind ((0 x : a) -> b x)
- 6 | 
+ 6 |
  7 | f : forall b. ErasedBind ((x : a) -> b x) -> Void
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -26,10 +26,10 @@ Missing cases:
 Error: g is not covering.
 
 ErasedBind:10:1--10:45
- 06 | 
+ 06 |
  07 | f : forall b. ErasedBind ((x : a) -> b x) -> Void
  08 | f Impossible impossible
- 09 | 
+ 09 |
  10 | g : (a : Type) -> ErasedBind a -> Maybe Void
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -41,7 +41,7 @@ NonDependentBind:14:1--14:12
  10 | g : (a : Type) -> NonDependentBind a -> Maybe Void
  11 | g (a -> b) e = Just (f e)
  12 | g _ _ = Nothing
- 13 | 
+ 13 |
  14 | boom : Void
       ^^^^^^^^^^^
 
@@ -52,7 +52,7 @@ NonDependentBind:7:1--7:56
  3 | data NonDependentBind : Type -> Type where
  4 |   Impossible   : Void => NonDependentBind a
  5 |   NonDependent : NonDependentBind (a -> b)
- 6 | 
+ 6 |
  7 | f : forall b. NonDependentBind ((x : a) -> b x) -> Void
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -62,10 +62,10 @@ Missing cases:
 Error: g is not covering.
 
 NonDependentBind:10:1--10:51
- 06 | 
+ 06 |
  07 | f : forall b. NonDependentBind ((x : a) -> b x) -> Void
  08 | f Impossible impossible
- 09 | 
+ 09 |
  10 | g : (a : Type) -> NonDependentBind a -> Maybe Void
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -74,10 +74,10 @@ Calls non covering function Main.f
 Error: bad is not covering.
 
 Issue2318:20:1--20:11
- 16 | 
+ 16 |
  17 | oopsie : P a -> Q a -> Void
  18 | oopsie C U impossible
- 19 | 
+ 19 |
  20 | bad : Void
       ^^^^^^^^^^
 
@@ -88,7 +88,7 @@ Issue2318:17:1--17:28
  13 | data Q : A -> Type where
  14 |     U : Q Z
  15 |     V : Q (S a)
- 16 | 
+ 16 |
  17 | oopsie : P a -> Q a -> Void
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/idris2/coverage/coverage026/expected
+++ b/tests/idris2/coverage/coverage026/expected
@@ -2,10 +2,10 @@
 Error: test10 is not covering.
 
 Issue1022-Generated:34:1--34:26
- 30 | 
+ 30 |
  31 | test9 : Not (MyEq a 'a')
  32 | test9 Impossible impossible
- 33 | 
+ 33 |
  34 | test10 : Not (MyEq a Nat)
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -15,10 +15,10 @@ Missing cases:
 Error: test11 is not covering.
 
 Issue1022-Generated:37:1--37:24
- 33 | 
+ 33 |
  34 | test10 : Not (MyEq a Nat)
  35 | test10 Impossible impossible
- 36 | 
+ 36 |
  37 | test11 : Not (MyEq 3 a)
       ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -29,9 +29,9 @@ Error: test8 is not covering.
 
 Issue1022-Generated:28:1--28:26
  24 | test7 Impossible impossible
- 25 | 
+ 25 |
  26 | -- The following ones are actually possible
- 27 | 
+ 27 |
  28 | test8 : Not (MyEq a Type)
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -41,10 +41,10 @@ Missing cases:
 Error: test9 is not covering.
 
 Issue1022-Generated:31:1--31:25
- 27 | 
+ 27 |
  28 | test8 : Not (MyEq a Type)
  29 | test8 Impossible impossible
- 30 | 
+ 30 |
  31 | test9 : Not (MyEq a 'a')
       ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/idris2/coverage/coverage027/expected
+++ b/tests/idris2/coverage/coverage027/expected
@@ -4,7 +4,7 @@ Can't match on X1 (Erased argument).
 
 Main:4:3--4:5
  1 | data X = X1 | X2
- 2 | 
+ 2 |
  3 | f : (0 _ : X) -> Void
  4 | f X1 impossible
        ^^
@@ -15,7 +15,7 @@ Can't match on X1 (Erased argument).
 Main:7:3--7:5
  3 | f : (0 _ : X) -> Void
  4 | f X1 impossible
- 5 | 
+ 5 |
  6 | g : (0 _ : X) -> Void
  7 | g X1 impossible
        ^^
@@ -24,9 +24,9 @@ Error: Impossible pattern gives an error:
 Can't match on Y1 ?_ (Erased argument).
 
 Main:14:4--14:8
- 10 | 
+ 10 |
  11 | data Y = Y1 Void | Y2
- 12 | 
+ 12 |
  13 | h : (0 _ : Y) -> Void
  14 | h (Y1 _) impossible
          ^^^^
@@ -36,7 +36,7 @@ Error: Impossible pattern gives an error:
 Can't match on ?search [no locals in scope] (Erased argument).
 
 Issue1800:19:8--19:15
- 15 | 
+ 15 |
  16 | mycase : {0 s : String} -> (0 prf : s `Elem` Example) -> (single : Singleton prf) -> Nat
  17 | mycase .(Here) (Is "String1") = 0
  18 | mycase .(There $ There Here) (Is "LastString") = 2
@@ -50,7 +50,7 @@ Can't match on 0 (Erased argument).
 Issue1800Shrinked:5:11--5:18
  1 | data View : Nat -> Type where
  2 |   Plus : (k, l : Nat) -> View (k + l)
- 3 | 
+ 3 |
  4 | view : View m -> Void
  5 | view {m = %search} v impossible
                ^^^^^^^

--- a/tests/idris2/coverage/coverage028/expected
+++ b/tests/idris2/coverage/coverage028/expected
@@ -4,7 +4,7 @@ Error: falseIsTrue is not covering.
 Issue1998:4:1--4:27
  1 | 0 proveit : (0 c : Bool) -> c = True
  2 | proveit True = Refl
- 3 | 
+ 3 |
  4 | falseIsTrue : False = True
      ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/idris2/coverage/coverage029/expected
+++ b/tests/idris2/coverage/coverage029/expected
@@ -3,7 +3,7 @@ Warning: Main:4:11--4:15:Type does not match expected type
 
 Main:4:11--4:15
  1 | import Language.Reflection
- 2 | 
+ 2 |
  3 | matchType : Bool -> Void
  4 | matchType Type impossible
                ^^^^
@@ -13,7 +13,7 @@ Warning: Main:7:12--7:20:Unsupported term in impossible clause: `((fromInteger 1
 Main:7:12--7:20
  3 | matchType : Bool -> Void
  4 | matchType Type impossible
- 5 | 
+ 5 |
  6 | matchQuote : Bool -> Void
  7 | matchQuote `(1 + 1) impossible
                 ^^^^^^^^
@@ -23,7 +23,7 @@ Warning: Main:10:12--10:31:Unsupported term in impossible clause: let _ = _ in _
 Main:10:12--10:31
  06 | matchQuote : Bool -> Void
  07 | matchQuote `(1 + 1) impossible
- 08 | 
+ 08 |
  09 | matchCase : Bool -> Void
  10 | matchCase (case () of () => ()) impossible
                  ^^^^^^^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ Warning: Main:13:15--13:21:Unsupported term in impossible clause: let x = _ in x
 Main:13:15--13:21
  09 | matchCase : Bool -> Void
  10 | matchCase (case () of () => ()) impossible
- 11 | 
+ 11 |
  12 | matchLet : Bool -> Void
  13 | matchLet (let x = () in x) impossible
                     ^^^^^^
@@ -43,7 +43,7 @@ Warning: Main:16:17--16:23:Unsupported term in impossible clause: let { << defin
 Main:16:17--16:23
  12 | matchLet : Bool -> Void
  13 | matchLet (let x = () in x) impossible
- 14 | 
+ 14 |
  15 | matchLocal : Bool -> Void
  16 | matchLocal (let x : () in x) impossible
                       ^^^^^^
@@ -53,7 +53,7 @@ Warning: Main:19:16--19:27:Unsupported term in impossible clause: \rec => record
 Main:19:16--19:27
  15 | matchLocal : Bool -> Void
  16 | matchLocal (let x : () in x) impossible
- 17 | 
+ 17 |
  18 | matchSetField : Bool -> Void
  19 | matchSetField ({ x := () }) impossible
                      ^^^^^^^^^^^
@@ -63,7 +63,7 @@ Warning: Main:22:16--22:27:Unsupported term in impossible clause: \rec => record
 Main:22:16--22:27
  18 | matchSetField : Bool -> Void
  19 | matchSetField ({ x := () }) impossible
- 20 | 
+ 20 |
  21 | matchAppField : Bool -> Void
  22 | matchAppField ({ x $= () }) impossible
                      ^^^^^^^^^^^
@@ -73,7 +73,7 @@ Warning: Main:25:12--25:26:Unsupported term in impossible clause: with [(Main:25
 Main:25:12--25:26
  21 | matchAppField : Bool -> Void
  22 | matchAppField ({ x $= () }) impossible
- 23 | 
+ 23 |
  24 | matchWith : Bool -> Void
  25 | matchWith (with MkUnit ()) impossible
                  ^^^^^^^^^^^^^^
@@ -81,10 +81,10 @@ Main:25:12--25:26
 Error: matchAppField is not covering.
 
 Main:21:1--21:29
- 17 | 
+ 17 |
  18 | matchSetField : Bool -> Void
  19 | matchSetField ({ x := () }) impossible
- 20 | 
+ 20 |
  21 | matchAppField : Bool -> Void
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -94,10 +94,10 @@ Missing cases:
 Error: matchCase is not covering.
 
 Main:9:1--9:25
- 5 | 
+ 5 |
  6 | matchQuote : Bool -> Void
  7 | matchQuote `(1 + 1) impossible
- 8 | 
+ 8 |
  9 | matchCase : Bool -> Void
      ^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -107,10 +107,10 @@ Missing cases:
 Error: matchLet is not covering.
 
 Main:12:1--12:24
- 08 | 
+ 08 |
  09 | matchCase : Bool -> Void
  10 | matchCase (case () of () => ()) impossible
- 11 | 
+ 11 |
  12 | matchLet : Bool -> Void
       ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -120,10 +120,10 @@ Missing cases:
 Error: matchLocal is not covering.
 
 Main:15:1--15:26
- 11 | 
+ 11 |
  12 | matchLet : Bool -> Void
  13 | matchLet (let x = () in x) impossible
- 14 | 
+ 14 |
  15 | matchLocal : Bool -> Void
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -133,10 +133,10 @@ Missing cases:
 Error: matchQuote is not covering.
 
 Main:6:1--6:26
- 2 | 
+ 2 |
  3 | matchType : Bool -> Void
  4 | matchType Type impossible
- 5 | 
+ 5 |
  6 | matchQuote : Bool -> Void
      ^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -146,10 +146,10 @@ Missing cases:
 Error: matchSetField is not covering.
 
 Main:18:1--18:29
- 14 | 
+ 14 |
  15 | matchLocal : Bool -> Void
  16 | matchLocal (let x : () in x) impossible
- 17 | 
+ 17 |
  18 | matchSetField : Bool -> Void
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -160,7 +160,7 @@ Error: matchType is not covering.
 
 Main:3:1--3:25
  1 | import Language.Reflection
- 2 | 
+ 2 |
  3 | matchType : Bool -> Void
      ^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -170,10 +170,10 @@ Missing cases:
 Error: matchWith is not covering.
 
 Main:24:1--24:25
- 20 | 
+ 20 |
  21 | matchAppField : Bool -> Void
  22 | matchAppField ({ x $= () }) impossible
- 23 | 
+ 23 |
  24 | matchWith : Bool -> Void
       ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/idris2/coverage/coverage030/expected
+++ b/tests/idris2/coverage/coverage030/expected
@@ -4,7 +4,7 @@ Error: f2 is not covering.
 Issue2822:4:1--4:10
  1 | fn : (x : Bool) -> if x then (Nat -> Nat) else Void
  2 | fn True x = x
- 3 | 
+ 3 |
  4 | f2 : Void
      ^^^^^^^^^
 

--- a/tests/idris2/coverage/impossible005/expected
+++ b/tests/idris2/coverage/impossible005/expected
@@ -11,7 +11,7 @@ Warning: Main:5:12--5:18:%World does not match expected type
 Main:5:12--5:18
  1 | matchInt : () -> Void
  2 | matchInt Int impossible
- 3 | 
+ 3 |
  4 | matchWorld : () -> Void
  5 | matchWorld %World impossible
                 ^^^^^^
@@ -30,7 +30,7 @@ Error: matchWorld is not covering.
 Main:4:1--4:24
  1 | matchInt : () -> Void
  2 | matchInt Int impossible
- 3 | 
+ 3 |
  4 | matchWorld : () -> Void
      ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/idris2/data/data003/expected
+++ b/tests/idris2/data/data003/expected
@@ -3,7 +3,7 @@ Error: foo x is not a valid impossible case.
 
 Test:5:1--5:17
  1 | data Bar : Type
- 2 | 
+ 2 |
  3 | total
  4 | foo : Bar -> a
  5 | foo x impossible
@@ -23,7 +23,7 @@ Issue3457:6:1--6:20
  2 | data Bar : Type
  3 | data Foo : Type where
  4 |   MkFoo : Three -> Bar -> Foo
- 5 | 
+ 5 |
  6 | fun : Foo -> String
      ^^^^^^^^^^^^^^^^^^^
 

--- a/tests/idris2/data/data006/expected
+++ b/tests/idris2/data/data006/expected
@@ -4,7 +4,7 @@ Error: Mismatch between: Type -> Type and Type.
 ConvertPiInfo:6:1--6:35
  2 | -- Explicit --
  3 | --------------
- 4 | 
+ 4 |
  5 | data EI : Type -> Type
  6 | data EI : {_ : Type} -> Type where
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -14,7 +14,7 @@ Error: Mismatch between: Type -> Type and Type => Type.
 ConvertPiInfo:9:1--9:40
  5 | data EI : Type -> Type
  6 | data EI : {_ : Type} -> Type where
- 7 | 
+ 7 |
  8 | data EA : Type -> Type
  9 | data EA : {auto _ : Type} -> Type where
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ Error: Mismatch between: Type -> Type and {default Int _ : Type} -> Type.
 ConvertPiInfo:12:1--12:47
  08 | data EA : Type -> Type
  09 | data EA : {auto _ : Type} -> Type where
- 10 | 
+ 10 |
  11 | data ED : Type -> Type
  12 | data ED : {default Int _ : Type} -> Type where
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,7 +34,7 @@ Error: Mismatch between: Type and Type -> Type.
 ConvertPiInfo:19:1--19:29
  15 | -- Implicit --
  16 | --------------
- 17 | 
+ 17 |
  18 | data IE : {_ : Type} -> Type
  19 | data IE : Type -> Type where
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ Error: Mismatch between: Type and Type => Type.
 ConvertPiInfo:22:1--22:40
  18 | data IE : {_ : Type} -> Type
  19 | data IE : Type -> Type where
- 20 | 
+ 20 |
  21 | data IA : {_ : Type} -> Type
  22 | data IA : {auto _ : Type} -> Type where
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -54,7 +54,7 @@ Error: Mismatch between: Type and {default Int _ : Type} -> Type.
 ConvertPiInfo:25:1--25:47
  21 | data IA : {_ : Type} -> Type
  22 | data IA : {auto _ : Type} -> Type where
- 23 | 
+ 23 |
  24 | data ID : {_ : Type} -> Type
  25 | data ID : {default Int _ : Type} -> Type where
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -64,7 +64,7 @@ Error: Mismatch between: Type => Type and Type -> Type.
 ConvertPiInfo:32:1--32:29
  28 | -- Auto --
  29 | ----------
- 30 | 
+ 30 |
  31 | data AE : {auto _ : Type} -> Type
  32 | data AE : Type -> Type where
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -74,7 +74,7 @@ Error: Mismatch between: Type => Type and Type.
 ConvertPiInfo:35:1--35:35
  31 | data AE : {auto _ : Type} -> Type
  32 | data AE : Type -> Type where
- 33 | 
+ 33 |
  34 | data AI : {auto _ : Type} -> Type
  35 | data AI : {_ : Type} -> Type where
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -84,7 +84,7 @@ Error: Mismatch between: Type => Type and {default Int _ : Type} -> Type.
 ConvertPiInfo:38:1--38:47
  34 | data AI : {auto _ : Type} -> Type
  35 | data AI : {_ : Type} -> Type where
- 36 | 
+ 36 |
  37 | data AD : {auto _ : Type} -> Type
  38 | data AD : {default Int _ : Type} -> Type where
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -94,7 +94,7 @@ Error: Mismatch between: {default Int _ : Type} -> Type and Type -> Type.
 ConvertPiInfo:45:1--45:29
  41 | -- Default --
  42 | -------------
- 43 | 
+ 43 |
  44 | data DE : {default Int _ : Type} -> Type
  45 | data DE : Type -> Type where
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -104,7 +104,7 @@ Error: Mismatch between: {default Int _ : Type} -> Type and Type.
 ConvertPiInfo:48:1--48:35
  44 | data DE : {default Int _ : Type} -> Type
  45 | data DE : Type -> Type where
- 46 | 
+ 46 |
  47 | data DI : {default Int _ : Type} -> Type
  48 | data DI : {_ : Type} -> Type where
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -114,7 +114,7 @@ Error: Mismatch between: {default Int _ : Type} -> Type and Type => Type.
 ConvertPiInfo:51:1--51:40
  47 | data DI : {default Int _ : Type} -> Type
  48 | data DI : {_ : Type} -> Type where
- 49 | 
+ 49 |
  50 | data DA : {default Int _ : Type} -> Type
  51 | data DA : {auto _ : Type} -> Type where
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/idris2/data/record021/expected
+++ b/tests/idris2/data/record021/expected
@@ -5,7 +5,7 @@ Warning: You may be unintentionally shadowing the following local bindings:
 RecordParam:23:3--23:87
  19 | record Record7 where
  20 |   f : {_ : Type} -> Type
- 21 | 
+ 21 |
  22 | record Record8 where
  23 |   f : {x : Type} -> {x : Int} -> {_ : String} -> (x : Double) => {x : Integer} -> Type
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ Warning: You may be unintentionally shadowing the following local bindings:
 RecordParam:23:3--23:87
  19 | record Record7 where
  20 |   f : {_ : Type} -> Type
- 21 | 
+ 21 |
  22 | record Record8 where
  23 |   f : {x : Type} -> {x : Int} -> {_ : String} -> (x : Double) => {x : Integer} -> Type
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/idris2/data/record023/expected
+++ b/tests/idris2/data/record023/expected
@@ -3,9 +3,9 @@
 Error: While processing right hand side of void. Can't find an implementation for VoidContainer.
 
 Main:8:16--8:23
- 4 | 
+ 4 |
  5 | %default total
- 6 | 
+ 6 |
  7 | void : Void
  8 | void = getVoid %search
                     ^^^^^^^

--- a/tests/idris2/error/error001/expected
+++ b/tests/idris2/error/error001/expected
@@ -8,7 +8,7 @@ Mismatch between: a and Vect ?k ?a.
 Error:6:19--6:20
  2 |      Nil : Vect Z a
  3 |      (::) : a -> Vect k a -> Vect (S k) a
- 4 | 
+ 4 |
  5 | wrong : a -> Vect (S n) a -> Vect (S n) a
  6 | wrong x xs = x :: x
                        ^

--- a/tests/idris2/error/error002/expected
+++ b/tests/idris2/error/error002/expected
@@ -4,7 +4,7 @@ Error: While processing right hand side of wrong. Undefined name ys.
 Error:6:17--6:19
  2 |      Nil : Vect Z a
  3 |      (::) : a -> Vect k a -> Vect (S k) a
- 4 | 
+ 4 |
  5 | wrong : a -> Vect (S n) a -> Vect (S n) a
  6 | wrong xs = x :: ys
                      ^^

--- a/tests/idris2/error/error003/expected
+++ b/tests/idris2/error/error003/expected
@@ -9,7 +9,7 @@ Mismatch between: Nat and Vect ?n ?a.
 Error:12:18--12:19
  08 | length [] = Z
  09 | length (x :: xs) = S (length xs)
- 10 | 
+ 10 |
  11 | wrong : Nat -> Nat
  12 | wrong x = length x
                        ^
@@ -23,7 +23,7 @@ Mismatch between: Nat and List ?a.
 Error:12:18--12:19
  08 | length [] = Z
  09 | length (x :: xs) = S (length xs)
- 10 | 
+ 10 |
  11 | wrong : Nat -> Nat
  12 | wrong x = length x
                        ^
@@ -37,7 +37,7 @@ Mismatch between: Nat and SnocList ?a.
 Error:12:18--12:19
  08 | length [] = Z
  09 | length (x :: xs) = S (length xs)
- 10 | 
+ 10 |
  11 | wrong : Nat -> Nat
  12 | wrong x = length x
                        ^
@@ -51,7 +51,7 @@ Mismatch between: Nat and String.
 Error:12:18--12:19
  08 | length [] = Z
  09 | length (x :: xs) = S (length xs)
- 10 | 
+ 10 |
  11 | wrong : Nat -> Nat
  12 | wrong x = length x
                        ^

--- a/tests/idris2/error/error004/expected
+++ b/tests/idris2/error/error004/expected
@@ -4,7 +4,7 @@ Error: While processing right hand side of wrong. Can't find an implementation f
 Error1:8:9--8:40
  4 |      Nil : Vect Z a
  5 |      (::) : a -> Vect k a -> Vect (S k) a
- 6 | 
+ 6 |
  7 | wrong : String
  8 | wrong = show (the (Vect _ _) [1,2,3,4])
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ Error: While processing right hand side of show. Multiple solutions found in sea
 
 Error2:13:38--13:45
  09 |   show (x :: xs) = show x ++ ", " ++ show xs
- 10 | 
+ 10 |
  11 | Show (Vect n Integer) where
  12 |   show [] = "END"
  13 |   show (x :: xs) = show x ++ ", " ++ show xs
@@ -30,7 +30,7 @@ Error: While processing right hand side of wrong. Multiple solutions found in se
 Error2:16:9--16:34
  12 |   show [] = "END"
  13 |   show (x :: xs) = show x ++ ", " ++ show xs
- 14 | 
+ 14 |
  15 | wrong : String
  16 | wrong = show (the (Vect _ _) [1])
               ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/idris2/error/error005/expected
+++ b/tests/idris2/error/error005/expected
@@ -3,7 +3,7 @@ Error: While processing right hand side of foo. Can't find an implementation for
 
 IfErr:4:11--4:17
  1 | data Wibble = Wobble
- 2 | 
+ 2 |
  3 | foo : a -> a -> Bool
  4 | foo x y = x == y
                ^^^^^^
@@ -13,7 +13,7 @@ Error: While processing right hand side of bar. Can't find an implementation for
 IfErr:7:11--7:17
  3 | foo : a -> a -> Bool
  4 | foo x y = x == y
- 5 | 
+ 5 |
  6 | bar : Wibble -> Wibble -> Bool
  7 | bar x y = x == y
                ^^^^^^

--- a/tests/idris2/error/error006/expected
+++ b/tests/idris2/error/error006/expected
@@ -4,7 +4,7 @@ Error: While processing right hand side of test. Can't find an implementation fo
 IfErr:15:10--15:30
  11 | -- hard to achieve and this way is better than displaying the whole
  12 | -- top level search when only part of it is relevant)
- 13 | 
+ 13 |
  14 | test : Int -> String
  15 | test x = showIfEq MkFoo MkBar
                ^^^^^^^^^^^^^^^^^^^^
@@ -14,7 +14,7 @@ Error: While processing right hand side of test2. Can't find an implementation f
 IfErr:23:9--23:29
  19 |   MkBar == MkBar = True
  20 |   _ == _ = False
- 21 | 
+ 21 |
  22 | test2 : String
  23 | test2 = showIfEq MkFoo MkBar
               ^^^^^^^^^^^^^^^^^^^^

--- a/tests/idris2/error/error007/expected
+++ b/tests/idris2/error/error007/expected
@@ -3,7 +3,7 @@ Error: While processing right hand side of fsprf. Can't solve constraint between
 
 CongErr:4:11--4:19
  1 | import Data.Fin
- 2 | 
+ 2 |
  3 | fsprf : x === y -> Fin.FS x = FS y
  4 | fsprf p = cong _ p
                ^^^^^^^^

--- a/tests/idris2/error/error011/expected
+++ b/tests/idris2/error/error011/expected
@@ -9,7 +9,7 @@ Error: Main.D is already defined.
 
 ConstructorDuplicate:5:3--5:15
  1 | data A = B | B
- 2 | 
+ 2 |
  3 | data C : Type -> Type where
  4 |   D : C Int
  5 |   D : C String

--- a/tests/idris2/error/error013/expected
+++ b/tests/idris2/error/error013/expected
@@ -3,9 +3,9 @@ Error: main is not total, possibly not terminating due to function Main.(==) bei
 
 Issue361:7:1--7:13
  3 | data S = T | F
- 4 | 
+ 4 |
  5 | Eq S where
- 6 | 
+ 6 |
  7 | main : IO ()
      ^^^^^^^^^^^^
 
@@ -13,9 +13,9 @@ Error: /= is not total, possibly not terminating due to call to Main.Eq implemen
 
 Issue361:5:1--5:11
  1 | %default total
- 2 | 
+ 2 |
  3 | data S = T | F
- 4 | 
+ 4 |
  5 | Eq S where
      ^^^^^^^^^^
 
@@ -23,9 +23,9 @@ Error: == is not total, possibly not terminating due to recursive path Main.(/=)
 
 Issue361:5:1--5:11
  1 | %default total
- 2 | 
+ 2 |
  3 | data S = T | F
- 4 | 
+ 4 |
  5 | Eq S where
      ^^^^^^^^^^
 

--- a/tests/idris2/error/error014/expected
+++ b/tests/idris2/error/error014/expected
@@ -3,7 +3,7 @@ Error: While processing left hand side of isCons. Can't match on (::) (Under-app
 
 Issue735:5:8--5:12
  1 | module Issue735
- 2 | 
+ 2 |
  3 | -- Not allowed to pattern-match on under-applied constructors
  4 | isCons : (a -> List a -> List a) -> Bool
  5 | isCons (::) = True
@@ -13,7 +13,7 @@ Error: While processing left hand side of test. Can't match on A (Under-applied 
 
 Issue735:12:6--12:7
  08 | interface A a where
- 09 | 
+ 09 |
  10 | -- Not allowed to pattern-match on under-applied type constructors
  11 | test : (kind : Type -> Type) -> Maybe Nat
  12 | test A = Just 1

--- a/tests/idris2/error/error015/expected
+++ b/tests/idris2/error/error015/expected
@@ -4,7 +4,7 @@ Error: Declaration name (f) shadowed by a pattern variable.
 Issue110:8:1--8:14
  4 | data Tup : (a,b : Type) -> Type where
  5 |   MkTup : (1 f : a) -> (1 s : b) -> Tup a b
- 6 | 
+ 6 |
  7 | f : Tup a b -> a
  8 | f (MkTup f s) = f
      ^^^^^^^^^^^^^

--- a/tests/idris2/error/error016/expected
+++ b/tests/idris2/error/error016/expected
@@ -4,7 +4,7 @@ Error: No type declaration for Main.myRec2.
 Issue1230:9:1--9:15
  5 | myRec1 : R
  6 | myRec1 = MkR 3
- 7 | 
+ 7 |
  8 | mkRec2 : R
  9 | myRec2 = MkR 3
      ^^^^^^^^^^^^^^

--- a/tests/idris2/error/error018/expected
+++ b/tests/idris2/error/error018/expected
@@ -3,7 +3,7 @@ Error: ? is not a valid pattern
 
 Issue1031:4:13--4:14
  1 | %default total
- 2 | 
+ 2 |
  3 | ohNo : Void
  4 | ohNo = let (? ** x) = the (a ** a) (Int ** 5) in x
                  ^
@@ -13,7 +13,7 @@ Error: ? is not a valid pattern
 
 Issue1031-2:4:9--4:10
  1 | %default total
- 2 | 
+ 2 |
  3 | foo : (x : Bool) -> x === True
  4 | foo = \ ? => Refl
              ^
@@ -23,7 +23,7 @@ Error: ? is not a valid pattern
 
 Issue1031-3:4:6--4:7
  1 | %default total
- 2 | 
+ 2 |
  3 | cool : (x : Bool) -> x === True
  4 | cool ? = Refl
           ^
@@ -33,7 +33,7 @@ Error: While processing left hand side of nice. Unsolved holes:
 Main.{dotTm:1} introduced at: 
 Issue1031-4:4:6--4:10
  1 | %default total
- 2 | 
+ 2 |
  3 | nice : (x : Bool) -> x === True
  4 | nice .(_) = Refl
           ^^^^

--- a/tests/idris2/error/error022/expected
+++ b/tests/idris2/error/error022/expected
@@ -8,7 +8,7 @@ Mismatch between: Nat and Double.
 UpdateLoc:5:5--5:21
  1 | record Nat2 where
  2 |   nat : Nat
- 3 | 
+ 3 |
  4 | f : Nat2 -> Nat2
  5 | f = { nat $= floor }
          ^^^^^^^^^^^^^^^^

--- a/tests/idris2/error/error024/expected
+++ b/tests/idris2/error/error024/expected
@@ -8,7 +8,7 @@ Mismatch between: Int and String.
 Error1:5:17--5:26
  1 | foo : Int -> IO Int
  2 | foo x = pure x
- 3 | 
+ 3 |
  4 | main : IO ()
  5 | main = putStrLn !(foo 10)
                      ^^^^^^^^^

--- a/tests/idris2/error/error025/expected
+++ b/tests/idris2/error/error025/expected
@@ -8,7 +8,7 @@ Mismatch between: Nat and Bool.
 
 IAlternativePrints:8:7--8:16
  4 | %default total
- 5 | 
+ 5 |
  6 | magicScript : Elab a
  7 | magicScript = check $ IAlternative EmptyFC FirstSuccess
  8 |   [ `(the Nat 5)
@@ -21,7 +21,7 @@ and:
 Mismatch between: String and Bool.
 
 IAlternativePrints:9:7--9:23
- 5 | 
+ 5 |
  6 | magicScript : Elab a
  7 | magicScript = check $ IAlternative EmptyFC FirstSuccess
  8 |   [ `(the Nat 5)

--- a/tests/idris2/error/error026/expected
+++ b/tests/idris2/error/error026/expected
@@ -7,7 +7,7 @@ Mismatch between: Maybe Int and Either ?_ ?_.
 
 DoBlockFC:6:3--6:10
  2 | bar : Maybe Int
- 3 | 
+ 3 |
  4 | foo : Either String Int
  5 | foo = do
  6 |   Right n <- pure bar | _ => Left "fail"

--- a/tests/idris2/error/error028/expected
+++ b/tests/idris2/error/error028/expected
@@ -5,7 +5,7 @@ Error: While processing right hand side of eval. Multiple solutions found in sea
 Issue3313:5:18--5:23
  1 | data Expr : Type -> Type where
  2 |     Add : (Integral n) => n -> n -> Expr n
- 3 | 
+ 3 |
  4 | eval : (Integral n) => Expr n -> n
  5 | eval (Add x y) = x + y
                       ^^^^^

--- a/tests/idris2/error/error033/expected
+++ b/tests/idris2/error/error033/expected
@@ -6,7 +6,7 @@ and:
 Mismatch between: Type -> Type and Type.
 
 UnifyPiInfo:8:7--8:8
- 4 | 
+ 4 |
  5 | namespace EI
  6 |   f : Type -> Type -> Type
  7 |   g : Type -> {_ : Type} -> Type
@@ -20,7 +20,7 @@ and:
 Mismatch between: Type -> Type and Type => Type.
 
 UnifyPiInfo:13:7--13:8
- 09 | 
+ 09 |
  10 | namespace EA
  11 |   f : Type -> Type -> Type
  12 |   g : Type -> {auto _ : Type} -> Type
@@ -34,7 +34,7 @@ and:
 Mismatch between: Type -> Type and {default Int _ : Type} -> Type.
 
 UnifyPiInfo:18:7--18:8
- 14 | 
+ 14 |
  15 | namespace ED
  16 |   f : Type -> Type -> Type
  17 |   g : Type -> {default Int _ : Type} -> Type
@@ -48,7 +48,7 @@ and:
 Mismatch between: Type and Type -> Type.
 
 UnifyPiInfo:27:7--27:8
- 23 | 
+ 23 |
  24 | namespace IE
  25 |   f : Type -> {_ : Type} -> Type
  26 |   g : Type -> Type -> Type
@@ -62,7 +62,7 @@ and:
 Mismatch between: Type and Type => Type.
 
 UnifyPiInfo:32:7--32:8
- 28 | 
+ 28 |
  29 | namespace IA
  30 |   f : Type -> {_ : Type} -> Type
  31 |   g : Type -> {auto _ : Type} -> Type
@@ -76,7 +76,7 @@ and:
 Mismatch between: Type and {default Int _ : Type} -> Type.
 
 UnifyPiInfo:37:7--37:8
- 33 | 
+ 33 |
  34 | namespace ID
  35 |   f : Type -> {_ : Type} -> Type
  36 |   g : Type -> {default Int _ : Type} -> Type
@@ -90,7 +90,7 @@ and:
 Mismatch between: Type => Type and Type -> Type.
 
 UnifyPiInfo:46:7--46:8
- 42 | 
+ 42 |
  43 | namespace AE
  44 |   f : Type -> {auto _ : Type} -> Type
  45 |   g : Type -> Type -> Type
@@ -104,7 +104,7 @@ and:
 Mismatch between: Type => Type and Type.
 
 UnifyPiInfo:51:7--51:8
- 47 | 
+ 47 |
  48 | namespace AI
  49 |   f : Type -> {auto _ : Type} -> Type
  50 |   g : Type -> {_ : Type} -> Type
@@ -118,7 +118,7 @@ and:
 Mismatch between: Type => Type and {default Int _ : Type} -> Type.
 
 UnifyPiInfo:56:7--56:8
- 52 | 
+ 52 |
  53 | namespace AD
  54 |   f : Type -> {auto _ : Type} -> Type
  55 |   g : Type -> {default Int _ : Type} -> Type
@@ -132,7 +132,7 @@ and:
 Mismatch between: {default Int _ : Type} -> Type and Type -> Type.
 
 UnifyPiInfo:65:7--65:8
- 61 | 
+ 61 |
  62 | namespace DE
  63 |   f : Type -> {default Int _ : Type} -> Type
  64 |   g : Type -> Type -> Type
@@ -146,7 +146,7 @@ and:
 Mismatch between: {default Int _ : Type} -> Type and Type.
 
 UnifyPiInfo:70:7--70:8
- 66 | 
+ 66 |
  67 | namespace DI
  68 |   f : Type -> {default Int _ : Type} -> Type
  69 |   g : Type -> {_ : Type} -> Type
@@ -160,7 +160,7 @@ and:
 Mismatch between: {default Int _ : Type} -> Type and Type => Type.
 
 UnifyPiInfo:75:7--75:8
- 71 | 
+ 71 |
  72 | namespace DA
  73 |   f : Type -> {default Int _ : Type} -> Type
  74 |   g : Type -> {auto _ : Type} -> Type
@@ -188,7 +188,7 @@ Mismatch between: Int -> Int and Int.
 Examples:8:19--8:22
  4 | higherOrder : (Int -> {_ : Int} -> Int) -> ()
  5 | higherOrder _ = ()
- 6 | 
+ 6 |
  7 | foo : ()
  8 | foo = higherOrder (+)
                        ^^^
@@ -206,7 +206,7 @@ Mismatch between: Int and Int -> ?b.
 Examples:11:16--11:46
  07 | foo : ()
  08 | foo = higherOrder (+)
- 09 | 
+ 09 |
  10 | maybePls : Maybe Int -> Maybe Int -> Maybe Int
  11 | maybePls x y = pure {f=Maybe} pls <*> x <*> y
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/idris2/error/perror001/expected
+++ b/tests/idris2/error/perror001/expected
@@ -4,7 +4,7 @@ Error: Bracket is not properly closed.
 PError:4:7--4:8
  1 | foo : Int -> Int
  2 | foo x = x
- 3 | 
+ 3 |
  4 | bar : (Int -> Int
            ^
 

--- a/tests/idris2/error/perror002/expected
+++ b/tests/idris2/error/perror002/expected
@@ -4,7 +4,7 @@ Error: Bracket is not properly closed.
 PError:5:23--5:24
  1 | foo : Int -> Int
  2 | foo x = x
- 3 | 
+ 3 |
  4 | bar : Int -> Int
  5 | bar x = let y = 42 in (y + x
                            ^

--- a/tests/idris2/error/perror003/expected
+++ b/tests/idris2/error/perror003/expected
@@ -4,7 +4,7 @@ Error: Bracket is not properly closed.
 PError:5:17--5:18
  1 | foo : Int -> Int
  2 | foo x = x
- 3 | 
+ 3 |
  4 | bar : Int -> Int
  5 | bar x = let y = (42 in y + x
                      ^
@@ -15,7 +15,7 @@ Error: Bracket is not properly closed.
 PError2:5:18--5:19
  1 | foo : Int -> Int
  2 | foo x = x
- 3 | 
+ 3 |
  4 | bar : Int -> Int
  5 | bar x = let y := (42 in y + x
                       ^

--- a/tests/idris2/error/perror005/expected
+++ b/tests/idris2/error/perror005/expected
@@ -2,10 +2,10 @@
 Error: Expected 'in'.
 
 PError:7:1--7:4
- 3 | 
+ 3 |
  4 | bar : Int -> Int
  5 | bar x = let y = 42
- 6 | 
+ 6 |
  7 | baz : Int -> Int
      ^^^
 

--- a/tests/idris2/error/perror006/expected
+++ b/tests/idris2/error/perror006/expected
@@ -2,10 +2,10 @@
 Error: Expected 'else'.
 
 PError:7:1--7:4
- 3 | 
+ 3 |
  4 | bar : Int -> Int
  5 | bar x = if x == 95 then 0
- 6 | 
+ 6 |
  7 | baz : Int -> Int
      ^^^
 

--- a/tests/idris2/error/perror008/expected
+++ b/tests/idris2/error/perror008/expected
@@ -4,7 +4,7 @@ Error: Couldn't parse any alternatives:
 
 Issue710a:3:8--3:9
  1 | module Issue710a
- 2 | 
+ 2 |
  3 | record r where
             ^
 ... (1 others)
@@ -14,7 +14,7 @@ Error: Couldn't parse any alternatives:
 
 Issue710b:3:6--3:7
  1 | module Issue710b
- 2 | 
+ 2 |
  3 | data r : Type where
           ^
 ... (1 others)
@@ -24,7 +24,7 @@ Error: Couldn't parse any alternatives:
 
 Issue710c:5:3--5:7
  1 | infix 3 #
- 2 | 
+ 2 |
  3 | data T : Type where
  4 |   (#) : T -> T -> T
  5 |   leaf : T
@@ -44,7 +44,7 @@ Error: Expected a capitalised identifier, got: a.
 
 Issue710e:3:11--3:12
  1 | %default total
- 2 | 
+ 2 |
  3 | namespace a
                ^
 

--- a/tests/idris2/error/perror009/expected
+++ b/tests/idris2/error/perror009/expected
@@ -2,7 +2,7 @@
 Error: Can't use reserved symbol @.
 
 Error1:4:4--4:5
- 1 | 
+ 1 |
  2 | data Foo : Type where
  3 |   FooBase : Foo
  4 |   (@) : Foo -> Foo -> Foo

--- a/tests/idris2/error/perror010/expected
+++ b/tests/idris2/error/perror010/expected
@@ -30,7 +30,7 @@ NamedReturn4:1:24--1:50
 Warning: DEPRECATED: trailing lambda. Use a $ or parens
 
 TrailingLam:3:9--3:22
- 1 | 
+ 1 |
  2 | f : (Nat -> Nat) -> Nat
  3 | f k = f \n => k (S n)
              ^^^^^^^^^^^^^

--- a/tests/idris2/error/perror011/expected
+++ b/tests/idris2/error/perror011/expected
@@ -9,7 +9,7 @@ Error: Bracket is not properly closed.
 
 Issue1496-1:5:24--5:25
  1 | module Main
- 2 | 
+ 2 |
  3 | export
  4 | Show Really where
  5 |   show (Really err) =  ["RR"

--- a/tests/idris2/error/perror013/expected
+++ b/tests/idris2/error/perror013/expected
@@ -3,9 +3,9 @@ Error: Expected an indented non-empty block.
 
 EmptyFailing:5:1--5:2
  1 | module EmptyFailing
- 2 | 
+ 2 |
  3 | failing
- 4 | 
+ 4 |
  5 | x : Void
      ^
 
@@ -14,9 +14,9 @@ Error: Expected an indented non-empty block.
 
 EmptyMutual:5:1--5:2
  1 | module EmptyMutual
- 2 | 
+ 2 |
  3 | mutual
- 4 | 
+ 4 |
  5 | a : Nat
      ^
 
@@ -25,9 +25,9 @@ Error: Expected an indented non-empty block.
 
 EmptyUsing:5:1--5:2
  1 | module EmptyUsing
- 2 | 
+ 2 |
  3 | using (Eq a)
- 4 | 
+ 4 |
  5 | f : a -> a -> Bool
      ^
 
@@ -36,9 +36,9 @@ Error: Expected an indented non-empty block.
 
 EmptyParameters:5:1--5:2
  1 | module EmptyParameters
- 2 | 
+ 2 |
  3 | parameters (m : Nat -> Type)
- 4 | 
+ 4 |
  5 | f : (y : Nat) -> m y -> Unit
      ^
 

--- a/tests/idris2/error/perror016/expected
+++ b/tests/idris2/error/perror016/expected
@@ -2,7 +2,7 @@
 Error: Expected 'then'.
 
 ParseIf:3:26--3:30
- 1 | 
+ 1 |
  2 | test : Int -> Int
  3 | test a = if a < 10 the 0 else a
                               ^^^^
@@ -11,7 +11,7 @@ ParseIf:3:26--3:30
 Error: Expected 'then'.
 
 ParseIf2:4:33--4:37
- 1 | 
+ 1 |
  2 | test : Int -> Int
  3 | test a = if a < 10
  4 |             then if a < 0 the 0 else 5
@@ -21,7 +21,7 @@ ParseIf2:4:33--4:37
 Error: Expected 'then'.
 
 ParseIf3:3:26--3:30
- 1 | 
+ 1 |
  2 | test : Int -> Int
  3 | test a = (if a < 0 the 0 else 5)
                               ^^^^

--- a/tests/idris2/error/perror019/expected
+++ b/tests/idris2/error/perror019/expected
@@ -3,7 +3,7 @@ Error: Implementation body can only contain definitions
 
 ImplError:5:3--5:4
  1 | data Foo = Bar
- 2 | 
+ 2 |
  3 | implementation Show Foo where
  4 |   show Bar = "a Foo"
  5 |   f

--- a/tests/idris2/error/perror021/expected
+++ b/tests/idris2/error/perror021/expected
@@ -2,7 +2,7 @@
 Error: Expected '}'.
 
 Implicit:6:15--6:17
- 2 | 
+ 2 |
  3 | myReverse : Vect n el -> Vect n el
  4 | myReverse [] = []
  5 | myReverse {n = S k} (x :: xs) =

--- a/tests/idris2/error/perror023/expected
+++ b/tests/idris2/error/perror023/expected
@@ -3,7 +3,7 @@ Error: Cannot begin a declaration with a reserved identifier.
 
 ParseError:3:1--3:7
  1 | module ParseError
- 2 | 
+ 2 |
  3 | String : Type
      ^^^^^^
 

--- a/tests/idris2/error/perror024/expected
+++ b/tests/idris2/error/perror024/expected
@@ -3,7 +3,7 @@ Error: Keyword 'module' is not a valid start to a declaration.
 
 ParseError:3:1--3:7
  1 | module ParseError
- 2 | 
+ 2 |
  3 | module : Type
      ^^^^^^
 

--- a/tests/idris2/error/perror026/expected
+++ b/tests/idris2/error/perror026/expected
@@ -3,7 +3,7 @@ Error: Expected ',' or '.'.
 
 Micro:3:14--3:15
  1 | module Micro
- 2 | 
+ 2 |
  3 | f : forall a b. (Unit -> Unit) -> Unit -> Unit
                   ^
 

--- a/tests/idris2/error/perror028/expected
+++ b/tests/idris2/error/perror028/expected
@@ -2,7 +2,7 @@
 Error: Let-in not supported in do block. Did you mean (let ... in ...)?.
 
 LetInDo:6:13--6:15
- 2 | 
+ 2 |
  3 | letInDo : Monad m => m Int
  4 | letInDo = do
  5 |   y <- pure 10

--- a/tests/idris2/error/perror029/expected
+++ b/tests/idris2/error/perror029/expected
@@ -2,7 +2,7 @@
 Error: Delay only takes one argument.
 
 DelayParse:13:44--13:46
- 09 | 
+ 09 |
  10 | public export
  11 | go : a -> (a -> a) -> MyStream
  12 | go initA fn =

--- a/tests/idris2/error/perror034/expected
+++ b/tests/idris2/error/perror034/expected
@@ -19,7 +19,7 @@ Mismatch between: Type and ().
 Error:5:9--5:27
  1 | unnamed : ()
  2 | unnamed = (Nat) -> Nat
- 3 | 
+ 3 |
  4 | named : ()
  5 | named = (arg : Nat) -> Nat
              ^^^^^^^^^^^^^^^^^^

--- a/tests/idris2/error/perror035/expected
+++ b/tests/idris2/error/perror035/expected
@@ -3,9 +3,9 @@ Error: Imports must go before any declarations or directives.
 
 ParseError:5:1--5:7
  1 | module ParseError
- 2 | 
+ 2 |
  3 | %default total
- 4 | 
+ 4 |
  5 | import Data.Nat
      ^^^^^^
 

--- a/tests/idris2/error/perror036/expected
+++ b/tests/idris2/error/perror036/expected
@@ -14,7 +14,7 @@ Error: Bracket is not properly closed.
 Issue3594:8:14--8:15
  4 |   Red : Color
  5 |   Blue : Color
- 6 | 
+ 6 |
  7 | implementation Show Color where
  8 |   show Red = "red
                   ^

--- a/tests/idris2/evaluator/interpreter008/expected
+++ b/tests/idris2/evaluator/interpreter008/expected
@@ -4,7 +4,7 @@ Main.{n:1} introduced at:
 Issue2041:5:17--5:19
  1 | ex : {n : Nat} -> String
  2 | ex {n} = "hello" ++ show n
- 3 | 
+ 3 |
  4 | main : IO ()
  5 | main = putStrLn ex
                      ^^

--- a/tests/idris2/interactive/interactive047/expected
+++ b/tests/idris2/interactive/interactive047/expected
@@ -3,7 +3,7 @@ Error: foo is not covering.
 
 Missing:3:1--3:37
  1 | import Data.Vect
- 2 | 
+ 2 |
  3 | foo : {n : Nat} -> Vect n Nat -> Nat
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/idris2/interface/interface008/expected
+++ b/tests/idris2/interface/interface008/expected
@@ -5,7 +5,7 @@ You may be unintentionally shadowing the associated global definitions:
 
 Deps:15:3--15:28
  11 |   to = id
- 12 | 
+ 12 |
  13 | interface BadFinite t where
  14 |   badcard   : Nat
  15 |   badto     : t -> Fin card
@@ -16,7 +16,7 @@ Error: While processing right hand side of badcard. k is not accessible in this 
 Deps:18:13--18:14
  14 |   badcard   : Nat
  15 |   badto     : t -> Fin card
- 16 | 
+ 16 |
  17 | implementation BadFinite (Fin k) where
  18 |   badcard = k
                   ^

--- a/tests/idris2/interface/interface013/expected
+++ b/tests/idris2/interface/interface013/expected
@@ -4,7 +4,7 @@ Error: While processing constructor MkRecord. Can't find an implementation for I
 TypeInt:14:25--14:49
  10 | 0 DependentValue : Interface s => Value s -> Type
  11 | DependentValue v = concrete (specifier v)
- 12 | 
+ 12 |
  13 | data Record : s -> Type where
  14 |   MkRecord : Value s -> DependentValue {s} value -> Record s
                               ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/idris2/interface/interface015/expected
+++ b/tests/idris2/interface/interface015/expected
@@ -3,7 +3,7 @@ Error: While processing right hand side of TestSurprise1. Multiple solutions fou
     Gnu
 
 gnu:47:27--47:32
- 43 | 
+ 43 |
  44 | ||| This is the meat. I'd expect this function to raise an error
  45 | ||| because it is ambiguous which local/local function to use.
  46 | TestSurprise1 : (gnu1, gnu2 : Gnu) -> String
@@ -19,7 +19,7 @@ Error: While processing right hand side of TestSurprise2. Multiple solutions fou
 gnu:50:21--50:26
  46 | TestSurprise1 : (gnu1, gnu2 : Gnu) -> String
  47 | TestSurprise1 gnu1 gnu2 = Guess
- 48 | 
+ 48 |
  49 | TestSurprise2 : (f,g : Unit -> Gnu) -> String
  50 | TestSurprise2 f g = Guess
                           ^^^^^
@@ -32,7 +32,7 @@ Error: While processing right hand side of TestSurprise3. Can't find an implemen
 gnu:53:19--53:24
  49 | TestSurprise2 : (f,g : Unit -> Gnu) -> String
  50 | TestSurprise2 f g = Guess
- 51 | 
+ 51 |
  52 | TestSurprise3 : (Unit -> Gnu, Unit -> Gnu) -> String
  53 | TestSurprise3 f = Guess
                         ^^^^^

--- a/tests/idris2/interface/interface026/expected
+++ b/tests/idris2/interface/interface026/expected
@@ -4,7 +4,7 @@ Error: While processing right hand side of lkup3Bad. Can't find an implementatio
 UninhabitedRec:30:12--30:21
  26 | lkup2Good : String
  27 | lkup2Good = fff xxs 2
- 28 | 
+ 28 |
  29 | lkup3Bad : String
  30 | lkup3Bad = fff xxs 3
                  ^^^^^^^^^
@@ -14,7 +14,7 @@ Error: While processing right hand side of uniqBad. Can't find an implementation
 UninhabitedRec:49:11--49:12
  45 | uniqGood : Uniq Nat
  46 | uniqGood = [1, 2, 3]
- 47 | 
+ 47 |
  48 | uniqBad : Uniq Nat
  49 | uniqBad = [1, 2, 1]
                 ^

--- a/tests/idris2/interface/interface036/expected
+++ b/tests/idris2/interface/interface036/expected
@@ -5,7 +5,7 @@ Warning: You may be unintentionally shadowing the following local bindings:
 Issue3474:23:3--23:10
  19 | interface Iface7 where
  20 |   method7 : {_ : Type} -> Type
- 21 | 
+ 21 |
  22 | interface Iface8 where
  23 |   method8 : {x : Type} -> {x : Int} -> {_ : String} -> (x : Double) => {x : Integer} -> Type
         ^^^^^^^

--- a/tests/idris2/linear/linear006/expected
+++ b/tests/idris2/linear/linear006/expected
@@ -4,7 +4,7 @@ Error: While processing right hand side of bar. Main.test is not accessible in t
 ZFun:13:7--13:11
  09 | 0 baz : Nat
  10 | baz = test foo -- fine!
- 11 | 
+ 11 |
  12 | bar : Nat
  13 | bar = test foo -- bad!
             ^^^^

--- a/tests/idris2/misc/import002/expected
+++ b/tests/idris2/misc/import002/expected
@@ -5,18 +5,18 @@ Error: While processing type of thing. Undefined name Nat.
 
 Test:5:9--5:12
  1 | module Test
- 2 | 
+ 2 |
  3 | import Mult
- 4 | 
+ 4 |
  5 | thing : Nat -> Nat
              ^^^
 
 Error: While processing right hand side of thing. Undefined name plus. 
 
 Test:6:19--6:23
- 2 | 
+ 2 |
  3 | import Mult
- 4 | 
+ 4 |
  5 | thing : Nat -> Nat
  6 | thing x = mult x (plus x x)
                        ^^^^

--- a/tests/idris2/misc/import007/expected
+++ b/tests/idris2/misc/import007/expected
@@ -6,7 +6,7 @@ Error: While processing right hand side of main. Undefined name foo.
 Mod:5:16--5:19
  1 | import Mod1
  2 | import Mod2
- 3 | 
+ 3 |
  4 | main : IO ()
  5 | main = printLn foo
                     ^^^

--- a/tests/idris2/misc/import009/expected
+++ b/tests/idris2/misc/import009/expected
@@ -5,7 +5,7 @@ Error: Unknown operator '~:>'
 Import:11:3--11:6
  07 | (|>) : (s : HasComp x) => {0 a, b, c : x} -> a ~> b -> b ~> c -> a ~> c
  08 | a |> b = comp s a b
- 09 | 
+ 09 |
  10 | (~:>) : Type -> Type -> Type
  11 | a ~:> b = Pair a b
         ^^^
@@ -19,7 +19,7 @@ Mismatch between: Either ((!!) a) ((!!) b) and Either a ?b -> Void.
 
 Prefix:12:17--12:27
  08 | (!!) = Not
- 09 | 
+ 09 |
  10 | export
  11 | test : Either (!! a) (!! b) -> !! (a, b)
  12 | test f (x, y) = f (Left x)

--- a/tests/idris2/misc/namespace002/expected
+++ b/tests/idris2/misc/namespace002/expected
@@ -6,9 +6,9 @@ and:
 Mismatch between: Int -> Int -> Int and Int.
 
 Issue1313:9:17--9:18
- 5 | 
+ 5 |
  6 | namespace Y
- 7 | 
+ 7 |
  8 |   g : Int -> Int -> Int
  9 |   g x y = x + f g
                      ^

--- a/tests/idris2/misc/namespace003/expected
+++ b/tests/idris2/misc/namespace003/expected
@@ -6,7 +6,7 @@ Error: While processing right hand side of testFailing1. Ambiguous elaboration. 
 Test:20:16--20:20
  16 |   (<*>) : IO (a -> b) -> IO a -> IO b
  17 |   (<*>) = (<*>) @{%search}
- 18 | 
+ 18 |
  19 | testFailing1 : IO ()
  20 | testFailing1 = pure ()
                      ^^^^
@@ -17,7 +17,7 @@ Error: While processing right hand side of testFailing2. Ambiguous elaboration. 
 
 Test:28:3--28:12
  24 |   pure ()
- 25 | 
+ 25 |
  26 | testFailing2 : (a -> b) -> IO a -> IO b
  27 | testFailing2 f a =
  28 |   [| f a |]

--- a/tests/idris2/misc/namespace005/expected
+++ b/tests/idris2/misc/namespace005/expected
@@ -13,7 +13,7 @@ For example: %hide Lib2.infixl.(%%%)
 MainFail:7:20--7:23
  3 | import Lib2
  4 | import Lib1
- 5 | 
+ 5 |
  6 | main : IO ()
  7 | main = printLn (10 %%% 10 %%% 1)
                         ^^^
@@ -28,7 +28,7 @@ For example: %hide Lib2.infixl.(%%%)
 MainFail:7:27--7:30
  3 | import Lib2
  4 | import Lib1
- 5 | 
+ 5 |
  6 | main : IO ()
  7 | main = printLn (10 %%% 10 %%% 1)
                                ^^^
@@ -44,7 +44,7 @@ For example: %hide Main3.prefix.(%%%)
 Main3:12:29--12:32
  08 | (%%%) : Nat -> Nat
  09 | (%%%) = S
- 10 | 
+ 10 |
  11 | main : IO ()
  12 | main = do printLn (the Nat (%%% 4))
                                   ^^^
@@ -58,7 +58,7 @@ For example: %hide Prelude.Ops.infixl.(-)
 
 Main3:13:22--13:23
  09 | (%%%) = S
- 10 | 
+ 10 |
  11 | main : IO ()
  12 | main = do printLn (the Nat (%%% 4))
  13 |           printLn (1 - 1 - 1)
@@ -73,7 +73,7 @@ For example: %hide Prelude.Ops.infixl.(-)
 
 Main3:13:26--13:27
  09 | (%%%) = S
- 10 | 
+ 10 |
  11 | main : IO ()
  12 | main = do printLn (the Nat (%%% 4))
  13 |           printLn (1 - 1 - 1)

--- a/tests/idris2/misc/params001/expected
+++ b/tests/idris2/misc/params001/expected
@@ -5,7 +5,7 @@ Error: While processing right hand side of U. Name Main.X.foo is private.
 parambad:7:7--7:10
  3 |     foo : Bool
  4 |     foo = True
- 5 | 
+ 5 |
  6 |   U : Bool
  7 |   U = foo
            ^^^

--- a/tests/idris2/misc/real001/expected
+++ b/tests/idris2/misc/real001/expected
@@ -6,7 +6,7 @@ You may be unintentionally shadowing the associated global definitions:
 
 Channel:63:6--63:41
  59 | AsServer proto = ServerK proto (\res => Close)
- 60 | 
+ 60 |
  61 | public export
  62 | data QueueEntry : Type where
  63 |      Entry : (1 val : any) -> QueueEntry

--- a/tests/idris2/operators/operators002/expected
+++ b/tests/idris2/operators/operators002/expected
@@ -4,7 +4,7 @@ Error: Operator =@ is a type-binding (typebind) operator, but is used as an auto
 Errors:8:19--8:21
  4 | 0 (=@) : (a : Type) -> (a -> Type) -> Type
  5 | (=@) a f = (1 x : a) -> f x
- 6 | 
+ 6 |
  7 | data S : {ty : Type} -> (x : ty) -> Type where
  8 |   MkS : (x <- ty) =@ S x
                        ^^
@@ -18,10 +18,10 @@ Possible solutions:
 Error: Operator =@ is an automatically-binding (autobind) operator, but is used as a regular operator.
 
 Errors2:7:29--7:31
- 3 | 
+ 3 |
  4 | 0 (=@) : (a : Type) -> (a -> Type) -> Type
  5 | (=@) a f = (1 x : a) -> f x
- 6 | 
+ 6 |
  7 | wrongId : {0 a : Type} -> a =@ a
                                  ^^
 Explanation: regular, typebind and autobind operators all use a slightly different syntax, typebind looks like this: '(name : type) =@ expr', autobind looks like this: '(name <- expr) =@ expr'.
@@ -34,10 +34,10 @@ Possible solutions:
 Error: Operator =@ is a type-binding (typebind) operator, but is used as a regular operator.
 
 Errors3:7:29--7:31
- 3 | 
+ 3 |
  4 | 0 (=@) : (a : Type) -> (a -> Type) -> Type
  5 | (=@) a f = (1 x : a) -> f x
- 6 | 
+ 6 |
  7 | wrongId : {0 a : Type} -> a =@ a
                                  ^^
 Explanation: regular, typebind and autobind operators all use a slightly different syntax, typebind looks like this: '(name : type) =@ expr', autobind looks like this: '(name <- expr) =@ expr'.
@@ -51,8 +51,8 @@ Error: Operator =@ is a regular operator, but is used as a type-binding (typebin
 
 Errors4:9:18--9:20
  5 | (=@) a f = (1 x : a) -> f x
- 6 | 
- 7 | 
+ 6 |
+ 7 |
  8 | data S : {ty : Type} -> (x : ty) -> Type where
  9 |   MkS : (x : ty) =@ S x
                       ^^
@@ -67,8 +67,8 @@ Error: Operator =@ is a regular operator, but is used as an automatically-bindin
 
 Errors5:10:19--10:21
  06 | (=@) a f = (1 x : a) -> f x
- 07 | 
- 08 | 
+ 07 |
+ 08 |
  09 | data S : {ty : Type} -> (x : ty) -> Type where
  10 |   MkS : (x <- ty) =@ S x
                         ^^
@@ -85,7 +85,7 @@ Error: Operator =@ is a type-binding (typebind) operator, but is used as an auto
 LinImport:8:19--8:21
  4 | 0 (=@) : (a : Type) -> (a -> Type) -> Type
  5 | (=@) a f = (1 x : a) -> f x
- 6 | 
+ 6 |
  7 | data S : {ty : Type} -> (x : ty) -> Type where
  8 |   MkS : (x <- ty) =@ S x
                        ^^

--- a/tests/idris2/operators/operators003/expected
+++ b/tests/idris2/operators/operators003/expected
@@ -3,7 +3,7 @@ Error: Invalid fixity, typebind operator must be infixr 0.
 
 Error1:3:10--3:21
  1 | module Error1
- 2 | 
+ 2 |
  3 | typebind infixl 0 =@
               ^^^^^^^^^^^
 
@@ -15,7 +15,7 @@ Error: Invalid fixity, typebind operator must be infixr 0.
 
 Error2:3:10--3:21
  1 | module Error2
- 2 | 
+ 2 |
  3 | typebind infixr 3 =@
               ^^^^^^^^^^^
 
@@ -27,7 +27,7 @@ Error: Invalid fixity, typebind operator must be infixr 0.
 
 Error3:3:10--3:21
  1 | module Error3
- 2 | 
+ 2 |
  3 | typebind infixl 3 =@
               ^^^^^^^^^^^
 

--- a/tests/idris2/operators/operators004/expected
+++ b/tests/idris2/operators/operators004/expected
@@ -4,7 +4,7 @@ Error: Operator -:- is non-associative
 Test:13:8--13:22
  09 | (:-:) : a -> List a -> List a
  10 | (:-:) = (::)
- 11 | 
+ 11 |
  12 | test : List Nat
  13 | test = 4 -:- 3 :-: []
              ^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ Error: Operator :-: is non-associative
 Test:16:9--16:23
  12 | test : List Nat
  13 | test = 4 -:- 3 :-: []
- 14 | 
+ 14 |
  15 | test2 : List Nat
  16 | test2 = 4 :-: 3 -:- []
               ^^^^^^^^^^^^^^

--- a/tests/idris2/operators/operators007/expected
+++ b/tests/idris2/operators/operators007/expected
@@ -4,7 +4,7 @@ Error: Operator >>= is a regular operator, but is used as an automatically-bindi
 Test:10:28--10:31
  06 | (>>) : Monad m => m a -> (a -> m b) -> m b
  07 | (>>) = (>>=)
- 08 | 
+ 08 |
  09 | both : Maybe (Nat, Nat) -> Maybe Nat
  10 | both m = (MkPair x y <- m) >>= Just (x + y)
                                  ^^^
@@ -21,7 +21,7 @@ Error: Operator >>= is a regular operator, but is used as an automatically-bindi
 Test2:14:28--14:31
  10 | (>=) : Monad m => m a -> (a -> m b) -> m b
  11 | (>=) = (>>=)
- 12 | 
+ 12 |
  13 | both : Maybe (Nat, Nat) -> Maybe Nat
  14 | both m = (MkPair x y <- m) >>= Just (x + y)
                                  ^^^

--- a/tests/idris2/operators/operators009/expected
+++ b/tests/idris2/operators/operators009/expected
@@ -5,7 +5,7 @@ To expose it outside of its module, write 'export infixr 0 =@'. If you
 intend to keep it private, write 'private infixr 0 =@'.
 
 Test:2:1--2:12
- 1 | 
+ 1 |
  2 | infixr 0 =@
      ^^^^^^^^^^^
 

--- a/tests/idris2/operators/operators011/expected
+++ b/tests/idris2/operators/operators011/expected
@@ -2,7 +2,7 @@
 Error: Fixity DoesNotExist.infixl.(+-+) not found
 
 Test:2:1--2:32
- 1 | 
+ 1 |
  2 | %hide DoesNotExist.infixl.(+-+)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -12,7 +12,7 @@ Error: Fixity Modul.infixl.(&&++) not found
 
 Test1:3:1--3:26
  1 | import Module
- 2 | 
+ 2 |
  3 | %hide Modul.infixl.(&&++)
      ^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -23,7 +23,7 @@ Error: Fixity Module.infixr.(&&++) not found
 
 Test2:3:1--3:27
  1 | import Module
- 2 | 
+ 2 |
  3 | %hide Module.infixr.(&&++)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -34,7 +34,7 @@ Error: Fixity Module.infixl.(&&+*) not found
 
 Test3:3:1--3:27
  1 | import Module
- 2 | 
+ 2 |
  3 | %hide Module.infixl.(&&+*)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -44,9 +44,9 @@ Did you mean:
 Error: Fixity DoesNotExist.infixl.(&&++) not found
 
 Test4:4:1--4:33
- 1 | 
+ 1 |
  2 | import Module
- 3 | 
+ 3 |
  4 | %hide DoesNotExist.infixl.(&&++)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/idris2/perf/perf005/expected
+++ b/tests/idris2/perf/perf005/expected
@@ -20,7 +20,7 @@ Error: Couldn't parse any alternatives:
 
 Bad1:3:20--3:21
  1 | module Bad1
- 2 | 
+ 2 |
  3 | data Bad = BadDCon (x : Nat)
                         ^
 ... (2 others)
@@ -29,7 +29,7 @@ Error: Cannot return a named argument.
 
 Bad2:3:13--3:29
  1 | module Bad2
- 2 | 
+ 2 |
  3 | badReturn : (whatever : Int)
                  ^^^^^^^^^^^^^^^^
 
@@ -38,7 +38,7 @@ Error: Couldn't parse declaration.
 
 Bad3:4:1--4:8
  1 | module Bad3
- 2 | 
+ 2 |
  3 | badExpr : ()
  4 | badExpr (whatever : ())
      ^^^^^^^

--- a/tests/idris2/perf/perf009/expected
+++ b/tests/idris2/perf/perf009/expected
@@ -4,7 +4,7 @@
 Error: While processing right hand side of foo. Can't find an implementation for Monad (StateT AFoo Identity).
 
 C:14:5--14:12
- 10 | 
+ 10 |
  11 | foo : X ()
  12 | foo =
  13 |   do

--- a/tests/idris2/perf/perf011/expected
+++ b/tests/idris2/perf/perf011/expected
@@ -5,9 +5,9 @@ Error: While processing type of foo. Can't find an implementation for BFromInteg
 
 C:5:7--5:14
  1 | module C
- 2 | 
+ 2 |
  3 | import B
- 4 | 
+ 4 |
  5 | foo : BFunc x
            ^^^^^^^
 
@@ -15,18 +15,18 @@ Possible cause: Undefined name A.BFromInteger.
 
 C:5:7--5:14
  1 | module C
- 2 | 
+ 2 |
  3 | import B
- 4 | 
+ 4 |
  5 | foo : BFunc x
            ^^^^^^^
 Did you mean: fromInteger?
 Error: While processing type of foo1. Can't find an implementation for BFromInteger ?x.
 
 C:6:8--6:15
- 2 | 
+ 2 |
  3 | import B
- 4 | 
+ 4 |
  5 | foo : BFunc x
  6 | foo1 : BFunc x
             ^^^^^^^
@@ -34,9 +34,9 @@ C:6:8--6:15
 Possible cause: Undefined name A.BFromInteger. 
 
 C:6:8--6:15
- 2 | 
+ 2 |
  3 | import B
- 4 | 
+ 4 |
  5 | foo : BFunc x
  6 | foo1 : BFunc x
             ^^^^^^^
@@ -45,7 +45,7 @@ Error: While processing type of foo2. Can't find an implementation for BFromInte
 
 C:7:8--7:15
  3 | import B
- 4 | 
+ 4 |
  5 | foo : BFunc x
  6 | foo1 : BFunc x
  7 | foo2 : BFunc x
@@ -55,7 +55,7 @@ Possible cause: Undefined name A.BFromInteger.
 
 C:7:8--7:15
  3 | import B
- 4 | 
+ 4 |
  5 | foo : BFunc x
  6 | foo1 : BFunc x
  7 | foo2 : BFunc x
@@ -64,7 +64,7 @@ Did you mean: fromInteger?
 Error: While processing type of foo3. Can't find an implementation for BFromInteger ?x.
 
 C:8:8--8:15
- 4 | 
+ 4 |
  5 | foo : BFunc x
  6 | foo1 : BFunc x
  7 | foo2 : BFunc x
@@ -74,7 +74,7 @@ C:8:8--8:15
 Possible cause: Undefined name A.BFromInteger. 
 
 C:8:8--8:15
- 4 | 
+ 4 |
  5 | foo : BFunc x
  6 | foo1 : BFunc x
  7 | foo2 : BFunc x

--- a/tests/idris2/reflection/reflection001/expected
+++ b/tests/idris2/reflection/reflection001/expected
@@ -16,10 +16,10 @@ quote:25:19--25:22
 Error: %language ElabReflection not enabled
 
 quote:33:1--33:21
- 29 | 
+ 29 |
  30 | noExtension : Elab ()
  31 | noExtension = fail "Should not print this message"
- 32 | 
+ 32 |
  33 | %runElab noExtension
       ^^^^^^^^^^^^^^^^^^^^
 
@@ -27,9 +27,9 @@ Error: Error during reflection: Should not print this message
 
 quote:37:1--37:21
  33 | %runElab noExtension
- 34 | 
+ 34 |
  35 | %language ElabReflection
- 36 | 
+ 36 |
  37 | %runElab noExtension
       ^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/idris2/reflection/reflection003/expected
+++ b/tests/idris2/reflection/reflection003/expected
@@ -18,7 +18,7 @@ Error: While processing right hand side of dummy1. Error during reflection: Not 
 refprims:45:10--45:27
  41 |         ns <- inCurrentNS n
  42 |         fail $ "failed after generating " ++ censorDigits (show ns)
- 43 | 
+ 43 |
  44 | dummy1 : a
  45 | dummy1 = %runElab logPrims
                ^^^^^^^^^^^^^^^^^
@@ -28,7 +28,7 @@ Error: While processing right hand side of dummy2. Error during reflection: Stil
 refprims:48:10--48:30
  44 | dummy1 : a
  45 | dummy1 = %runElab logPrims
- 46 | 
+ 46 |
  47 | dummy2 : a
  48 | dummy2 = %runElab logDataCons
                ^^^^^^^^^^^^^^^^^^^^
@@ -38,7 +38,7 @@ Error: While processing right hand side of dummy3. Error during reflection: Unde
 refprims:51:10--51:25
  47 | dummy2 : a
  48 | dummy2 = %runElab logDataCons
- 49 | 
+ 49 |
  50 | dummy3 : a
  51 | dummy3 = %runElab logBad
                ^^^^^^^^^^^^^^^
@@ -48,7 +48,7 @@ Error: While processing right hand side of dummy4. Error during reflection: fail
 refprims:54:10--54:28
  50 | dummy3 : a
  51 | dummy3 = %runElab logBad
- 52 | 
+ 52 |
  53 | dummy4 : a
  54 | dummy4 = %runElab tryGenSym
                ^^^^^^^^^^^^^^^^^^

--- a/tests/idris2/reflection/reflection005/expected
+++ b/tests/idris2/reflection/reflection005/expected
@@ -6,9 +6,9 @@ and:
 Mismatch between: () and a.
 
 refdecl:13:16--13:29
- 09 | 
+ 09 |
  10 | %runElab mkDecls `(94)
- 11 | 
+ 11 |
  12 | bad : a
  13 | bad = %runElab mkDecls `(94)
                      ^^^^^^^^^^^^^

--- a/tests/idris2/reflection/reflection006/expected
+++ b/tests/idris2/reflection/reflection006/expected
@@ -8,9 +8,9 @@ You may be unintentionally shadowing the associated global definitions:
 
 refleq:5:1--5:35
  1 | import Language.Reflection
- 2 | 
+ 2 |
  3 | %language ElabReflection
- 4 | 
+ 4 |
  5 | solveReflected : TTImp -> Elab any
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -21,7 +21,7 @@ You may be unintentionally shadowing the associated global definitions:
 refleq:15:1--15:17
  11 |     = do logTerm "" 0 "Goal" g
  12 |          fail "I don't know how to prove this"
- 13 | 
+ 13 |
  14 | %macro
  15 | prove : Elab any
       ^^^^^^^^^^^^^^^^
@@ -31,7 +31,7 @@ Error: While processing right hand side of commutes. Error during reflection: No
 refleq:24:16--24:21
  20 |          logMsg "" 0 (show env)
  21 |          solveReflected g
- 22 | 
+ 22 |
  23 | commutes : (x, y : Nat) -> plus x y = plus y x
  24 | commutes x y = prove
                      ^^^^^

--- a/tests/idris2/reflection/reflection019/expected
+++ b/tests/idris2/reflection/reflection019/expected
@@ -2,9 +2,9 @@
 Warning: The first argument worth a warning
 
 ElabScriptWarning:19:27--19:39
- 15 | 
- 16 | 
- 17 | 
+ 15 |
+ 16 |
+ 17 |
  18 | x : Nat
  19 | x = %runElab showsWarning "Suspicious" 15
                                 ^^^^^^^^^^^^

--- a/tests/idris2/reflection/reflection022/expected
+++ b/tests/idris2/reflection/reflection022/expected
@@ -4,7 +4,7 @@ Error: While processing right hand side of y. Bad elaborator script ?someHole [n
 BadElabScript:14:5--14:15
  10 |   ?someHole
  11 |   check `(%search)
- 12 | 
+ 12 |
  13 | y : Nat
  14 | y = %runElab x
           ^^^^^^^^^^
@@ -12,7 +12,7 @@ BadElabScript:14:5--14:15
 Stuck place in the script:
 
 BadElabScript:10:3--10:12
- 06 | 
+ 06 |
  07 | x : Elab Nat
  08 | x = do
  09 |   ignore $ check {expected=Type} `(Nat)

--- a/tests/idris2/reflection/reflection035/expected
+++ b/tests/idris2/reflection/reflection035/expected
@@ -3,9 +3,9 @@
 Error: While processing right hand side of broken. Can't find an implementation for VoidContainer.
 
 Main:8:10--8:17
- 4 | 
+ 4 |
  5 | %default total
- 6 | 
+ 6 |
  7 | broken : VoidContainer
  8 | broken = %search
               ^^^^^^^

--- a/tests/idris2/reg/reg003/expected
+++ b/tests/idris2/reg/reg003/expected
@@ -3,7 +3,7 @@ Warning: Unreachable clause: f True
 
 Holes:12:1--12:7
  08 | Weird v =  Vect_ext ?hole0 ?hole1 ?hole2
- 09 | 
+ 09 |
  10 | f : Bool -> Nat
  11 | f True = 0
  12 | f True = ?help

--- a/tests/idris2/reg/reg005/expected
+++ b/tests/idris2/reg/reg005/expected
@@ -3,7 +3,7 @@ Error: While processing right hand side of isInListBad. Can't solve constraint b
 
 iftype:15:15--15:19
  11 | isInList = Here
- 12 | 
+ 12 |
  13 | isInListBad : Elem (ABC Bool String (\c => if c then "Foo" else "Bar"))
  14 |                   [(ABC Bool String (\c => if c then "Foo" else "Baz"))]
  15 | isInListBad = Here

--- a/tests/idris2/reg/reg007/expected
+++ b/tests/idris2/reg/reg007/expected
@@ -8,7 +8,7 @@ Mismatch between: [MN 0] and [].
 Main:27:27--27:36
  23 | dpairWithExtraInfoWorks : List (vars : List Name ** Expr vars)
  24 | dpairWithExtraInfoWorks = [([MN 0] ** CLocal {x=MN 0} (First {ns=[]}))]
- 25 | 
+ 25 |
  26 | dpairWithExtraInfoBad : List (vars : List Name ** Expr vars)
  27 | dpairWithExtraInfoBad = [([MN 0] ** CLocal {x=MN 0} (First {ns=[MN 0]}))]
                                 ^^^^^^^^^

--- a/tests/idris2/reg/reg013/expected
+++ b/tests/idris2/reg/reg013/expected
@@ -3,19 +3,19 @@ Error: While processing constructor Foo. Undefined name n.
 
 UnboundImplicits:6:22--6:23
  2 | import Data.Vect
- 3 | 
+ 3 |
  4 | %unbound_implicits off
- 5 | 
+ 5 |
  6 | record Foo (x : Vect n Nat) where
                           ^
 
 Error: Undefined name n. 
 
 UnboundImplicits:9:24--9:25
- 5 | 
+ 5 |
  6 | record Foo (x : Vect n Nat) where
  7 |   constructor MkFoo
- 8 | 
+ 8 |
  9 | parameters (Foo : Vect n Nat)
                             ^
 
@@ -24,18 +24,18 @@ Error: While processing constructor Foo. Undefined name n.
 UnboundImplicits:14:25--14:26
  10 |   bar : Nat
  11 |   bar = 0
- 12 | 
- 13 | 
+ 12 |
+ 13 |
  14 | interface Foo (a : Vect n Nat) where
                               ^
 
 Error: While processing type of Functor implementation at UnboundImplicits:1. Undefined name n. 
 
 UnboundImplicits:17:30--17:31
- 13 | 
+ 13 |
  14 | interface Foo (a : Vect n Nat) where
  15 |   baz : Nat
- 16 | 
+ 16 |
  17 | implementation Functor (Vect n) where
                                    ^
 

--- a/tests/idris2/reg/reg015/expected
+++ b/tests/idris2/reg/reg015/expected
@@ -4,7 +4,7 @@ Error: showing (MkEvenMoreComplicated (MkMoreComplicated (MkComplicated (PtrAndS
 anyfail:21:1--21:48
  17 |         TooComplicatedToBeTrue
  18 |             (MkEvenMoreComplicated (MkMoreComplicated (MkComplicated (PtrAndSize addr len))))
- 19 | 
+ 19 |
  20 | showing  :  (something : EvenMoreComplicated) -> (TooComplicatedToBeTrue something) -> Void
  21 | showing _ SomethingVeryComplicatedIs impossible
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/idris2/reg/reg019/expected
+++ b/tests/idris2/reg/reg019/expected
@@ -4,7 +4,7 @@ Error: While processing right hand side of main. Can't solve constraint between:
 lazybug:5:22--5:34
  1 | bools : List Bool
  2 | bools = [True, False]
- 3 | 
+ 3 |
  4 | main : IO ()
  5 | main = printLn $ or (map id bools)
                           ^^^^^^^^^^^^
@@ -14,7 +14,7 @@ Error: While processing right hand side of main2. Can't solve constraint between
 lazybug:8:23--8:42
  4 | main : IO ()
  5 | main = printLn $ or (map id bools)
- 6 | 
+ 6 |
  7 | main2 : IO ()
  8 | main2 = printLn $ or (map (\x => x) bools)
                            ^^^^^^^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ Error: While processing right hand side of main4. Can't solve constraint between
 lazybug:14:22--14:27
  10 | main3 : IO ()
  11 | main3 = printLn $ or (map (\x => Delay x) bools)
- 12 | 
+ 12 |
  13 | main4 : IO ()
  14 | main4 = printLn $ or bools
                            ^^^^^

--- a/tests/idris2/reg/reg034/expected
+++ b/tests/idris2/reg/reg034/expected
@@ -2,7 +2,7 @@
 Error: While processing left hand side of Calc. Can't match on ?y [no locals in scope] (Non linear pattern variable).
 
 void:18:19--18:20
- 14 | 
+ 14 |
  15 | public export
  16 | Calc : {x : a} -> {y : b} -> FastDerivation x y -> x = y
  17 | Calc (|~ x) = Refl

--- a/tests/idris2/reg/reg038/expected
+++ b/tests/idris2/reg/reg038/expected
@@ -3,7 +3,7 @@ Error: While processing right hand side of G. yv is not accessible in this conte
 
 Test1:4:12--4:14
  1 | data Foo : Nat -> Type where
- 2 | 
+ 2 |
  3 | G : (0 yv : Nat) -> Type
  4 | G yv = Foo yv -> Bool
                 ^^
@@ -13,7 +13,7 @@ Error: While processing right hand side of f. Main.G is not accessible in this c
 
 Test2:8:12--8:13
  4 | G yv = Foo yv -> Bool
- 5 | 
+ 5 |
  6 | partial
  7 | f : (0 x : Nat) -> Nat
  8 | f x = case G x of

--- a/tests/idris2/reg/reg040/expected
+++ b/tests/idris2/reg/reg040/expected
@@ -5,7 +5,7 @@ CoverBug:20:1--20:26
  16 | fromInteger v =
  17 |   let (v ** p) = prv1 $ v
  18 |   in MkFastNat v
- 19 | 
+ 19 |
  20 | doit : FastNat -> FastNat
       ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/idris2/reg/reg041/expected
+++ b/tests/idris2/reg/reg041/expected
@@ -11,7 +11,7 @@ Error: While processing left hand side of odd. Can't match on () as it must have
 tuple:5:5--5:7
  1 | tupleBug : Pair () a -> ()
  2 | tupleBug (_, (_, _)) = ()
- 3 | 
+ 3 |
  4 | odd : a -> Bool
  5 | odd () = False
          ^^

--- a/tests/idris2/reg/reg044/expected
+++ b/tests/idris2/reg/reg044/expected
@@ -3,7 +3,7 @@ Error: Missing methods in Read: readPrefix
 
 Methods:17:1--21:15
  17 | Read Foo where
- 18 | 
+ 18 |
  19 |   read "A" = A
  20 |   read "B" = B
  21 |   read "C" = C

--- a/tests/idris2/reg/reg048/expected
+++ b/tests/idris2/reg/reg048/expected
@@ -6,7 +6,7 @@ Error: While processing right hand side of g. Ambiguous elaboration. Possible re
 inferror:9:17--9:23
  5 | f m = case sortBy (\(x, _), (y, _) => compare x y) (SortedMap.toList m) of
  6 |     as => as
- 7 | 
+ 7 |
  8 | g : Ord k => SortedMap k v -> List (k, v)
  9 | g m = let kvs = toList m in
                      ^^^^^^

--- a/tests/idris2/termination/termination001/expected
+++ b/tests/idris2/termination/termination001/expected
@@ -4,7 +4,7 @@ Error: f is not total, possibly not terminating due to call to Main.g
 AgdaIssue6059:23:3--23:21
  19 | lem 0 = Refl
  20 | lem (S n) = Refl
- 21 | 
+ 21 |
  22 | mutual
  23 |   f : (x : D) -> P x
         ^^^^^^^^^^^^^^^^^^
@@ -15,17 +15,17 @@ AgdaIssue6059:31:3--31:32
  27 |   -- Base cases:
  28 |   f (MkD 0 0) = ()
  29 |   f (MkD 0 1) = ()
- 30 | 
+ 30 |
  31 |   g : (h : Nat -> D) -> P (h 2)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Error: loop is not total, possibly not terminating due to call to Main.f
 
 AgdaIssue6059:34:1--34:12
- 30 | 
+ 30 |
  31 |   g : (h : Nat -> D) -> P (h 2)
  32 |   g h = f (h 2)
- 33 | 
+ 33 |
  34 | loop : Void
       ^^^^^^^^^^^
 

--- a/tests/idris2/total/positivity004/expected
+++ b/tests/idris2/total/positivity004/expected
@@ -9,7 +9,7 @@ Error: MkFix is not total, not strictly positive
 
 Issue1771-1:4:3--4:29
  1 | %default total
- 2 | 
+ 2 |
  3 | data Fix : (Type -> Type) -> Type where
  4 |   MkFix : f (Fix f) -> Fix f
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -17,30 +17,30 @@ Issue1771-1:4:3--4:29
 Error: argh is not total, possibly not terminating due to function Main.MkFix being reachable via Main.yesF -> Main.MkFix
 
 Issue1771-1:15:1--15:12
- 11 | 
+ 11 |
  12 | notF : Not F
  13 | notF (MkFix f) = f (yesF f)
- 14 | 
+ 14 |
  15 | argh : Void
       ^^^^^^^^^^^
 
 Error: notF is not total, possibly not terminating due to call to Main.yesF
 
 Issue1771-1:12:1--12:13
- 08 | 
+ 08 |
  09 | yesF : Not F -> F
  10 | yesF nf = MkFix nf
- 11 | 
+ 11 |
  12 | notF : Not F
       ^^^^^^^^^^^^
 
 Error: yesF is not total, possibly not terminating due to call to Main.MkFix
 
 Issue1771-1:9:1--9:18
- 5 | 
+ 5 |
  6 | F : Type
  7 | F = Fix Not
- 8 | 
+ 8 |
  9 | yesF : Not F -> F
      ^^^^^^^^^^^^^^^^^
 
@@ -55,7 +55,7 @@ Error: MkFix is not total, not strictly positive
 
 Issue1771-2:4:3--4:58
  1 | %default total
- 2 | 
+ 2 |
  3 | data F : Type where
  4 |   MkFix : ((0 g : Type -> Type) -> g === Not -> g F) -> F
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -66,27 +66,27 @@ Issue1771-2:14:1--14:12
  10 | notF (MkFix f) =
  11 |   let g = f Not Refl in
  12 |   g (yesF g)
- 13 | 
+ 13 |
  14 | argh : Void
       ^^^^^^^^^^^
 
 Error: notF is not total, possibly not terminating due to call to Main.yesF
 
 Issue1771-2:9:1--9:13
- 5 | 
+ 5 |
  6 | yesF : Not F -> F
  7 | yesF nf = MkFix (\ g, Refl => nf)
- 8 | 
+ 8 |
  9 | notF : Not F
      ^^^^^^^^^^^^
 
 Error: yesF is not total, possibly not terminating due to call to Main.MkFix
 
 Issue1771-2:6:1--6:18
- 2 | 
+ 2 |
  3 | data F : Type where
  4 |   MkFix : ((0 g : Type -> Type) -> g === Not -> g F) -> F
- 5 | 
+ 5 |
  6 | yesF : Not F -> F
      ^^^^^^^^^^^^^^^^^
 
@@ -102,7 +102,7 @@ Error: MkF is not total, not strictly positive
 Issue1771-3:10:3--10:26
  06 | unwrap : Wrap a -> a
  07 | unwrap (MkWrap v) = v
- 08 | 
+ 08 |
  09 | data F : Type where
  10 |   MkF : Wrap (Not F) -> F
         ^^^^^^^^^^^^^^^^^^^^^^^
@@ -110,30 +110,30 @@ Issue1771-3:10:3--10:26
 Error: argh is not total, possibly not terminating due to function Main.MkF being reachable via Main.yesF -> Main.MkF
 
 Issue1771-3:18:1--18:12
- 14 | 
+ 14 |
  15 | notF : Not F
  16 | notF (MkF f) = unwrap f (yesF $ unwrap f)
- 17 | 
+ 17 |
  18 | argh : Void
       ^^^^^^^^^^^
 
 Error: notF is not total, possibly not terminating due to calls to Main.F, Main.yesF
 
 Issue1771-3:15:1--15:13
- 11 | 
+ 11 |
  12 | yesF : Not F -> F
  13 | yesF = MkF . MkWrap
- 14 | 
+ 14 |
  15 | notF : Not F
       ^^^^^^^^^^^^
 
 Error: yesF is not total, possibly not terminating due to call to Main.MkF
 
 Issue1771-3:12:1--12:18
- 08 | 
+ 08 |
  09 | data F : Type where
  10 |   MkF : Wrap (Not F) -> F
- 11 | 
+ 11 |
  12 | yesF : Not F -> F
       ^^^^^^^^^^^^^^^^^
 

--- a/tests/idris2/total/positivity005/expected
+++ b/tests/idris2/total/positivity005/expected
@@ -8,20 +8,20 @@ Issue2548:3:1--4:53
 Error: argh is not total, possibly not terminating due to function Main.Recursing being reachable via Main.f -> Main.Recursing
 
 Issue2548:15:1--15:12
- 11 | 
+ 11 |
  12 | f : F
  13 | f = Recursing notF
- 14 | 
+ 14 |
  15 | argh : Void
       ^^^^^^^^^^^
 
 Error: f is not total, possibly not terminating due to call to Main.Recursing
 
 Issue2548:12:1--12:6
- 08 | 
+ 08 |
  09 | notF : Not F
  10 | notF f@(Recursing nF) = nF f
- 11 | 
+ 11 |
  12 | f : F
       ^^^^^
 

--- a/tests/idris2/total/total011/expected
+++ b/tests/idris2/total/total011/expected
@@ -10,7 +10,7 @@ Error: nonproductive is not total, possibly not terminating due to recursive pat
 
 Issue1460:3:1--3:43
  1 | %default total
- 2 | 
+ 2 |
  3 | nonproductive : Stream a -> (Stream a, ())
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -19,7 +19,7 @@ Error: fix is not total, possibly not terminating due to recursive path Main.fix
 
 Issue1859:3:1--3:11
  1 | %default total
- 2 | 
+ 2 |
  3 | fix : Void
      ^^^^^^^^^^
 
@@ -30,7 +30,7 @@ Issue1859-2:8:1--8:15
  4 | tailRecId f a = case f a of
  5 |   Left a2 => tailRecId f a2
  6 |   Right b => b
- 7 | 
+ 7 |
  8 | iamvoid : Void
      ^^^^^^^^^^^^^^
 
@@ -38,7 +38,7 @@ Error: tailRecId is not total, possibly not terminating due to recursive path Ma
 
 Issue1859-2:3:1--3:40
  1 | %default total
- 2 | 
+ 2 |
  3 | tailRecId : (a -> Either a b) -> a -> b
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -47,7 +47,7 @@ Error: caseTest is not total, possibly not terminating due to call to Main.dummy
 
 Issue1828:4:3--4:25
  1 | %default total
- 2 | 
+ 2 |
  3 | mutual
  4 |   caseTest : Nat -> Bool
        ^^^^^^^^^^^^^^^^^^^^^^
@@ -58,7 +58,7 @@ Issue1828:8:3--8:14
  4 |   caseTest : Nat -> Bool
  5 |   caseTest p with (dummy)
  6 |    caseTest p | _ = True
- 7 | 
+ 7 |
  8 |   dummy : Nat
        ^^^^^^^^^^^
 

--- a/tests/idris2/total/total012/expected
+++ b/tests/idris2/total/total012/expected
@@ -16,7 +16,7 @@ Issue1828:6:3--6:14
  2 |   caseTest : Nat -> Bool
  3 |   caseTest p with (dummy)
  4 |    caseTest p | _ = True
- 5 | 
+ 5 |
  6 |   dummy : Nat
        ^^^^^^^^^^^
 

--- a/tests/idris2/total/total013/expected
+++ b/tests/idris2/total/total013/expected
@@ -8,7 +8,7 @@ Issue1404:3:1--4:30
 Error: MkFoo is not total, not strictly positive
 
 Issue1404:4:3--4:30
- 1 | 
+ 1 |
  2 | total
  3 | data Foo : Type where
  4 |   MkFoo : (Foo -> Foo) -> Foo

--- a/tests/idris2/total/total018/expected
+++ b/tests/idris2/total/total018/expected
@@ -3,9 +3,9 @@ Error: boom is not total, possibly not terminating due to recursive path Main.bo
 
 Issue2448:5:1--5:19
  1 | -- https://github.com/idris-lang/Idris2/issues/2448#issuecomment-1117103496
- 2 | 
+ 2 |
  3 | %default total
- 4 | 
+ 4 |
  5 | boom : Nat -> Void
      ^^^^^^^^^^^^^^^^^^
 

--- a/tests/idris2/total/total019/expected
+++ b/tests/idris2/total/total019/expected
@@ -3,7 +3,7 @@ Error: foo is not total, possibly not terminating due to recursive path Main.foo
 
 Check:3:1--3:35
  1 | %default total
- 2 | 
+ 2 |
  3 | foo : List Char -> List Char -> ()
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/idris2/total/total030/expected
+++ b/tests/idris2/total/total030/expected
@@ -23,10 +23,10 @@ ProofOfFalse:8:3--9:13
 Error: boom is not total, possibly not terminating due to call to Main.Foo.foo
 
 ProofOfFalse:15:1--15:12
- 11 | 
+ 11 |
  12 | namespace Foo
  13 |   foo = bar
- 14 | 
+ 14 |
  15 | boom : Void
       ^^^^^^^^^^^
 

--- a/tests/idris2/warning/warning001/expected
+++ b/tests/idris2/warning/warning001/expected
@@ -4,10 +4,10 @@ You may be unintentionally shadowing the associated global definitions:
   idF is shadowing Main.idF
 
 Issue539:10:1--10:39
- 06 | 
+ 06 |
  07 | leftIdPoint : (f : a -> b) -> (x : a) -> idF (f x) = f x
  08 | leftIdPoint f x = Refl
- 09 | 
+ 09 |
  10 | leftId : (f : a -> b) -> (idF . f = f)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -18,10 +18,10 @@ You may be unintentionally shadowing the associated global definitions:
   a2 is shadowing Main.a2
 
 Issue621:8:1--8:17
- 4 | 
+ 4 |
  5 | a2 : Char
  6 | a2 = 'a'
- 7 | 
+ 7 |
  8 | whyNot : a1 = a2
      ^^^^^^^^^^^^^^^^
 
@@ -44,7 +44,7 @@ PR1407:7:3--7:79
  3 |   f : Either a b -> Either b a
  4 |   f (Left a) = Right a
  5 |   f (Right b) = Left b
- 6 | 
+ 6 |
  7 |   natural : (xs : Either a b) -> ((f . f) . map g) xs === (map g . (f . f)) xs
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -53,10 +53,10 @@ You may be unintentionally shadowing the associated global definitions:
   g is shadowing Main.g
 
 PR1407:15:3--15:14
- 11 | 
+ 11 |
  12 |   g : h === h
  13 |   g = Refl
- 14 | 
+ 14 |
  15 |   h : g === g
         ^^^^^^^^^^^
 

--- a/tests/idris2/warning/warning003/expected
+++ b/tests/idris2/warning/warning003/expected
@@ -6,7 +6,7 @@ Warning: DEPRECATED: old record update syntax.
 Main:11:14--11:37
  07 | testRec : TestRecord
  08 | testRec = MkTestRecord 0
- 09 | 
+ 09 |
  10 | updatedRec : TestRecord
  11 | updatedRec = record { recField = 1 } testRec
                    ^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/idris2/warning/warning004/expected
+++ b/tests/idris2/warning/warning004/expected
@@ -11,7 +11,7 @@ For example: %hide Lib2.infixl.(%%%)
 Main1:7:20--7:23
  3 | import Lib2
  4 | import Lib1
- 5 | 
+ 5 |
  6 | main : IO ()
  7 | main = printLn (10 %%% 10 %%% 1)
                         ^^^
@@ -26,7 +26,7 @@ For example: %hide Lib2.infixl.(%%%)
 Main1:7:27--7:30
  3 | import Lib2
  4 | import Lib1
- 5 | 
+ 5 |
  6 | main : IO ()
  7 | main = printLn (10 %%% 10 %%% 1)
                                ^^^

--- a/tests/idris2/warning/warning006/expected
+++ b/tests/idris2/warning/warning006/expected
@@ -3,7 +3,7 @@ Warning: Main:6:6--6:7:Can't deal with fromInteger in impossible clauses yet
 
 Main:6:6--6:7
  2 | import Data.Vect
- 3 | 
+ 3 |
  4 | -- fromInteger on LHS
  5 | head : (n : Nat) -> {auto 0 prf : IsSucc n} -> Vect n a -> a
  6 | head 0 _ impossible
@@ -13,7 +13,7 @@ Warning: Main:13:9--13:10:Z does not match expected type
 
 Main:13:9--13:10
  09 | data Foo = Z | S Foo
- 10 | 
+ 10 |
  11 | -- No matching constuctor of a known type
  12 | head' : (n : Nat) -> {auto 0 prf : IsSucc n} -> (Foo,Foo) -> Vect n a -> a
  13 | head' Z Z _ impossible
@@ -23,7 +23,7 @@ Warning: Main:18:11--18:12:Ambiguous name [Main.Z, Prelude.Types.Z]
 
 Main:18:11--18:12
  14 | head' (S k) _ (x :: xs) = x
- 15 | 
+ 15 |
  16 | -- Ambiguous constructor of unknown type
  17 | head'' : (n : Nat) -> {auto 0 prf : IsSucc n} -> (Foo,Foo) -> Vect n a -> a
  18 | head'' Z (Z,_) _ impossible

--- a/tests/idris2/with/with008/expected
+++ b/tests/idris2/with/with008/expected
@@ -12,7 +12,7 @@ WithClause:2:25--2:28
 
 
 WithClause:11:3--11:4
- 07 | 
+ 07 |
  08 | pred : Nat -> Nat
  09 | pred n with (isS n)
  10 |   _ | Nothing = Z

--- a/tests/node/node006/expected
+++ b/tests/node/node006/expected
@@ -19,7 +19,7 @@ Error: While processing left hand side of strangeId. Can't match on Nat (Erased 
 TypeCase2:5:14--5:17
  1 | data Bar = MkBar
  2 | data Baz = MkBaz
- 3 | 
+ 3 |
  4 | strangeId : a -> a
  5 | strangeId {a=Nat} x = x+1
                   ^^^
@@ -29,7 +29,7 @@ Error: While processing left hand side of foo. Can't match on Nat (Erased argume
 TypeCase2:9:5--9:8
  5 | strangeId {a=Nat} x = x+1
  6 | strangeId x = x
- 7 | 
+ 7 |
  8 | foo : (0 x : Type) -> String
  9 | foo Nat = "Nat"
          ^^^

--- a/tests/prelude/unpack/expected
+++ b/tests/prelude/unpack/expected
@@ -8,7 +8,7 @@ Mismatch between: String -> InterpFormat (format [assert_total (prim__strIndex (
 unpack:39:11--39:55
  35 | printf : (s : String) -> InterpFormat (formatString s)
  36 | printf s = toFunction (formatString s) ""
- 37 | 
+ 37 |
  38 | message : String
  39 | message = printf "My name is %s and I am %d years old"
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/typedd-book/chapter03/expected
+++ b/tests/typedd-book/chapter03/expected
@@ -6,7 +6,7 @@ You may be unintentionally shadowing the associated global definitions:
 
 Matrix:3:1--3:48
  1 | import Data.Vect
- 2 | 
+ 2 |
  3 | createEmpties : {n : _} -> Vect n (Vect 0 elem)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -18,7 +18,7 @@ Matrix:7:1--7:101
  3 | createEmpties : {n : _} -> Vect n (Vect 0 elem)
  4 | createEmpties {n = Z} = []
  5 | createEmpties {n = (S k)} = [] :: createEmpties
- 6 | 
+ 6 |
  7 | transposeHelper : (x : Vect n elem) -> (xs_trans : Vect n (Vect k elem)) -> Vect n (Vect (S k) elem)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -30,7 +30,7 @@ Matrix:11:1--11:71
  07 | transposeHelper : (x : Vect n elem) -> (xs_trans : Vect n (Vect k elem)) -> Vect n (Vect (S k) elem)
  08 | transposeHelper [] [] = []
  09 | transposeHelper (x :: xs) (y :: ys) = (x :: y) :: transposeHelper xs ys
- 10 | 
+ 10 |
  11 | transposeMat : {n : _} -> Vect m (Vect n elem) -> Vect n (Vect m elem)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -41,7 +41,7 @@ You may be unintentionally shadowing the associated global definitions:
 
 VecSort:3:1--3:79
  1 | import Data.Vect
- 2 | 
+ 2 |
  3 | insert : Ord elem => (x : elem) -> (xsSorted : Vect k elem) -> Vect (S k) elem
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -53,7 +53,7 @@ VecSort:9:1--9:49
  5 | insert x (y :: xs) = case x < y of
  6 |                           False => y :: insert x xs
  7 |                           True => x :: y :: xs
- 8 | 
+ 8 |
  9 | insSort : Ord elem => Vect n elem -> Vect n elem
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/typedd-book/chapter04/expected
+++ b/tests/typedd-book/chapter04/expected
@@ -24,7 +24,7 @@ BSTree:6:1--6:44
  2 |      Empty : Ord elem => BSTree elem
  3 |      Node : Ord elem => (left : BSTree elem) -> (val : elem) ->
  4 |                         (right : BSTree elem) -> BSTree elem
- 5 | 
+ 5 |
  6 | insert : elem -> BSTree elem -> BSTree elem
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -58,9 +58,9 @@ You may be unintentionally shadowing the associated global definitions:
 
 Tree:6:1--6:52
  2 |                | Node (Tree elem) elem (Tree elem)
- 3 | 
+ 3 |
  4 | %name Tree tree, tree1
- 5 | 
+ 5 |
  6 | insert : Ord elem => elem -> Tree elem -> Tree elem
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -72,9 +72,9 @@ You may be unintentionally shadowing the associated global definitions:
 
 Vect:7:1--7:57
  3 |      (::) : (x : a) -> (xs : Vect k a) -> Vect (S k) a
- 4 | 
+ 4 |
  5 | %name Vect xs, ys, zs
- 6 | 
+ 6 |
  7 | append : Vect n elem -> Vect m elem -> Vect (n + m) elem
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/typedd-book/chapter06/expected
+++ b/tests/typedd-book/chapter06/expected
@@ -5,7 +5,7 @@ You may be unintentionally shadowing the associated global definitions:
   schema is shadowing Main.DataStore.schema
 
 DataStore:26:5--26:89
- 22 | 
+ 22 |
  23 | addToStore : (store : DataStore) -> SchemaType (schema store) -> DataStore
  24 | addToStore (MkData schema size store) newitem = MkData schema _ (addToData store)
  25 |   where
@@ -19,7 +19,7 @@ You may be unintentionally shadowing the associated global definitions:
 DataStore:36:6--36:42
  32 |                               Z => Just (MkData schema _ [])
  33 |                               S k => Nothing
- 34 | 
+ 34 |
  35 | data Command : Schema -> Type where
  36 |      SetSchema : Schema -> Command schema
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -30,7 +30,7 @@ You may be unintentionally shadowing the associated global definitions:
 
 DataStore:37:6--37:47
  33 |                               S k => Nothing
- 34 | 
+ 34 |
  35 | data Command : Schema -> Type where
  36 |      SetSchema : Schema -> Command schema
  37 |      Add : SchemaType schema -> Command schema
@@ -41,7 +41,7 @@ You may be unintentionally shadowing the associated global definitions:
   schema is shadowing Main.DataStore.schema
 
 DataStore:38:6--38:37
- 34 | 
+ 34 |
  35 | data Command : Schema -> Type where
  36 |      SetSchema : Schema -> Command schema
  37 |      Add : SchemaType schema -> Command schema
@@ -66,7 +66,7 @@ You may be unintentionally shadowing the associated global definitions:
   schema is shadowing Main.DataStore.schema
 
 DataStoreHoles:25:5--25:89
- 21 | 
+ 21 |
  22 | addToStore : (d : DataStore) -> SchemaType (schema d) -> DataStore
  23 | addToStore (MkData schema size store) newitem = MkData schema _ (addToData store)
  24 |   where
@@ -80,7 +80,7 @@ You may be unintentionally shadowing the associated global definitions:
 DataStoreHoles:30:6--30:47
  26 |     addToData [] = [newitem]
  27 |     addToData (x :: xs) = x :: addToData xs
- 28 | 
+ 28 |
  29 | data Command : Schema -> Type where
  30 |      Add : SchemaType schema -> Command schema
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -91,7 +91,7 @@ You may be unintentionally shadowing the associated global definitions:
 
 DataStoreHoles:31:6--31:37
  27 |     addToData (x :: xs) = x :: addToData xs
- 28 | 
+ 28 |
  29 | data Command : Schema -> Type where
  30 |      Add : SchemaType schema -> Command schema
  31 |      Get : Integer -> Command schema
@@ -102,7 +102,7 @@ You may be unintentionally shadowing the associated global definitions:
   schema is shadowing Main.DataStore.schema
 
 DataStoreHoles:32:6--32:27
- 28 | 
+ 28 |
  29 | data Command : Schema -> Type where
  30 |      Add : SchemaType schema -> Command schema
  31 |      Get : Integer -> Command schema
@@ -117,7 +117,7 @@ DataStoreHoles:34:1--34:58
  30 |      Add : SchemaType schema -> Command schema
  31 |      Get : Integer -> Command schema
  32 |      Quit : Command schema
- 33 | 
+ 33 |
  34 | parseCommand : String -> String -> Maybe (Command schema)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/typedd-book/chapter08/expected
+++ b/tests/typedd-book/chapter08/expected
@@ -6,7 +6,7 @@ You may be unintentionally shadowing the associated global definitions:
 AppendVec:4:1--4:49
  1 | import Data.Nat
  2 | import Data.Vect
- 3 | 
+ 3 |
  4 | append_nil : Vect m elem -> Vect (plus m 0) elem
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -15,10 +15,10 @@ You may be unintentionally shadowing the associated global definitions:
   elem is shadowing Prelude.Types.elem
 
 AppendVec:7:1--7:62
- 3 | 
+ 3 |
  4 | append_nil : Vect m elem -> Vect (plus m 0) elem
  5 | append_nil {m} xs = rewrite plusZeroRightNeutral m in xs
- 6 | 
+ 6 |
  7 | append_xs : Vect (S (m + k)) elem -> Vect (plus m (S k)) elem
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -27,10 +27,10 @@ You may be unintentionally shadowing the associated global definitions:
   elem is shadowing Prelude.Types.elem
 
 AppendVec:10:1--10:57
- 06 | 
+ 06 |
  07 | append_xs : Vect (S (m + k)) elem -> Vect (plus m (S k)) elem
  08 | append_xs {m} {k} xs = rewrite sym (plusSuccRightSucc m k) in xs
- 09 | 
+ 09 |
  10 | append : Vect n elem -> Vect m elem -> Vect (m + n) elem
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/typedd-book/chapter12/expected
+++ b/tests/typedd-book/chapter12/expected
@@ -7,7 +7,7 @@ You may be unintentionally shadowing the associated global definitions:
 DataStore:23:6--23:42
  19 | setSchema : DataStore 0 -> Schema -> DataStore 0
  20 | setSchema (MkData schema []) schema' = MkData schema' []
- 21 | 
+ 21 |
  22 | data Command : Schema -> Type where
  23 |      SetSchema : Schema -> Command schema
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -18,7 +18,7 @@ You may be unintentionally shadowing the associated global definitions:
 
 DataStore:24:6--24:47
  20 | setSchema (MkData schema []) schema' = MkData schema' []
- 21 | 
+ 21 |
  22 | data Command : Schema -> Type where
  23 |      SetSchema : Schema -> Command schema
  24 |      Add : SchemaType schema -> Command schema
@@ -29,7 +29,7 @@ You may be unintentionally shadowing the associated global definitions:
   schema is shadowing Main.DataStore.schema
 
 DataStore:25:6--25:37
- 21 | 
+ 21 |
  22 | data Command : Schema -> Type where
  23 |      SetSchema : Schema -> Command schema
  24 |      Add : SchemaType schema -> Command schema


### PR DESCRIPTION
# Description

We normally use `(<++>)` for non-empty string concatenation. If one string happens to be empty, it introduces a space at the end or beginning. This creates trailing spaces in errors, so I’m proposing a change to how it works

