### PR TITLE
[ error ] improve errors in string interpolation

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -59,7 +59,7 @@ should target this file (`CHANGELOG_NEXT`).
   - `Libraries.Data.List.Quantifiers.Extra.tabulate`.
   - `Libraries.Utils.Binary.nonEmptyRev`
   - `Libraries.Utils.String.dotSep`
-* Fixes an issue when unifying labmda terms with implicits (#3670)
+* Fixes an issue when unifying lambda terms with implicits (#3670)
 * The "With clause does not match parent" error now points to the correct location
 * The compiler now warns the user when `impossible` clauses are ignored. This
   typically happens when a numeric literal or an ambiguous name appears in an
@@ -68,6 +68,7 @@ should target this file (`CHANGELOG_NEXT`).
 * Fixed coverage checker issues (#1800, #1998, #2318, #2822, #3679).
 * Fixed totality checking in namespace and mutual blocks (#2868, #3692).
 * Fixed incorrect argument multiplicity when using an as-pattern (#3687).
+* Better messages for errors inside string interpolation.
 
 ### Building/Packaging changes
 

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1066,7 +1066,7 @@ mutual
      <|> opExpr q fname indents
 
   interpBlock : ParseOpts -> OriginDesc -> IndentInfo -> Rule PTerm
-  interpBlock q fname idents = interpBegin *> (mustWork $ expr q fname idents) <* interpEnd
+  interpBlock q fname idents = interpBegin *> (mustWork $ expr q fname idents <* interpEnd)
 
   export
   singlelineStr : ParseOpts -> OriginDesc -> IndentInfo -> Rule PTerm

--- a/tests/idris2/error/perror007/expected
+++ b/tests/idris2/error/perror007/expected
@@ -8,23 +8,21 @@ StrError1:2:24--2:25
                             ^
 ... (42 others)
 1/1: Building StrError2 (StrError2.idr)
-Error: Couldn't parse any alternatives:
-1: Expected 'case', 'if', 'do', application or operator expression.
+Error: Expected string interp end.
 
-StrError2:2:19--2:20
+StrError2:2:26--2:27
  1 | foo : String
  2 | foo = "nested: \{ " \{ 1 +  } " }"
-                       ^
-... (31 others)
-1/1: Building StrError3 (StrError3.idr)
-Error: Couldn't parse any alternatives:
-1: Expected 'case', 'if', 'do', application or operator expression.
+                              ^
 
-StrError3:2:7--2:8
+1/1: Building StrError3 (StrError3.idr)
+Error: Expected string interp end.
+
+StrError3:2:25--2:28
  1 | foo : String
  2 | foo = "incomplete: \{ a <+> }"
-           ^
-... (32 others)
+                             ^^^
+
 1/1: Building StrError4 (StrError4.idr)
 Error: Bracket is not properly closed.
 


### PR DESCRIPTION
# Description

Some a parse error in a string interpolation is lost and a generic "Expected 'case', 'if', 'do', application or operator expression" is reported at an earlier location.

We already have a `mustWork` on the `expr` inside the interpolation, but in cases where there are extra tokens after the expression, the error is lost. One case where this happens is for a trailing operator, which occurs in the perror007 tests.

Currently we see:
```
1/1: Building StrError2 (StrError2.idr)
Error: Couldn't parse any alternatives:
1: Expected 'case', 'if', 'do', application or operator expression.

StrError2:2:19--2:20
 1 | foo : String
 2 | foo = "nested: \{ " \{ 1 +  } " }"
                       ^
... (31 others)
```
And with this patch, we get:
```
1/1: Building StrError2 (StrError2.idr)
Error: Expected string interp end.

StrError2:2:26--2:27
 1 | foo : String
 2 | foo = "nested: \{ " \{ 1 +  } " }"
                              ^
```


## Self-check

- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)

