### PR TITLE
[ perf ] Do not wrap local argument in `Closure`

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -72,6 +72,7 @@ should target this file (`CHANGELOG_NEXT`).
   names/operators (#3712)
 * Better messages for errors inside string interpolation.
 * Added execution time logging for elaboration scripts.
+* Optimised the passing of local variables during compile-time normalisation.
 
 ### Building/Packaging changes
 

--- a/src/Core/Normalise/Eval.idr
+++ b/src/Core/Normalise/Eval.idr
@@ -55,6 +55,22 @@ export
 toClosure : EvalOpts -> Env Term outer -> Term outer -> Closure outer
 toClosure opts env tm = MkClosure opts LocalEnv.empty env tm
 
+mkClosure : {vars : _} ->
+            EvalOpts ->
+            LocalEnv free vars -> Env Term free ->
+            Term (vars ++ free) -> Closure free
+mkClosure opts locs env tm@(Local _ _ idx prf)
+    = fromMaybe (MkClosure opts locs env tm) (getLocal idx prf locs)
+  where
+    getLocal : {vars : _} ->
+               (idx : Nat) -> (0 p : IsVar nm idx (vars ++ free)) ->
+               LocalEnv free vars ->
+               Maybe (Closure free)
+    getLocal idx prf [] = Nothing
+    getLocal Z First (x :: locs) = Just x
+    getLocal (S idx) (Later p) (_ :: locs) = getLocal idx p locs
+mkClosure opts locs env tm = MkClosure opts locs env tm
+
 updateLimit : NameType -> Name -> EvalOpts -> Core (Maybe EvalOpts)
 updateLimit Func n opts
     = pure $ if isNil (reduceLimit opts)
@@ -102,18 +118,18 @@ parameters (defs : Defs) (topopts : EvalOpts)
         -- a closure and calling APPLY.
         closeArgs : List (Term (Scope.addInner free vars)) -> List (Closure free)
         closeArgs [] = []
-        closeArgs (t :: ts) = MkClosure topopts locs env t :: closeArgs ts
+        closeArgs (t :: ts) = mkClosure topopts locs env t :: closeArgs ts
     eval env locs (Bind fc x (Lam _ r _ ty) scope) (thunk :: stk)
         = eval env (snd thunk :: locs) scope stk
     eval env locs (Bind fc x b@(Let _ r val ty) scope) stk
         = if (holesOnly topopts || argHolesOnly topopts) && not (tcInline topopts)
-             then do let b' = map (MkClosure topopts locs env) b
+             then do let b' = map (mkClosure topopts locs env) b
                      pure $ NBind fc x b'
                         (\defs', arg => evalWithOpts defs' topopts
                                                 env (arg :: locs) scope stk)
-             else eval env (MkClosure topopts locs env val :: locs) scope stk
+             else eval env (mkClosure topopts locs env val :: locs) scope stk
     eval env locs (Bind fc x b scope) stk
-        = do let b' = map (MkClosure topopts locs env) b
+        = do let b' = map (mkClosure topopts locs env) b
              pure $ NBind fc x b'
                       (\defs', arg => evalWithOpts defs' topopts
                                               env (arg :: locs) scope stk)
@@ -121,7 +137,7 @@ parameters (defs : Defs) (topopts : EvalOpts)
         = case strategy topopts of
                CBV => do arg' <- eval env locs arg []
                          eval env locs fn ((fc, MkNFClosure topopts env arg') :: stk)
-               CBN => eval env locs fn ((fc, MkClosure topopts locs env arg) :: stk)
+               CBN => eval env locs fn ((fc, mkClosure topopts locs env arg) :: stk)
     eval env locs (As fc s n tm) stk
         = if removeAs topopts
              then eval env locs tm stk
@@ -132,8 +148,8 @@ parameters (defs : Defs) (topopts : EvalOpts)
         = do ty' <- eval env locs ty stk
              pure (NDelayed fc r ty')
     eval env locs (TDelay fc r ty tm) stk
-        = pure (NDelay fc r (MkClosure topopts locs env ty)
-                            (MkClosure topopts locs env tm))
+        = pure (NDelay fc r (mkClosure topopts locs env ty)
+                            (mkClosure topopts locs env tm))
     eval env locs (TForce fc r tm) stk
         = do tm' <- eval env locs tm []
              case tm' of
@@ -229,9 +245,8 @@ parameters (defs : Defs) (topopts : EvalOpts)
              else pure $ NApp fc (NLocal mrig idx prf) stk
     evalLocal env fc mrig Z First stk (x :: locs)
         = evalLocClosure env fc mrig stk x
-    evalLocal {vars = x :: xs} {free}
-              env fc mrig (S idx) (Later p) stk (_ :: locs)
-        = evalLocal {vars = xs} env fc mrig idx p stk locs
+    evalLocal env fc mrig (S idx) (Later p) stk (_ :: locs)
+        = evalLocal env fc mrig idx p stk locs
 
     updateLocal : EvalOpts -> Env Term free ->
                   (idx : Nat) -> (0 p : IsVar nm idx (vars ++ free)) ->

--- a/tests/idris2/perf/perf013/Main.idr
+++ b/tests/idris2/perf/perf013/Main.idr
@@ -1,0 +1,7 @@
+foo : Monad m => Int -> m ()
+foo 0 = pure ()
+foo n = do pure ()
+           foo (n - 1)
+
+bar : foo 1000000 === Just ()
+bar = Refl

--- a/tests/idris2/perf/perf013/expected
+++ b/tests/idris2/perf/perf013/expected
@@ -1,0 +1,1 @@
+1/1: Building Main (Main.idr)

--- a/tests/idris2/perf/perf013/run
+++ b/tests/idris2/perf/perf013/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check Main.idr


### PR DESCRIPTION
# Description

Consider the following code:

```idris
foo : Monad m => Int -> m ()
foo 0 = pure ()
foo n = do pure ()
           foo (n - 1)

bar : foo 1000000 === Just ()
bar = Refl
```

Currently, compile-time normalisation of `foo` performs at $\mathcal{O}(n^2)$ instead of $\mathcal{O}(n)$. The issue arises because local values in the evaluator are stored as `Closure`s. When a function is called, all arguments are similarly wrapped in a `Closure`.  Consequently, when passing the `Monad m` instance into a recursive call, we are wrapping the local variable (which already points to a `Closure`) into yet another `Closure`. This creates multiple nested layers, each of which must be unwrapped repeatedly to evaluate `pure`.

With this fix, this example compiles in 4 seconds on my machine. The current version did not complete compilation in half an hour.

## Self-check

- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)

