### PR TITLE
Fix pretty pkg fields

### DIFF
--- a/.github/workflows/ci-idris2-and-libs.yml
+++ b/.github/workflows/ci-idris2-and-libs.yml
@@ -500,8 +500,11 @@ jobs:
       - name: Build API
         run: make install-api
         shell: bash
-      - name: Test API
+      - name: Test API 001
         run: cd tests/idris2/api/api001 && ./run "$HOME/.idris2/bin/idris2"
+        shell: bash
+      - name: Test API 002
+        run: cd tests/idris2/api/api002 && ./run "$HOME/.idris2/bin/idris2"
         shell: bash
 
   ######################################################################

--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -82,6 +82,7 @@ should target this file (`CHANGELOG_NEXT`).
 * Fix parsing of capitalised package names containing hyphens.
 * Change `flake.nix` to point at `idris-community/idris2-mode` as the URL for
   `inputs.idris-emacs-src` (from the user fork `redfish64/idris2-mode`).
+* Fix UTF-8 character handling in package description fields.
 
 ### Backend changes
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -88,6 +88,7 @@ Thomas E. Hansen
 Timmy Jose
 Tim Süberkrüb
 Tom Harley
+Tomáš Zemanovič
 troiganto
 Viktor Yudov
 Wen Kokke

--- a/src/Idris/Package/Types.idr
+++ b/src/Idris/Package/Types.idr
@@ -303,7 +303,7 @@ Pretty Void PkgDesc where
     verSeqField nm = field {printEquals=False} nm . map pretty
 
     strField : String -> Maybe String -> Doc Void
-    strField nm = field nm . map (pretty . show)
+    strField nm = field nm . map (dquotes . pretty)
 
     seqField : Pretty Void a => String -> List a -> Doc Void
     seqField nm [] = hsep [ pretty "--", pretty nm, equals ]

--- a/tests/idris2/api/api002/Main.idr
+++ b/tests/idris2/api/api002/Main.idr
@@ -1,0 +1,13 @@
+module Main
+
+import Idris.Package.Types
+import Idris.Pretty
+import Libraries.Text.PrettyPrint.Prettyprinter.Render.String
+
+pkg : PkgDesc
+pkg =
+  { authors := Just "Tomáš"
+  } (initPkgDesc "package")
+
+main : IO ()
+main = putStrLn $ renderString $ layoutUnbounded $ pretty pkg

--- a/tests/idris2/api/api002/expected
+++ b/tests/idris2/api/api002/expected
@@ -1,0 +1,47 @@
+package package
+-- version =
+authors = "Tomáš"
+-- maintainers =
+-- license =
+-- brief =
+-- readme =
+-- homepage =
+-- sourceloc =
+-- bugtracker =
+
+-- the Idris2 version required (e.g. langversion >= 0.5.1)
+-- langversion
+
+-- packages to add to search path
+-- depends =
+
+-- modules to install
+-- modules =
+
+-- main file (i.e. file to load at REPL)
+-- main =
+
+-- name of executable
+-- executable =
+-- opts =
+-- sourcedir =
+-- builddir =
+-- outputdir =
+
+-- script to run before building
+-- prebuild =
+
+-- script to run after building
+-- postbuild =
+
+-- script to run after building, before installing
+-- preinstall =
+
+-- script to run after installing
+-- postinstall =
+
+-- script to run before cleaning
+-- preclean =
+
+-- script to run after cleaning
+-- postclean =

--- a/tests/idris2/api/api002/run
+++ b/tests/idris2/api/api002/run
@@ -1,0 +1,5 @@
+. ../../../testutils.sh
+
+idris2 --exec main Main.idr -p idris2 > output
+diff expected output
+cmp expected output


### PR DESCRIPTION
# Description

When I used `pack new` it got my name from git, but it inserted it into ipkg file with the non-ascii characters escaped. Pack uses pretty printing provided by idris, which uses `show` over string fields (similar to the issue fixed by #3699).

## Self-check

<!-- /!\ Please delete sections that do not apply -->
- [x] This is my first time contributing, I've carefully read [`CONTRIBUTING.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTING.md)
      and I've updated [`CONTRIBUTORS`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTORS) with my name.
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)
- [x] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.

