### PR TITLE
Reject by default non-human contributions

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-requests-and-proposals.md
+++ b/.github/ISSUE_TEMPLATE/feature-requests-and-proposals.md
@@ -18,6 +18,7 @@ We cannot guarantee your proposal will be implemented in a timely manner (or at 
 
 - [ ] I have read [CONTRIBUTING.md](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTING.md).
 - [ ] I have checked that there is no existing PR/issue about my proposal.
+- [ ] I am a human, not an AI, my contribution is human-written and designed for human consumption.
 
 ## Summary
 

--- a/.github/ISSUE_TEMPLATE/feature-requests-and-proposals.md
+++ b/.github/ISSUE_TEMPLATE/feature-requests-and-proposals.md
@@ -18,7 +18,7 @@ We cannot guarantee your proposal will be implemented in a timely manner (or at 
 
 - [ ] I have read [CONTRIBUTING.md](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTING.md).
 - [ ] I have checked that there is no existing PR/issue about my proposal.
-- [ ] I am a human, not an AI, my contribution is human-written and designed for human consumption.
+- [ ] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.
 
 ## Summary
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,4 +13,4 @@ the proposed change. -->
       and I've updated [`CONTRIBUTORS`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTORS) with my name.
 - [ ] If this is a fix, user-facing change, a compiler change, or a new paper
       implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)
-- [ ] I am a human, not an AI, my contribution is human-written and designed for human consumption.
+- [ ] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,4 +13,4 @@ the proposed change. -->
       and I've updated [`CONTRIBUTORS`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTORS) with my name.
 - [ ] If this is a fix, user-facing change, a compiler change, or a new paper
       implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)
-
+- [ ] I am a human, not an AI, my contribution is human-written and designed for human consumption.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,6 +132,16 @@ could be any other knowledgable community member.
   several people have. The backends in this repository are limited to those we
   are able to commit to maintaining.
 
+## Things We Will Not Accept
+
+Any contribution done by, or using, autonomous coding agents, Large Language
+Models and/or generative AI  will be rejected. That is to say, issues, pull
+requests, commits, and comments are all to be written and submitted by humans.
+Idris is a primarily academic project with roots in human-driven understanding
+and experience, designed to improve the human experience of programming and we
+want our processes to reflect that.
+
+
 ## Other possible contributions
 
 There's plenty of other things that might be good ideas. If it isn't covered

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,12 +134,14 @@ could be any other knowledgable community member.
 
 ## Things We Will Not Accept
 
-Any contribution done by, or using, autonomous coding agents, Large Language
-Models and/or generative AI  will be rejected. That is to say, issues, pull
-requests, commits, and comments are all to be written and submitted by humans.
 Idris is a primarily academic project with roots in human-driven understanding
-and experience, designed to improve the human experience of programming and we
-want our processes to reflect that.
+and experience, designed to improve the human experience of programming, and we
+want our processes to reflect that. Generative AI can reduce, and ultimately
+remove, the human-element. Within the Idris Project, we want issues, pull
+requests, commits, and comments to be written and submitted by humans. As such,
+all contributions that arise from Generative AI or Large Language Models,
+including contributions made by Autonomous Coding Agents that use 'Agentic
+Coding', will not be considered.
 
 
 ## Other possible contributions


### PR DESCRIPTION
We're changing the contributing guidelines to reject LLM-based contributions.

Just to get ahead of the opposition here is what I've seen cited as counterpoints:
* "This is raising the bar for contributing", The bar for contributing is indeed raised from "you don't need to understand anything" to "you need to understand the code you're submitting". We believe it both in the interest of the project that people understand their contributions, and in the interest of the community that their members understand how to write Idris code.
* "LLMs help fix bugs". People are not entitled to have their own pet bug fixed, not by a human, not by an LLM. The benefit of an open source project is that you can fork it and change it yourself. Which the licence entirely permits, if you want to use an LLM to fix a bug, you're encouraged to do so in your own fork
* "This is going to reduce the spread of Idris" Idris is an academic programming language with no aspirations for market share. Worse, an increased use of the language in the industry would result in losing the ability to make breaking changes which we do want to be doing.
* "LLMs are just getting started, they're getting better every day" The contributing policy isn't being changed because LLMs are poor at generating code, it's being introduced to ensure we have a consistent supply of people able to program in Idris, and people able to make judgements about what programming in Idris should be like.
* "I use LLMs for some tasks and I think it's justified" The contributing policy isn't about each contributor's individual preference but about the code that makes it into the Idris repository specifically. We ask that you leave your agentic tools at the door before entering the Idris bar.
* "I have an ideological position that makes me unable to contribute to the project with this policy" You can still contribute by means other than code submitted to this repository. For example writing tutorials, helping people online, or writing your own libraries. The scope of this policy only applies to the activity on the Idris repository.
* "But banning tech right now might hold us back in the future" The policy can change as needed, but it is designed to address the needs we have _right now_ not the needs we _might have_ in the future. As of today, it is important that we safeguard the cultural process of writing idris code. 

This is not really up for debate as I am writing this jointly with the pre-approval of @edwinb, @CodingCellist and @gallais . As such this is more of an announcement than a review process. 

Note that this is explicitly not based on one person's specific value and opinions. We all have our core values and ethics with different red-lines but came to the same conclusion: We need to protect how Idris is built. With that in mind, adding a single paragraph to the contributing policy seems like a no-brainer