### PR TITLE
Remove unsafe `writeIORef1`

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -94,3 +94,4 @@ should target this file (`CHANGELOG_NEXT`).
 * Added `rtrim` to `Data.String`.
 * Added `decToMaybe`, `maybeCong` and `maybeCong2` to `Data.Maybe`.
 * Added `maybeEq` to `Decidable.Equality`.
+* Removed `writeIORef1`, which unsafely allowed a linear value to become unrestricted.

--- a/libs/base/Data/IORef.idr
+++ b/libs/base/Data/IORef.idr
@@ -11,7 +11,7 @@ data Mut : Type -> Type where [external]
 
 %extern prim__newIORef : forall a . a -> (1 x : %World) -> IORes (Mut a)
 %extern prim__readIORef : forall a . Mut a -> (1 x : %World) -> IORes a
-%extern prim__writeIORef : forall a . Mut a -> (1 val : a) -> (1 x : %World) -> IORes ()
+%extern prim__writeIORef : forall a . Mut a -> a -> (1 x : %World) -> IORes ()
 
 export
 data IORef : Type -> Type where
@@ -37,14 +37,6 @@ readIORef (MkRef m) = primIO (prim__readIORef m)
 export
 writeIORef : HasIO io => IORef a -> (val : a) -> io ()
 writeIORef (MkRef m) val = primIO (prim__writeIORef m val)
-
-||| Write a new value into an IORef.
-||| This function does not create a memory barrier and can be reordered with other independent reads and writes within a thread,
-||| which may cause issues for multithreaded execution.
-%inline
-export
-writeIORef1 : HasLinearIO io => IORef a -> (1 val : a) -> io ()
-writeIORef1 (MkRef m) val = primIO1 (prim__writeIORef m val)
 
 ||| Mutate the contents of an IORef, combining readIORef and writeIORef.
 ||| This is not an atomic update, consider using atomically when operating in a multithreaded environment.


### PR DESCRIPTION
# Description

See the Zulip topic [#general > Is writeIORef1 unsound?](https://idris-lang.zulipchat.com/#narrow/channel/556701-general/topic/Is.20writeIORef1.20unsound.3F/with/574780047)

Essentially, this function lets you expose a linear value via the unrestricted `IORef a`, and cannot be fixed.

## Self-check

<!-- /!\ Please delete sections that do not apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)

