### PR TITLE
[ log ] Log timing for elaboration scripts

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -71,6 +71,7 @@ should target this file (`CHANGELOG_NEXT`).
 * Type inspection now resugars primitive functions to more likely
   names/operators (#3712)
 * Better messages for errors inside string interpolation.
+* Added execution time logging for elaboration scripts.
 
 ### Building/Packaging changes
 

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -372,8 +372,9 @@ checkRunElab rig elabinfo nest env fc reqExt script exp
                            check rig elabinfo nest env script (Just (gnf env elabtt))
          solveConstraints inTerm Normal
          defs <- get Ctxt -- checking might have resolved some holes
-         ntm <- elabScript rig fc nest env
-                           !(nfOpts withAll defs env stm) (Just (gnf env expected))
+         nfstm <- nfOpts withAll defs env stm
+         ntm <- logTime 2 "Elaboration script" $
+                  elabScript rig fc nest env nfstm $ Just (gnf env expected)
          defs <- get Ctxt -- might have updated as part of the script
          empty <- clearDefs defs
          pure (!(quote empty env ntm), gnf env expected)

--- a/src/TTImp/ProcessRunElab.idr
+++ b/src/TTImp/ProcessRunElab.idr
@@ -35,4 +35,6 @@ processRunElab eopts nest env fc tm
          exp <- appCon fc defs n [unit]
 
          stm <- checkTerm tidx InExpr eopts nest env tm (gnf env exp)
-         ignore $ elabScript top fc nest env !(nfOpts withAll defs env stm) Nothing
+         nfstm <- nfOpts withAll defs env stm
+         ignore $ logTime 2 "Elaboration script" $
+           elabScript top fc nest env nfstm Nothing


### PR DESCRIPTION
# Description

Elaborator scripts can sometimes become quite complex and time-consuming to execute. To improve debuggability and help identify performance bottlenecks, this PR adds `logTime` instrumentation to capture the execution duration of these scripts.

## Self-check

<!-- /!\ Please delete sections that do not apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)

