### PR TITLE
Prefix RefC internal names to disambiguate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ idris2docs_venv
 .vscode/*
 # JetBrains IDEs
 .idea/
+# Zed editor
+.zed/
 
 # macOS
 .DS_Store

--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -89,10 +89,13 @@ should target this file (`CHANGELOG_NEXT`).
   systems, the compiler will now use `posix_memalign`.
 * Fixed integer comparison operators returning incorrect results on WASM32.
   The `idris2_extractInt` function incorrectly used `idris2_vp_to_Int32` for
-  unboxed values, which dereferences unboxed pointers as `Idris2_Int32*` on
-  32-bit platforms when `UINTPTR_WIDTH` is not defined (common in Emscripten).
+  unboxed values, which dereferences unboxed pointers as `Idris2_Int32*`
+  (previously `Value_Int32*`) on 32-bit platforms when `UINTPTR_WIDTH` is not
+  defined (common in Emscripten).
 * Fix missing support for sized, signed integers in FFI.
 * Fix headers for numeric negation.
+* Prefix RefC Idris values with `Idris2_` to prevent name collisions with third
+  partly libraries.
 
 ### Library changes
 

--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -89,7 +89,7 @@ should target this file (`CHANGELOG_NEXT`).
   systems, the compiler will now use `posix_memalign`.
 * Fixed integer comparison operators returning incorrect results on WASM32.
   The `idris2_extractInt` function incorrectly used `idris2_vp_to_Int32` for
-  unboxed values, which dereferences unboxed pointers as `Value_Int32*` on
+  unboxed values, which dereferences unboxed pointers as `Idris2_Int32*` on
   32-bit platforms when `UINTPTR_WIDTH` is not defined (common in Emscripten).
 * Fix missing support for sized, signed integers in FFI.
 * Fix headers for numeric negation.

--- a/src/Compiler/RefC/RefC.idr
+++ b/src/Compiler/RefC/RefC.idr
@@ -345,8 +345,8 @@ makeClosure : {auto a : Ref ArgCounter Nat}
 makeClosure fc n args missing = do
     let closure = "closure_\{!(getNextCounter)}"
     let nargs = length args
-    emit fc "Value *\{closure} = (Value *)idris2_mkClosure((Value *(*)())\{cName n}, \{show $ nargs + missing}, \{show nargs});"
-    fillArgs !(get EnvTracker) "((Value_Closure*)\{closure})->args" args 0
+    emit fc "Idris2_Value *\{closure} = (Idris2_Value *)idris2_mkClosure((Idris2_Value *(*)())\{cName n}, \{show $ nargs + missing}, \{show nargs});"
+    fillArgs !(get EnvTracker) "((Idris2_Closure*)\{closure})->args" args 0
     pure closure
 
 -- When changing this number, also change idris2_dispatch_closure in runtime.c.
@@ -426,11 +426,11 @@ addReuseConstructor reuseMap sc conName conArgs consts shouldDrop actualReuseCon
        && contains conName consts
        && (isJust $ find (== sc) shouldDrop) then do
         let constr = "constructor_" ++ !(getNextCounter)
-        emit EmptyFC $ "Value_Constructor* " ++ constr ++ " = NULL;"
+        emit EmptyFC $ "Idris2_Constructor* " ++ constr ++ " = NULL;"
         -- If the constructor variable is unique (has 1 reference), then assign it for reuse
         emit EmptyFC $ "if (idris2_isUnique(" ++ sc ++ ")) {"
         increaseIndentation
-        emit EmptyFC $ constr ++ " = (Value_Constructor*)" ++ sc ++ ";"
+        emit EmptyFC $ constr ++ " = (Idris2_Constructor*)" ++ sc ++ ";"
         decreaseIndentation
         emit EmptyFC "}"
         -- Otherwise, delete and duplicate constructor variables
@@ -458,7 +458,7 @@ mutual
     concaseBody env returnvar expr args body tailPosition = do
         increaseIndentation
         _ <- foldlC (\k, arg => do
-            emit emptyFC "Value *var_\{show arg} = ((Value_Constructor*)\{expr})->args[\{show k}];"
+            emit emptyFC "Idris2_Value *var_\{show arg} = ((Idris2_Constructor*)\{expr})->args[\{show k}];"
             pure (S k) ) 0 args
 
         let (shouldDrop, actualOwned) = dropUnusedOwnedVars env.owned (freeVariables body)
@@ -507,7 +507,7 @@ mutual
         -- When translating value into C, we borrow variables that will be used in body
         let valueEnv = { reuseMap $= (`intersectionMap` usedCons) } (moveFromOwnedToBorrowed env borrowVal)
         put EnvTracker valueEnv
-        emit fc $ "Value * var_\{show var} = \{!(cStatementsFromANF value NotInTailPosition)};"
+        emit fc $ "Idris2_Value * var_\{show var} = \{!(cStatementsFromANF value NotInTailPosition)};"
         unless (contains (ALocal var) usedVars) $ emit fc $ "idris2_removeReference(var_\{show var});"
         put EnvTracker ({ owned := owned', reuseMap $= (`differenceMap` usedCons) } env)
         cStatementsFromANF body tailPosition
@@ -532,11 +532,11 @@ mutual
                         pure constr
                     Nothing => do
                         let constr = "constructor_\{!(getNextCounter)}"
-                        emit fc $ "Value_Constructor* " ++ constr ++ createNewConstructor
+                        emit fc $ "Idris2_Constructor* " ++ constr ++ createNewConstructor
                         when (Nothing == tag) $ emit fc "\{constr}->name = idris2_constr_\{cName n};"
                         pure constr
                 fillArgs env "\{constr}->args" args 0
-                pure "(Value*)\{constr}"
+                pure "(Idris2_Value*)\{constr}"
 
     cStatementsFromANF (AOp fc _ op args) _ = do
         let resultVar = "primVar_" ++ !(getNextCounter)
@@ -546,7 +546,7 @@ mutual
               let ownedVars = if contains v env.owned then singleton v else empty
               in (avarToC env v) :: argsVect (moveFromOwnedToBorrowed env ownedVars) vars
 
-        emit fc $ "Value *" ++ resultVar ++ " = " ++ cOp op (argsVect !(get EnvTracker) args) ++ ";"
+        emit fc $ "Idris2_Value *" ++ resultVar ++ " = " ++ cOp op (argsVect !(get EnvTracker) args) ++ ";"
         -- Removing arguments that apply to primitive functions
         removeVars $ toList $ map varName args
         pure resultVar
@@ -566,7 +566,7 @@ mutual
     cStatementsFromANF (AConCase fc sc alts mDef) tailPosition = do
         let sc' = varName sc
         switchReturnVar <- getNewVarThatWillNotBeFreedAtEndOfBlock
-        emit fc "Value * \{switchReturnVar} = NULL;"
+        emit fc "Idris2_Value * \{switchReturnVar} = NULL;"
         env <- get EnvTracker
         _ <- foldlC (\els, (MkAConAlt name coninfo tag args body) => do
             let erased = coninfo == NIL || coninfo == NOTHING || coninfo == ZERO || coninfo == UNIT
@@ -575,8 +575,8 @@ mutual
                 then emit emptyFC "\{els}if (NULL != \{sc'} /* \{show name} \{show coninfo} */) {"
                 else do
                     case tag of
-                        Nothing   => emit emptyFC "\{els}if (! strcmp(((Value_Constructor *)\{sc'})->name, idris2_constr_\{cName name})) {"
-                        Just tag' => emit emptyFC "\{els}if (((Value_Constructor *)\{sc'})->tag == \{show tag'} /* \{show name} */) {"
+                        Nothing   => emit emptyFC "\{els}if (! strcmp(((Idris2_Constructor *)\{sc'})->name, idris2_constr_\{cName name})) {"
+                        Just tag' => emit emptyFC "\{els}if (((Idris2_Constructor *)\{sc'})->tag == \{show tag'} /* \{show name} */) {"
 
             let conArgs = ALocal <$> args
             let ownedWithArgs = union (fromList conArgs) $ if erased then delete sc env.owned else env.owned
@@ -585,7 +585,7 @@ mutual
             let (dropReuseCons, actualReuseMap) = dropUnusedReuseCons env.reuseMap usedCons
             increaseIndentation
             _ <- foldlC (\k, arg => do
-                emit emptyFC "Value *var_\{show arg} = ((Value_Constructor*)\{sc'})->args[\{show k}];"
+                emit emptyFC "Idris2_Value *var_\{show arg} = ((Idris2_Constructor*)\{sc'})->args[\{show k}];"
                 pure (S k) ) 0 args
             (shouldDrop, actualReuseMap) <- addReuseConstructor env.reuseMap sc' name (varName <$> conArgs) usedCons shouldDrop actualReuseMap
             removeVars shouldDrop
@@ -606,7 +606,7 @@ mutual
     cStatementsFromANF (AConstCase fc sc alts def) tailPosition = do
         let sc' = varName sc
         switchReturnVar <- getNewVarThatWillNotBeFreedAtEndOfBlock
-        emit fc "Value *\{switchReturnVar} = NULL;"
+        emit fc "Idris2_Value *\{switchReturnVar} = NULL;"
         env <- get EnvTracker
         case integer_switch alts of
             True => do
@@ -621,8 +621,8 @@ mutual
             False => do
                 _ <- foldlC (\els, (MkAConstAlt c body) => do
                     case c of
-                        Str x => emit emptyFC "\{els}if (! strcmp(\{cStringQuoted x}, ((Value_String *)\{sc'})->str)) {"
-                        Db  x => emit emptyFC "\{els}if (((Value_Double *)\{sc'})->d == \{show x}) {"
+                        Str x => emit emptyFC "\{els}if (! strcmp(\{cStringQuoted x}, ((Idris2_String *)\{sc'})->str)) {"
+                        Db  x => emit emptyFC "\{els}if (((Idris2_Double *)\{sc'})->d == \{show x}) {"
                         x => throw $ InternalError "[refc] AConstCase : unsupported type. \{show fc} \{show x}"
                     concaseBody env switchReturnVar "" [] body tailPosition
                     pure "} else ") "" alts
@@ -640,24 +640,24 @@ mutual
     cStatementsFromANF (APrimVal fc c) _ = do
       constdefs <- get ConstDef
       case lookup c constdefs of
-           Just cdef => pure "((Value*)&\{constantName cdef})" -- the constant already booked.
+           Just cdef => pure "((Idris2_Value*)&\{constantName cdef})" -- the constant already booked.
            Nothing => dyngen
      where
         orStagen : ConstDef -> Core String
         orStagen cdef = do -- booking the constant to generate later
             constdefs <- get ConstDef
             put ConstDef $ insert c cdef constdefs
-            pure "((Value*)&\{constantName cdef})" -- the constant already booked.
+            pure "((Idris2_Value*)&\{constantName cdef})" -- the constant already booked.
         dyngen : Core String
         dyngen = case c of
             I x => if x >= 0 && x < 100
-                then pure "(Value*)(&idris2_predefined_Int64[\{show x}])"
+                then pure "(Idris2_Value*)(&idris2_predefined_Int64[\{show x}])"
                 else orStagen $ CDI64 $ cCleanString $ show x
             I8 x  => pure "idris2_mkInt8(INT8_C(\{show x}))"
             I16 x => pure "idris2_mkInt16(INT16_C(\{show x}))"
             I32 x => pure "idris2_mkInt32(INT32_C(\{show x}))"
             I64 x => if x >= 0 && x < 100
-                then pure "(Value*)(&idris2_predefined_Int64[\{show x}])"
+                then pure "(Idris2_Value*)(&idris2_predefined_Int64[\{show x}])"
                 else orStagen $ CDI64 $ cCleanString $ show x
             BI x => if x >= 0 && x < 100
                 then pure "idris2_getPredefinedInteger(\{show x})"
@@ -666,7 +666,7 @@ mutual
             B16 x => pure "idris2_mkBits16(UINT16_C(\{show x}))"
             B32 x => pure "idris2_mkBits32(UINT32_C(\{show x}))"
             B64 x => if x >= 0 && x < 100
-               then pure "(Value*)(&idris2_predefined_Bits64[\{show x}])"
+               then pure "(Idris2_Value*)(&idris2_predefined_Bits64[\{show x}])"
                else orStagen $ CDB64 $ show x
             Db x => orStagen $ CDDb $ cCleanString $ show x
             Ch x  => pure "idris2_mkChar(\{escapeChar x})"
@@ -726,13 +726,13 @@ emitFDef : {auto oft : Ref OutfileText Output}
         -> (funcName:Name)
         -> (arglist:List (String, String, CFType))
         -> Core ()
-emitFDef funcName [] = emit EmptyFC $ "Value *" ++ cName funcName ++ "(void)"
+emitFDef funcName [] = emit EmptyFC $ "Idris2_Value *" ++ cName funcName ++ "(void)"
 emitFDef funcName ((varType, varName, varCFType) :: xs) = do
-    emit EmptyFC $ "Value *" ++ cName funcName
+    emit EmptyFC $ "Idris2_Value *" ++ cName funcName
     emit EmptyFC "("
     increaseIndentation
-    emit EmptyFC $ "  Value *" ++ varName
-    traverse_ (\(varType, varName, varCFType) => emit EmptyFC $ ", Value *" ++ varName) xs
+    emit EmptyFC $ "  Idris2_Value *" ++ varName
+    traverse_ (\(varType, varName, varCFType) => emit EmptyFC $ ", Idris2_Value *" ++ varName) xs
     decreaseIndentation
     emit EmptyFC ")"
 
@@ -750,23 +750,23 @@ extractValue _ CFUnsigned8      varName = "(idris2_vp_to_Bits8(" ++ varName ++ "
 extractValue _ CFUnsigned16     varName = "(idris2_vp_to_Bits16(" ++ varName ++ "))"
 extractValue _ CFUnsigned32     varName = "(idris2_vp_to_Bits32(" ++ varName ++ "))"
 extractValue _ CFUnsigned64     varName = "(idris2_vp_to_Bits64(" ++ varName ++ "))"
-extractValue _ CFString         varName = "((Value_String*)" ++ varName ++ ")->str"
+extractValue _ CFString         varName = "((Idris2_String*)" ++ varName ++ ")->str"
 extractValue _ CFDouble         varName = "(idris2_vp_to_Double(" ++ varName ++ "))"
 extractValue _ CFChar           varName = "(idris2_vp_to_Char(" ++ varName ++ "))"
-extractValue _ CFPtr            varName = "((Value_Pointer*)" ++ varName ++ ")->p"
-extractValue _ CFGCPtr          varName = "((Value_GCPointer*)" ++ varName ++ ")->p->p"
-extractValue CLangC    CFBuffer varName = "((Value_Buffer*)" ++ varName ++ ")->buffer->data"
-extractValue CLangRefC CFBuffer varName = "((Value_Buffer*)" ++ varName ++ ")->buffer"
-extractValue _ CFWorld          _       = "(Value *)NULL"
-extractValue _ (CFFun x y)      varName = "(Value_Closure*)" ++ varName
+extractValue _ CFPtr            varName = "((Idris2_Pointer*)" ++ varName ++ ")->p"
+extractValue _ CFGCPtr          varName = "((Idris2_GCPointer*)" ++ varName ++ ")->p->p"
+extractValue CLangC    CFBuffer varName = "((Idris2_Buffer*)" ++ varName ++ ")->buffer->data"
+extractValue CLangRefC CFBuffer varName = "((Idris2_Buffer*)" ++ varName ++ ")->buffer"
+extractValue _ CFWorld          _       = "(Idris2_Value *)NULL"
+extractValue _ (CFFun x y)      varName = "(Idris2_Closure*)" ++ varName
 extractValue c (CFIORes x)      varName = extractValue c x varName
 extractValue _ (CFStruct x xs)  varName = assert_total $ idris_crash ("INTERNAL ERROR: Struct access not implemented: " ++ varName)
 -- not really total but this way this internal error does not contaminate everything else
-extractValue _ (CFUser x xs)    varName = "(Value*)" ++ varName
+extractValue _ (CFUser x xs)    varName = "(Idris2_Value*)" ++ varName
 extractValue _ n _ = assert_total $ idris_crash ("INTERNAL ERROR: Unknown FFI type in C backend: " ++ show n)
 
 packCFType : (cfType:CFType) -> (varName:String) -> String
-packCFType CFUnit          varName = "((Value *)NULL)"
+packCFType CFUnit          varName = "((Idris2_Value *)NULL)"
 packCFType CFInt           varName = "idris2_mkInt64(" ++ varName ++ ")"
 packCFType CFInt8          varName = "idris2_mkInt8(" ++ varName ++ ")"
 packCFType CFInt16         varName = "idris2_mkInt16(" ++ varName ++ ")"
@@ -782,7 +782,7 @@ packCFType CFChar          varName = "idris2_mkChar(" ++ varName ++ ")"
 packCFType CFPtr           varName = "idris2_makePointer(" ++ varName ++ ")"
 packCFType CFGCPtr         varName = "idris2_makePointer(" ++ varName ++ ")"
 packCFType CFBuffer        varName = "idris2_makeBuffer(" ++ varName ++ ")"
-packCFType CFWorld         _       = "(Value *)NULL"
+packCFType CFWorld         _       = "(Idris2_Value *)NULL"
 packCFType (CFFun x y)     varName = "makeFunction(" ++ varName ++ ")"
 packCFType (CFIORes x)     varName = packCFType x varName
 packCFType (CFStruct x xs) varName = "makeStruct(" ++ varName ++ ")"
@@ -813,10 +813,10 @@ createCFunctions : {auto c : Ref Ctxt Defs}
                 -> Core ()
 createCFunctions n (MkAFun args anf) = do
     let nargs = length args
-    let fn = "Value *\{cName !(getFullName n)}"
+    let fn = "Idris2_Value *\{cName !(getFullName n)}"
             ++ (if nargs == 0 then "(void)"
-               else if nargs > MaxExtractFunArgs then "(Value *var_arglist[\{show nargs}])"
-               else ("\n(\n" ++ (showSep "\n" $ addCommaToList (map (\i =>  "  Value * var_" ++ (show i)) args))) ++ "\n)")
+               else if nargs > MaxExtractFunArgs then "(Idris2_Value *var_arglist[\{show nargs}])"
+               else ("\n(\n" ++ (showSep "\n" $ addCommaToList (map (\i =>  "  Idris2_Value * var_" ++ (show i)) args))) ++ "\n)")
     update FunctionDefinitions $ \otherDefs => (fn ++ ";\n") :: otherDefs
 
     let argsVars = fromList $ ALocal <$> args
@@ -828,7 +828,7 @@ createCFunctions n (MkAFun args anf) = do
     increaseIndentation
     when (nargs > MaxExtractFunArgs) $ do
       _ <- foldlC (\i, j => do
-         emit EmptyFC "Value *var_\{show j} = var_arglist[\{show i}];"
+         emit EmptyFC "Idris2_Value *var_\{show j} = var_arglist[\{show i}];"
          pure $ i + 1) 0 args
       pure ()
     removeVars (varName <$> Prelude.toList shouldDrop)
@@ -865,7 +865,7 @@ createCFunctions n (MkAForeign ccs fargs ret) = do
                       [lib, header] => update HeaderFiles $ insert header
                       _ => pure ()
              else emit EmptyFC $ additionalFFIStub fctName fargs ret
-          let fnDef = "Value *" ++ (cName n) ++ "(" ++ showSep ", " (replicate (length fargs) "Value *") ++ ");"
+          let fnDef = "Idris2_Value *" ++ (cName n) ++ "(" ++ showSep ", " (replicate (length fargs) "Idris2_Value *") ++ ");"
           update FunctionDefinitions $ \otherDefs => (fnDef ++ "\n") :: otherDefs
           typeVarNameArgList <- createFFIArgList fargs
 
@@ -888,14 +888,14 @@ createCFunctions n (MkAForeign ccs fargs ret) = do
                               ++ showSep ", " (map (\(_, vn, vt) => extractValue cLang vt vn) (discardLastArgument typeVarNameArgList))
                               ++ ");"
                   removeVarsArgList
-                  emit EmptyFC $ "return (Value*)" ++ packCFType ret "retVal" ++ ";"
+                  emit EmptyFC $ "return (Idris2_Value*)" ++ packCFType ret "retVal" ++ ";"
               _ => do
                   emit EmptyFC $ cTypeOfCFType ret ++ " retVal = " ++ cName fctName
                               ++ "("
                               ++ showSep ", " (map (\(_, vn, vt) => extractValue cLang vt vn) typeVarNameArgList)
                               ++ ");"
                   removeVarsArgList
-                  emit EmptyFC $ "return (Value*)" ++ packCFType ret "retVal" ++ ";"
+                  emit EmptyFC $ "return (Idris2_Value*)" ++ packCFType ret "retVal" ++ ";"
 
           decreaseIndentation
           emit EmptyFC "}"
@@ -959,7 +959,7 @@ footer = do
                         "idris2_setArgs(argc, argv);"
                         ""
           }
-          Value *mainExprVal = __mainExpression_0();
+          Idris2_Value *mainExprVal = __mainExpression_0();
           idris2_trampoline(mainExprVal);
           return 0; // bye bye
       }

--- a/src/Compiler/RefC/RefC.idr
+++ b/src/Compiler/RefC/RefC.idr
@@ -930,7 +930,7 @@ header = do
   where
     go : ConstDef -> String -> String -> String -> String
     go cdef ty tag v =
-      "static Value_\{ty} const \{constantName cdef}"
+      "static Idris2_\{ty} const \{constantName cdef}"
         ++ " = { IDRIS2_STOCKVAL(\{tag}_TAG), \{v} };"
     genConstant : Constant -> ConstDef -> String
     genConstant c cdef = case c of

--- a/support/refc/_datatypes.h
+++ b/support/refc/_datatypes.h
@@ -44,10 +44,10 @@ typedef struct {
 
 typedef struct {
   Value_header header;
-  // `Value` is an "abstract" struct,
+  // `Idris2_Value` is an "abstract" struct,
   // `Value_Xxx` structs have the same header
   // followed by type-specific payload.
-} Value;
+} Idris2_Value;
 
 /*
 We expect at least 4 bytes for `Value_header` alignment, to use bit0 and bit1 of
@@ -56,24 +56,24 @@ pointer as flags.
 RefC does not have complete static tracking of type information, so types are
 identified at runtime using Value_Header's tag field. However, Int that are
 pretending to be pointers cannot have that tag, so use that flag to identify
-them first. Of course, this flag is not used if it is clear that Value* is
+them first. Of course, this flag is not used if it is clear that Idris2_Value* is
 actually an Int. But places like newReference/removeReference require this flag.
  */
 #define idris2_vp_is_unboxed(p) ((uintptr_t)(p)&3)
 
 #define idris2_vp_int_shift                                                    \
-  ((sizeof(uintptr_t) >= 8 && sizeof(Value *) >= 8) ? 32 : 16)
+  ((sizeof(uintptr_t) >= 8 && sizeof(Idris2_Value *) >= 8) ? 32 : 16)
 
-#define idris2_vp_to_Bits64(p) (((Value_Bits64 *)(p))->ui64)
+#define idris2_vp_to_Bits64(p) (((Idris2_Bits64 *)(p))->ui64)
 
 #if !defined(UINTPTR_WIDTH)
 #define idris2_vp_to_Bits32(p)                                                 \
   ((idris2_vp_int_shift == 16)                                                 \
-       ? (((Value_Bits32 *)(p))->ui32)                                         \
+       ? (((Idris2_Bits32 *)(p))->ui32)                                         \
        : ((uint32_t)((uintptr_t)(p) >> idris2_vp_int_shift)))
 #define idris2_vp_to_Int32(p)                                                  \
   ((idris2_vp_int_shift == 16)                                                 \
-       ? (((Value_Int32 *)(p))->i32)                                           \
+       ? (((Idris2_Int32 *)(p))->i32)                                           \
        : ((int32_t)((uintptr_t)(p) >> idris2_vp_int_shift)))
 
 #elif UINTPTR_WIDTH >= 64
@@ -84,8 +84,8 @@ actually an Int. But places like newReference/removeReference require this flag.
 #define idris2_vp_to_Int32(p) ((int32_t)((uintptr_t)(p) >> idris2_vp_int_shift))
 
 #elif UINTPTR_WIDTH >= 32
-#define idris2_vp_to_Bits32(p) (((Value_Bits32 *)(p))->ui32)
-#define idris2_vp_to_Int32(p) (((Value_Int32 *)(p))->i32)
+#define idris2_vp_to_Bits32(p) (((Idris2_Bits32 *)(p))->ui32)
+#define idris2_vp_to_Int32(p) (((Idris2_Int32 *)(p))->i32)
 
 #else
 #error "unsupported uintptr_t width"
@@ -94,56 +94,56 @@ actually an Int. But places like newReference/removeReference require this flag.
 #define idris2_vp_to_Bits16(p)                                                 \
   ((uint16_t)((uintptr_t)(p) >> idris2_vp_int_shift))
 #define idris2_vp_to_Bits8(p) ((uint8_t)((uintptr_t)(p) >> idris2_vp_int_shift))
-#define idris2_vp_to_Int64(p) (((Value_Int64 *)(p))->i64)
+#define idris2_vp_to_Int64(p) (((Idris2_Int64 *)(p))->i64)
 #define idris2_vp_to_Int16(p) ((int16_t)((uintptr_t)(p) >> idris2_vp_int_shift))
 #define idris2_vp_to_Int8(p) ((int8_t)((uintptr_t)(p) >> idris2_vp_int_shift))
 #define idris2_vp_to_Char(p)                                                   \
   ((unsigned char)((uintptr_t)(p) >> idris2_vp_int_shift))
-#define idris2_vp_to_Double(p) (((Value_Double *)(p))->d)
+#define idris2_vp_to_Double(p) (((Idris2_Double *)(p))->d)
 #define idris2_vp_to_Bool(p) (idris2_vp_to_Int8(p))
 
 typedef struct {
   Value_header header;
   uint32_t ui32;
-} Value_Bits32;
+} Idris2_Bits32;
 
 typedef struct {
   Value_header header;
   uint64_t ui64;
-} Value_Bits64;
+} Idris2_Bits64;
 
 typedef struct {
   Value_header header;
   int32_t i32;
-} Value_Int32;
+} Idris2_Int32;
 
 typedef struct {
   Value_header header;
   int64_t i64;
-} Value_Int64;
+} Idris2_Int64;
 
 typedef struct {
   Value_header header;
   mpz_t i;
-} Value_Integer;
+} Idris2_Integer;
 
 typedef struct {
   Value_header header;
   double d;
-} Value_Double;
+} Idris2_Double;
 
 typedef struct {
   Value_header header;
   char *str;
-} Value_String;
+} Idris2_String;
 
 typedef struct {
   Value_header header;
   int32_t total;
   int32_t tag;
   char const *name;
-  Value *args[];
-} Value_Constructor;
+  Idris2_Value *args[];
+} Idris2_Constructor;
 
 typedef struct {
   Value_header header;
@@ -151,44 +151,44 @@ typedef struct {
   void *f;
   uint8_t arity;
   uint8_t filled; // length of args.
-  Value *args[];
-} Value_Closure;
+  Idris2_Value *args[];
+} Idris2_Closure;
 
 typedef struct {
   Value_header header;
-  Value *v;
-} Value_IORef;
+  Idris2_Value *v;
+} Idris2_IORef;
 
 typedef struct {
   Value_header header;
   void *p;
-} Value_Pointer;
+} Idris2_Pointer;
 
 typedef struct {
   Value_header header;
-  Value_Pointer *p;
-  Value_Closure *onCollectFct;
-} Value_GCPointer;
+  Idris2_Pointer *p;
+  Idris2_Closure *onCollectFct;
+} Idris2_GCPointer;
 
 typedef struct {
   Value_header header;
   int capacity;
-  Value **arr;
-} Value_Array;
+  Idris2_Value **arr;
+} Idris2_Array;
 
 typedef struct {
   Value_header header;
   Buffer *buffer;
-} Value_Buffer;
+} Idris2_Buffer;
 
 typedef struct {
   Value_header header;
   pthread_mutex_t *mutex;
-} Value_Mutex;
+} Idris2_Mutex;
 
 typedef struct {
   Value_header header;
   pthread_cond_t *cond;
-} Value_Condition;
+} Idris2_Condition;
 
 void idris2_dumpMemoryStats(void);

--- a/support/refc/_datatypes.h
+++ b/support/refc/_datatypes.h
@@ -56,8 +56,8 @@ pointer as flags.
 RefC does not have complete static tracking of type information, so types are
 identified at runtime using Value_Header's tag field. However, Int that are
 pretending to be pointers cannot have that tag, so use that flag to identify
-them first. Of course, this flag is not used if it is clear that Idris2_Value* is
-actually an Int. But places like newReference/removeReference require this flag.
+them first. Of course, this flag is not used if it is clear that Idris2_Value*
+is actually an Int. But places like newReference/removeReference require this flag.
  */
 #define idris2_vp_is_unboxed(p) ((uintptr_t)(p)&3)
 
@@ -69,11 +69,11 @@ actually an Int. But places like newReference/removeReference require this flag.
 #if !defined(UINTPTR_WIDTH)
 #define idris2_vp_to_Bits32(p)                                                 \
   ((idris2_vp_int_shift == 16)                                                 \
-       ? (((Idris2_Bits32 *)(p))->ui32)                                         \
+       ? (((Idris2_Bits32 *)(p))->ui32)                                        \
        : ((uint32_t)((uintptr_t)(p) >> idris2_vp_int_shift)))
 #define idris2_vp_to_Int32(p)                                                  \
   ((idris2_vp_int_shift == 16)                                                 \
-       ? (((Idris2_Int32 *)(p))->i32)                                           \
+       ? (((Idris2_Int32 *)(p))->i32)                                          \
        : ((int32_t)((uintptr_t)(p) >> idris2_vp_int_shift)))
 
 #elif UINTPTR_WIDTH >= 64

--- a/support/refc/_datatypes.h
+++ b/support/refc/_datatypes.h
@@ -60,7 +60,7 @@ them first. Of course, this flag is not used if it is clear that Idris2_Value*
 is actually an Int. But places like newReference/removeReference require this
 flag.
  */
-#define idris2_vp_is_unboxed(p) ((uintptr_t)(p) & 3)
+#define idris2_vp_is_unboxed(p) ((uintptr_t)(p)&3)
 
 #define idris2_vp_int_shift                                                    \
   ((sizeof(uintptr_t) >= 8 && sizeof(Idris2_Value *) >= 8) ? 32 : 16)

--- a/support/refc/_datatypes.h
+++ b/support/refc/_datatypes.h
@@ -50,16 +50,17 @@ typedef struct {
 } Idris2_Value;
 
 /*
-We expect at least 4 bytes for `Idris2_header` alignment, to use bit0 and bit1 of
-pointer as flags.
+We expect at least 4 bytes for `Idris2_header` alignment, to use bit0 and bit1
+of pointer as flags.
 
 RefC does not have complete static tracking of type information, so types are
 identified at runtime using Idris2_header's tag field. However, Int that are
 pretending to be pointers cannot have that tag, so use that flag to identify
 them first. Of course, this flag is not used if it is clear that Idris2_Value*
-is actually an Int. But places like newReference/removeReference require this flag.
+is actually an Int. But places like newReference/removeReference require this
+flag.
  */
-#define idris2_vp_is_unboxed(p) ((uintptr_t)(p)&3)
+#define idris2_vp_is_unboxed(p) ((uintptr_t)(p) & 3)
 
 #define idris2_vp_int_shift                                                    \
   ((sizeof(uintptr_t) >= 8 && sizeof(Idris2_Value *) >= 8) ? 32 : 16)

--- a/support/refc/_datatypes.h
+++ b/support/refc/_datatypes.h
@@ -38,23 +38,23 @@ typedef struct {
   uint16_t refCounter;
   uint8_t tag;
   uint8_t reserved;
-} Value_header;
+} Idris2_header;
 #define IDRIS2_STOCKVAL(t)                                                     \
   { IDRIS2_VP_REFCOUNTER_MAX, t, 0 }
 
 typedef struct {
-  Value_header header;
+  Idris2_header header;
   // `Idris2_Value` is an "abstract" struct,
   // `Value_Xxx` structs have the same header
   // followed by type-specific payload.
 } Idris2_Value;
 
 /*
-We expect at least 4 bytes for `Value_header` alignment, to use bit0 and bit1 of
+We expect at least 4 bytes for `Idris2_header` alignment, to use bit0 and bit1 of
 pointer as flags.
 
 RefC does not have complete static tracking of type information, so types are
-identified at runtime using Value_Header's tag field. However, Int that are
+identified at runtime using Idris2_header's tag field. However, Int that are
 pretending to be pointers cannot have that tag, so use that flag to identify
 them first. Of course, this flag is not used if it is clear that Idris2_Value*
 is actually an Int. But places like newReference/removeReference require this flag.
@@ -103,42 +103,42 @@ is actually an Int. But places like newReference/removeReference require this fl
 #define idris2_vp_to_Bool(p) (idris2_vp_to_Int8(p))
 
 typedef struct {
-  Value_header header;
+  Idris2_header header;
   uint32_t ui32;
 } Idris2_Bits32;
 
 typedef struct {
-  Value_header header;
+  Idris2_header header;
   uint64_t ui64;
 } Idris2_Bits64;
 
 typedef struct {
-  Value_header header;
+  Idris2_header header;
   int32_t i32;
 } Idris2_Int32;
 
 typedef struct {
-  Value_header header;
+  Idris2_header header;
   int64_t i64;
 } Idris2_Int64;
 
 typedef struct {
-  Value_header header;
+  Idris2_header header;
   mpz_t i;
 } Idris2_Integer;
 
 typedef struct {
-  Value_header header;
+  Idris2_header header;
   double d;
 } Idris2_Double;
 
 typedef struct {
-  Value_header header;
+  Idris2_header header;
   char *str;
 } Idris2_String;
 
 typedef struct {
-  Value_header header;
+  Idris2_header header;
   int32_t total;
   int32_t tag;
   char const *name;
@@ -146,7 +146,7 @@ typedef struct {
 } Idris2_Constructor;
 
 typedef struct {
-  Value_header header;
+  Idris2_header header;
   // function type depends on arity, see idris2_dispatch_closure
   void *f;
   uint8_t arity;
@@ -155,39 +155,39 @@ typedef struct {
 } Idris2_Closure;
 
 typedef struct {
-  Value_header header;
+  Idris2_header header;
   Idris2_Value *v;
 } Idris2_IORef;
 
 typedef struct {
-  Value_header header;
+  Idris2_header header;
   void *p;
 } Idris2_Pointer;
 
 typedef struct {
-  Value_header header;
+  Idris2_header header;
   Idris2_Pointer *p;
   Idris2_Closure *onCollectFct;
 } Idris2_GCPointer;
 
 typedef struct {
-  Value_header header;
+  Idris2_header header;
   int capacity;
   Idris2_Value **arr;
 } Idris2_Array;
 
 typedef struct {
-  Value_header header;
+  Idris2_header header;
   Buffer *buffer;
 } Idris2_Buffer;
 
 typedef struct {
-  Value_header header;
+  Idris2_header header;
   pthread_mutex_t *mutex;
 } Idris2_Mutex;
 
 typedef struct {
-  Value_header header;
+  Idris2_header header;
   pthread_cond_t *cond;
 } Idris2_Condition;
 

--- a/support/refc/casts.c
+++ b/support/refc/casts.c
@@ -3,230 +3,230 @@
 #include <inttypes.h>
 
 /*  conversions from Int8  */
-Value *idris2_cast_Int8_to_Integer(Value *input) {
-  Value_Integer *retVal = idris2_mkInteger();
+Idris2_Value *idris2_cast_Int8_to_Integer(Idris2_Value *input) {
+  Idris2_Integer *retVal = idris2_mkInteger();
   mpz_set_si(retVal->i, idris2_vp_to_Int8(input));
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
-Value *idris2_cast_Int8_to_string(Value *input) {
+Idris2_Value *idris2_cast_Int8_to_string(Idris2_Value *input) {
   int8_t x = idris2_vp_to_Int8(input);
 
   int l = snprintf(NULL, 0, "%" PRId8 "", x);
-  Value_String *retVal = idris2_mkEmptyString(l + 1);
+  Idris2_String *retVal = idris2_mkEmptyString(l + 1);
   sprintf(retVal->str, "%" PRId8 "", x);
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
 /*  conversions from Int16  */
-Value *idris2_cast_Int16_to_Integer(Value *input) {
-  Value_Integer *retVal = idris2_mkInteger();
+Idris2_Value *idris2_cast_Int16_to_Integer(Idris2_Value *input) {
+  Idris2_Integer *retVal = idris2_mkInteger();
   mpz_set_si(retVal->i, idris2_vp_to_Int16(input));
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
-Value *idris2_cast_Int16_to_string(Value *input) {
+Idris2_Value *idris2_cast_Int16_to_string(Idris2_Value *input) {
   int16_t x = idris2_vp_to_Int16(input);
 
   int l = snprintf(NULL, 0, "%" PRId16 "", x);
-  Value_String *retVal = idris2_mkEmptyString(l + 1);
+  Idris2_String *retVal = idris2_mkEmptyString(l + 1);
   sprintf(retVal->str, "%" PRId16 "", x);
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
 /*  conversions from Int32  */
-Value *idris2_cast_Int32_to_Integer(Value *input) {
-  Value_Integer *retVal = idris2_mkInteger();
+Idris2_Value *idris2_cast_Int32_to_Integer(Idris2_Value *input) {
+  Idris2_Integer *retVal = idris2_mkInteger();
   mpz_set_si(retVal->i, idris2_vp_to_Int32(input));
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
-Value *idris2_cast_Int32_to_string(Value *input) {
+Idris2_Value *idris2_cast_Int32_to_string(Idris2_Value *input) {
   int32_t x = idris2_vp_to_Int32(input);
 
   int l = snprintf(NULL, 0, "%" PRId32 "", x);
-  Value_String *retVal = idris2_mkEmptyString(l + 1);
+  Idris2_String *retVal = idris2_mkEmptyString(l + 1);
   sprintf(retVal->str, "%" PRId32 "", x);
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
 /*  conversions from Int64  */
-Value *idris2_cast_Int64_to_Integer(Value *input) {
-  Value_Integer *retVal = idris2_mkInteger();
+Idris2_Value *idris2_cast_Int64_to_Integer(Idris2_Value *input) {
+  Idris2_Integer *retVal = idris2_mkInteger();
   mpz_set_si(retVal->i, idris2_vp_to_Int64(input));
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
-Value *idris2_cast_Int64_to_string(Value *input) {
+Idris2_Value *idris2_cast_Int64_to_string(Idris2_Value *input) {
   int64_t from = idris2_vp_to_Int64(input);
   int l = snprintf(NULL, 0, "%" PRId64 "", from);
-  Value_String *retVal = idris2_mkEmptyString(l + 1);
+  Idris2_String *retVal = idris2_mkEmptyString(l + 1);
   sprintf(retVal->str, "%" PRId64 "", from);
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
-Value *idris2_cast_Double_to_Integer(Value *input) {
-  Value_Integer *retVal = idris2_mkInteger();
+Idris2_Value *idris2_cast_Double_to_Integer(Idris2_Value *input) {
+  Idris2_Integer *retVal = idris2_mkInteger();
   mpz_set_d(retVal->i, idris2_vp_to_Double(input));
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
-Value *idris2_cast_Double_to_string(Value *input) {
+Idris2_Value *idris2_cast_Double_to_string(Idris2_Value *input) {
   double x = idris2_vp_to_Double(input);
 
   int l = snprintf(NULL, 0, "%f", x);
-  Value_String *retVal = idris2_mkEmptyString(l + 1);
+  Idris2_String *retVal = idris2_mkEmptyString(l + 1);
   sprintf(retVal->str, "%f", x);
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
-Value *idris2_cast_Char_to_Integer(Value *input) {
-  Value_Integer *retVal = idris2_mkInteger();
+Idris2_Value *idris2_cast_Char_to_Integer(Idris2_Value *input) {
+  Idris2_Integer *retVal = idris2_mkInteger();
   mpz_set_si(retVal->i, idris2_vp_to_Char(input));
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
-Value *idris2_cast_Char_to_string(Value *input) {
-  Value_String *retVal = idris2_mkEmptyString(2);
+Idris2_Value *idris2_cast_Char_to_string(Idris2_Value *input) {
+  Idris2_String *retVal = idris2_mkEmptyString(2);
   retVal->str[0] = idris2_vp_to_Char(input);
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
-Value *idris2_cast_String_to_Bits8(Value *input) {
-  Value_String *from = (Value_String *)input;
-  return (Value *)idris2_mkBits8((uint8_t)atoi(from->str));
+Idris2_Value *idris2_cast_String_to_Bits8(Idris2_Value *input) {
+  Idris2_String *from = (Idris2_String *)input;
+  return (Idris2_Value *)idris2_mkBits8((uint8_t)atoi(from->str));
 }
 
-Value *idris2_cast_String_to_Bits16(Value *input) {
-  Value_String *from = (Value_String *)input;
-  return (Value *)idris2_mkBits16((uint16_t)atoi(from->str));
+Idris2_Value *idris2_cast_String_to_Bits16(Idris2_Value *input) {
+  Idris2_String *from = (Idris2_String *)input;
+  return (Idris2_Value *)idris2_mkBits16((uint16_t)atoi(from->str));
 }
 
-Value *idris2_cast_String_to_Bits32(Value *input) {
-  Value_String *from = (Value_String *)input;
-  return (Value *)idris2_mkBits32((uint32_t)atoi(from->str));
+Idris2_Value *idris2_cast_String_to_Bits32(Idris2_Value *input) {
+  Idris2_String *from = (Idris2_String *)input;
+  return (Idris2_Value *)idris2_mkBits32((uint32_t)atoi(from->str));
 }
 
-Value *idris2_cast_String_to_Bits64(Value *input) {
-  Value_String *from = (Value_String *)input;
-  return (Value *)idris2_mkBits64((uint64_t)atoi(from->str));
+Idris2_Value *idris2_cast_String_to_Bits64(Idris2_Value *input) {
+  Idris2_String *from = (Idris2_String *)input;
+  return (Idris2_Value *)idris2_mkBits64((uint64_t)atoi(from->str));
 }
 
-Value *idris2_cast_String_to_Int8(Value *input) {
-  Value_String *from = (Value_String *)input;
-  return (Value *)idris2_mkInt8((int8_t)atoi(from->str));
+Idris2_Value *idris2_cast_String_to_Int8(Idris2_Value *input) {
+  Idris2_String *from = (Idris2_String *)input;
+  return (Idris2_Value *)idris2_mkInt8((int8_t)atoi(from->str));
 }
 
-Value *idris2_cast_String_to_Int16(Value *input) {
-  Value_String *from = (Value_String *)input;
-  return (Value *)idris2_mkInt16((int16_t)atoi(from->str));
+Idris2_Value *idris2_cast_String_to_Int16(Idris2_Value *input) {
+  Idris2_String *from = (Idris2_String *)input;
+  return (Idris2_Value *)idris2_mkInt16((int16_t)atoi(from->str));
 }
 
-Value *idris2_cast_String_to_Int32(Value *input) {
-  Value_String *from = (Value_String *)input;
-  return (Value *)idris2_mkInt32((int32_t)atoi(from->str));
+Idris2_Value *idris2_cast_String_to_Int32(Idris2_Value *input) {
+  Idris2_String *from = (Idris2_String *)input;
+  return (Idris2_Value *)idris2_mkInt32((int32_t)atoi(from->str));
 }
 
-Value *idris2_cast_String_to_Int64(Value *input) {
-  Value_String *from = (Value_String *)input;
-  return (Value *)idris2_mkInt64((int64_t)atoi(from->str));
+Idris2_Value *idris2_cast_String_to_Int64(Idris2_Value *input) {
+  Idris2_String *from = (Idris2_String *)input;
+  return (Idris2_Value *)idris2_mkInt64((int64_t)atoi(from->str));
 }
 
-Value *idris2_cast_String_to_Integer(Value *input) {
-  Value_String *from = (Value_String *)input;
+Idris2_Value *idris2_cast_String_to_Integer(Idris2_Value *input) {
+  Idris2_String *from = (Idris2_String *)input;
 
-  Value_Integer *retVal = idris2_mkInteger();
+  Idris2_Integer *retVal = idris2_mkInteger();
   mpz_set_str(retVal->i, from->str, 10);
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
-Value *idris2_cast_String_to_Double(Value *input) {
-  return (Value *)idris2_mkDouble(atof(((Value_String *)input)->str));
+Idris2_Value *idris2_cast_String_to_Double(Idris2_Value *input) {
+  return (Idris2_Value *)idris2_mkDouble(atof(((Idris2_String *)input)->str));
 }
 
 /*  conversions from Bits8  */
-Value *idris2_cast_Bits8_to_Integer(Value *input) {
-  Value_Integer *retVal = idris2_mkInteger();
+Idris2_Value *idris2_cast_Bits8_to_Integer(Idris2_Value *input) {
+  Idris2_Integer *retVal = idris2_mkInteger();
   mpz_set_ui(retVal->i, idris2_vp_to_Bits8(input));
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
-Value *idris2_cast_Bits8_to_string(Value *input) {
+Idris2_Value *idris2_cast_Bits8_to_string(Idris2_Value *input) {
   uint8_t x = idris2_vp_to_Bits8(input);
 
   int l = snprintf(NULL, 0, "%" PRIu8 "", x);
-  Value_String *retVal = idris2_mkEmptyString(l + 1);
+  Idris2_String *retVal = idris2_mkEmptyString(l + 1);
   sprintf(retVal->str, "%" PRIu8 "", x);
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
 /*  conversions from Bits16  */
-Value *idris2_cast_Bits16_to_Integer(Value *input) {
-  Value_Integer *retVal = idris2_mkInteger();
+Idris2_Value *idris2_cast_Bits16_to_Integer(Idris2_Value *input) {
+  Idris2_Integer *retVal = idris2_mkInteger();
   mpz_set_ui(retVal->i, idris2_vp_to_Bits16(input));
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
-Value *idris2_cast_Bits16_to_string(Value *input) {
+Idris2_Value *idris2_cast_Bits16_to_string(Idris2_Value *input) {
   uint16_t x = idris2_vp_to_Bits16(input);
 
   int l = snprintf(NULL, 0, "%" PRIu16 "", x);
-  Value_String *retVal = idris2_mkEmptyString(l + 1);
+  Idris2_String *retVal = idris2_mkEmptyString(l + 1);
   sprintf(retVal->str, "%" PRIu16 "", x);
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
 /*  conversions from Bits32  */
-Value *idris2_cast_Bits32_to_Integer(Value *input) {
-  Value_Integer *retVal = idris2_mkInteger();
+Idris2_Value *idris2_cast_Bits32_to_Integer(Idris2_Value *input) {
+  Idris2_Integer *retVal = idris2_mkInteger();
   mpz_set_ui(retVal->i, idris2_vp_to_Bits32(input));
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
-Value *idris2_cast_Bits32_to_string(Value *input) {
+Idris2_Value *idris2_cast_Bits32_to_string(Idris2_Value *input) {
   uint32_t x = idris2_vp_to_Bits32(input);
 
   int l = snprintf(NULL, 0, "%" PRIu32 "", x);
-  Value_String *retVal = idris2_mkEmptyString(l + 1);
+  Idris2_String *retVal = idris2_mkEmptyString(l + 1);
   sprintf(retVal->str, "%" PRIu32 "", x);
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
 /*  conversions from Bits64  */
-Value *idris2_cast_Bits64_to_Integer(Value *input) {
-  Value_Integer *retVal = idris2_mkInteger();
+Idris2_Value *idris2_cast_Bits64_to_Integer(Idris2_Value *input) {
+  Idris2_Integer *retVal = idris2_mkInteger();
   mpz_set_ui(retVal->i, idris2_vp_to_Bits64(input));
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
-Value *idris2_cast_Bits64_to_string(Value *input) {
+Idris2_Value *idris2_cast_Bits64_to_string(Idris2_Value *input) {
   uint64_t x = idris2_vp_to_Bits64(input);
 
   int l = snprintf(NULL, 0, "%" PRIu64 "", x);
-  Value_String *retVal = idris2_mkEmptyString(l + 1);
+  Idris2_String *retVal = idris2_mkEmptyString(l + 1);
   sprintf(retVal->str, "%" PRIu64 "", x);
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
 /*  conversions from Integer */
@@ -239,62 +239,62 @@ uint64_t mpz_get_lsb(mpz_t i, mp_bitcnt_t b) {
   return retVal;
 }
 
-Value *idris2_cast_Integer_to_Bits8(Value *input) {
-  Value_Integer *from = (Value_Integer *)input;
-  return (Value *)idris2_mkBits8((uint8_t)mpz_get_lsb(from->i, 8));
+Idris2_Value *idris2_cast_Integer_to_Bits8(Idris2_Value *input) {
+  Idris2_Integer *from = (Idris2_Integer *)input;
+  return (Idris2_Value *)idris2_mkBits8((uint8_t)mpz_get_lsb(from->i, 8));
 }
 
-Value *idris2_cast_Integer_to_Bits16(Value *input) {
-  Value_Integer *from = (Value_Integer *)input;
-  return (Value *)idris2_mkBits16((uint16_t)mpz_get_lsb(from->i, 16));
+Idris2_Value *idris2_cast_Integer_to_Bits16(Idris2_Value *input) {
+  Idris2_Integer *from = (Idris2_Integer *)input;
+  return (Idris2_Value *)idris2_mkBits16((uint16_t)mpz_get_lsb(from->i, 16));
 }
 
-Value *idris2_cast_Integer_to_Bits32(Value *input) {
-  Value_Integer *from = (Value_Integer *)input;
-  return (Value *)idris2_mkBits32((uint32_t)mpz_get_lsb(from->i, 32));
+Idris2_Value *idris2_cast_Integer_to_Bits32(Idris2_Value *input) {
+  Idris2_Integer *from = (Idris2_Integer *)input;
+  return (Idris2_Value *)idris2_mkBits32((uint32_t)mpz_get_lsb(from->i, 32));
 }
 
-Value *idris2_cast_Integer_to_Bits64(Value *input) {
-  Value_Integer *from = (Value_Integer *)input;
-  return (Value *)idris2_mkBits64((uint64_t)mpz_get_lsb(from->i, 64));
+Idris2_Value *idris2_cast_Integer_to_Bits64(Idris2_Value *input) {
+  Idris2_Integer *from = (Idris2_Integer *)input;
+  return (Idris2_Value *)idris2_mkBits64((uint64_t)mpz_get_lsb(from->i, 64));
 }
 
-Value *idris2_cast_Integer_to_Int8(Value *input) {
-  Value_Integer *from = (Value_Integer *)input;
-  return (Value *)idris2_mkInt8((int8_t)mpz_get_lsb(from->i, 8));
+Idris2_Value *idris2_cast_Integer_to_Int8(Idris2_Value *input) {
+  Idris2_Integer *from = (Idris2_Integer *)input;
+  return (Idris2_Value *)idris2_mkInt8((int8_t)mpz_get_lsb(from->i, 8));
 }
 
-Value *idris2_cast_Integer_to_Int16(Value *input) {
-  Value_Integer *from = (Value_Integer *)input;
-  return (Value *)idris2_mkInt16((int16_t)mpz_get_lsb(from->i, 16));
+Idris2_Value *idris2_cast_Integer_to_Int16(Idris2_Value *input) {
+  Idris2_Integer *from = (Idris2_Integer *)input;
+  return (Idris2_Value *)idris2_mkInt16((int16_t)mpz_get_lsb(from->i, 16));
 }
 
-Value *idris2_cast_Integer_to_Int32(Value *input) {
-  Value_Integer *from = (Value_Integer *)input;
-  return (Value *)idris2_mkInt32((int32_t)mpz_get_lsb(from->i, 32));
+Idris2_Value *idris2_cast_Integer_to_Int32(Idris2_Value *input) {
+  Idris2_Integer *from = (Idris2_Integer *)input;
+  return (Idris2_Value *)idris2_mkInt32((int32_t)mpz_get_lsb(from->i, 32));
 }
 
-Value *idris2_cast_Integer_to_Int64(Value *input) {
-  Value_Integer *from = (Value_Integer *)input;
-  return (Value *)idris2_mkInt64((int64_t)mpz_get_lsb(from->i, 64));
+Idris2_Value *idris2_cast_Integer_to_Int64(Idris2_Value *input) {
+  Idris2_Integer *from = (Idris2_Integer *)input;
+  return (Idris2_Value *)idris2_mkInt64((int64_t)mpz_get_lsb(from->i, 64));
 }
 
-Value *idris2_cast_Integer_to_Double(Value *input) {
-  Value_Integer *from = (Value_Integer *)input;
-  return (Value *)idris2_mkDouble(mpz_get_d(from->i));
+Idris2_Value *idris2_cast_Integer_to_Double(Idris2_Value *input) {
+  Idris2_Integer *from = (Idris2_Integer *)input;
+  return (Idris2_Value *)idris2_mkDouble(mpz_get_d(from->i));
 }
 
-Value *idris2_cast_Integer_to_Char(Value *input) {
-  Value_Integer *from = (Value_Integer *)input;
-  return (Value *)idris2_mkChar((unsigned char)mpz_get_lsb(from->i, 8));
+Idris2_Value *idris2_cast_Integer_to_Char(Idris2_Value *input) {
+  Idris2_Integer *from = (Idris2_Integer *)input;
+  return (Idris2_Value *)idris2_mkChar((unsigned char)mpz_get_lsb(from->i, 8));
 }
 
-Value *idris2_cast_Integer_to_string(Value *input) {
-  Value_Integer *from = (Value_Integer *)input;
+Idris2_Value *idris2_cast_Integer_to_string(Idris2_Value *input) {
+  Idris2_Integer *from = (Idris2_Integer *)input;
 
-  Value_String *retVal = IDRIS2_NEW_VALUE(Value_String);
+  Idris2_String *retVal = IDRIS2_NEW_VALUE(Idris2_String);
   retVal->header.tag = STRING_TAG;
   retVal->str = mpz_get_str(NULL, 10, from->i);
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }

--- a/support/refc/casts.h
+++ b/support/refc/casts.h
@@ -15,12 +15,12 @@
   (idris2_mkInt32((int32_t)idris2_vp_to_Int8(x)))
 #define idris2_cast_Int8_to_Int64(x)                                           \
   (idris2_mkInt64((int64_t)idris2_vp_to_Int8(x)))
-Value *idris2_cast_Int8_to_Integer(Value *);
+Idris2_Value *idris2_cast_Int8_to_Integer(Idris2_Value *);
 #define idris2_cast_Int8_to_Double(x)                                          \
   (idris2_mkDouble((double)idris2_vp_to_Int8(x)))
 #define idris2_cast_Int8_to_Char(x)                                            \
   (idris2_mkChar((unsigned char)idris2_vp_to_Int8(x)))
-Value *idris2_cast_Int8_to_string(Value *);
+Idris2_Value *idris2_cast_Int8_to_string(Idris2_Value *);
 
 #define idris2_cast_Int16_to_Bits8(x)                                          \
   (idris2_mkBits8((uint8_t)idris2_vp_to_Int16(x)))
@@ -33,12 +33,12 @@ Value *idris2_cast_Int8_to_string(Value *);
 #define idris2_cast_Int16_to_Int32(x) (x)
 #define idris2_cast_Int16_to_Int64(x)                                          \
   (idris2_mkInt64((int64_t)idris2_vp_to_Int16(x)))
-Value *idris2_cast_Int16_to_Integer(Value *);
+Idris2_Value *idris2_cast_Int16_to_Integer(Idris2_Value *);
 #define idris2_cast_Int16_to_Double(x)                                         \
   (idris2_mkDouble((double)idris2_vp_to_Int16(x)))
 #define idris2_cast_Int16_to_Char(x)                                           \
   (idris2_mkChar((unsigned char)idris2_vp_to_Int16(x)))
-Value *idris2_cast_Int16_to_string(Value *);
+Idris2_Value *idris2_cast_Int16_to_string(Idris2_Value *);
 
 #define idris2_cast_Int32_to_Bits8(x)                                          \
   (idris2_mkBits8((uint8_t)idris2_vp_to_Int32(x)))
@@ -53,12 +53,12 @@ Value *idris2_cast_Int16_to_string(Value *);
   (idris2_mkInt16((int16_t)idris2_vp_to_Int32(x)))
 #define idris2_cast_Int32_to_Int64(x)                                          \
   (idris2_mkInt64((int64_t)idris2_vp_to_Int32(x)))
-Value *idris2_cast_Int32_to_Integer(Value *);
+Idris2_Value *idris2_cast_Int32_to_Integer(Idris2_Value *);
 #define idris2_cast_Int32_to_Double(x)                                         \
   (idris2_mkDouble((double)idris2_vp_to_Int32(x)))
 #define idris2_cast_Int32_to_Char(x)                                           \
   (idris2_mkChar((unsigned char)idris2_vp_to_Int32(x)))
-Value *idris2_cast_Int32_to_string(Value *);
+Idris2_Value *idris2_cast_Int32_to_string(Idris2_Value *);
 
 #define idris2_cast_Int64_to_Bits8(x)                                          \
   (idris2_mkBits8((uint8_t)idris2_vp_to_Int64(x)))
@@ -75,12 +75,12 @@ Value *idris2_cast_Int32_to_string(Value *);
 #define idris2_cast_Int64_to_Int32(x)                                          \
   (idris2_mkInt32((int32_t)idris2_vp_to_Int64(x)))
 #define idris2_cast_Int64_to_Int64(x) (idris2_newReference(x))
-Value *idris2_cast_Int64_to_Integer(Value *);
+Idris2_Value *idris2_cast_Int64_to_Integer(Idris2_Value *);
 #define idris2_cast_Int64_to_Double(x)                                         \
   (idris2_mkDouble((double)idris2_vp_to_Int64(x)))
 #define idris2_cast_Int64_to_Char(x)                                           \
   (idris2_mkChar((unsigned char)idris2_vp_to_Int64(x)))
-Value *idris2_cast_Int64_to_string(Value *);
+Idris2_Value *idris2_cast_Int64_to_string(Idris2_Value *);
 
 #define idris2_cast_Double_to_Bits8(x)                                         \
   (idris2_mkBits8((uint8_t)idris2_vp_to_Double(x)))
@@ -98,10 +98,10 @@ Value *idris2_cast_Int64_to_string(Value *);
   (idris2_mkInt32((int32_t)idris2_vp_to_Double(x)))
 #define idris2_cast_Double_to_Int64(x)                                         \
   (idris2_mkInt64((int64_t)idris2_vp_to_Double(x)))
-Value *idris2_cast_Double_to_Integer(Value *);
+Idris2_Value *idris2_cast_Double_to_Integer(Idris2_Value *);
 #define idris2_cast_Double_to_Char(x)                                          \
   (idris2_mkChar((unsigned char)idris2_vp_to_Double))
-Value *idris2_cast_Double_to_string(Value *);
+Idris2_Value *idris2_cast_Double_to_string(Idris2_Value *);
 
 #define idris2_cast_Char_to_Bits8(x)                                           \
   (idris2_mkBits8((uint8_t)idris2_vp_to_Char(x)))
@@ -119,23 +119,23 @@ Value *idris2_cast_Double_to_string(Value *);
   (idris2_mkInt32((int32_t)idris2_vp_to_Char(x)))
 #define idris2_cast_Char_to_Int64(x)                                           \
   (idris2_mkInt64((int64_t)idris2_vp_to_Char(x)))
-Value *idris2_cast_Char_to_Integer(Value *);
+Idris2_Value *idris2_cast_Char_to_Integer(Idris2_Value *);
 #define idris2_cast_Char_to_Double(x)                                          \
   (idris2_mkDouble((double)idris2_vp_to_Char(x)))
-Value *idris2_cast_Char_to_string(Value *);
+Idris2_Value *idris2_cast_Char_to_string(Idris2_Value *);
 
-Value *idris2_cast_String_to_Bits8(Value *);
-Value *idris2_cast_String_to_Bits16(Value *);
-Value *idris2_cast_String_to_Bits32(Value *);
-Value *idris2_cast_String_to_Bits64(Value *);
-Value *idris2_cast_String_to_Int8(Value *);
-Value *idris2_cast_String_to_Int16(Value *);
-Value *idris2_cast_String_to_Int32(Value *);
-Value *idris2_cast_String_to_Int64(Value *);
-Value *idris2_cast_String_to_Integer(Value *);
-Value *idris2_cast_String_to_Double(Value *);
+Idris2_Value *idris2_cast_String_to_Bits8(Idris2_Value *);
+Idris2_Value *idris2_cast_String_to_Bits16(Idris2_Value *);
+Idris2_Value *idris2_cast_String_to_Bits32(Idris2_Value *);
+Idris2_Value *idris2_cast_String_to_Bits64(Idris2_Value *);
+Idris2_Value *idris2_cast_String_to_Int8(Idris2_Value *);
+Idris2_Value *idris2_cast_String_to_Int16(Idris2_Value *);
+Idris2_Value *idris2_cast_String_to_Int32(Idris2_Value *);
+Idris2_Value *idris2_cast_String_to_Int64(Idris2_Value *);
+Idris2_Value *idris2_cast_String_to_Integer(Idris2_Value *);
+Idris2_Value *idris2_cast_String_to_Double(Idris2_Value *);
 #define idris2_cast_String_to_Char(x)                                          \
-  (idris2_mkChar(((Value_String *)(x))->str[0]))
+  (idris2_mkChar(((Idris2_String *)(x))->str[0]))
 
 #define idris2_cast_Bits8_to_Bits16(x) (x)
 #define idris2_cast_Bits8_to_Bits32(x) (x)
@@ -146,12 +146,12 @@ Value *idris2_cast_String_to_Double(Value *);
 #define idris2_cast_Bits8_to_Int32(x) (x)
 #define idris2_cast_Bits8_to_Int64(x)                                          \
   (idris2_mkInt64((int64_t)idris2_vp_to_Bits8(x)))
-Value *idris2_cast_Bits8_to_Integer(Value *input);
+Idris2_Value *idris2_cast_Bits8_to_Integer(Idris2_Value *input);
 #define idris2_cast_Bits8_to_Double(x)                                         \
   (idris2_mkDouble((double)idris2_vp_to_Bits8(x)))
 #define idris2_cast_Bits8_to_Char(x)                                           \
   (idris2_mkChar((unsigned char)idris2_vp_to_Bits8(x)))
-Value *idris2_cast_Bits8_to_string(Value *input);
+Idris2_Value *idris2_cast_Bits8_to_string(Idris2_Value *input);
 
 #define idris2_cast_Bits16_to_Bits8(x)                                         \
   (idris2_mkBits8((uint8_t)idris2_vp_to_Bits16(x)))
@@ -167,12 +167,12 @@ Value *idris2_cast_Bits8_to_string(Value *input);
   (idris2_mkInt32((int32_t)idris2_vp_to_Bits16(x)))
 #define idris2_cast_Bits16_to_Int64(x)                                         \
   (idris2_mkInt64((int64_t)idris2_vp_to_Bits16(x)))
-Value *idris2_cast_Bits16_to_Integer(Value *input);
+Idris2_Value *idris2_cast_Bits16_to_Integer(Idris2_Value *input);
 #define idris2_cast_Bits16_to_Double(x)                                        \
   (idris2_mkDouble((double)idris2_vp_to_Bits16(x)))
 #define idris2_cast_Bits16_to_Char(x)                                          \
   (idris2_mkChar((unsigned char)idris2_vp_to_Bits16(x)))
-Value *idris2_cast_Bits16_to_string(Value *input);
+Idris2_Value *idris2_cast_Bits16_to_string(Idris2_Value *input);
 
 #define idris2_cast_Bits32_to_Bits8(x)                                         \
   (idris2_mkBits8((uint8_t)idris2_vp_to_Bits32(x)))
@@ -188,12 +188,12 @@ Value *idris2_cast_Bits16_to_string(Value *input);
   (idris2_mkBits32((int32_t)idris2_vp_to_Bits32(x)))
 #define idris2_cast_Bits32_to_Int64(x)                                         \
   (idris2_mkBits64((int64_t)idris2_vp_to_Bits32(x)))
-Value *idris2_cast_Bits32_to_Integer(Value *input);
+Idris2_Value *idris2_cast_Bits32_to_Integer(Idris2_Value *input);
 #define idris2_cast_Bits32_to_Double(x)                                        \
   (idris2_mkDouble((double)idris2_vp_to_Bits32(x)))
 #define idris2_cast_Bits32_to_Char(x)                                          \
   (idris2_mkChar((unsigned char)idris2_vp_to_Bits32(x)))
-Value *idris2_cast_Bits32_to_string(Value *input);
+Idris2_Value *idris2_cast_Bits32_to_string(Idris2_Value *input);
 
 #define idris2_cast_Bits64_to_Bits8(x)                                         \
   (idris2_mkBits8((uint8_t)idris2_vp_to_Bits64(x)))
@@ -209,21 +209,21 @@ Value *idris2_cast_Bits32_to_string(Value *input);
   (idris2_mkInt32((int32_t)idris2_vp_to_Bits64(x)))
 #define idris2_cast_Bits64_to_Int64(x)                                         \
   (idris2_mkInt64((int64_t)idris2_vp_to_Bits64(x)))
-Value *idris2_cast_Bits64_to_Integer(Value *input);
+Idris2_Value *idris2_cast_Bits64_to_Integer(Idris2_Value *input);
 #define idris2_cast_Bits64_to_Double(x)                                        \
   (idris2_mkDouble((double)idris2_vp_to_Bits64(x)))
 #define idris2_cast_Bits64_to_Char(x)                                          \
   (idris2_mkChar((unsigned char)idris2_vp_to_Bits64(x)))
-Value *idris2_cast_Bits64_to_string(Value *input);
+Idris2_Value *idris2_cast_Bits64_to_string(Idris2_Value *input);
 
-Value *idris2_cast_Integer_to_Bits8(Value *input);
-Value *idris2_cast_Integer_to_Bits16(Value *input);
-Value *idris2_cast_Integer_to_Bits32(Value *input);
-Value *idris2_cast_Integer_to_Bits64(Value *input);
-Value *idris2_cast_Integer_to_Int8(Value *input);
-Value *idris2_cast_Integer_to_Int16(Value *input);
-Value *idris2_cast_Integer_to_Int32(Value *input);
-Value *idris2_cast_Integer_to_Int64(Value *input);
-Value *idris2_cast_Integer_to_Double(Value *input);
-Value *idris2_cast_Integer_to_Char(Value *input);
-Value *idris2_cast_Integer_to_string(Value *input);
+Idris2_Value *idris2_cast_Integer_to_Bits8(Idris2_Value *input);
+Idris2_Value *idris2_cast_Integer_to_Bits16(Idris2_Value *input);
+Idris2_Value *idris2_cast_Integer_to_Bits32(Idris2_Value *input);
+Idris2_Value *idris2_cast_Integer_to_Bits64(Idris2_Value *input);
+Idris2_Value *idris2_cast_Integer_to_Int8(Idris2_Value *input);
+Idris2_Value *idris2_cast_Integer_to_Int16(Idris2_Value *input);
+Idris2_Value *idris2_cast_Integer_to_Int32(Idris2_Value *input);
+Idris2_Value *idris2_cast_Integer_to_Int64(Idris2_Value *input);
+Idris2_Value *idris2_cast_Integer_to_Double(Idris2_Value *input);
+Idris2_Value *idris2_cast_Integer_to_Char(Idris2_Value *input);
+Idris2_Value *idris2_cast_Integer_to_string(Idris2_Value *input);

--- a/support/refc/clock.c
+++ b/support/refc/clock.c
@@ -3,29 +3,29 @@
 #define NSEC_PER_SEC 1000000000
 #define CLOCKS_PER_NSEC ((float)CLOCKS_PER_SEC / NSEC_PER_SEC)
 
-Value *clockTimeMonotonic() { return clockTimeUtc(); }
+Idris2_Value *clockTimeMonotonic() { return clockTimeUtc(); }
 
-Value *clockTimeUtc() {
-  return (Value *)idris2_mkBits64(time(NULL) * NSEC_PER_SEC);
+Idris2_Value *clockTimeUtc() {
+  return (Idris2_Value *)idris2_mkBits64(time(NULL) * NSEC_PER_SEC);
 }
 
-Value *clockTimeProcess() {
+Idris2_Value *clockTimeProcess() {
   uint64_t time_ns = clock() / CLOCKS_PER_NSEC;
-  return (Value *)idris2_mkBits64(time_ns);
+  return (Idris2_Value *)idris2_mkBits64(time_ns);
 }
 
-Value *clockTimeThread() { return clockTimeProcess(); }
+Idris2_Value *clockTimeThread() { return clockTimeProcess(); }
 
-Value *clockTimeGcCpu() { return NULL; }
+Idris2_Value *clockTimeGcCpu() { return NULL; }
 
-Value *clockTimeGcReal() { return NULL; }
+Idris2_Value *clockTimeGcReal() { return NULL; }
 
-int clockValid(Value *clock) { return clock != NULL; }
+int clockValid(Idris2_Value *clock) { return clock != NULL; }
 
-uint64_t clockSecond(Value *clock) {
+uint64_t clockSecond(Idris2_Value *clock) {
   return idris2_vp_to_Bits64(clock) / NSEC_PER_SEC;
 }
 
-uint64_t clockNanosecond(Value *clock) {
+uint64_t clockNanosecond(Idris2_Value *clock) {
   return idris2_vp_to_Bits64(clock) % NSEC_PER_SEC;
 }

--- a/support/refc/clock.h
+++ b/support/refc/clock.h
@@ -4,13 +4,13 @@
 
 #include "cBackend.h"
 
-Value *clockTimeMonotonic();
-Value *clockTimeUtc();
-Value *clockTimeProcess();
-Value *clockTimeThread();
-Value *clockTimeGcCpu();
-Value *clockTimeGcReal();
+Idris2_Value *clockTimeMonotonic();
+Idris2_Value *clockTimeUtc();
+Idris2_Value *clockTimeProcess();
+Idris2_Value *clockTimeThread();
+Idris2_Value *clockTimeGcCpu();
+Idris2_Value *clockTimeGcReal();
 
-int clockValid(Value *clock);
-uint64_t clockSecond(Value *clock);
-uint64_t clockNanosecond(Value *clock);
+int clockValid(Idris2_Value *clock);
+uint64_t clockSecond(Idris2_Value *clock);
+uint64_t clockNanosecond(Idris2_Value *clock);

--- a/support/refc/mathFunctions.c
+++ b/support/refc/mathFunctions.c
@@ -3,35 +3,35 @@
 #include "runtime.h"
 
 /* add */
-Value *idris2_add_Integer(Value *x, Value *y) {
-  Value_Integer *retVal = idris2_mkInteger();
-  mpz_add(retVal->i, ((Value_Integer *)x)->i, ((Value_Integer *)y)->i);
-  return (Value *)retVal;
+Idris2_Value *idris2_add_Integer(Idris2_Value *x, Idris2_Value *y) {
+  Idris2_Integer *retVal = idris2_mkInteger();
+  mpz_add(retVal->i, ((Idris2_Integer *)x)->i, ((Idris2_Integer *)y)->i);
+  return (Idris2_Value *)retVal;
 }
 
 /* sub */
-Value *idris2_sub_Integer(Value *x, Value *y) {
-  Value_Integer *retVal = idris2_mkInteger();
-  mpz_sub(retVal->i, ((Value_Integer *)x)->i, ((Value_Integer *)y)->i);
-  return (Value *)retVal;
+Idris2_Value *idris2_sub_Integer(Idris2_Value *x, Idris2_Value *y) {
+  Idris2_Integer *retVal = idris2_mkInteger();
+  mpz_sub(retVal->i, ((Idris2_Integer *)x)->i, ((Idris2_Integer *)y)->i);
+  return (Idris2_Value *)retVal;
 }
 
 /* negate */
-Value *idris2_negate_Integer(Value *x) {
-  Value_Integer *retVal = idris2_mkInteger();
-  mpz_neg(retVal->i, ((Value_Integer *)x)->i);
-  return (Value *)retVal;
+Idris2_Value *idris2_negate_Integer(Idris2_Value *x) {
+  Idris2_Integer *retVal = idris2_mkInteger();
+  mpz_neg(retVal->i, ((Idris2_Integer *)x)->i);
+  return (Idris2_Value *)retVal;
 }
 
 /* mul */
-Value *idris2_mul_Integer(Value *x, Value *y) {
-  Value_Integer *retVal = idris2_mkInteger();
-  mpz_mul(retVal->i, ((Value_Integer *)x)->i, ((Value_Integer *)y)->i);
-  return (Value *)retVal;
+Idris2_Value *idris2_mul_Integer(Idris2_Value *x, Idris2_Value *y) {
+  Idris2_Integer *retVal = idris2_mkInteger();
+  mpz_mul(retVal->i, ((Idris2_Integer *)x)->i, ((Idris2_Integer *)y)->i);
+  return (Idris2_Value *)retVal;
 }
 
 /* div */
-Value *idris2_div_Int8(Value *x, Value *y) {
+Idris2_Value *idris2_div_Int8(Idris2_Value *x, Idris2_Value *y) {
   // Correction term added to convert from truncated division (C default) to
   // Euclidean division For proof of correctness, see Division and Modulus for
   // Computer Scientists (Daan Leijen)
@@ -42,7 +42,7 @@ Value *idris2_div_Int8(Value *x, Value *y) {
   int8_t rem = num % denom;
   return idris2_mkInt8(num / denom + ((rem < 0) ? (denom < 0) ? 1 : -1 : 0));
 }
-Value *idris2_div_Int16(Value *x, Value *y) {
+Idris2_Value *idris2_div_Int16(Idris2_Value *x, Idris2_Value *y) {
   // Correction term added to convert from truncated division (C default) to
   // Euclidean division For proof of correctness, see Division and Modulus for
   // Computer Scientists (Daan Leijen)
@@ -53,7 +53,7 @@ Value *idris2_div_Int16(Value *x, Value *y) {
   int16_t rem = num % denom;
   return idris2_mkInt16(num / denom + ((rem < 0) ? (denom < 0) ? 1 : -1 : 0));
 }
-Value *idris2_div_Int32(Value *x, Value *y) {
+Idris2_Value *idris2_div_Int32(Idris2_Value *x, Idris2_Value *y) {
   // Correction term added to convert from truncated division (C default) to
   // Euclidean division For proof of correctness, see Division and Modulus for
   // Computer Scientists (Daan Leijen)
@@ -64,7 +64,7 @@ Value *idris2_div_Int32(Value *x, Value *y) {
   int32_t rem = num % denom;
   return idris2_mkInt32(num / denom + ((rem < 0) ? (denom < 0) ? 1 : -1 : 0));
 }
-Value *idris2_div_Int64(Value *x, Value *y) {
+Idris2_Value *idris2_div_Int64(Idris2_Value *x, Idris2_Value *y) {
   // Correction term added to convert from truncated division (C default) to
   // Euclidean division For proof of correctness, see Division and Modulus for
   // Computer Scientists (Daan Leijen)
@@ -73,90 +73,90 @@ Value *idris2_div_Int64(Value *x, Value *y) {
   int64_t num = idris2_vp_to_Int64(x);
   int64_t denom = idris2_vp_to_Int64(y);
   int64_t rem = num % denom;
-  return (Value *)idris2_mkInt64(num / denom +
+  return (Idris2_Value *)idris2_mkInt64(num / denom +
                                  ((rem < 0) ? (denom < 0) ? 1 : -1 : 0));
 }
 
-Value *idris2_div_Integer(Value *x, Value *y) {
+Idris2_Value *idris2_div_Integer(Idris2_Value *x, Idris2_Value *y) {
   mpz_t rem, yq;
   mpz_inits(rem, yq, NULL);
 
-  mpz_mod(rem, ((Value_Integer *)x)->i, ((Value_Integer *)y)->i);
-  mpz_sub(yq, ((Value_Integer *)x)->i, rem);
+  mpz_mod(rem, ((Idris2_Integer *)x)->i, ((Idris2_Integer *)y)->i);
+  mpz_sub(yq, ((Idris2_Integer *)x)->i, rem);
 
-  Value_Integer *retVal = idris2_mkInteger();
-  mpz_divexact(retVal->i, yq, ((Value_Integer *)y)->i);
+  Idris2_Integer *retVal = idris2_mkInteger();
+  mpz_divexact(retVal->i, yq, ((Idris2_Integer *)y)->i);
 
   mpz_clears(rem, yq, NULL);
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
 /* mod */
-Value *idris2_mod_Int8(Value *x, Value *y) {
+Idris2_Value *idris2_mod_Int8(Idris2_Value *x, Idris2_Value *y) {
   int8_t num = idris2_vp_to_Int8(x);
   int8_t denom = idris2_vp_to_Int8(y);
   denom = (denom < 0) ? -denom : denom;
-  return (Value *)idris2_mkInt8(num % denom + (num < 0 ? denom : 0));
+  return (Idris2_Value *)idris2_mkInt8(num % denom + (num < 0 ? denom : 0));
 }
 
-Value *idris2_mod_Int16(Value *x, Value *y) {
+Idris2_Value *idris2_mod_Int16(Idris2_Value *x, Idris2_Value *y) {
   int16_t num = idris2_vp_to_Int16(x);
   int16_t denom = idris2_vp_to_Int16(y);
   denom = (denom < 0) ? -denom : denom;
-  return (Value *)idris2_mkInt16(num % denom + (num < 0 ? denom : 0));
+  return (Idris2_Value *)idris2_mkInt16(num % denom + (num < 0 ? denom : 0));
 }
-Value *idris2_mod_Int32(Value *x, Value *y) {
+Idris2_Value *idris2_mod_Int32(Idris2_Value *x, Idris2_Value *y) {
   int32_t num = idris2_vp_to_Int32(x);
   int32_t denom = idris2_vp_to_Int32(y);
   denom = (denom < 0) ? -denom : denom;
-  return (Value *)idris2_mkInt32(num % denom + (num < 0 ? denom : 0));
+  return (Idris2_Value *)idris2_mkInt32(num % denom + (num < 0 ? denom : 0));
 }
-Value *idris2_mod_Int64(Value *x, Value *y) {
+Idris2_Value *idris2_mod_Int64(Idris2_Value *x, Idris2_Value *y) {
   int64_t num = idris2_vp_to_Int64(x);
   int64_t denom = idris2_vp_to_Int64(y);
   denom = (denom < 0) ? -denom : denom;
-  return (Value *)idris2_mkInt64(num % denom + (num < 0 ? denom : 0));
+  return (Idris2_Value *)idris2_mkInt64(num % denom + (num < 0 ? denom : 0));
 }
-Value *idris2_mod_Integer(Value *x, Value *y) {
-  Value_Integer *retVal = idris2_mkInteger();
-  mpz_mod(retVal->i, ((Value_Integer *)x)->i, ((Value_Integer *)y)->i);
-  return (Value *)retVal;
+Idris2_Value *idris2_mod_Integer(Idris2_Value *x, Idris2_Value *y) {
+  Idris2_Integer *retVal = idris2_mkInteger();
+  mpz_mod(retVal->i, ((Idris2_Integer *)x)->i, ((Idris2_Integer *)y)->i);
+  return (Idris2_Value *)retVal;
 }
 
 /* shiftl */
-Value *idris2_shiftl_Integer(Value *x, Value *y) {
-  Value_Integer *retVal = idris2_mkInteger();
-  mp_bitcnt_t cnt = (mp_bitcnt_t)mpz_get_ui(((Value_Integer *)y)->i);
-  mpz_mul_2exp(retVal->i, ((Value_Integer *)x)->i, cnt);
-  return (Value *)retVal;
+Idris2_Value *idris2_shiftl_Integer(Idris2_Value *x, Idris2_Value *y) {
+  Idris2_Integer *retVal = idris2_mkInteger();
+  mp_bitcnt_t cnt = (mp_bitcnt_t)mpz_get_ui(((Idris2_Integer *)y)->i);
+  mpz_mul_2exp(retVal->i, ((Idris2_Integer *)x)->i, cnt);
+  return (Idris2_Value *)retVal;
 }
 
 /* shiftr */
-Value *idris2_shiftr_Integer(Value *x, Value *y) {
-  Value_Integer *retVal = idris2_mkInteger();
-  mp_bitcnt_t cnt = (mp_bitcnt_t)mpz_get_ui(((Value_Integer *)y)->i);
-  mpz_fdiv_q_2exp(retVal->i, ((Value_Integer *)x)->i, cnt);
-  return (Value *)retVal;
+Idris2_Value *idris2_shiftr_Integer(Idris2_Value *x, Idris2_Value *y) {
+  Idris2_Integer *retVal = idris2_mkInteger();
+  mp_bitcnt_t cnt = (mp_bitcnt_t)mpz_get_ui(((Idris2_Integer *)y)->i);
+  mpz_fdiv_q_2exp(retVal->i, ((Idris2_Integer *)x)->i, cnt);
+  return (Idris2_Value *)retVal;
 }
 
 /* and */
-Value *idris2_and_Integer(Value *x, Value *y) {
-  Value_Integer *retVal = idris2_mkInteger();
-  mpz_and(retVal->i, ((Value_Integer *)x)->i, ((Value_Integer *)y)->i);
-  return (Value *)retVal;
+Idris2_Value *idris2_and_Integer(Idris2_Value *x, Idris2_Value *y) {
+  Idris2_Integer *retVal = idris2_mkInteger();
+  mpz_and(retVal->i, ((Idris2_Integer *)x)->i, ((Idris2_Integer *)y)->i);
+  return (Idris2_Value *)retVal;
 }
 
 /* or */
-Value *idris2_or_Integer(Value *x, Value *y) {
-  Value_Integer *retVal = idris2_mkInteger();
-  mpz_ior(retVal->i, ((Value_Integer *)x)->i, ((Value_Integer *)y)->i);
-  return (Value *)retVal;
+Idris2_Value *idris2_or_Integer(Idris2_Value *x, Idris2_Value *y) {
+  Idris2_Integer *retVal = idris2_mkInteger();
+  mpz_ior(retVal->i, ((Idris2_Integer *)x)->i, ((Idris2_Integer *)y)->i);
+  return (Idris2_Value *)retVal;
 }
 
 /* xor */
-Value *idris2_xor_Integer(Value *x, Value *y) {
-  Value_Integer *retVal = idris2_mkInteger();
-  mpz_xor(retVal->i, ((Value_Integer *)x)->i, ((Value_Integer *)y)->i);
-  return (Value *)retVal;
+Idris2_Value *idris2_xor_Integer(Idris2_Value *x, Idris2_Value *y) {
+  Idris2_Integer *retVal = idris2_mkInteger();
+  mpz_xor(retVal->i, ((Idris2_Integer *)x)->i, ((Idris2_Integer *)y)->i);
+  return (Idris2_Value *)retVal;
 }

--- a/support/refc/mathFunctions.c
+++ b/support/refc/mathFunctions.c
@@ -74,7 +74,7 @@ Idris2_Value *idris2_div_Int64(Idris2_Value *x, Idris2_Value *y) {
   int64_t denom = idris2_vp_to_Int64(y);
   int64_t rem = num % denom;
   return (Idris2_Value *)idris2_mkInt64(num / denom +
-                                 ((rem < 0) ? (denom < 0) ? 1 : -1 : 0));
+                                        ((rem < 0) ? (denom < 0) ? 1 : -1 : 0));
 }
 
 Idris2_Value *idris2_div_Integer(Idris2_Value *x, Idris2_Value *y) {

--- a/support/refc/mathFunctions.h
+++ b/support/refc/mathFunctions.h
@@ -5,7 +5,7 @@
 #include <math.h>
 
 #define idris2_binop(ty, op, l, r)                                             \
-  ((Value *)idris2_mk##ty(idris2_vp_to_##ty(l) op idris2_vp_to_##ty(r)))
+  ((Idris2_Value *)idris2_mk##ty(idris2_vp_to_##ty(l) op idris2_vp_to_##ty(r)))
 
 /* add */
 #define idris2_add_Bits8(l, r) (idris2_binop(Bits8, +, l, r))
@@ -16,7 +16,7 @@
 #define idris2_add_Int16(l, r) (idris2_binop(Int16, +, l, r))
 #define idris2_add_Int32(l, r) (idris2_binop(Int32, +, l, r))
 #define idris2_add_Int64(l, r) (idris2_binop(Int64, +, l, r))
-Value *idris2_add_Integer(Value *x, Value *y);
+Idris2_Value *idris2_add_Integer(Idris2_Value *x, Idris2_Value *y);
 #define idris2_add_Double(l, r) (idris2_binop(Double, +, l, r))
 
 /* sub */
@@ -28,7 +28,7 @@ Value *idris2_add_Integer(Value *x, Value *y);
 #define idris2_sub_Int16(l, r) (idris2_binop(Int16, -, l, r))
 #define idris2_sub_Int32(l, r) (idris2_binop(Int32, -, l, r))
 #define idris2_sub_Int64(l, r) (idris2_binop(Int64, -, l, r))
-Value *idris2_sub_Integer(Value *x, Value *y);
+Idris2_Value *idris2_sub_Integer(Idris2_Value *x, Idris2_Value *y);
 #define idris2_sub_Double(l, r) (idris2_binop(Double, -, l, r))
 
 /* negate */
@@ -36,7 +36,7 @@ Value *idris2_sub_Integer(Value *x, Value *y);
 #define idris2_negate_Int16(x) (idris2_mkInt16(-(idris2_vp_to_Int16(x))))
 #define idris2_negate_Int32(x) (idris2_mkInt32(-(idris2_vp_to_Int32(x))))
 #define idris2_negate_Int64(x) (idris2_mkInt64(-(idris2_vp_to_Int64(x))))
-Value *idris2_negate_Integer(Value *x);
+Idris2_Value *idris2_negate_Integer(Idris2_Value *x);
 #define idris2_negate_Double(x) (idris2_mkDouble(-(idris2_vp_to_Double(x))))
 
 /* mul */
@@ -48,7 +48,7 @@ Value *idris2_negate_Integer(Value *x);
 #define idris2_mul_Int16(l, r) (idris2_binop(Int16, *, l, r))
 #define idris2_mul_Int32(l, r) (idris2_binop(Int32, *, l, r))
 #define idris2_mul_Int64(l, r) (idris2_binop(Int64, *, l, r))
-Value *idris2_mul_Integer(Value *x, Value *y);
+Idris2_Value *idris2_mul_Integer(Idris2_Value *x, Idris2_Value *y);
 #define idris2_mul_Double(l, r) (idris2_binop(Double, *, l, r))
 
 /* div */
@@ -56,11 +56,11 @@ Value *idris2_mul_Integer(Value *x, Value *y);
 #define idris2_div_Bits16(l, r) (idris2_binop(Bits16, /, l, r))
 #define idris2_div_Bits32(l, r) (idris2_binop(Bits32, /, l, r))
 #define idris2_div_Bits64(l, r) (idris2_binop(Bits64, /, l, r))
-Value *idris2_div_Int8(Value *x, Value *y);
-Value *idris2_div_Int16(Value *x, Value *y);
-Value *idris2_div_Int32(Value *x, Value *y);
-Value *idris2_div_Int64(Value *x, Value *y);
-Value *idris2_div_Integer(Value *x, Value *y);
+Idris2_Value *idris2_div_Int8(Idris2_Value *x, Idris2_Value *y);
+Idris2_Value *idris2_div_Int16(Idris2_Value *x, Idris2_Value *y);
+Idris2_Value *idris2_div_Int32(Idris2_Value *x, Idris2_Value *y);
+Idris2_Value *idris2_div_Int64(Idris2_Value *x, Idris2_Value *y);
+Idris2_Value *idris2_div_Integer(Idris2_Value *x, Idris2_Value *y);
 #define idris2_div_Double(l, r) (idris2_binop(Double, /, l, r))
 
 /* mod */
@@ -68,11 +68,11 @@ Value *idris2_div_Integer(Value *x, Value *y);
 #define idris2_mod_Bits16(l, r) (idris2_binop(Bits16, %, l, r))
 #define idris2_mod_Bits32(l, r) (idris2_binop(Bits32, %, l, r))
 #define idris2_mod_Bits64(l, r) (idris2_binop(Bits64, %, l, r))
-Value *idris2_mod_Int8(Value *x, Value *y);
-Value *idris2_mod_Int16(Value *x, Value *y);
-Value *idris2_mod_Int32(Value *x, Value *y);
-Value *idris2_mod_Int64(Value *x, Value *y);
-Value *idris2_mod_Integer(Value *x, Value *y);
+Idris2_Value *idris2_mod_Int8(Idris2_Value *x, Idris2_Value *y);
+Idris2_Value *idris2_mod_Int16(Idris2_Value *x, Idris2_Value *y);
+Idris2_Value *idris2_mod_Int32(Idris2_Value *x, Idris2_Value *y);
+Idris2_Value *idris2_mod_Int64(Idris2_Value *x, Idris2_Value *y);
+Idris2_Value *idris2_mod_Integer(Idris2_Value *x, Idris2_Value *y);
 
 /* shiftl */
 #define idris2_shiftl_Bits8(l, r) (idris2_binop(Bits8, <<, l, r))
@@ -83,7 +83,7 @@ Value *idris2_mod_Integer(Value *x, Value *y);
 #define idris2_shiftl_Int16(l, r) (idris2_binop(Int16, <<, l, r))
 #define idris2_shiftl_Int32(l, r) (idris2_binop(Int32, <<, l, r))
 #define idris2_shiftl_Int64(l, r) (idris2_binop(Int64, <<, l, r))
-Value *idris2_shiftl_Integer(Value *x, Value *y);
+Idris2_Value *idris2_shiftl_Integer(Idris2_Value *x, Idris2_Value *y);
 
 /* shiftr */
 #define idris2_shiftr_Bits8(l, r) (idris2_binop(Bits8, >>, l, r))
@@ -94,7 +94,7 @@ Value *idris2_shiftl_Integer(Value *x, Value *y);
 #define idris2_shiftr_Int16(l, r) (idris2_binop(Int16, >>, l, r))
 #define idris2_shiftr_Int32(l, r) (idris2_binop(Int32, >>, l, r))
 #define idris2_shiftr_Int64(l, r) (idris2_binop(Int64, >>, l, r))
-Value *idris2_shiftr_Integer(Value *x, Value *y);
+Idris2_Value *idris2_shiftr_Integer(Idris2_Value *x, Idris2_Value *y);
 
 /* and */
 #define idris2_and_Bits8(l, r) (idris2_binop(Bits8, &, l, r))
@@ -105,7 +105,7 @@ Value *idris2_shiftr_Integer(Value *x, Value *y);
 #define idris2_and_Int16(l, r) (idris2_binop(Int16, &, l, r))
 #define idris2_and_Int32(l, r) (idris2_binop(Int32, &, l, r))
 #define idris2_and_Int64(l, r) (idris2_binop(Int64, &, l, r))
-Value *idris2_and_Integer(Value *x, Value *y);
+Idris2_Value *idris2_and_Integer(Idris2_Value *x, Idris2_Value *y);
 
 /* or */
 #define idris2_or_Bits8(l, r) (idris2_binop(Bits8, |, l, r))
@@ -116,7 +116,7 @@ Value *idris2_and_Integer(Value *x, Value *y);
 #define idris2_or_Int16(l, r) (idris2_binop(Int16, |, l, r))
 #define idris2_or_Int32(l, r) (idris2_binop(Int32, |, l, r))
 #define idris2_or_Int64(l, r) (idris2_binop(Int64, |, l, r))
-Value *idris2_or_Integer(Value *x, Value *y);
+Idris2_Value *idris2_or_Integer(Idris2_Value *x, Idris2_Value *y);
 
 /* xor */
 #define idris2_xor_Bits8(l, r) (idris2_binop(Bits8, ^, l, r))
@@ -127,7 +127,7 @@ Value *idris2_or_Integer(Value *x, Value *y);
 #define idris2_xor_Int16(l, r) (idris2_binop(Int16, ^, l, r))
 #define idris2_xor_Int32(l, r) (idris2_binop(Int32, ^, l, r))
 #define idris2_xor_Int64(l, r) (idris2_binop(Int64, ^, l, r))
-Value *idris2_xor_Integer(Value *x, Value *y);
+Idris2_Value *idris2_xor_Integer(Idris2_Value *x, Idris2_Value *y);
 
 #define idris2_cmpop(ty, op, l, r)                                             \
   (idris2_mkBool((idris2_vp_to_##ty(l) op idris2_vp_to_##ty(r)) ? 1 : 0))
@@ -143,12 +143,12 @@ Value *idris2_xor_Integer(Value *x, Value *y);
 #define idris2_lt_Int64(l, r) (idris2_cmpop(Int64, <, l, r))
 #define idris2_lt_Integer(l, r)                                                \
   (idris2_mkBool(                                                              \
-      mpz_cmp(((Value_Integer *)(l))->i, ((Value_Integer *)(r))->i) < 0))
+      mpz_cmp(((Idris2_Integer *)(l))->i, ((Idris2_Integer *)(r))->i) < 0))
 #define idris2_lt_Double(l, r) (idris2_cmpop(Double, <, l, r))
 #define idris2_lt_Char(l, r) (idris2_cmpop(Char, <, l, r))
 #define idris2_lt_string(l, r)                                                 \
   (idris2_mkBool(                                                              \
-      strcmp(((Value_String *)(l))->str, ((Value_String *)(r))->str) < 0))
+      strcmp(((Idris2_String *)(l))->str, ((Idris2_String *)(r))->str) < 0))
 
 /* gt */
 #define idris2_gt_Bits8(l, r) (idris2_cmpop(Bits8, >, l, r))
@@ -161,12 +161,12 @@ Value *idris2_xor_Integer(Value *x, Value *y);
 #define idris2_gt_Int64(l, r) (idris2_cmpop(Int64, >, l, r))
 #define idris2_gt_Integer(l, r)                                                \
   (idris2_mkBool(                                                              \
-      mpz_cmp(((Value_Integer *)(l))->i, ((Value_Integer *)(r))->i) > 0))
+      mpz_cmp(((Idris2_Integer *)(l))->i, ((Idris2_Integer *)(r))->i) > 0))
 #define idris2_gt_Double(l, r) (idris2_cmpop(Double, >, l, r))
 #define idris2_gt_Char(l, r) (idris2_cmpop(Char, >, l, r))
 #define idris2_gt_string(l, r)                                                 \
   (idris2_mkBool(                                                              \
-      strcmp(((Value_String *)(l))->str, ((Value_String *)(r))->str) > 0))
+      strcmp(((Idris2_String *)(l))->str, ((Idris2_String *)(r))->str) > 0))
 
 /* eq */
 #define idris2_eq_Bits8(l, r) (idris2_cmpop(Bits8, ==, l, r))
@@ -179,12 +179,12 @@ Value *idris2_xor_Integer(Value *x, Value *y);
 #define idris2_eq_Int64(l, r) (idris2_cmpop(Int64, ==, l, r))
 #define idris2_eq_Integer(l, r)                                                \
   (idris2_mkBool(                                                              \
-      mpz_cmp(((Value_Integer *)(l))->i, ((Value_Integer *)(r))->i) == 0))
+      mpz_cmp(((Idris2_Integer *)(l))->i, ((Idris2_Integer *)(r))->i) == 0))
 #define idris2_eq_Double(l, r) (idris2_cmpop(Double, ==, l, r))
 #define idris2_eq_Char(l, r) (idris2_cmpop(Char, ==, l, r))
 #define idris2_eq_string(l, r)                                                 \
   (idris2_mkBool(                                                              \
-      strcmp(((Value_String *)(l))->str, ((Value_String *)(r))->str) == 0))
+      strcmp(((Idris2_String *)(l))->str, ((Idris2_String *)(r))->str) == 0))
 
 /* lte */
 #define idris2_lte_Bits8(l, r) (idris2_cmpop(Bits8, <=, l, r))
@@ -197,12 +197,12 @@ Value *idris2_xor_Integer(Value *x, Value *y);
 #define idris2_lte_Int64(l, r) (idris2_cmpop(Int64, <=, l, r))
 #define idris2_lte_Integer(l, r)                                               \
   (idris2_mkBool(                                                              \
-      mpz_cmp(((Value_Integer *)(l))->i, ((Value_Integer *)(r))->i) <= 0))
+      mpz_cmp(((Idris2_Integer *)(l))->i, ((Idris2_Integer *)(r))->i) <= 0))
 #define idris2_lte_Double(l, r) (idris2_cmpop(Double, <=, l, r))
 #define idris2_lte_Char(l, r) (idris2_cmpop(Char, <=, l, r))
 #define idris2_lte_string(l, r)                                                \
   (idris2_mkBool(                                                              \
-      strcmp(((Value_String *)(l))->str, ((Value_String *)(r))->str) <= 0))
+      strcmp(((Idris2_String *)(l))->str, ((Idris2_String *)(r))->str) <= 0))
 
 /* gte */
 #define idris2_gte_Bits8(l, r) (idris2_cmpop(Bits8, >=, l, r))
@@ -215,9 +215,9 @@ Value *idris2_xor_Integer(Value *x, Value *y);
 #define idris2_gte_Int64(l, r) (idris2_cmpop(Int64, >=, l, r))
 #define idris2_gte_Integer(l, r)                                               \
   (idris2_mkBool(                                                              \
-      mpz_cmp(((Value_Integer *)(l))->i, ((Value_Integer *)(r))->i) >= 0))
+      mpz_cmp(((Idris2_Integer *)(l))->i, ((Idris2_Integer *)(r))->i) >= 0))
 #define idris2_gte_Double(l, r) (idris2_cmpop(Double, >=, l, r))
 #define idris2_gte_Char(l, r) (idris2_cmpop(Char, >=, l, r))
 #define idris2_gte_string(l, r)                                                \
   (idris2_mkBool(                                                              \
-      strcmp(((Value_String *)(l))->str, ((Value_String *)(r))->str) >= 0))
+      strcmp(((Idris2_String *)(l))->str, ((Idris2_String *)(r))->str) >= 0))

--- a/support/refc/memoryManagement.c
+++ b/support/refc/memoryManagement.c
@@ -81,9 +81,8 @@ Idris2_Constructor *idris2_newConstructor(int total, int tag) {
   return retVal;
 }
 
-Idris2_Closure *idris2_mkClosure(
-  Idris2_Value *(*f)(), uint8_t arity, uint8_t filled
-) {
+Idris2_Closure *idris2_mkClosure(Idris2_Value *(*f)(), uint8_t arity,
+                                 uint8_t filled) {
   Idris2_Closure *retVal = (Idris2_Closure *)idris2_newValue(
       sizeof(Idris2_Closure) + sizeof(Idris2_Value *) * filled);
   retVal->header.tag = CLOSURE_TAG;
@@ -179,7 +178,7 @@ Idris2_Pointer *idris2_makePointer(void *ptr_Raw) {
 }
 
 Idris2_GCPointer *idris2_makeGCPointer(void *ptr_Raw,
-                                      Idris2_Closure *onCollectFct) {
+                                       Idris2_Closure *onCollectFct) {
   Idris2_GCPointer *p = IDRIS2_NEW_VALUE(Idris2_GCPointer);
   p->header.tag = GC_POINTER_TAG;
   p->p = idris2_makePointer(ptr_Raw);
@@ -287,8 +286,7 @@ void idris2_removeReference(Idris2_Value *elem) {
       /* maybe here we need to invoke onCollectAny */
       Idris2_GCPointer *vPtr = (Idris2_GCPointer *)elem;
       Idris2_Value *closure1 = idris2_apply_closure(
-          (Idris2_Value *)vPtr->onCollectFct, (Idris2_Value *)vPtr->p
-      );
+          (Idris2_Value *)vPtr->onCollectFct, (Idris2_Value *)vPtr->p);
       idris2_apply_closure(closure1, NULL);
       idris2_removeReference((Idris2_Value *)vPtr->p);
       break;
@@ -338,7 +336,7 @@ Idris2_Bits64 const idris2_predefined_Bits64[100] = {
     IDRIS2_MK_PREDEFINED_INT_10(BITS64_TAG, 90)};
 
 Idris2_String const idris2_predefined_nullstring = {IDRIS2_STOCKVAL(STRING_TAG),
-                                                   ""};
+                                                    ""};
 
 static bool idris2_predefined_integer_initialized = false;
 Idris2_Integer idris2_predefined_Integer[100];

--- a/support/refc/memoryManagement.c
+++ b/support/refc/memoryManagement.c
@@ -81,7 +81,9 @@ Idris2_Constructor *idris2_newConstructor(int total, int tag) {
   return retVal;
 }
 
-Idris2_Closure *idris2_mkClosure(Idris2_Value *(*f)(), uint8_t arity, uint8_t filled) {
+Idris2_Closure *idris2_mkClosure(
+  Idris2_Value *(*f)(), uint8_t arity, uint8_t filled
+) {
   Idris2_Closure *retVal = (Idris2_Closure *)idris2_newValue(
       sizeof(Idris2_Closure) + sizeof(Idris2_Value *) * filled);
   retVal->header.tag = CLOSURE_TAG;
@@ -284,8 +286,9 @@ void idris2_removeReference(Idris2_Value *elem) {
     case GC_POINTER_TAG: {
       /* maybe here we need to invoke onCollectAny */
       Idris2_GCPointer *vPtr = (Idris2_GCPointer *)elem;
-      Idris2_Value *closure1 =
-          idris2_apply_closure((Idris2_Value *)vPtr->onCollectFct, (Idris2_Value *)vPtr->p);
+      Idris2_Value *closure1 = idris2_apply_closure(
+          (Idris2_Value *)vPtr->onCollectFct, (Idris2_Value *)vPtr->p
+      );
       idris2_apply_closure(closure1, NULL);
       idris2_removeReference((Idris2_Value *)vPtr->p);
       break;

--- a/support/refc/memoryManagement.c
+++ b/support/refc/memoryManagement.c
@@ -42,27 +42,27 @@ void idris2_dumpMemoryStats(void) {
 void idris2_dumpMemoryStats() {}
 #endif
 
-Value *idris2_newValue(size_t size) {
+Idris2_Value *idris2_newValue(size_t size) {
   /* Try to get memory aligned to pointer-size. Prefer C11 aligned_alloc
      (not available on some platforms like older macOS), then posix_memalign,
      and finally fall back to malloc which typically returns pointer-aligned
      memory suitable for our needs. */
 #if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) &&              \
     !defined(__APPLE__) && !defined(_WIN32)
-  Value *retVal = (Value *)aligned_alloc(
+  Idris2_Value *retVal = (Idris2_Value *)aligned_alloc(
       sizeof(void *),
       ((size + sizeof(void *) - 1) / sizeof(void *)) * sizeof(void *));
 #elif ((defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200112L)) ||           \
        (defined(_XOPEN_SOURCE) && (_XOPEN_SOURCE >= 600))) &&                  \
     !defined(_WIN32)
-  Value *retVal = NULL;
+  Idris2_Value *retVal = NULL;
   IDRIS2_REFC_VERIFY(
       posix_memalign((void **)&retVal, sizeof(void *),
                      ((size + sizeof(void *) - 1) / sizeof(void *)) *
                          sizeof(void *)) == 0,
       "posix_memalign failed");
 #else
-  Value *retVal = (Value *)malloc(size);
+  Idris2_Value *retVal = (Idris2_Value *)malloc(size);
 #endif
   IDRIS2_REFC_VERIFY(retVal && !idris2_vp_is_unboxed(retVal), "malloc failed");
   IDRIS2_INC_MEMSTAT(n_newValue);
@@ -71,9 +71,9 @@ Value *idris2_newValue(size_t size) {
   return retVal;
 }
 
-Value_Constructor *idris2_newConstructor(int total, int tag) {
-  Value_Constructor *retVal = (Value_Constructor *)idris2_newValue(
-      sizeof(Value_Constructor) + sizeof(Value *) * total);
+Idris2_Constructor *idris2_newConstructor(int total, int tag) {
+  Idris2_Constructor *retVal = (Idris2_Constructor *)idris2_newValue(
+      sizeof(Idris2_Constructor) + sizeof(Idris2_Value *) * total);
   retVal->header.tag = CONSTRUCTOR_TAG;
   retVal->total = total;
   retVal->tag = tag;
@@ -81,9 +81,9 @@ Value_Constructor *idris2_newConstructor(int total, int tag) {
   return retVal;
 }
 
-Value_Closure *idris2_mkClosure(Value *(*f)(), uint8_t arity, uint8_t filled) {
-  Value_Closure *retVal = (Value_Closure *)idris2_newValue(
-      sizeof(Value_Closure) + sizeof(Value *) * filled);
+Idris2_Closure *idris2_mkClosure(Idris2_Value *(*f)(), uint8_t arity, uint8_t filled) {
+  Idris2_Closure *retVal = (Idris2_Closure *)idris2_newValue(
+      sizeof(Idris2_Closure) + sizeof(Idris2_Value *) * filled);
   retVal->header.tag = CLOSURE_TAG;
   retVal->f = f;
   retVal->arity = arity;
@@ -91,76 +91,76 @@ Value_Closure *idris2_mkClosure(Value *(*f)(), uint8_t arity, uint8_t filled) {
   return retVal; // caller must initialize args[].
 }
 
-Value *idris2_mkDouble(double d) {
-  Value_Double *retVal = IDRIS2_NEW_VALUE(Value_Double);
+Idris2_Value *idris2_mkDouble(double d) {
+  Idris2_Double *retVal = IDRIS2_NEW_VALUE(Idris2_Double);
   retVal->header.tag = DOUBLE_TAG;
   retVal->d = d;
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
-Value *idris2_mkBits32_Boxed(uint32_t i) {
-  Value_Bits32 *retVal = IDRIS2_NEW_VALUE(Value_Bits32);
+Idris2_Value *idris2_mkBits32_Boxed(uint32_t i) {
+  Idris2_Bits32 *retVal = IDRIS2_NEW_VALUE(Idris2_Bits32);
   retVal->header.tag = BITS32_TAG;
   retVal->ui32 = i;
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
-Value *idris2_mkBits64(uint64_t i) {
+Idris2_Value *idris2_mkBits64(uint64_t i) {
   if (i < 100)
-    return (Value *)&idris2_predefined_Bits64[i];
+    return (Idris2_Value *)&idris2_predefined_Bits64[i];
 
-  Value_Bits64 *retVal = IDRIS2_NEW_VALUE(Value_Bits64);
+  Idris2_Bits64 *retVal = IDRIS2_NEW_VALUE(Idris2_Bits64);
   retVal->header.tag = BITS64_TAG;
   retVal->ui64 = i;
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
-Value *idris2_mkInt32_Boxed(int32_t i) {
-  Value_Int32 *retVal = IDRIS2_NEW_VALUE(Value_Int32);
+Idris2_Value *idris2_mkInt32_Boxed(int32_t i) {
+  Idris2_Int32 *retVal = IDRIS2_NEW_VALUE(Idris2_Int32);
   retVal->header.tag = INT32_TAG;
   retVal->i32 = i;
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
-Value *idris2_mkInt64(int64_t i) {
+Idris2_Value *idris2_mkInt64(int64_t i) {
   if (i >= 0 && i < 100)
-    return (Value *)&idris2_predefined_Int64[i];
+    return (Idris2_Value *)&idris2_predefined_Int64[i];
 
-  Value_Int64 *retVal = IDRIS2_NEW_VALUE(Value_Int64);
+  Idris2_Int64 *retVal = IDRIS2_NEW_VALUE(Idris2_Int64);
   retVal->header.tag = INT64_TAG;
   retVal->i64 = i;
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
-Value_Integer *idris2_mkInteger() {
-  Value_Integer *retVal = IDRIS2_NEW_VALUE(Value_Integer);
+Idris2_Integer *idris2_mkInteger() {
+  Idris2_Integer *retVal = IDRIS2_NEW_VALUE(Idris2_Integer);
   retVal->header.tag = INTEGER_TAG;
   mpz_init(retVal->i);
   return retVal;
 }
 
-Value *idris2_mkIntegerLiteral(char *i) {
-  Value_Integer *retVal = idris2_mkInteger();
+Idris2_Value *idris2_mkIntegerLiteral(char *i) {
+  Idris2_Integer *retVal = idris2_mkInteger();
   mpz_set_str(retVal->i, i, 10);
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
-Value_String *idris2_mkEmptyString(size_t l) {
+Idris2_String *idris2_mkEmptyString(size_t l) {
   if (l == 1)
-    return (Value_String *)&idris2_predefined_nullstring;
+    return (Idris2_String *)&idris2_predefined_nullstring;
 
-  Value_String *retVal = IDRIS2_NEW_VALUE(Value_String);
+  Idris2_String *retVal = IDRIS2_NEW_VALUE(Idris2_String);
   retVal->header.tag = STRING_TAG;
   retVal->str = malloc(l);
   memset(retVal->str, 0, l);
   return retVal;
 }
 
-Value_String *idris2_mkString(char *s) {
+Idris2_String *idris2_mkString(char *s) {
   if (s[0] == '\0')
-    return (Value_String *)&idris2_predefined_nullstring;
+    return (Idris2_String *)&idris2_predefined_nullstring;
 
-  Value_String *retVal = IDRIS2_NEW_VALUE(Value_String);
+  Idris2_String *retVal = IDRIS2_NEW_VALUE(Idris2_String);
   int l = strlen(s);
   retVal->header.tag = STRING_TAG;
   retVal->str = malloc(l + 1);
@@ -169,39 +169,39 @@ Value_String *idris2_mkString(char *s) {
   return retVal;
 }
 
-Value_Pointer *idris2_makePointer(void *ptr_Raw) {
-  Value_Pointer *p = IDRIS2_NEW_VALUE(Value_Pointer);
+Idris2_Pointer *idris2_makePointer(void *ptr_Raw) {
+  Idris2_Pointer *p = IDRIS2_NEW_VALUE(Idris2_Pointer);
   p->header.tag = POINTER_TAG;
   p->p = ptr_Raw;
   return p;
 }
 
-Value_GCPointer *idris2_makeGCPointer(void *ptr_Raw,
-                                      Value_Closure *onCollectFct) {
-  Value_GCPointer *p = IDRIS2_NEW_VALUE(Value_GCPointer);
+Idris2_GCPointer *idris2_makeGCPointer(void *ptr_Raw,
+                                      Idris2_Closure *onCollectFct) {
+  Idris2_GCPointer *p = IDRIS2_NEW_VALUE(Idris2_GCPointer);
   p->header.tag = GC_POINTER_TAG;
   p->p = idris2_makePointer(ptr_Raw);
   p->onCollectFct = onCollectFct;
   return p;
 }
 
-Value_Buffer *idris2_makeBuffer(void *buf) {
-  Value_Buffer *b = IDRIS2_NEW_VALUE(Value_Buffer);
+Idris2_Buffer *idris2_makeBuffer(void *buf) {
+  Idris2_Buffer *b = IDRIS2_NEW_VALUE(Idris2_Buffer);
   b->header.tag = BUFFER_TAG;
   b->buffer = buf;
   return b;
 }
 
-Value_Array *idris2_makeArray(int length) {
-  Value_Array *a = IDRIS2_NEW_VALUE(Value_Array);
+Idris2_Array *idris2_makeArray(int length) {
+  Idris2_Array *a = IDRIS2_NEW_VALUE(Idris2_Array);
   a->header.tag = ARRAY_TAG;
   a->capacity = length;
-  a->arr = (Value **)malloc(sizeof(Value *) * length);
-  memset(a->arr, 0, sizeof(Value *) * length);
+  a->arr = (Idris2_Value **)malloc(sizeof(Idris2_Value *) * length);
+  memset(a->arr, 0, sizeof(Idris2_Value *) * length);
   return a;
 }
 
-Value *idris2_newReference(Value *source) {
+Idris2_Value *idris2_newReference(Idris2_Value *source) {
   IDRIS2_INC_MEMSTAT(n_newReference);
   // note that we explicitly allow NULL as source (for erased arguments)
   if (source && !idris2_vp_is_unboxed(source) &&
@@ -214,7 +214,7 @@ Value *idris2_newReference(Value *source) {
   return source;
 }
 
-void idris2_removeReference(Value *elem) {
+void idris2_removeReference(Idris2_Value *elem) {
   IDRIS2_INC_MEMSTAT(n_removeReference);
   if (!elem || idris2_vp_is_unboxed(elem))
     return;
@@ -234,7 +234,7 @@ void idris2_removeReference(Value *elem) {
       /* nothing to delete, added for sake of completeness */
       break;
     case INTEGER_TAG:
-      mpz_clear(((Value_Integer *)elem)->i);
+      mpz_clear(((Idris2_Integer *)elem)->i);
       break;
 
     case DOUBLE_TAG:
@@ -242,35 +242,35 @@ void idris2_removeReference(Value *elem) {
       break;
 
     case STRING_TAG:
-      free(((Value_String *)elem)->str);
+      free(((Idris2_String *)elem)->str);
       break;
 
     case CLOSURE_TAG: {
-      Value_Closure *cl = (Value_Closure *)elem;
+      Idris2_Closure *cl = (Idris2_Closure *)elem;
       for (int i = 0; i < cl->filled; ++i)
         idris2_removeReference(cl->args[i]);
       break;
     }
 
     case CONSTRUCTOR_TAG: {
-      Value_Constructor *constr = (Value_Constructor *)elem;
+      Idris2_Constructor *constr = (Idris2_Constructor *)elem;
       for (int i = 0; i < constr->total; i++) {
         idris2_removeReference(constr->args[i]);
       }
       break;
     }
     case IOREF_TAG:
-      idris2_removeReference(((Value_IORef *)elem)->v);
+      idris2_removeReference(((Idris2_IORef *)elem)->v);
       break;
 
     case BUFFER_TAG: {
-      Value_Buffer *b = (Value_Buffer *)elem;
+      Idris2_Buffer *b = (Idris2_Buffer *)elem;
       free(b->buffer);
       break;
     }
 
     case ARRAY_TAG: {
-      Value_Array *a = (Value_Array *)elem;
+      Idris2_Array *a = (Idris2_Array *)elem;
       for (int i = 0; i < a->capacity; i++) {
         idris2_removeReference(a->arr[i]);
       }
@@ -283,11 +283,11 @@ void idris2_removeReference(Value *elem) {
 
     case GC_POINTER_TAG: {
       /* maybe here we need to invoke onCollectAny */
-      Value_GCPointer *vPtr = (Value_GCPointer *)elem;
-      Value *closure1 =
-          idris2_apply_closure((Value *)vPtr->onCollectFct, (Value *)vPtr->p);
+      Idris2_GCPointer *vPtr = (Idris2_GCPointer *)elem;
+      Idris2_Value *closure1 =
+          idris2_apply_closure((Idris2_Value *)vPtr->onCollectFct, (Idris2_Value *)vPtr->p);
       idris2_apply_closure(closure1, NULL);
-      idris2_removeReference((Value *)vPtr->p);
+      idris2_removeReference((Idris2_Value *)vPtr->p);
       break;
     }
 
@@ -310,7 +310,7 @@ void idris2_removeReference(Value *elem) {
       {IDRIS2_STOCKVAL(t), (n + 8)}, {                                         \
     IDRIS2_STOCKVAL(t), (n + 9)                                                \
   }
-Value_Int64 const idris2_predefined_Int64[100] = {
+Idris2_Int64 const idris2_predefined_Int64[100] = {
     IDRIS2_MK_PREDEFINED_INT_10(INT64_TAG, 0),
     IDRIS2_MK_PREDEFINED_INT_10(INT64_TAG, 10),
     IDRIS2_MK_PREDEFINED_INT_10(INT64_TAG, 20),
@@ -322,7 +322,7 @@ Value_Int64 const idris2_predefined_Int64[100] = {
     IDRIS2_MK_PREDEFINED_INT_10(INT64_TAG, 80),
     IDRIS2_MK_PREDEFINED_INT_10(INT64_TAG, 90)};
 
-Value_Bits64 const idris2_predefined_Bits64[100] = {
+Idris2_Bits64 const idris2_predefined_Bits64[100] = {
     IDRIS2_MK_PREDEFINED_INT_10(BITS64_TAG, 0),
     IDRIS2_MK_PREDEFINED_INT_10(BITS64_TAG, 10),
     IDRIS2_MK_PREDEFINED_INT_10(BITS64_TAG, 20),
@@ -334,13 +334,13 @@ Value_Bits64 const idris2_predefined_Bits64[100] = {
     IDRIS2_MK_PREDEFINED_INT_10(BITS64_TAG, 80),
     IDRIS2_MK_PREDEFINED_INT_10(BITS64_TAG, 90)};
 
-Value_String const idris2_predefined_nullstring = {IDRIS2_STOCKVAL(STRING_TAG),
+Idris2_String const idris2_predefined_nullstring = {IDRIS2_STOCKVAL(STRING_TAG),
                                                    ""};
 
 static bool idris2_predefined_integer_initialized = false;
-Value_Integer idris2_predefined_Integer[100];
+Idris2_Integer idris2_predefined_Integer[100];
 
-Value *idris2_getPredefinedInteger(int n) {
+Idris2_Value *idris2_getPredefinedInteger(int n) {
   IDRIS2_REFC_VERIFY(n >= 0 && n < 100,
                      "invalid range of predefined integers.");
 
@@ -355,5 +355,5 @@ Value *idris2_getPredefinedInteger(int n) {
       mpz_set_si(idris2_predefined_Integer[i].i, i);
     }
   }
-  return (Value *)&idris2_predefined_Integer[n];
+  return (Idris2_Value *)&idris2_predefined_Integer[n];
 }

--- a/support/refc/memoryManagement.h
+++ b/support/refc/memoryManagement.h
@@ -9,9 +9,8 @@ void idris2_removeReference(Idris2_Value *source);
 #define IDRIS2_NEW_VALUE(t) ((t *)idris2_newValue(sizeof(t)))
 
 Idris2_Constructor *idris2_newConstructor(int total, int tag);
-Idris2_Closure *idris2_mkClosure(
-  Idris2_Value *(*f)(), uint8_t arity, uint8_t filled
-);
+Idris2_Closure *idris2_mkClosure(Idris2_Value *(*f)(), uint8_t arity,
+                                 uint8_t filled);
 
 Idris2_Value *idris2_mkDouble(double d);
 #define idris2_mkChar(x)                                                       \
@@ -63,7 +62,7 @@ Idris2_String *idris2_mkString(char *);
 
 Idris2_Pointer *idris2_makePointer(void *);
 Idris2_GCPointer *idris2_makeGCPointer(void *ptr_Raw,
-                                      Idris2_Closure *onCollectFct);
+                                       Idris2_Closure *onCollectFct);
 Idris2_Buffer *idris2_makeBuffer(void *buf);
 Idris2_Array *idris2_makeArray(int length);
 

--- a/support/refc/memoryManagement.h
+++ b/support/refc/memoryManagement.h
@@ -2,38 +2,38 @@
 
 #include "cBackend.h"
 
-Value *idris2_newValue(size_t size);
-Value *idris2_newReference(Value *source);
-void idris2_removeReference(Value *source);
+Idris2_Value *idris2_newValue(size_t size);
+Idris2_Value *idris2_newReference(Idris2_Value *source);
+void idris2_removeReference(Idris2_Value *source);
 
 #define IDRIS2_NEW_VALUE(t) ((t *)idris2_newValue(sizeof(t)))
 
-Value_Constructor *idris2_newConstructor(int total, int tag);
-Value_Closure *idris2_mkClosure(Value *(*f)(), uint8_t arity, uint8_t filled);
+Idris2_Constructor *idris2_newConstructor(int total, int tag);
+Idris2_Closure *idris2_mkClosure(Idris2_Value *(*f)(), uint8_t arity, uint8_t filled);
 
-Value *idris2_mkDouble(double d);
+Idris2_Value *idris2_mkDouble(double d);
 #define idris2_mkChar(x)                                                       \
-  ((Value *)(((uintptr_t)(x) << idris2_vp_int_shift) + 1))
+  ((Idris2_Value *)(((uintptr_t)(x) << idris2_vp_int_shift) + 1))
 #define idris2_mkBits8(x)                                                      \
-  ((Value *)(((uintptr_t)(x) << idris2_vp_int_shift) + 1))
+  ((Idris2_Value *)(((uintptr_t)(x) << idris2_vp_int_shift) + 1))
 #define idris2_mkBits16(x)                                                     \
-  ((Value *)(((uintptr_t)(x) << idris2_vp_int_shift) + 1))
+  ((Idris2_Value *)(((uintptr_t)(x) << idris2_vp_int_shift) + 1))
 
 #if !defined(UINTPTR_WIDTH)
 #define idris2_mkBits32(x)                                                     \
   ((idris2_vp_int_shift == 16)                                                 \
        ? (idris2_mkBits32_Boxed(x))                                            \
-       : ((Value *)(((uintptr_t)(x) << idris2_vp_int_shift) + 1)))
+       : ((Idris2_Value *)(((uintptr_t)(x) << idris2_vp_int_shift) + 1)))
 #define idris2_mkInt32(x)                                                      \
   ((idris2_vp_int_shift == 16)                                                 \
        ? (idris2_mkInt32_Boxed(x))                                             \
-       : ((Value *)(((uintptr_t)(x) << idris2_vp_int_shift) + 1)))
+       : ((Idris2_Value *)(((uintptr_t)(x) << idris2_vp_int_shift) + 1)))
 
 #elif UINTPTR_WIDTH >= 64
 #define idris2_mkBits32(x)                                                     \
-  ((Value *)(((uintptr_t)(x) << idris2_vp_int_shift) + 1))
+  ((Idris2_Value *)(((uintptr_t)(x) << idris2_vp_int_shift) + 1))
 #define idris2_mkInt32(x)                                                      \
-  ((Value *)(((uintptr_t)(x) << idris2_vp_int_shift) + 1))
+  ((Idris2_Value *)(((uintptr_t)(x) << idris2_vp_int_shift) + 1))
 
 #elif UINTPTR_WIDTH >= 32
 #define idris2_mkBits32(x) (idris2_mkBits32_Boxed(x))
@@ -44,32 +44,32 @@ Value *idris2_mkDouble(double d);
 #endif
 
 #define idris2_mkInt8(x)                                                       \
-  ((Value *)(((uintptr_t)(x) << idris2_vp_int_shift) + 1))
+  ((Idris2_Value *)(((uintptr_t)(x) << idris2_vp_int_shift) + 1))
 #define idris2_mkInt16(x)                                                      \
-  ((Value *)(((uintptr_t)(x) << idris2_vp_int_shift) + 1))
+  ((Idris2_Value *)(((uintptr_t)(x) << idris2_vp_int_shift) + 1))
 #define idris2_mkBool(x) (idris2_mkInt8(x))
 
-Value *idris2_mkBits32_Boxed(uint32_t i);
-Value *idris2_mkBits64(uint64_t i);
-Value *idris2_mkInt32_Boxed(int32_t i);
-Value *idris2_mkInt64(int64_t i);
+Idris2_Value *idris2_mkBits32_Boxed(uint32_t i);
+Idris2_Value *idris2_mkBits64(uint64_t i);
+Idris2_Value *idris2_mkInt32_Boxed(int32_t i);
+Idris2_Value *idris2_mkInt64(int64_t i);
 
-Value_Integer *idris2_mkInteger();
-Value *idris2_mkIntegerLiteral(char *i);
-Value_String *idris2_mkEmptyString(size_t l);
-Value_String *idris2_mkString(char *);
+Idris2_Integer *idris2_mkInteger();
+Idris2_Value *idris2_mkIntegerLiteral(char *i);
+Idris2_String *idris2_mkEmptyString(size_t l);
+Idris2_String *idris2_mkString(char *);
 
-Value_Pointer *idris2_makePointer(void *);
-Value_GCPointer *idris2_makeGCPointer(void *ptr_Raw,
-                                      Value_Closure *onCollectFct);
-Value_Buffer *idris2_makeBuffer(void *buf);
-Value_Array *idris2_makeArray(int length);
+Idris2_Pointer *idris2_makePointer(void *);
+Idris2_GCPointer *idris2_makeGCPointer(void *ptr_Raw,
+                                      Idris2_Closure *onCollectFct);
+Idris2_Buffer *idris2_makeBuffer(void *buf);
+Idris2_Array *idris2_makeArray(int length);
 
-extern Value_Int64 const idris2_predefined_Int64[100];
-extern Value_Bits64 const idris2_predefined_Bits64[100];
-extern Value_Integer idris2_predefined_Integer[100];
-Value *idris2_getPredefinedInteger(int n);
-extern Value_String const idris2_predefined_nullstring;
+extern Idris2_Int64 const idris2_predefined_Int64[100];
+extern Idris2_Bits64 const idris2_predefined_Bits64[100];
+extern Idris2_Integer idris2_predefined_Integer[100];
+Idris2_Value *idris2_getPredefinedInteger(int n);
+extern Idris2_String const idris2_predefined_nullstring;
 
 // You need uncomment a debugging code in memoryManagement.c to use this.
 void idris2_dumpMemoryStats(void);

--- a/support/refc/memoryManagement.h
+++ b/support/refc/memoryManagement.h
@@ -9,7 +9,9 @@ void idris2_removeReference(Idris2_Value *source);
 #define IDRIS2_NEW_VALUE(t) ((t *)idris2_newValue(sizeof(t)))
 
 Idris2_Constructor *idris2_newConstructor(int total, int tag);
-Idris2_Closure *idris2_mkClosure(Idris2_Value *(*f)(), uint8_t arity, uint8_t filled);
+Idris2_Closure *idris2_mkClosure(
+  Idris2_Value *(*f)(), uint8_t arity, uint8_t filled
+);
 
 Idris2_Value *idris2_mkDouble(double d);
 #define idris2_mkChar(x)                                                       \

--- a/support/refc/prim.c
+++ b/support/refc/prim.c
@@ -3,21 +3,19 @@
 #include <string.h>
 #include <unistd.h>
 
-Idris2_Value *idris2_Data_IORef_prim__newIORef(
-  Idris2_Value *erased, Idris2_Value *input_value, Idris2_Value *_world
-) {
+Idris2_Value *idris2_Data_IORef_prim__newIORef(Idris2_Value *erased,
+                                               Idris2_Value *input_value,
+                                               Idris2_Value *_world) {
   Idris2_IORef *ioRef = IDRIS2_NEW_VALUE(Idris2_IORef);
   ioRef->header.tag = IOREF_TAG;
   ioRef->v = idris2_newReference(input_value);
   return (Idris2_Value *)ioRef;
 }
 
-Idris2_Value *idris2_Data_IORef_prim__writeIORef(
-  Idris2_Value *erased,
-  Idris2_Value *_ioref,
-  Idris2_Value *new_value,
-  Idris2_Value *_world
-) {
+Idris2_Value *idris2_Data_IORef_prim__writeIORef(Idris2_Value *erased,
+                                                 Idris2_Value *_ioref,
+                                                 Idris2_Value *new_value,
+                                                 Idris2_Value *_world) {
   Idris2_IORef *ioref = (Idris2_IORef *)_ioref;
   idris2_newReference(new_value);
   Idris2_Value *old = ioref->v;
@@ -32,25 +30,25 @@ Idris2_Value *idris2_Data_IORef_prim__writeIORef(
 
 Idris2_String const idris2_predefined_osstring = {IDRIS2_STOCKVAL(STRING_TAG),
 #ifdef _WIN32
-                                                 "windows"
+                                                  "windows"
 #elif _WIN64
-                                                 "windows"
+                                                  "windows"
 #elif __APPLE__ || __MACH__
-                                                 "macOS"
+                                                  "macOS"
 #elif __linux__
-                                                 "Linux"
+                                                  "Linux"
 #elif __FreeBSD__
-                                                 "FreeBSD"
+                                                  "FreeBSD"
 #elif __OpenBSD__
-                                                 "OpenBSD"
+                                                  "OpenBSD"
 #elif __NetBSD__
-                                                 "NetBSD"
+                                                  "NetBSD"
 #elif __DragonFly__
-                                                 "DragonFly"
+                                                  "DragonFly"
 #elif __unix || __unix__
-                                                 "Unix"
+                                                  "Unix"
 #else
-                                                 "Other"
+                                                  "Other"
 #endif
 };
 
@@ -73,12 +71,10 @@ Idris2_Value *idris2_crash(Idris2_Value *msg) {
 // //         Array operations
 // // -----------------------------------
 
-Idris2_Value *idris2_Data_IOArray_Prims_prim__newArray(
-  Idris2_Value *erased,
-  Idris2_Value *_length,
-  Idris2_Value *v,
-  Idris2_Value *_word
-) {
+Idris2_Value *idris2_Data_IOArray_Prims_prim__newArray(Idris2_Value *erased,
+                                                       Idris2_Value *_length,
+                                                       Idris2_Value *v,
+                                                       Idris2_Value *_word) {
   int length = idris2_vp_to_Int64(_length);
   Idris2_Array *a = idris2_makeArray(length);
 
@@ -89,13 +85,11 @@ Idris2_Value *idris2_Data_IOArray_Prims_prim__newArray(
   return (Idris2_Value *)a;
 }
 
-Idris2_Value *idris2_Data_IOArray_Prims_prim__arraySet(
-  Idris2_Value *erased,
-  Idris2_Value *_array,
-  Idris2_Value *index,
-  Idris2_Value *v,
-  Idris2_Value *_word
-) {
+Idris2_Value *idris2_Data_IOArray_Prims_prim__arraySet(Idris2_Value *erased,
+                                                       Idris2_Value *_array,
+                                                       Idris2_Value *index,
+                                                       Idris2_Value *v,
+                                                       Idris2_Value *_word) {
   Idris2_Array *a = (Idris2_Array *)_array;
   idris2_removeReference(a->arr[idris2_vp_to_Int64(index)]);
   a->arr[idris2_vp_to_Int64(index)] = idris2_newReference(v);
@@ -107,12 +101,10 @@ Idris2_Value *idris2_Data_IOArray_Prims_prim__arraySet(
 //      Pointer operations
 // -----------------------------------
 
-Idris2_Value *idris2_Prelude_IO_prim__onCollect(
-  Idris2_Value *_erased,
-  Idris2_Value *_anyPtr,
-  Idris2_Value *_freeingFunction,
-  Idris2_Value *_world
-) {
+Idris2_Value *idris2_Prelude_IO_prim__onCollect(Idris2_Value *_erased,
+                                                Idris2_Value *_anyPtr,
+                                                Idris2_Value *_freeingFunction,
+                                                Idris2_Value *_world) {
   Idris2_GCPointer *retVal = IDRIS2_NEW_VALUE(Idris2_GCPointer);
   retVal->header.tag = GC_POINTER_TAG;
   retVal->p = (Idris2_Pointer *)idris2_newReference(_anyPtr);
@@ -120,9 +112,10 @@ Idris2_Value *idris2_Prelude_IO_prim__onCollect(
   return (Idris2_Value *)retVal;
 }
 
-Idris2_Value *idris2_Prelude_IO_prim__onCollectAny(
-  Idris2_Value *_anyPtr, Idris2_Value *_freeingFunction, Idris2_Value *_world
-) {
+Idris2_Value *
+idris2_Prelude_IO_prim__onCollectAny(Idris2_Value *_anyPtr,
+                                     Idris2_Value *_freeingFunction,
+                                     Idris2_Value *_world) {
   Idris2_GCPointer *retVal = IDRIS2_NEW_VALUE(Idris2_GCPointer);
   retVal->header.tag = GC_POINTER_TAG;
   retVal->p = (Idris2_Pointer *)idris2_newReference(_anyPtr);
@@ -148,9 +141,8 @@ Idris2_Value *System_Concurrency_Raw_prim__makeMutex(Idris2_Value *_world) {
 // %foreign "scheme:blodwen-lock"
 // prim__mutexAcquire : Mutex -> PrimIO ()
 // using pthread_mutex_lock(pthread_mutex_t *mutex)
-Idris2_Value *System_Concurrency_Raw_prim__mutexAcquire(
-  Idris2_Value *_mutex, Idris2_Value *_world
-) {
+Idris2_Value *System_Concurrency_Raw_prim__mutexAcquire(Idris2_Value *_mutex,
+                                                        Idris2_Value *_world) {
   int r = pthread_mutex_lock(((Idris2_Mutex *)_mutex)->mutex);
   IDRIS2_REFC_VERIFY(!r, "pthread_mutex_lock failed: %s", strerror(r));
   return NULL;
@@ -159,9 +151,8 @@ Idris2_Value *System_Concurrency_Raw_prim__mutexAcquire(
 // %foreign "scheme:blodwen-unlock"
 // prim__mutexRelease : Mutex -> PrimIO ()
 // using int pthread_mutex_unlock(pthread_mutex_t *mutex)
-Idris2_Value *System_Concurrency_Raw_prim__mutexRelease(
-  Idris2_Value *_mutex, Idris2_Value *_world
-) {
+Idris2_Value *System_Concurrency_Raw_prim__mutexRelease(Idris2_Value *_mutex,
+                                                        Idris2_Value *_world) {
   int r = pthread_mutex_unlock(((Idris2_Mutex *)_mutex)->mutex);
   IDRIS2_REFC_VERIFY(!r, "pthread_mutex_unlock failed: %s", strerror(r));
   return NULL;
@@ -190,8 +181,7 @@ Idris2_Value *System_Concurrency_Raw_prim__makeCondition(Idris2_Value *_world) {
 // prim__conditionWait : Condition -> Mutex -> PrimIO ()
 // using int pthread_cond_wait(pthread_cond_t *, pthread_mutex_t *mutex)
 Idris2_Value *System_Concurrency_Raw_prim__conditionWait(
-  Idris2_Value *_condition, Idris2_Value *_mutex, Idris2_Value *_world
-) {
+    Idris2_Value *_condition, Idris2_Value *_mutex, Idris2_Value *_world) {
   Idris2_Condition *cond = (Idris2_Condition *)_condition;
   Idris2_Mutex *mutex = (Idris2_Mutex *)_mutex;
   int r = pthread_cond_wait(cond->cond, mutex->mutex);
@@ -204,11 +194,8 @@ Idris2_Value *System_Concurrency_Raw_prim__conditionWait(
 // using int pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t
 // *mutex, const struct timespec *abstime)
 Idris2_Value *System_Concurrency_Raw_prim__conditionWaitTimeout(
-  Idris2_Value *_condition,
-  Idris2_Value *_mutex,
-  Idris2_Value *_timeout,
-  Idris2_Value *_world
-) {
+    Idris2_Value *_condition, Idris2_Value *_mutex, Idris2_Value *_timeout,
+    Idris2_Value *_world) {
   Idris2_Condition *cond = (Idris2_Condition *)_condition;
   Idris2_Mutex *mutex = (Idris2_Mutex *)_mutex;
   int64_t timeout = idris2_vp_to_Int64(_timeout);
@@ -223,9 +210,9 @@ Idris2_Value *System_Concurrency_Raw_prim__conditionWaitTimeout(
 // %foreign "scheme:blodwen-condition-signal"
 // prim__conditionSignal : Condition -> PrimIO ()
 // using int pthread_cond_signal(pthread_cond_t *cond)
-Idris2_Value *System_Concurrency_Raw_prim__conditionSignal(
-  Idris2_Value *_condition, Idris2_Value *_world
-) {
+Idris2_Value *
+System_Concurrency_Raw_prim__conditionSignal(Idris2_Value *_condition,
+                                             Idris2_Value *_world) {
   Idris2_Condition *cond = (Idris2_Condition *)_condition;
   int r = pthread_cond_signal(cond->cond);
   IDRIS2_REFC_VERIFY(!r, "pthread_cond_signal failed: %s", strerror(r));
@@ -235,9 +222,9 @@ Idris2_Value *System_Concurrency_Raw_prim__conditionSignal(
 // %foreign "scheme:blodwen-condition-broadcast"
 // prim__conditionBroadcast : Condition -> PrimIO ()
 // using int pthread_cond_broadcast(pthread_cond_t *cond)
-Idris2_Value *System_Concurrency_Raw_prim__conditionBroadcast(
-  Idris2_Value *_condition, Idris2_Value *_mutex
-) {
+Idris2_Value *
+System_Concurrency_Raw_prim__conditionBroadcast(Idris2_Value *_condition,
+                                                Idris2_Value *_mutex) {
   Idris2_Condition *cond = (Idris2_Condition *)_condition;
   int r = pthread_cond_broadcast(cond->cond);
   IDRIS2_REFC_VERIFY(!r, "pthread_cond_broadcast failed: %s", strerror(r));

--- a/support/refc/prim.c
+++ b/support/refc/prim.c
@@ -3,16 +3,21 @@
 #include <string.h>
 #include <unistd.h>
 
-Idris2_Value *idris2_Data_IORef_prim__newIORef(Idris2_Value *erased, Idris2_Value *input_value,
-                                        Idris2_Value *_world) {
+Idris2_Value *idris2_Data_IORef_prim__newIORef(
+  Idris2_Value *erased, Idris2_Value *input_value, Idris2_Value *_world
+) {
   Idris2_IORef *ioRef = IDRIS2_NEW_VALUE(Idris2_IORef);
   ioRef->header.tag = IOREF_TAG;
   ioRef->v = idris2_newReference(input_value);
   return (Idris2_Value *)ioRef;
 }
 
-Idris2_Value *idris2_Data_IORef_prim__writeIORef(Idris2_Value *erased, Idris2_Value *_ioref,
-                                          Idris2_Value *new_value, Idris2_Value *_world) {
+Idris2_Value *idris2_Data_IORef_prim__writeIORef(
+  Idris2_Value *erased,
+  Idris2_Value *_ioref,
+  Idris2_Value *new_value,
+  Idris2_Value *_world
+) {
   Idris2_IORef *ioref = (Idris2_IORef *)_ioref;
   idris2_newReference(new_value);
   Idris2_Value *old = ioref->v;
@@ -68,8 +73,12 @@ Idris2_Value *idris2_crash(Idris2_Value *msg) {
 // //         Array operations
 // // -----------------------------------
 
-Idris2_Value *idris2_Data_IOArray_Prims_prim__newArray(Idris2_Value *erased, Idris2_Value *_length,
-                                                Idris2_Value *v, Idris2_Value *_word) {
+Idris2_Value *idris2_Data_IOArray_Prims_prim__newArray(
+  Idris2_Value *erased,
+  Idris2_Value *_length,
+  Idris2_Value *v,
+  Idris2_Value *_word
+) {
   int length = idris2_vp_to_Int64(_length);
   Idris2_Array *a = idris2_makeArray(length);
 
@@ -80,9 +89,13 @@ Idris2_Value *idris2_Data_IOArray_Prims_prim__newArray(Idris2_Value *erased, Idr
   return (Idris2_Value *)a;
 }
 
-Idris2_Value *idris2_Data_IOArray_Prims_prim__arraySet(Idris2_Value *erased, Idris2_Value *_array,
-                                                Idris2_Value *index, Idris2_Value *v,
-                                                Idris2_Value *_word) {
+Idris2_Value *idris2_Data_IOArray_Prims_prim__arraySet(
+  Idris2_Value *erased,
+  Idris2_Value *_array,
+  Idris2_Value *index,
+  Idris2_Value *v,
+  Idris2_Value *_word
+) {
   Idris2_Array *a = (Idris2_Array *)_array;
   idris2_removeReference(a->arr[idris2_vp_to_Int64(index)]);
   a->arr[idris2_vp_to_Int64(index)] = idris2_newReference(v);
@@ -94,9 +107,12 @@ Idris2_Value *idris2_Data_IOArray_Prims_prim__arraySet(Idris2_Value *erased, Idr
 //      Pointer operations
 // -----------------------------------
 
-Idris2_Value *idris2_Prelude_IO_prim__onCollect(Idris2_Value *_erased, Idris2_Value *_anyPtr,
-                                         Idris2_Value *_freeingFunction,
-                                         Idris2_Value *_world) {
+Idris2_Value *idris2_Prelude_IO_prim__onCollect(
+  Idris2_Value *_erased,
+  Idris2_Value *_anyPtr,
+  Idris2_Value *_freeingFunction,
+  Idris2_Value *_world
+) {
   Idris2_GCPointer *retVal = IDRIS2_NEW_VALUE(Idris2_GCPointer);
   retVal->header.tag = GC_POINTER_TAG;
   retVal->p = (Idris2_Pointer *)idris2_newReference(_anyPtr);
@@ -104,9 +120,9 @@ Idris2_Value *idris2_Prelude_IO_prim__onCollect(Idris2_Value *_erased, Idris2_Va
   return (Idris2_Value *)retVal;
 }
 
-Idris2_Value *idris2_Prelude_IO_prim__onCollectAny(Idris2_Value *_anyPtr,
-                                            Idris2_Value *_freeingFunction,
-                                            Idris2_Value *_world) {
+Idris2_Value *idris2_Prelude_IO_prim__onCollectAny(
+  Idris2_Value *_anyPtr, Idris2_Value *_freeingFunction, Idris2_Value *_world
+) {
   Idris2_GCPointer *retVal = IDRIS2_NEW_VALUE(Idris2_GCPointer);
   retVal->header.tag = GC_POINTER_TAG;
   retVal->p = (Idris2_Pointer *)idris2_newReference(_anyPtr);
@@ -132,7 +148,9 @@ Idris2_Value *System_Concurrency_Raw_prim__makeMutex(Idris2_Value *_world) {
 // %foreign "scheme:blodwen-lock"
 // prim__mutexAcquire : Mutex -> PrimIO ()
 // using pthread_mutex_lock(pthread_mutex_t *mutex)
-Idris2_Value *System_Concurrency_Raw_prim__mutexAcquire(Idris2_Value *_mutex, Idris2_Value *_world) {
+Idris2_Value *System_Concurrency_Raw_prim__mutexAcquire(
+  Idris2_Value *_mutex, Idris2_Value *_world
+) {
   int r = pthread_mutex_lock(((Idris2_Mutex *)_mutex)->mutex);
   IDRIS2_REFC_VERIFY(!r, "pthread_mutex_lock failed: %s", strerror(r));
   return NULL;
@@ -141,7 +159,9 @@ Idris2_Value *System_Concurrency_Raw_prim__mutexAcquire(Idris2_Value *_mutex, Id
 // %foreign "scheme:blodwen-unlock"
 // prim__mutexRelease : Mutex -> PrimIO ()
 // using int pthread_mutex_unlock(pthread_mutex_t *mutex)
-Idris2_Value *System_Concurrency_Raw_prim__mutexRelease(Idris2_Value *_mutex, Idris2_Value *_world) {
+Idris2_Value *System_Concurrency_Raw_prim__mutexRelease(
+  Idris2_Value *_mutex, Idris2_Value *_world
+) {
   int r = pthread_mutex_unlock(((Idris2_Mutex *)_mutex)->mutex);
   IDRIS2_REFC_VERIFY(!r, "pthread_mutex_unlock failed: %s", strerror(r));
   return NULL;
@@ -169,9 +189,9 @@ Idris2_Value *System_Concurrency_Raw_prim__makeCondition(Idris2_Value *_world) {
 // %foreign "scheme:blodwen-condition-wait"
 // prim__conditionWait : Condition -> Mutex -> PrimIO ()
 // using int pthread_cond_wait(pthread_cond_t *, pthread_mutex_t *mutex)
-Idris2_Value *System_Concurrency_Raw_prim__conditionWait(Idris2_Value *_condition,
-                                                  Idris2_Value *_mutex,
-                                                  Idris2_Value *_world) {
+Idris2_Value *System_Concurrency_Raw_prim__conditionWait(
+  Idris2_Value *_condition, Idris2_Value *_mutex, Idris2_Value *_world
+) {
   Idris2_Condition *cond = (Idris2_Condition *)_condition;
   Idris2_Mutex *mutex = (Idris2_Mutex *)_mutex;
   int r = pthread_cond_wait(cond->cond, mutex->mutex);
@@ -183,10 +203,12 @@ Idris2_Value *System_Concurrency_Raw_prim__conditionWait(Idris2_Value *_conditio
 // prim__conditionWaitTimeout : Condition -> Mutex -> Int -> PrimIO ()
 // using int pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t
 // *mutex, const struct timespec *abstime)
-Idris2_Value *System_Concurrency_Raw_prim__conditionWaitTimeout(Idris2_Value *_condition,
-                                                         Idris2_Value *_mutex,
-                                                         Idris2_Value *_timeout,
-                                                         Idris2_Value *_world) {
+Idris2_Value *System_Concurrency_Raw_prim__conditionWaitTimeout(
+  Idris2_Value *_condition,
+  Idris2_Value *_mutex,
+  Idris2_Value *_timeout,
+  Idris2_Value *_world
+) {
   Idris2_Condition *cond = (Idris2_Condition *)_condition;
   Idris2_Mutex *mutex = (Idris2_Mutex *)_mutex;
   int64_t timeout = idris2_vp_to_Int64(_timeout);
@@ -201,8 +223,9 @@ Idris2_Value *System_Concurrency_Raw_prim__conditionWaitTimeout(Idris2_Value *_c
 // %foreign "scheme:blodwen-condition-signal"
 // prim__conditionSignal : Condition -> PrimIO ()
 // using int pthread_cond_signal(pthread_cond_t *cond)
-Idris2_Value *System_Concurrency_Raw_prim__conditionSignal(Idris2_Value *_condition,
-                                                    Idris2_Value *_world) {
+Idris2_Value *System_Concurrency_Raw_prim__conditionSignal(
+  Idris2_Value *_condition, Idris2_Value *_world
+) {
   Idris2_Condition *cond = (Idris2_Condition *)_condition;
   int r = pthread_cond_signal(cond->cond);
   IDRIS2_REFC_VERIFY(!r, "pthread_cond_signal failed: %s", strerror(r));
@@ -212,8 +235,9 @@ Idris2_Value *System_Concurrency_Raw_prim__conditionSignal(Idris2_Value *_condit
 // %foreign "scheme:blodwen-condition-broadcast"
 // prim__conditionBroadcast : Condition -> PrimIO ()
 // using int pthread_cond_broadcast(pthread_cond_t *cond)
-Idris2_Value *System_Concurrency_Raw_prim__conditionBroadcast(Idris2_Value *_condition,
-                                                       Idris2_Value *_mutex) {
+Idris2_Value *System_Concurrency_Raw_prim__conditionBroadcast(
+  Idris2_Value *_condition, Idris2_Value *_mutex
+) {
   Idris2_Condition *cond = (Idris2_Condition *)_condition;
   int r = pthread_cond_broadcast(cond->cond);
   IDRIS2_REFC_VERIFY(!r, "pthread_cond_broadcast failed: %s", strerror(r));

--- a/support/refc/prim.c
+++ b/support/refc/prim.c
@@ -3,19 +3,19 @@
 #include <string.h>
 #include <unistd.h>
 
-Value *idris2_Data_IORef_prim__newIORef(Value *erased, Value *input_value,
-                                        Value *_world) {
-  Value_IORef *ioRef = IDRIS2_NEW_VALUE(Value_IORef);
+Idris2_Value *idris2_Data_IORef_prim__newIORef(Idris2_Value *erased, Idris2_Value *input_value,
+                                        Idris2_Value *_world) {
+  Idris2_IORef *ioRef = IDRIS2_NEW_VALUE(Idris2_IORef);
   ioRef->header.tag = IOREF_TAG;
   ioRef->v = idris2_newReference(input_value);
-  return (Value *)ioRef;
+  return (Idris2_Value *)ioRef;
 }
 
-Value *idris2_Data_IORef_prim__writeIORef(Value *erased, Value *_ioref,
-                                          Value *new_value, Value *_world) {
-  Value_IORef *ioref = (Value_IORef *)_ioref;
+Idris2_Value *idris2_Data_IORef_prim__writeIORef(Idris2_Value *erased, Idris2_Value *_ioref,
+                                          Idris2_Value *new_value, Idris2_Value *_world) {
+  Idris2_IORef *ioref = (Idris2_IORef *)_ioref;
   idris2_newReference(new_value);
-  Value *old = ioref->v;
+  Idris2_Value *old = ioref->v;
   ioref->v = new_value;
   idris2_removeReference(old);
   return NULL;
@@ -25,7 +25,7 @@ Value *idris2_Data_IORef_prim__writeIORef(Value *erased, Value *_ioref,
 //       System operations
 // -----------------------------------
 
-Value_String const idris2_predefined_osstring = {IDRIS2_STOCKVAL(STRING_TAG),
+Idris2_String const idris2_predefined_osstring = {IDRIS2_STOCKVAL(STRING_TAG),
 #ifdef _WIN32
                                                  "windows"
 #elif _WIN64
@@ -52,11 +52,11 @@ Value_String const idris2_predefined_osstring = {IDRIS2_STOCKVAL(STRING_TAG),
 // NOTE: The codegen is obviously determined at compile time,
 //       so the backend should optimize it by replacing it with a constant.
 //       It would probably also be useful for conditional compilation.
-Value_String const idris2_predefined_codegenstring = {
+Idris2_String const idris2_predefined_codegenstring = {
     IDRIS2_STOCKVAL(STRING_TAG), "refc"};
 
-Value *idris2_crash(Value *msg) {
-  Value_String *str = (Value_String *)msg;
+Idris2_Value *idris2_crash(Idris2_Value *msg) {
+  Idris2_String *str = (Idris2_String *)msg;
   printf("ERROR: %s\n", str->str);
   exit(-1);
 }
@@ -68,22 +68,22 @@ Value *idris2_crash(Value *msg) {
 // //         Array operations
 // // -----------------------------------
 
-Value *idris2_Data_IOArray_Prims_prim__newArray(Value *erased, Value *_length,
-                                                Value *v, Value *_word) {
+Idris2_Value *idris2_Data_IOArray_Prims_prim__newArray(Idris2_Value *erased, Idris2_Value *_length,
+                                                Idris2_Value *v, Idris2_Value *_word) {
   int length = idris2_vp_to_Int64(_length);
-  Value_Array *a = idris2_makeArray(length);
+  Idris2_Array *a = idris2_makeArray(length);
 
   for (int i = 0; i < length; i++) {
     a->arr[i] = idris2_newReference(v);
   }
 
-  return (Value *)a;
+  return (Idris2_Value *)a;
 }
 
-Value *idris2_Data_IOArray_Prims_prim__arraySet(Value *erased, Value *_array,
-                                                Value *index, Value *v,
-                                                Value *_word) {
-  Value_Array *a = (Value_Array *)_array;
+Idris2_Value *idris2_Data_IOArray_Prims_prim__arraySet(Idris2_Value *erased, Idris2_Value *_array,
+                                                Idris2_Value *index, Idris2_Value *v,
+                                                Idris2_Value *_word) {
+  Idris2_Array *a = (Idris2_Array *)_array;
   idris2_removeReference(a->arr[idris2_vp_to_Int64(index)]);
   a->arr[idris2_vp_to_Int64(index)] = idris2_newReference(v);
   return NULL;
@@ -94,24 +94,24 @@ Value *idris2_Data_IOArray_Prims_prim__arraySet(Value *erased, Value *_array,
 //      Pointer operations
 // -----------------------------------
 
-Value *idris2_Prelude_IO_prim__onCollect(Value *_erased, Value *_anyPtr,
-                                         Value *_freeingFunction,
-                                         Value *_world) {
-  Value_GCPointer *retVal = IDRIS2_NEW_VALUE(Value_GCPointer);
+Idris2_Value *idris2_Prelude_IO_prim__onCollect(Idris2_Value *_erased, Idris2_Value *_anyPtr,
+                                         Idris2_Value *_freeingFunction,
+                                         Idris2_Value *_world) {
+  Idris2_GCPointer *retVal = IDRIS2_NEW_VALUE(Idris2_GCPointer);
   retVal->header.tag = GC_POINTER_TAG;
-  retVal->p = (Value_Pointer *)idris2_newReference(_anyPtr);
-  retVal->onCollectFct = (Value_Closure *)_freeingFunction;
-  return (Value *)retVal;
+  retVal->p = (Idris2_Pointer *)idris2_newReference(_anyPtr);
+  retVal->onCollectFct = (Idris2_Closure *)_freeingFunction;
+  return (Idris2_Value *)retVal;
 }
 
-Value *idris2_Prelude_IO_prim__onCollectAny(Value *_anyPtr,
-                                            Value *_freeingFunction,
-                                            Value *_world) {
-  Value_GCPointer *retVal = IDRIS2_NEW_VALUE(Value_GCPointer);
+Idris2_Value *idris2_Prelude_IO_prim__onCollectAny(Idris2_Value *_anyPtr,
+                                            Idris2_Value *_freeingFunction,
+                                            Idris2_Value *_world) {
+  Idris2_GCPointer *retVal = IDRIS2_NEW_VALUE(Idris2_GCPointer);
   retVal->header.tag = GC_POINTER_TAG;
-  retVal->p = (Value_Pointer *)idris2_newReference(_anyPtr);
-  retVal->onCollectFct = (Value_Closure *)_freeingFunction;
-  return (Value *)retVal;
+  retVal->p = (Idris2_Pointer *)idris2_newReference(_anyPtr);
+  retVal->onCollectFct = (Idris2_Closure *)_freeingFunction;
+  return (Idris2_Value *)retVal;
 }
 
 // Threads
@@ -120,20 +120,20 @@ Value *idris2_Prelude_IO_prim__onCollectAny(Value *_anyPtr,
 // prim__makeMutex : PrimIO Mutex
 // using pthread_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t
 // *attr)
-Value *System_Concurrency_Raw_prim__makeMutex(Value *_world) {
-  Value_Mutex *mut = IDRIS2_NEW_VALUE(Value_Mutex);
+Idris2_Value *System_Concurrency_Raw_prim__makeMutex(Idris2_Value *_world) {
+  Idris2_Mutex *mut = IDRIS2_NEW_VALUE(Idris2_Mutex);
   mut->header.tag = MUTEX_TAG;
   mut->mutex = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
   int r = pthread_mutex_init(mut->mutex, NULL);
   IDRIS2_REFC_VERIFY(!r, "pthread_mutex_init failed: %s", strerror(r));
-  return (Value *)mut;
+  return (Idris2_Value *)mut;
 }
 
 // %foreign "scheme:blodwen-lock"
 // prim__mutexAcquire : Mutex -> PrimIO ()
 // using pthread_mutex_lock(pthread_mutex_t *mutex)
-Value *System_Concurrency_Raw_prim__mutexAcquire(Value *_mutex, Value *_world) {
-  int r = pthread_mutex_lock(((Value_Mutex *)_mutex)->mutex);
+Idris2_Value *System_Concurrency_Raw_prim__mutexAcquire(Idris2_Value *_mutex, Idris2_Value *_world) {
+  int r = pthread_mutex_lock(((Idris2_Mutex *)_mutex)->mutex);
   IDRIS2_REFC_VERIFY(!r, "pthread_mutex_lock failed: %s", strerror(r));
   return NULL;
 }
@@ -141,8 +141,8 @@ Value *System_Concurrency_Raw_prim__mutexAcquire(Value *_mutex, Value *_world) {
 // %foreign "scheme:blodwen-unlock"
 // prim__mutexRelease : Mutex -> PrimIO ()
 // using int pthread_mutex_unlock(pthread_mutex_t *mutex)
-Value *System_Concurrency_Raw_prim__mutexRelease(Value *_mutex, Value *_world) {
-  int r = pthread_mutex_unlock(((Value_Mutex *)_mutex)->mutex);
+Idris2_Value *System_Concurrency_Raw_prim__mutexRelease(Idris2_Value *_mutex, Idris2_Value *_world) {
+  int r = pthread_mutex_unlock(((Idris2_Mutex *)_mutex)->mutex);
   IDRIS2_REFC_VERIFY(!r, "pthread_mutex_unlock failed: %s", strerror(r));
   return NULL;
 }
@@ -151,29 +151,29 @@ Value *System_Concurrency_Raw_prim__mutexRelease(Value *_mutex, Value *_world) {
 // prim__makeCondition : PrimIO Condition
 // using int pthread_cond_init(pthread_cond_t *cond, const pthread_condattr_t
 // *attr) with standard initialisation
-Value *System_Concurrency_Raw_prim__makeCondition(Value *_world) {
+Idris2_Value *System_Concurrency_Raw_prim__makeCondition(Idris2_Value *_world) {
   // typedef struct{
   //     Value_header header;
   //     pthread_cond_t *cond;
-  // }Value_Condition;
+  // }Idris2_Condition;
 
-  Value_Condition *c = IDRIS2_NEW_VALUE(Value_Condition);
+  Idris2_Condition *c = IDRIS2_NEW_VALUE(Idris2_Condition);
   c->header.tag = CONDITION_TAG;
   c->cond = (pthread_cond_t *)malloc(sizeof(pthread_cond_t));
   IDRIS2_REFC_VERIFY(c->cond, "malloc failed");
   int r = pthread_cond_init(c->cond, NULL);
   IDRIS2_REFC_VERIFY(!r, "pthread_cond_init failed: %s", strerror(r));
-  return (Value *)c;
+  return (Idris2_Value *)c;
 }
 
 // %foreign "scheme:blodwen-condition-wait"
 // prim__conditionWait : Condition -> Mutex -> PrimIO ()
 // using int pthread_cond_wait(pthread_cond_t *, pthread_mutex_t *mutex)
-Value *System_Concurrency_Raw_prim__conditionWait(Value *_condition,
-                                                  Value *_mutex,
-                                                  Value *_world) {
-  Value_Condition *cond = (Value_Condition *)_condition;
-  Value_Mutex *mutex = (Value_Mutex *)_mutex;
+Idris2_Value *System_Concurrency_Raw_prim__conditionWait(Idris2_Value *_condition,
+                                                  Idris2_Value *_mutex,
+                                                  Idris2_Value *_world) {
+  Idris2_Condition *cond = (Idris2_Condition *)_condition;
+  Idris2_Mutex *mutex = (Idris2_Mutex *)_mutex;
   int r = pthread_cond_wait(cond->cond, mutex->mutex);
   IDRIS2_REFC_VERIFY(!r, "pthread_cond_wait failed: %s", strerror(r));
   return NULL;
@@ -183,12 +183,12 @@ Value *System_Concurrency_Raw_prim__conditionWait(Value *_condition,
 // prim__conditionWaitTimeout : Condition -> Mutex -> Int -> PrimIO ()
 // using int pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t
 // *mutex, const struct timespec *abstime)
-Value *System_Concurrency_Raw_prim__conditionWaitTimeout(Value *_condition,
-                                                         Value *_mutex,
-                                                         Value *_timeout,
-                                                         Value *_world) {
-  Value_Condition *cond = (Value_Condition *)_condition;
-  Value_Mutex *mutex = (Value_Mutex *)_mutex;
+Idris2_Value *System_Concurrency_Raw_prim__conditionWaitTimeout(Idris2_Value *_condition,
+                                                         Idris2_Value *_mutex,
+                                                         Idris2_Value *_timeout,
+                                                         Idris2_Value *_world) {
+  Idris2_Condition *cond = (Idris2_Condition *)_condition;
+  Idris2_Mutex *mutex = (Idris2_Mutex *)_mutex;
   int64_t timeout = idris2_vp_to_Int64(_timeout);
   struct timespec t;
   t.tv_sec = timeout / 1000000;
@@ -201,9 +201,9 @@ Value *System_Concurrency_Raw_prim__conditionWaitTimeout(Value *_condition,
 // %foreign "scheme:blodwen-condition-signal"
 // prim__conditionSignal : Condition -> PrimIO ()
 // using int pthread_cond_signal(pthread_cond_t *cond)
-Value *System_Concurrency_Raw_prim__conditionSignal(Value *_condition,
-                                                    Value *_world) {
-  Value_Condition *cond = (Value_Condition *)_condition;
+Idris2_Value *System_Concurrency_Raw_prim__conditionSignal(Idris2_Value *_condition,
+                                                    Idris2_Value *_world) {
+  Idris2_Condition *cond = (Idris2_Condition *)_condition;
   int r = pthread_cond_signal(cond->cond);
   IDRIS2_REFC_VERIFY(!r, "pthread_cond_signal failed: %s", strerror(r));
   return NULL;
@@ -212,9 +212,9 @@ Value *System_Concurrency_Raw_prim__conditionSignal(Value *_condition,
 // %foreign "scheme:blodwen-condition-broadcast"
 // prim__conditionBroadcast : Condition -> PrimIO ()
 // using int pthread_cond_broadcast(pthread_cond_t *cond)
-Value *System_Concurrency_Raw_prim__conditionBroadcast(Value *_condition,
-                                                       Value *_mutex) {
-  Value_Condition *cond = (Value_Condition *)_condition;
+Idris2_Value *System_Concurrency_Raw_prim__conditionBroadcast(Idris2_Value *_condition,
+                                                       Idris2_Value *_mutex) {
+  Idris2_Condition *cond = (Idris2_Condition *)_condition;
   int r = pthread_cond_broadcast(cond->cond);
   IDRIS2_REFC_VERIFY(!r, "pthread_cond_broadcast failed: %s", strerror(r));
   return NULL;

--- a/support/refc/prim.c
+++ b/support/refc/prim.c
@@ -173,7 +173,7 @@ Idris2_Value *System_Concurrency_Raw_prim__mutexRelease(
 // *attr) with standard initialisation
 Idris2_Value *System_Concurrency_Raw_prim__makeCondition(Idris2_Value *_world) {
   // typedef struct{
-  //     Value_header header;
+  //     Idris2_header header;
   //     pthread_cond_t *cond;
   // }Idris2_Condition;
 

--- a/support/refc/prim.h
+++ b/support/refc/prim.h
@@ -4,51 +4,73 @@
 
 // IORef
 
-Idris2_Value *idris2_Data_IORef_prim__newIORef(Idris2_Value *, Idris2_Value *, Idris2_Value *);
+Idris2_Value *idris2_Data_IORef_prim__newIORef(
+  Idris2_Value *, Idris2_Value *, Idris2_Value *
+);
 #define idris2_Data_IORef_prim__readIORef(erased, ioref, world)                \
   (idris2_newReference(((Idris2_IORef *)ioref)->v))
 
-Idris2_Value *idris2_Data_IORef_prim__writeIORef(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *);
+Idris2_Value *idris2_Data_IORef_prim__writeIORef(
+  Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *
+);
 
 // Sys
 
 extern Idris2_String const idris2_predefined_osstring;
 extern Idris2_String const idris2_predefined_codegenstring;
-#define idris2_System_Info_prim__os() ((Idris2_Value *)&idris2_predefined_osstring)
+#define idris2_System_Info_prim__os()                                          \
+  ((Idris2_Value *)&idris2_predefined_osstring)
 #define idris2_System_Info_prim__codegen()                                     \
   ((Idris2_Value *)&idris2_predefined_codegenstring)
 Idris2_Value *idris2_crash(Idris2_Value *msg);
 
 // Array
 
-Idris2_Value *idris2_Data_IOArray_Prims_prim__newArray(Idris2_Value *, Idris2_Value *, Idris2_Value *,
-                                                Idris2_Value *);
+Idris2_Value *idris2_Data_IOArray_Prims_prim__newArray(
+  Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *
+);
 #define idris2_Data_IOArray_Prims_prim__arrayGet(rased, array, i, word)        \
   (idris2_newReference(((Idris2_Array *)(array))->arr[idris2_vp_to_Int64(i)]))
-Idris2_Value *idris2_Data_IOArray_Prims_prim__arraySet(Idris2_Value *, Idris2_Value *, Idris2_Value *,
-                                                Idris2_Value *, Idris2_Value *);
+Idris2_Value *idris2_Data_IOArray_Prims_prim__arraySet(
+  Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *
+);
 
 // Pointer
-Idris2_Value *idris2_Prelude_IO_prim__onCollect(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *);
-Idris2_Value *idris2_Prelude_IO_prim__onCollectAny(Idris2_Value *, Idris2_Value *, Idris2_Value *);
+Idris2_Value *idris2_Prelude_IO_prim__onCollect(
+  Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *
+);
+Idris2_Value *idris2_Prelude_IO_prim__onCollectAny(
+  Idris2_Value *, Idris2_Value *, Idris2_Value *
+);
 
 // Threads
-Idris2_Value *System_Concurrency_Raw_prim__mutexRelease(Idris2_Value *, Idris2_Value *);
+Idris2_Value *System_Concurrency_Raw_prim__mutexRelease(
+  Idris2_Value *, Idris2_Value *
+);
 
-Idris2_Value *System_Concurrency_Raw_prim__mutexAcquire(Idris2_Value *, Idris2_Value *);
+Idris2_Value *System_Concurrency_Raw_prim__mutexAcquire(
+  Idris2_Value *, Idris2_Value *
+);
 
 Idris2_Value *System_Concurrency_Raw_prim__makeMutex(Idris2_Value *);
 
 Idris2_Value *System_Concurrency_Raw_prim__makeCondition(Idris2_Value *);
 
-Idris2_Value *System_Concurrency_Raw_prim__conditionWait(Idris2_Value *, Idris2_Value *, Idris2_Value *);
+Idris2_Value *System_Concurrency_Raw_prim__conditionWait(
+  Idris2_Value *, Idris2_Value *, Idris2_Value *
+);
 
-Idris2_Value *System_Concurrency_Raw_prim__conditionWaitTimeout(Idris2_Value *, Idris2_Value *,
-                                                         Idris2_Value *, Idris2_Value *);
+Idris2_Value *System_Concurrency_Raw_prim__conditionWaitTimeout(
+  Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *
+);
 
-Idris2_Value *System_Concurrency_Raw_prim__conditionSignal(Idris2_Value *, Idris2_Value *);
+Idris2_Value *System_Concurrency_Raw_prim__conditionSignal(
+  Idris2_Value *, Idris2_Value *
+);
 
-Idris2_Value *System_Concurrency_Raw_prim__conditionBroadcast(Idris2_Value *, Idris2_Value *);
+Idris2_Value *System_Concurrency_Raw_prim__conditionBroadcast(
+  Idris2_Value *, Idris2_Value *
+);
 
 extern char const idris2_constr_Int[];
 extern char const idris2_constr_Int8[];

--- a/support/refc/prim.h
+++ b/support/refc/prim.h
@@ -4,15 +4,14 @@
 
 // IORef
 
-Idris2_Value *idris2_Data_IORef_prim__newIORef(
-  Idris2_Value *, Idris2_Value *, Idris2_Value *
-);
+Idris2_Value *idris2_Data_IORef_prim__newIORef(Idris2_Value *, Idris2_Value *,
+                                               Idris2_Value *);
 #define idris2_Data_IORef_prim__readIORef(erased, ioref, world)                \
   (idris2_newReference(((Idris2_IORef *)ioref)->v))
 
-Idris2_Value *idris2_Data_IORef_prim__writeIORef(
-  Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *
-);
+Idris2_Value *idris2_Data_IORef_prim__writeIORef(Idris2_Value *, Idris2_Value *,
+                                                 Idris2_Value *,
+                                                 Idris2_Value *);
 
 // Sys
 
@@ -26,51 +25,50 @@ Idris2_Value *idris2_crash(Idris2_Value *msg);
 
 // Array
 
-Idris2_Value *idris2_Data_IOArray_Prims_prim__newArray(
-  Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *
-);
+Idris2_Value *idris2_Data_IOArray_Prims_prim__newArray(Idris2_Value *,
+                                                       Idris2_Value *,
+                                                       Idris2_Value *,
+                                                       Idris2_Value *);
 #define idris2_Data_IOArray_Prims_prim__arrayGet(rased, array, i, word)        \
   (idris2_newReference(((Idris2_Array *)(array))->arr[idris2_vp_to_Int64(i)]))
-Idris2_Value *idris2_Data_IOArray_Prims_prim__arraySet(
-  Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *
-);
+Idris2_Value *idris2_Data_IOArray_Prims_prim__arraySet(Idris2_Value *,
+                                                       Idris2_Value *,
+                                                       Idris2_Value *,
+                                                       Idris2_Value *,
+                                                       Idris2_Value *);
 
 // Pointer
-Idris2_Value *idris2_Prelude_IO_prim__onCollect(
-  Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *
-);
-Idris2_Value *idris2_Prelude_IO_prim__onCollectAny(
-  Idris2_Value *, Idris2_Value *, Idris2_Value *
-);
+Idris2_Value *idris2_Prelude_IO_prim__onCollect(Idris2_Value *, Idris2_Value *,
+                                                Idris2_Value *, Idris2_Value *);
+Idris2_Value *idris2_Prelude_IO_prim__onCollectAny(Idris2_Value *,
+                                                   Idris2_Value *,
+                                                   Idris2_Value *);
 
 // Threads
-Idris2_Value *System_Concurrency_Raw_prim__mutexRelease(
-  Idris2_Value *, Idris2_Value *
-);
+Idris2_Value *System_Concurrency_Raw_prim__mutexRelease(Idris2_Value *,
+                                                        Idris2_Value *);
 
-Idris2_Value *System_Concurrency_Raw_prim__mutexAcquire(
-  Idris2_Value *, Idris2_Value *
-);
+Idris2_Value *System_Concurrency_Raw_prim__mutexAcquire(Idris2_Value *,
+                                                        Idris2_Value *);
 
 Idris2_Value *System_Concurrency_Raw_prim__makeMutex(Idris2_Value *);
 
 Idris2_Value *System_Concurrency_Raw_prim__makeCondition(Idris2_Value *);
 
-Idris2_Value *System_Concurrency_Raw_prim__conditionWait(
-  Idris2_Value *, Idris2_Value *, Idris2_Value *
-);
+Idris2_Value *System_Concurrency_Raw_prim__conditionWait(Idris2_Value *,
+                                                         Idris2_Value *,
+                                                         Idris2_Value *);
 
-Idris2_Value *System_Concurrency_Raw_prim__conditionWaitTimeout(
-  Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *
-);
+Idris2_Value *System_Concurrency_Raw_prim__conditionWaitTimeout(Idris2_Value *,
+                                                                Idris2_Value *,
+                                                                Idris2_Value *,
+                                                                Idris2_Value *);
 
-Idris2_Value *System_Concurrency_Raw_prim__conditionSignal(
-  Idris2_Value *, Idris2_Value *
-);
+Idris2_Value *System_Concurrency_Raw_prim__conditionSignal(Idris2_Value *,
+                                                           Idris2_Value *);
 
-Idris2_Value *System_Concurrency_Raw_prim__conditionBroadcast(
-  Idris2_Value *, Idris2_Value *
-);
+Idris2_Value *System_Concurrency_Raw_prim__conditionBroadcast(Idris2_Value *,
+                                                              Idris2_Value *);
 
 extern char const idris2_constr_Int[];
 extern char const idris2_constr_Int8[];

--- a/support/refc/prim.h
+++ b/support/refc/prim.h
@@ -4,51 +4,51 @@
 
 // IORef
 
-Value *idris2_Data_IORef_prim__newIORef(Value *, Value *, Value *);
+Idris2_Value *idris2_Data_IORef_prim__newIORef(Idris2_Value *, Idris2_Value *, Idris2_Value *);
 #define idris2_Data_IORef_prim__readIORef(erased, ioref, world)                \
-  (idris2_newReference(((Value_IORef *)ioref)->v))
+  (idris2_newReference(((Idris2_IORef *)ioref)->v))
 
-Value *idris2_Data_IORef_prim__writeIORef(Value *, Value *, Value *, Value *);
+Idris2_Value *idris2_Data_IORef_prim__writeIORef(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *);
 
 // Sys
 
-extern Value_String const idris2_predefined_osstring;
-extern Value_String const idris2_predefined_codegenstring;
-#define idris2_System_Info_prim__os() ((Value *)&idris2_predefined_osstring)
+extern Idris2_String const idris2_predefined_osstring;
+extern Idris2_String const idris2_predefined_codegenstring;
+#define idris2_System_Info_prim__os() ((Idris2_Value *)&idris2_predefined_osstring)
 #define idris2_System_Info_prim__codegen()                                     \
-  ((Value *)&idris2_predefined_codegenstring)
-Value *idris2_crash(Value *msg);
+  ((Idris2_Value *)&idris2_predefined_codegenstring)
+Idris2_Value *idris2_crash(Idris2_Value *msg);
 
 // Array
 
-Value *idris2_Data_IOArray_Prims_prim__newArray(Value *, Value *, Value *,
-                                                Value *);
+Idris2_Value *idris2_Data_IOArray_Prims_prim__newArray(Idris2_Value *, Idris2_Value *, Idris2_Value *,
+                                                Idris2_Value *);
 #define idris2_Data_IOArray_Prims_prim__arrayGet(rased, array, i, word)        \
-  (idris2_newReference(((Value_Array *)(array))->arr[idris2_vp_to_Int64(i)]))
-Value *idris2_Data_IOArray_Prims_prim__arraySet(Value *, Value *, Value *,
-                                                Value *, Value *);
+  (idris2_newReference(((Idris2_Array *)(array))->arr[idris2_vp_to_Int64(i)]))
+Idris2_Value *idris2_Data_IOArray_Prims_prim__arraySet(Idris2_Value *, Idris2_Value *, Idris2_Value *,
+                                                Idris2_Value *, Idris2_Value *);
 
 // Pointer
-Value *idris2_Prelude_IO_prim__onCollect(Value *, Value *, Value *, Value *);
-Value *idris2_Prelude_IO_prim__onCollectAny(Value *, Value *, Value *);
+Idris2_Value *idris2_Prelude_IO_prim__onCollect(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *);
+Idris2_Value *idris2_Prelude_IO_prim__onCollectAny(Idris2_Value *, Idris2_Value *, Idris2_Value *);
 
 // Threads
-Value *System_Concurrency_Raw_prim__mutexRelease(Value *, Value *);
+Idris2_Value *System_Concurrency_Raw_prim__mutexRelease(Idris2_Value *, Idris2_Value *);
 
-Value *System_Concurrency_Raw_prim__mutexAcquire(Value *, Value *);
+Idris2_Value *System_Concurrency_Raw_prim__mutexAcquire(Idris2_Value *, Idris2_Value *);
 
-Value *System_Concurrency_Raw_prim__makeMutex(Value *);
+Idris2_Value *System_Concurrency_Raw_prim__makeMutex(Idris2_Value *);
 
-Value *System_Concurrency_Raw_prim__makeCondition(Value *);
+Idris2_Value *System_Concurrency_Raw_prim__makeCondition(Idris2_Value *);
 
-Value *System_Concurrency_Raw_prim__conditionWait(Value *, Value *, Value *);
+Idris2_Value *System_Concurrency_Raw_prim__conditionWait(Idris2_Value *, Idris2_Value *, Idris2_Value *);
 
-Value *System_Concurrency_Raw_prim__conditionWaitTimeout(Value *, Value *,
-                                                         Value *, Value *);
+Idris2_Value *System_Concurrency_Raw_prim__conditionWaitTimeout(Idris2_Value *, Idris2_Value *,
+                                                         Idris2_Value *, Idris2_Value *);
 
-Value *System_Concurrency_Raw_prim__conditionSignal(Value *, Value *);
+Idris2_Value *System_Concurrency_Raw_prim__conditionSignal(Idris2_Value *, Idris2_Value *);
 
-Value *System_Concurrency_Raw_prim__conditionBroadcast(Value *, Value *);
+Idris2_Value *System_Concurrency_Raw_prim__conditionBroadcast(Idris2_Value *, Idris2_Value *);
 
 extern char const idris2_constr_Int[];
 extern char const idris2_constr_Int8[];

--- a/support/refc/runtime.c
+++ b/support/refc/runtime.c
@@ -44,6 +44,7 @@ typedef Idris2_Value *(*const FUN8)(
   Idris2_Value *,
   Idris2_Value *,
   Idris2_Value *,
+  Idris2_Value *,
   Idris2_Value *
 );
 typedef Idris2_Value *(*const FUN9)(
@@ -125,7 +126,7 @@ typedef Idris2_Value *(*const FUN14)(
   Idris2_Value *,
   Idris2_Value *,
   Idris2_Value *,
-  Idris2_Value *,
+  Idris2_Value *
 );
 typedef Idris2_Value *(*const FUN15)(
   Idris2_Value *,

--- a/support/refc/runtime.c
+++ b/support/refc/runtime.c
@@ -11,38 +11,157 @@ void idris2_missing_ffi() {
 typedef Idris2_Value *(*const FUN0)();
 typedef Idris2_Value *(*const FUN1)(Idris2_Value *);
 typedef Idris2_Value *(*const FUN2)(Idris2_Value *, Idris2_Value *);
-typedef Idris2_Value *(*const FUN3)(Idris2_Value *, Idris2_Value *, Idris2_Value *);
-typedef Idris2_Value *(*const FUN4)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *);
-typedef Idris2_Value *(*const FUN5)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *);
-typedef Idris2_Value *(*const FUN6)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
-                             Idris2_Value *);
-typedef Idris2_Value *(*const FUN7)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
-                             Idris2_Value *, Idris2_Value *);
-typedef Idris2_Value *(*const FUN8)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
-                             Idris2_Value *, Idris2_Value *, Idris2_Value *);
-typedef Idris2_Value *(*const FUN9)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
-                             Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *);
-typedef Idris2_Value *(*const FUN10)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
-                              Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *);
-typedef Idris2_Value *(*const FUN11)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
-                              Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
-                              Idris2_Value *);
-typedef Idris2_Value *(*const FUN12)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
-                              Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
-                              Idris2_Value *, Idris2_Value *);
-typedef Idris2_Value *(*const FUN13)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
-                              Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
-                              Idris2_Value *, Idris2_Value *, Idris2_Value *);
-typedef Idris2_Value *(*const FUN14)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
-                              Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
-                              Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *);
-typedef Idris2_Value *(*const FUN15)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
-                              Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
-                              Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *);
-typedef Idris2_Value *(*const FUN16)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
-                              Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
-                              Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
-                              Idris2_Value *);
+typedef Idris2_Value *(*const FUN3)(
+  Idris2_Value *, Idris2_Value *, Idris2_Value *
+);
+typedef Idris2_Value *(*const FUN4)(
+  Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *
+);
+typedef Idris2_Value *(*const FUN5)(
+  Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *
+);
+typedef Idris2_Value *(*const FUN6)(
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *
+);
+typedef Idris2_Value *(*const FUN7)(
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *
+);
+typedef Idris2_Value *(*const FUN8)(
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *
+);
+typedef Idris2_Value *(*const FUN9)(
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *
+);
+typedef Idris2_Value *(*const FUN10)(
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *
+);
+typedef Idris2_Value *(*const FUN11)(
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *
+);
+typedef Idris2_Value *(*const FUN12)(
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *
+);
+typedef Idris2_Value *(*const FUN13)(
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *
+);
+typedef Idris2_Value *(*const FUN14)(
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+);
+typedef Idris2_Value *(*const FUN15)(
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *
+);
+typedef Idris2_Value *(*const FUN16)(
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *,
+  Idris2_Value *
+);
 typedef Idris2_Value *(*const FUNStar)(Idris2_Value **);
 
 static inline Idris2_Value *idris2_dispatch_closure(Idris2_Closure *clo) {
@@ -116,7 +235,9 @@ Idris2_Value *idris2_trampoline(Idris2_Value *it) {
   return it;
 }
 
-Idris2_Value *idris2_tailcall_apply_closure(Idris2_Value *_clos, Idris2_Value *arg) {
+Idris2_Value *idris2_tailcall_apply_closure(
+  Idris2_Value *_clos, Idris2_Value *arg
+) {
   // create a new closure and copy args.
   Idris2_Closure *clos = (Idris2_Closure *)_clos;
   Idris2_Closure *newclos = idris2_mkClosure(

--- a/support/refc/runtime.c
+++ b/support/refc/runtime.c
@@ -11,158 +11,70 @@ void idris2_missing_ffi() {
 typedef Idris2_Value *(*const FUN0)();
 typedef Idris2_Value *(*const FUN1)(Idris2_Value *);
 typedef Idris2_Value *(*const FUN2)(Idris2_Value *, Idris2_Value *);
-typedef Idris2_Value *(*const FUN3)(
-  Idris2_Value *, Idris2_Value *, Idris2_Value *
-);
-typedef Idris2_Value *(*const FUN4)(
-  Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *
-);
-typedef Idris2_Value *(*const FUN5)(
-  Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *
-);
-typedef Idris2_Value *(*const FUN6)(
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *
-);
-typedef Idris2_Value *(*const FUN7)(
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *
-);
-typedef Idris2_Value *(*const FUN8)(
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *
-);
-typedef Idris2_Value *(*const FUN9)(
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *
-);
-typedef Idris2_Value *(*const FUN10)(
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *
-);
-typedef Idris2_Value *(*const FUN11)(
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *
-);
-typedef Idris2_Value *(*const FUN12)(
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *
-);
-typedef Idris2_Value *(*const FUN13)(
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *
-);
-typedef Idris2_Value *(*const FUN14)(
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *
-);
+typedef Idris2_Value *(*const FUN3)(Idris2_Value *, Idris2_Value *,
+                                    Idris2_Value *);
+typedef Idris2_Value *(*const FUN4)(Idris2_Value *, Idris2_Value *,
+                                    Idris2_Value *, Idris2_Value *);
+typedef Idris2_Value *(*const FUN5)(Idris2_Value *, Idris2_Value *,
+                                    Idris2_Value *, Idris2_Value *,
+                                    Idris2_Value *);
+typedef Idris2_Value *(*const FUN6)(Idris2_Value *, Idris2_Value *,
+                                    Idris2_Value *, Idris2_Value *,
+                                    Idris2_Value *, Idris2_Value *);
+typedef Idris2_Value *(*const FUN7)(Idris2_Value *, Idris2_Value *,
+                                    Idris2_Value *, Idris2_Value *,
+                                    Idris2_Value *, Idris2_Value *,
+                                    Idris2_Value *);
+typedef Idris2_Value *(*const FUN8)(Idris2_Value *, Idris2_Value *,
+                                    Idris2_Value *, Idris2_Value *,
+                                    Idris2_Value *, Idris2_Value *,
+                                    Idris2_Value *, Idris2_Value *);
+typedef Idris2_Value *(*const FUN9)(Idris2_Value *, Idris2_Value *,
+                                    Idris2_Value *, Idris2_Value *,
+                                    Idris2_Value *, Idris2_Value *,
+                                    Idris2_Value *, Idris2_Value *,
+                                    Idris2_Value *);
+typedef Idris2_Value *(*const FUN10)(Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *, Idris2_Value *);
+typedef Idris2_Value *(*const FUN11)(Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *);
+typedef Idris2_Value *(*const FUN12)(Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *, Idris2_Value *);
+typedef Idris2_Value *(*const FUN13)(Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *);
+typedef Idris2_Value *(*const FUN14)(Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *, Idris2_Value *,
+                                     Idris2_Value *, Idris2_Value *);
 typedef Idris2_Value *(*const FUN15)(
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *
-);
+    Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
+    Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
+    Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
+    Idris2_Value *, Idris2_Value *, Idris2_Value *);
 typedef Idris2_Value *(*const FUN16)(
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *,
-  Idris2_Value *
-);
+    Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
+    Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
+    Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
+    Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *);
 typedef Idris2_Value *(*const FUNStar)(Idris2_Value **);
 
 static inline Idris2_Value *idris2_dispatch_closure(Idris2_Closure *clo) {
@@ -236,9 +148,8 @@ Idris2_Value *idris2_trampoline(Idris2_Value *it) {
   return it;
 }
 
-Idris2_Value *idris2_tailcall_apply_closure(
-  Idris2_Value *_clos, Idris2_Value *arg
-) {
+Idris2_Value *idris2_tailcall_apply_closure(Idris2_Value *_clos,
+                                            Idris2_Value *arg) {
   // create a new closure and copy args.
   Idris2_Closure *clos = (Idris2_Closure *)_clos;
   Idris2_Closure *newclos = idris2_mkClosure(

--- a/support/refc/runtime.c
+++ b/support/refc/runtime.c
@@ -8,45 +8,45 @@ void idris2_missing_ffi() {
   exit(1);
 }
 
-typedef Value *(*const FUN0)();
-typedef Value *(*const FUN1)(Value *);
-typedef Value *(*const FUN2)(Value *, Value *);
-typedef Value *(*const FUN3)(Value *, Value *, Value *);
-typedef Value *(*const FUN4)(Value *, Value *, Value *, Value *);
-typedef Value *(*const FUN5)(Value *, Value *, Value *, Value *, Value *);
-typedef Value *(*const FUN6)(Value *, Value *, Value *, Value *, Value *,
-                             Value *);
-typedef Value *(*const FUN7)(Value *, Value *, Value *, Value *, Value *,
-                             Value *, Value *);
-typedef Value *(*const FUN8)(Value *, Value *, Value *, Value *, Value *,
-                             Value *, Value *, Value *);
-typedef Value *(*const FUN9)(Value *, Value *, Value *, Value *, Value *,
-                             Value *, Value *, Value *, Value *);
-typedef Value *(*const FUN10)(Value *, Value *, Value *, Value *, Value *,
-                              Value *, Value *, Value *, Value *, Value *);
-typedef Value *(*const FUN11)(Value *, Value *, Value *, Value *, Value *,
-                              Value *, Value *, Value *, Value *, Value *,
-                              Value *);
-typedef Value *(*const FUN12)(Value *, Value *, Value *, Value *, Value *,
-                              Value *, Value *, Value *, Value *, Value *,
-                              Value *, Value *);
-typedef Value *(*const FUN13)(Value *, Value *, Value *, Value *, Value *,
-                              Value *, Value *, Value *, Value *, Value *,
-                              Value *, Value *, Value *);
-typedef Value *(*const FUN14)(Value *, Value *, Value *, Value *, Value *,
-                              Value *, Value *, Value *, Value *, Value *,
-                              Value *, Value *, Value *, Value *);
-typedef Value *(*const FUN15)(Value *, Value *, Value *, Value *, Value *,
-                              Value *, Value *, Value *, Value *, Value *,
-                              Value *, Value *, Value *, Value *, Value *);
-typedef Value *(*const FUN16)(Value *, Value *, Value *, Value *, Value *,
-                              Value *, Value *, Value *, Value *, Value *,
-                              Value *, Value *, Value *, Value *, Value *,
-                              Value *);
-typedef Value *(*const FUNStar)(Value **);
+typedef Idris2_Value *(*const FUN0)();
+typedef Idris2_Value *(*const FUN1)(Idris2_Value *);
+typedef Idris2_Value *(*const FUN2)(Idris2_Value *, Idris2_Value *);
+typedef Idris2_Value *(*const FUN3)(Idris2_Value *, Idris2_Value *, Idris2_Value *);
+typedef Idris2_Value *(*const FUN4)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *);
+typedef Idris2_Value *(*const FUN5)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *);
+typedef Idris2_Value *(*const FUN6)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
+                             Idris2_Value *);
+typedef Idris2_Value *(*const FUN7)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
+                             Idris2_Value *, Idris2_Value *);
+typedef Idris2_Value *(*const FUN8)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
+                             Idris2_Value *, Idris2_Value *, Idris2_Value *);
+typedef Idris2_Value *(*const FUN9)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
+                             Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *);
+typedef Idris2_Value *(*const FUN10)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
+                              Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *);
+typedef Idris2_Value *(*const FUN11)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
+                              Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
+                              Idris2_Value *);
+typedef Idris2_Value *(*const FUN12)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
+                              Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
+                              Idris2_Value *, Idris2_Value *);
+typedef Idris2_Value *(*const FUN13)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
+                              Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
+                              Idris2_Value *, Idris2_Value *, Idris2_Value *);
+typedef Idris2_Value *(*const FUN14)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
+                              Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
+                              Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *);
+typedef Idris2_Value *(*const FUN15)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
+                              Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
+                              Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *);
+typedef Idris2_Value *(*const FUN16)(Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
+                              Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
+                              Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *, Idris2_Value *,
+                              Idris2_Value *);
+typedef Idris2_Value *(*const FUNStar)(Idris2_Value **);
 
-static inline Value *idris2_dispatch_closure(Value_Closure *clo) {
-  Value **const xs = clo->args;
+static inline Idris2_Value *idris2_dispatch_closure(Idris2_Closure *clo) {
+  Idris2_Value **const xs = clo->args;
 
   switch (clo->arity) {
   default:
@@ -101,9 +101,9 @@ static inline Value *idris2_dispatch_closure(Value_Closure *clo) {
   }
 }
 
-Value *idris2_trampoline(Value *it) {
+Idris2_Value *idris2_trampoline(Idris2_Value *it) {
   while (it && !idris2_vp_is_unboxed(it) && it->header.tag == CLOSURE_TAG) {
-    Value_Closure *clos = (Value_Closure *)it;
+    Idris2_Closure *clos = (Idris2_Closure *)it;
     if (clos->filled < clos->arity)
       break;
 
@@ -116,14 +116,14 @@ Value *idris2_trampoline(Value *it) {
   return it;
 }
 
-Value *idris2_tailcall_apply_closure(Value *_clos, Value *arg) {
+Idris2_Value *idris2_tailcall_apply_closure(Idris2_Value *_clos, Idris2_Value *arg) {
   // create a new closure and copy args.
-  Value_Closure *clos = (Value_Closure *)_clos;
-  Value_Closure *newclos = idris2_mkClosure(
+  Idris2_Closure *clos = (Idris2_Closure *)_clos;
+  Idris2_Closure *newclos = idris2_mkClosure(
       clos->f, clos->arity, clos->filled + 1 /* expanding a payload */);
 
   if (clos->header.refCounter <= 1) {
-    memcpy(newclos->args, clos->args, sizeof(Value *) * clos->filled);
+    memcpy(newclos->args, clos->args, sizeof(Idris2_Value *) * clos->filled);
   } else {
     // if the closure has multiple references, then apply newReference to
     // arguments to avoid premature clearing of arguments
@@ -138,14 +138,14 @@ Value *idris2_tailcall_apply_closure(Value *_clos, Value *arg) {
     --clos->header.refCounter;
   }
 
-  return (Value *)newclos;
+  return (Idris2_Value *)newclos;
 }
 
-Value *idris2_apply_closure(Value *_clos, Value *arg) {
+Idris2_Value *idris2_apply_closure(Idris2_Value *_clos, Idris2_Value *arg) {
   return idris2_trampoline(idris2_tailcall_apply_closure(_clos, arg));
 }
 
-void idris2_removeReuseConstructor(Value_Constructor *constr) {
+void idris2_removeReuseConstructor(Idris2_Constructor *constr) {
   if (!constr) {
     return;
   }
@@ -157,7 +157,7 @@ void idris2_removeReuseConstructor(Value_Constructor *constr) {
   }
 }
 
-int idris2_extractInt(Value *v) {
+int idris2_extractInt(Idris2_Value *v) {
   if (idris2_vp_is_unboxed(v))
     return (int)((uintptr_t)(v) >> idris2_vp_int_shift);
 
@@ -171,7 +171,7 @@ int idris2_extractInt(Value *v) {
   case INT64_TAG:
     return (int)idris2_vp_to_Int64(v);
   case INTEGER_TAG:
-    return (int)mpz_get_si(((Value_Integer *)v)->i);
+    return (int)mpz_get_si(((Idris2_Integer *)v)->i);
   case DOUBLE_TAG:
     return (int)idris2_vp_to_Double(v);
   default:

--- a/support/refc/runtime.h
+++ b/support/refc/runtime.h
@@ -5,10 +5,10 @@
 void idris2_missing_ffi();
 
 #define idris2_isUnique(x) ((x)->header.refCounter == 1)
-void idris2_removeReuseConstructor(Value_Constructor *constr);
+void idris2_removeReuseConstructor(Idris2_Constructor *constr);
 
-Value *idris2_apply_closure(Value *, Value *arg);
-Value *idris2_tailcall_apply_closure(Value *_clos, Value *arg);
-Value *idris2_trampoline(Value *closure);
+Idris2_Value *idris2_apply_closure(Idris2_Value *, Idris2_Value *arg);
+Idris2_Value *idris2_tailcall_apply_closure(Idris2_Value *_clos, Idris2_Value *arg);
+Idris2_Value *idris2_trampoline(Idris2_Value *closure);
 
-int idris2_extractInt(Value *);
+int idris2_extractInt(Idris2_Value *);

--- a/support/refc/runtime.h
+++ b/support/refc/runtime.h
@@ -8,7 +8,9 @@ void idris2_missing_ffi();
 void idris2_removeReuseConstructor(Idris2_Constructor *constr);
 
 Idris2_Value *idris2_apply_closure(Idris2_Value *, Idris2_Value *arg);
-Idris2_Value *idris2_tailcall_apply_closure(Idris2_Value *_clos, Idris2_Value *arg);
+Idris2_Value *idris2_tailcall_apply_closure(
+  Idris2_Value *_clos, Idris2_Value *arg
+);
 Idris2_Value *idris2_trampoline(Idris2_Value *closure);
 
 int idris2_extractInt(Idris2_Value *);

--- a/support/refc/runtime.h
+++ b/support/refc/runtime.h
@@ -8,9 +8,8 @@ void idris2_missing_ffi();
 void idris2_removeReuseConstructor(Idris2_Constructor *constr);
 
 Idris2_Value *idris2_apply_closure(Idris2_Value *, Idris2_Value *arg);
-Idris2_Value *idris2_tailcall_apply_closure(
-  Idris2_Value *_clos, Idris2_Value *arg
-);
+Idris2_Value *idris2_tailcall_apply_closure(Idris2_Value *_clos,
+                                            Idris2_Value *arg);
 Idris2_Value *idris2_trampoline(Idris2_Value *closure);
 
 int idris2_extractInt(Idris2_Value *);

--- a/support/refc/stringOps.c
+++ b/support/refc/stringOps.c
@@ -1,25 +1,25 @@
 #include "stringOps.h"
 #include "refc_util.h"
 
-Value *tail(Value *input) {
-  Value_String *tailStr = IDRIS2_NEW_VALUE(Value_String);
+Idris2_Value *tail(Idris2_Value *input) {
+  Idris2_String *tailStr = IDRIS2_NEW_VALUE(Idris2_String);
   tailStr->header.tag = STRING_TAG;
-  Value_String *s = (Value_String *)input;
+  Idris2_String *s = (Idris2_String *)input;
   int l = strlen(s->str);
   if (l == 0)
-    return (Value *)&idris2_predefined_nullstring;
+    return (Idris2_Value *)&idris2_predefined_nullstring;
 
   tailStr->str = malloc(l);
   IDRIS2_REFC_VERIFY(tailStr->str, "malloc failed");
   memset(tailStr->str, 0, l);
   memcpy(tailStr->str, s->str + 1, l - 1);
-  return (Value *)tailStr;
+  return (Idris2_Value *)tailStr;
 }
 
-Value *reverse(Value *str) {
-  Value_String *retVal = IDRIS2_NEW_VALUE(Value_String);
+Idris2_Value *reverse(Idris2_Value *str) {
+  Idris2_String *retVal = IDRIS2_NEW_VALUE(Idris2_String);
   retVal->header.tag = STRING_TAG;
-  Value_String *input = (Value_String *)str;
+  Idris2_String *input = (Idris2_String *)str;
   int l = strlen(input->str);
   retVal->str = malloc(l + 1);
   IDRIS2_REFC_VERIFY(retVal->str, "malloc failed");
@@ -29,34 +29,34 @@ Value *reverse(Value *str) {
   for (int i = 0; i < l; i++) {
     *p++ = *q--;
   }
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
-Value *strIndex(Value *str, Value *i) {
-  char *s = ((Value_String *)str)->str;
+Idris2_Value *strIndex(Idris2_Value *str, Idris2_Value *i) {
+  char *s = ((Idris2_String *)str)->str;
   int idx = idris2_vp_to_Int64(i);
-  return (Value *)idris2_mkChar(s[idx]);
+  return (Idris2_Value *)idris2_mkChar(s[idx]);
 }
 
-Value *strCons(Value *c, Value *str) {
-  int l = strlen(((Value_String *)str)->str);
-  Value_String *retVal = idris2_mkEmptyString(l + 2);
+Idris2_Value *strCons(Idris2_Value *c, Idris2_Value *str) {
+  int l = strlen(((Idris2_String *)str)->str);
+  Idris2_String *retVal = idris2_mkEmptyString(l + 2);
   retVal->str[0] = idris2_vp_to_Char(c);
-  memcpy(retVal->str + 1, ((Value_String *)str)->str, l);
-  return (Value *)retVal;
+  memcpy(retVal->str + 1, ((Idris2_String *)str)->str, l);
+  return (Idris2_Value *)retVal;
 }
 
-Value *strAppend(Value *a, Value *b) {
-  int la = strlen(((Value_String *)a)->str);
-  int lb = strlen(((Value_String *)b)->str);
-  Value_String *retVal = idris2_mkEmptyString(la + lb + 1);
-  memcpy(retVal->str, ((Value_String *)a)->str, la);
-  memcpy(retVal->str + la, ((Value_String *)b)->str, lb);
-  return (Value *)retVal;
+Idris2_Value *strAppend(Idris2_Value *a, Idris2_Value *b) {
+  int la = strlen(((Idris2_String *)a)->str);
+  int lb = strlen(((Idris2_String *)b)->str);
+  Idris2_String *retVal = idris2_mkEmptyString(la + lb + 1);
+  memcpy(retVal->str, ((Idris2_String *)a)->str, la);
+  memcpy(retVal->str + la, ((Idris2_String *)b)->str, lb);
+  return (Idris2_Value *)retVal;
 }
 
-Value *strSubstr(Value *start, Value *len, Value *s) {
-  char *input = ((Value_String *)s)->str;
+Idris2_Value *strSubstr(Idris2_Value *start, Idris2_Value *len, Idris2_Value *s) {
+  char *input = ((Idris2_String *)s)->str;
   int offset = idris2_vp_to_Int64(start); /* start and len was come from Nat. */
   int l = idris2_vp_to_Int64(len);
 
@@ -65,67 +65,67 @@ Value *strSubstr(Value *start, Value *len, Value *s) {
     l = tailLen;
   }
 
-  Value_String *retVal = idris2_mkEmptyString(l + 1);
+  Idris2_String *retVal = idris2_mkEmptyString(l + 1);
   memcpy(retVal->str, input + offset, l);
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
-char *fastPack(Value *charList) {
-  Value_Constructor *current;
+char *fastPack(Idris2_Value *charList) {
+  Idris2_Constructor *current;
 
   int l = 0;
-  current = (Value_Constructor *)charList;
+  current = (Idris2_Constructor *)charList;
   while (current != NULL) {
     l++;
-    current = (Value_Constructor *)current->args[1];
+    current = (Idris2_Constructor *)current->args[1];
   }
 
   char *retVal = malloc(l + 1);
   retVal[l] = 0;
 
   int i = 0;
-  current = (Value_Constructor *)charList;
+  current = (Idris2_Constructor *)charList;
   while (current != NULL) {
     retVal[i++] = idris2_vp_to_Char(current->args[0]);
-    current = (Value_Constructor *)current->args[1];
+    current = (Idris2_Constructor *)current->args[1];
   }
 
   return retVal;
 }
 
-Value *fastUnpack(char *str) {
+Idris2_Value *fastUnpack(char *str) {
   if (str[0] == '\0') {
     return NULL;
   }
 
-  Value_Constructor *retVal = idris2_newConstructor(2, 1);
+  Idris2_Constructor *retVal = idris2_newConstructor(2, 1);
   retVal->args[0] = idris2_mkChar(str[0]);
 
   int i = 1;
-  Value_Constructor *current = (Value_Constructor *)retVal;
-  Value_Constructor *next;
+  Idris2_Constructor *current = (Idris2_Constructor *)retVal;
+  Idris2_Constructor *next;
   while (str[i] != '\0') {
     next = idris2_newConstructor(2, 1);
     next->args[0] = idris2_mkChar(str[i]);
-    current->args[1] = (Value *)next;
+    current->args[1] = (Idris2_Value *)next;
 
     i++;
     current = next;
   }
   current->args[1] = NULL;
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }
 
-char *fastConcat(Value *strList) {
-  Value_Constructor *current;
+char *fastConcat(Idris2_Value *strList) {
+  Idris2_Constructor *current;
 
   int totalLength = 0;
-  current = (Value_Constructor *)strList;
+  current = (Idris2_Constructor *)strList;
   while (current != NULL) {
-    totalLength += strlen(((Value_String *)current->args[0])->str);
-    current = (Value_Constructor *)current->args[1];
+    totalLength += strlen(((Idris2_String *)current->args[0])->str);
+    current = (Idris2_Constructor *)current->args[1];
   }
 
   char *retVal = malloc(totalLength + 1);
@@ -134,14 +134,14 @@ char *fastConcat(Value *strList) {
   char *currentStr;
   int currentStrLen;
   int offset = 0;
-  current = (Value_Constructor *)strList;
+  current = (Idris2_Constructor *)strList;
   while (current != NULL) {
-    currentStr = ((Value_String *)current->args[0])->str;
+    currentStr = ((Idris2_String *)current->args[0])->str;
     currentStrLen = strlen(currentStr);
     memcpy(retVal + offset, currentStr, currentStrLen);
 
     offset += currentStrLen;
-    current = (Value_Constructor *)current->args[1];
+    current = (Idris2_Constructor *)current->args[1];
   }
 
   return retVal;
@@ -152,7 +152,7 @@ typedef struct {
   int pos;
 } String_Iterator;
 
-Value *stringIteratorNew(char *str) {
+Idris2_Value *stringIteratorNew(char *str) {
   int l = strlen(str);
 
   String_Iterator *it = (String_Iterator *)malloc(sizeof(String_Iterator));
@@ -161,29 +161,29 @@ Value *stringIteratorNew(char *str) {
   it->pos = 0;
   memcpy(it->str, str, l + 1); // Take a copy of str, in case it gets GCed
 
-  return (Value *)idris2_makeGCPointer(
-      it, (Value_Closure *)idris2_mkClosure(
-              (Value * (*)()) onCollectStringIterator, 2, 0));
+  return (Idris2_Value *)idris2_makeGCPointer(
+      it, (Idris2_Closure *)idris2_mkClosure(
+              (Idris2_Value * (*)()) onCollectStringIterator, 2, 0));
 }
 
-Value *onCollectStringIterator(Value_Pointer *ptr, void *null) {
+Idris2_Value *onCollectStringIterator(Idris2_Pointer *ptr, void *null) {
   String_Iterator *it = (String_Iterator *)ptr->p;
   free(it->str);
   free(it);
   return NULL;
 }
 
-Value *stringIteratorToString(void *a, char *str, Value *it_p,
-                              Value_Closure *f) {
-  String_Iterator *it = ((Value_GCPointer *)it_p)->p->p;
-  Value *strVal = (Value *)idris2_mkString(it->str + it->pos);
-  return idris2_apply_closure(idris2_newReference((Value *)f), strVal);
+Idris2_Value *stringIteratorToString(void *a, char *str, Idris2_Value *it_p,
+                              Idris2_Closure *f) {
+  String_Iterator *it = ((Idris2_GCPointer *)it_p)->p->p;
+  Idris2_Value *strVal = (Idris2_Value *)idris2_mkString(it->str + it->pos);
+  return idris2_apply_closure(idris2_newReference((Idris2_Value *)f), strVal);
 }
 
 // contrib/Data.String.Iterator.uncons :
 //   (str : String) -> (1 it : StringIterator str) -> UnconsResult str
-Value *stringIteratorNext(char *s, Value *it_p) {
-  String_Iterator *it = (String_Iterator *)((Value_GCPointer *)it_p)->p->p;
+Idris2_Value *stringIteratorNext(char *s, Idris2_Value *it_p) {
+  String_Iterator *it = (String_Iterator *)((Idris2_GCPointer *)it_p)->p->p;
   char c = it->str[it->pos];
 
   if (c == '\0')
@@ -192,9 +192,9 @@ Value *stringIteratorNext(char *s, Value *it_p) {
   it->pos++; // Ok to do this as StringIterator linear
 
   // Character [cons]
-  Value_Constructor *retVal = (Value_Constructor *)idris2_newConstructor(2, 1);
+  Idris2_Constructor *retVal = (Idris2_Constructor *)idris2_newConstructor(2, 1);
   retVal->args[0] = idris2_mkChar(c);
   retVal->args[1] = idris2_newReference(it_p);
 
-  return (Value *)retVal;
+  return (Idris2_Value *)retVal;
 }

--- a/support/refc/stringOps.c
+++ b/support/refc/stringOps.c
@@ -55,7 +55,9 @@ Idris2_Value *strAppend(Idris2_Value *a, Idris2_Value *b) {
   return (Idris2_Value *)retVal;
 }
 
-Idris2_Value *strSubstr(Idris2_Value *start, Idris2_Value *len, Idris2_Value *s) {
+Idris2_Value *strSubstr(
+  Idris2_Value *start, Idris2_Value *len, Idris2_Value *s
+) {
   char *input = ((Idris2_String *)s)->str;
   int offset = idris2_vp_to_Int64(start); /* start and len was come from Nat. */
   int l = idris2_vp_to_Int64(len);

--- a/support/refc/stringOps.c
+++ b/support/refc/stringOps.c
@@ -55,9 +55,8 @@ Idris2_Value *strAppend(Idris2_Value *a, Idris2_Value *b) {
   return (Idris2_Value *)retVal;
 }
 
-Idris2_Value *strSubstr(
-  Idris2_Value *start, Idris2_Value *len, Idris2_Value *s
-) {
+Idris2_Value *strSubstr(Idris2_Value *start, Idris2_Value *len,
+                        Idris2_Value *s) {
   char *input = ((Idris2_String *)s)->str;
   int offset = idris2_vp_to_Int64(start); /* start and len was come from Nat. */
   int l = idris2_vp_to_Int64(len);
@@ -176,7 +175,7 @@ Idris2_Value *onCollectStringIterator(Idris2_Pointer *ptr, void *null) {
 }
 
 Idris2_Value *stringIteratorToString(void *a, char *str, Idris2_Value *it_p,
-                              Idris2_Closure *f) {
+                                     Idris2_Closure *f) {
   String_Iterator *it = ((Idris2_GCPointer *)it_p)->p->p;
   Idris2_Value *strVal = (Idris2_Value *)idris2_mkString(it->str + it->pos);
   return idris2_apply_closure(idris2_newReference((Idris2_Value *)f), strVal);
@@ -194,7 +193,8 @@ Idris2_Value *stringIteratorNext(char *s, Idris2_Value *it_p) {
   it->pos++; // Ok to do this as StringIterator linear
 
   // Character [cons]
-  Idris2_Constructor *retVal = (Idris2_Constructor *)idris2_newConstructor(2, 1);
+  Idris2_Constructor *retVal =
+      (Idris2_Constructor *)idris2_newConstructor(2, 1);
   retVal->args[0] = idris2_mkChar(c);
   retVal->args[1] = idris2_newReference(it_p);
 

--- a/support/refc/stringOps.h
+++ b/support/refc/stringOps.h
@@ -12,7 +12,8 @@ Idris2_Value *reverse(Idris2_Value *str);
 Idris2_Value *strIndex(Idris2_Value *str, Idris2_Value *i);
 Idris2_Value *strCons(Idris2_Value *c, Idris2_Value *str);
 Idris2_Value *strAppend(Idris2_Value *a, Idris2_Value *b);
-Idris2_Value *strSubstr(Idris2_Value *s, Idris2_Value *start, Idris2_Value *len);
+Idris2_Value *strSubstr(Idris2_Value *s, Idris2_Value *start,
+                        Idris2_Value *len);
 char *fastPack(Idris2_Value *charList);
 Idris2_Value *fastUnpack(char *str);
 char *fastConcat(Idris2_Value *strList);
@@ -20,5 +21,5 @@ char *fastConcat(Idris2_Value *strList);
 Idris2_Value *stringIteratorNew(char *str);
 Idris2_Value *onCollectStringIterator(Idris2_Pointer *ptr, void *null);
 Idris2_Value *stringIteratorToString(void *a, char *str, Idris2_Value *it_p,
-                              Idris2_Closure *f);
+                                     Idris2_Closure *f);
 Idris2_Value *stringIteratorNext(char *s, Idris2_Value *it_p);

--- a/support/refc/stringOps.h
+++ b/support/refc/stringOps.h
@@ -5,20 +5,20 @@
 
 /* stringLength : String -> Int64!? WTH!. do you have over 4Gbytes text on
  * memory!? */
-#define stringLength(x) (idris2_mkInt64(strlen(((Value_String *)(x))->str)))
+#define stringLength(x) (idris2_mkInt64(strlen(((Idris2_String *)(x))->str)))
 #define head(x) (idris2_cast_String_to_Char(x))
-Value *tail(Value *str);
-Value *reverse(Value *str);
-Value *strIndex(Value *str, Value *i);
-Value *strCons(Value *c, Value *str);
-Value *strAppend(Value *a, Value *b);
-Value *strSubstr(Value *s, Value *start, Value *len);
-char *fastPack(Value *charList);
-Value *fastUnpack(char *str);
-char *fastConcat(Value *strList);
+Idris2_Value *tail(Idris2_Value *str);
+Idris2_Value *reverse(Idris2_Value *str);
+Idris2_Value *strIndex(Idris2_Value *str, Idris2_Value *i);
+Idris2_Value *strCons(Idris2_Value *c, Idris2_Value *str);
+Idris2_Value *strAppend(Idris2_Value *a, Idris2_Value *b);
+Idris2_Value *strSubstr(Idris2_Value *s, Idris2_Value *start, Idris2_Value *len);
+char *fastPack(Idris2_Value *charList);
+Idris2_Value *fastUnpack(char *str);
+char *fastConcat(Idris2_Value *strList);
 
-Value *stringIteratorNew(char *str);
-Value *onCollectStringIterator(Value_Pointer *ptr, void *null);
-Value *stringIteratorToString(void *a, char *str, Value *it_p,
-                              Value_Closure *f);
-Value *stringIteratorNext(char *s, Value *it_p);
+Idris2_Value *stringIteratorNew(char *str);
+Idris2_Value *onCollectStringIterator(Idris2_Pointer *ptr, void *null);
+Idris2_Value *stringIteratorToString(void *a, char *str, Idris2_Value *it_p,
+                              Idris2_Closure *f);
+Idris2_Value *stringIteratorNext(char *s, Idris2_Value *it_p);

--- a/support/refc/threads.c
+++ b/support/refc/threads.c
@@ -1,6 +1,6 @@
 #include "threads.h"
 
-Value *refc_fork(Value_Closure *fct) {
+Idris2_Value *refc_fork(Idris2_Closure *fct) {
   printf("Threads not implemented in the RefC backend!\n");
   exit(0);
 }

--- a/support/refc/threads.h
+++ b/support/refc/threads.h
@@ -1,4 +1,4 @@
 #pragma once
 #include "cBackend.h"
 
-Value *refc_fork(Value_Closure *fct);
+Idris2_Value *refc_fork(Idris2_Closure *fct);

--- a/tests/refc/callingConvention/expected
+++ b/tests/refc/callingConvention/expected
@@ -27,16 +27,16 @@ Value *Main_last
     if (NULL == var_0 /* _builtin.NIL [nil] */) {
         tmp_70 = var_1;
     } else if (NULL != var_0 /* _builtin.CONS [cons] */) {
-        Value *var_2 = ((Value_Constructor*)var_0)->args[0];
-        Value *var_3 = ((Value_Constructor*)var_0)->args[1];
+        Value *var_2 = ((Idris2_Constructor*)var_0)->args[0];
+        Value *var_3 = ((Idris2_Constructor*)var_0)->args[1];
         idris2_newReference(var_2);
         idris2_newReference(var_3);
         idris2_removeReference(var_0);
         idris2_removeReference(var_1);
         Value *closure_71 = (Value *)idris2_mkClosure((Value *(*)())Main_last, 2, 2);
                                                              // Main:10:20--10:24
-        ((Value_Closure*)closure_71)->args[0] = var_3;
-        ((Value_Closure*)closure_71)->args[1] = var_2;
+        ((Idris2_Closure*)closure_71)->args[0] = var_3;
+        ((Idris2_Closure*)closure_71)->args[1] = var_2;
         tmp_70 = closure_71;
     }
     return tmp_70;
@@ -149,7 +149,7 @@ Value *Main_main
     Value * var_9 = idris2_trampoline(Prelude_Types_List_mapAppend(var_5, var_6, var_7));
                                                              // Main:15:11--15:13
      // constructor _builtin.CONS                            // Main:15:11--15:13
-    Value_Constructor* constructor_45 = idris2_newConstructor(2, 1);
+    Idris2_Constructor* constructor_45 = idris2_newConstructor(2, 1);
                                                              // Main:15:11--15:13
     constructor_45->args[0] = var_8;
     constructor_45->args[1] = var_9;
@@ -170,8 +170,8 @@ Value *Main_main
     Value * var_18 = primVar_47;                             // Prelude.IO:98:22--98:34
     Value *closure_48 = (Value *)idris2_mkClosure((Value *(*)())Prelude_IO_prim__putStr, 2, 2);
                                                              // Prelude.IO:98:22--98:34
-    ((Value_Closure*)closure_48)->args[0] = var_18;
-    ((Value_Closure*)closure_48)->args[1] = var_0;
+    ((Idris2_Closure*)closure_48)->args[0] = var_18;
+    ((Idris2_Closure*)closure_48)->args[1] = var_0;
     return closure_48;
 }
 Value *Main_main_11
@@ -183,9 +183,9 @@ Value *Main_main_11
     Value * var_2 = idris2_getPredefinedInteger(1);          // Prelude.Types:1121:1--1138:48
     Value *closure_49 = (Value *)idris2_mkClosure((Value *(*)())Prelude_Types_rangeFromTo_Range__dollara, 3, 3);
                                                              // Prelude.Types:1121:1--1138:48
-    ((Value_Closure*)closure_49)->args[0] = var_1;
-    ((Value_Closure*)closure_49)->args[1] = var_2;
-    ((Value_Closure*)closure_49)->args[2] = var_0;
+    ((Idris2_Closure*)closure_49)->args[0] = var_1;
+    ((Idris2_Closure*)closure_49)->args[1] = var_2;
+    ((Idris2_Closure*)closure_49)->args[2] = var_0;
     return closure_49;
 }
 Value *Main_main_10
@@ -205,8 +205,8 @@ Value *Main_main_10
     Value * var_6 = primVar_50;                              // Prelude.IO:98:22--98:34
     Value *closure_51 = (Value *)idris2_mkClosure((Value *(*)())Prelude_IO_prim__putStr, 2, 2);
                                                              // Prelude.IO:98:22--98:34
-    ((Value_Closure*)closure_51)->args[0] = var_6;
-    ((Value_Closure*)closure_51)->args[1] = var_0;
+    ((Idris2_Closure*)closure_51)->args[0] = var_6;
+    ((Idris2_Closure*)closure_51)->args[1] = var_0;
     return closure_51;
 }
 Value *Main_main_9
@@ -222,7 +222,7 @@ Value *Main_main_9
     Value *closure_54 = (Value *)idris2_mkClosure((Value *(*)())Main_main_2, 5, 0);
     Value * var_4 = closure_54;                              // Prelude.IO:19:1--26:30
      // constructor Prelude.Interfaces.MkApplicative         // Prelude.IO:19:1--26:30
-    Value_Constructor* constructor_55 = idris2_newConstructor(3, 0);
+    Idris2_Constructor* constructor_55 = idris2_newConstructor(3, 0);
                                                              // Prelude.IO:19:1--26:30
     constructor_55->args[0] = var_2;
     constructor_55->args[1] = var_3;
@@ -241,7 +241,7 @@ Value *Main_main_9
     Value *closure_61 = (Value *)idris2_mkClosure((Value *(*)())Main_main_8, 5, 0);
     Value * var_10 = closure_61;                             // Prelude.Types:656:1--669:59
      // constructor Prelude.Interfaces.MkFoldable            // Prelude.Types:656:1--669:59
-    Value_Constructor* constructor_62 = idris2_newConstructor(6, 0);
+    Idris2_Constructor* constructor_62 = idris2_newConstructor(6, 0);
                                                              // Prelude.Types:656:1--669:59
     constructor_62->args[0] = var_5;
     constructor_62->args[1] = var_6;
@@ -252,10 +252,10 @@ Value *Main_main_9
     Value * var_12 = (Value*)constructor_62;                 // Main:14:8--14:12
     Value *closure_63 = (Value *)idris2_mkClosure((Value *(*)())Prelude_Interfaces_for_, 4, 4);
                                                              // Main:14:8--14:12
-    ((Value_Closure*)closure_63)->args[0] = var_11;
-    ((Value_Closure*)closure_63)->args[1] = var_12;
-    ((Value_Closure*)closure_63)->args[2] = var_1;
-    ((Value_Closure*)closure_63)->args[3] = var_0;
+    ((Idris2_Closure*)closure_63)->args[0] = var_11;
+    ((Idris2_Closure*)closure_63)->args[1] = var_12;
+    ((Idris2_Closure*)closure_63)->args[2] = var_1;
+    ((Idris2_Closure*)closure_63)->args[3] = var_0;
     return closure_63;
 }
 Value *Main_main_8
@@ -271,9 +271,9 @@ Value *Main_main_8
     idris2_removeReference(var_4);
     Value *closure_64 = (Value *)idris2_mkClosure((Value *(*)())Prelude_Types_foldMap_Foldable_List, 3, 3);
                                                              // Prelude.Types:656:1--669:59
-    ((Value_Closure*)closure_64)->args[0] = var_2;
-    ((Value_Closure*)closure_64)->args[1] = var_1;
-    ((Value_Closure*)closure_64)->args[2] = var_0;
+    ((Idris2_Closure*)closure_64)->args[0] = var_2;
+    ((Idris2_Closure*)closure_64)->args[1] = var_1;
+    ((Idris2_Closure*)closure_64)->args[2] = var_0;
     return closure_64;
 }
 Value *Main_main_7
@@ -301,10 +301,10 @@ Value *Main_main_6
     idris2_removeReference(var_6);
     Value *closure_65 = (Value *)idris2_mkClosure((Value *(*)())Prelude_Types_foldlM_Foldable_List, 4, 4);
                                                              // Prelude.Types:656:1--669:59
-    ((Value_Closure*)closure_65)->args[0] = var_3;
-    ((Value_Closure*)closure_65)->args[1] = var_2;
-    ((Value_Closure*)closure_65)->args[2] = var_1;
-    ((Value_Closure*)closure_65)->args[3] = var_0;
+    ((Idris2_Closure*)closure_65)->args[0] = var_3;
+    ((Idris2_Closure*)closure_65)->args[1] = var_2;
+    ((Idris2_Closure*)closure_65)->args[2] = var_1;
+    ((Idris2_Closure*)closure_65)->args[3] = var_0;
     return closure_65;
 }
 Value *Main_main_5
@@ -316,7 +316,7 @@ Value *Main_main_5
     idris2_removeReference(var_1);
     Value *closure_66 = (Value *)idris2_mkClosure((Value *(*)())Prelude_Types_null_Foldable_List, 1, 1);
                                                              // Prelude.Types:656:1--669:59
-    ((Value_Closure*)closure_66)->args[0] = var_0;
+    ((Idris2_Closure*)closure_66)->args[0] = var_0;
     return closure_66;
 }
 Value *Main_main_4
@@ -332,9 +332,9 @@ Value *Main_main_4
     idris2_removeReference(var_4);
     Value *closure_67 = (Value *)idris2_mkClosure((Value *(*)())Prelude_Types_foldl_Foldable_List, 3, 3);
                                                              // Prelude.Types:656:1--669:59
-    ((Value_Closure*)closure_67)->args[0] = var_2;
-    ((Value_Closure*)closure_67)->args[1] = var_1;
-    ((Value_Closure*)closure_67)->args[2] = var_0;
+    ((Idris2_Closure*)closure_67)->args[0] = var_2;
+    ((Idris2_Closure*)closure_67)->args[1] = var_1;
+    ((Idris2_Closure*)closure_67)->args[2] = var_0;
     return closure_67;
 }
 Value *Main_main_3
@@ -350,9 +350,9 @@ Value *Main_main_3
     idris2_removeReference(var_4);
     Value *closure_68 = (Value *)idris2_mkClosure((Value *(*)())Prelude_Types_foldr_Foldable_List, 3, 3);
                                                              // Prelude.Types:656:1--669:59
-    ((Value_Closure*)closure_68)->args[0] = var_2;
-    ((Value_Closure*)closure_68)->args[1] = var_1;
-    ((Value_Closure*)closure_68)->args[2] = var_0;
+    ((Idris2_Closure*)closure_68)->args[0] = var_2;
+    ((Idris2_Closure*)closure_68)->args[1] = var_1;
+    ((Idris2_Closure*)closure_68)->args[2] = var_0;
     return closure_68;
 }
 Value *Main_main_2
@@ -395,8 +395,8 @@ Value *Main_main_0
     idris2_removeReference(var_4);
     Value *closure_69 = (Value *)idris2_mkClosure((Value *(*)())Prelude_IO_map_Functor_IO, 3, 3);
                                                              // Prelude.IO:15:1--17:38
-    ((Value_Closure*)closure_69)->args[0] = var_2;
-    ((Value_Closure*)closure_69)->args[1] = var_1;
-    ((Value_Closure*)closure_69)->args[2] = var_0;
+    ((Idris2_Closure*)closure_69)->args[0] = var_2;
+    ((Idris2_Closure*)closure_69)->args[1] = var_1;
+    ((Idris2_Closure*)closure_69)->args[2] = var_0;
     return closure_69;
 }

--- a/tests/refc/callingConvention/expected
+++ b/tests/refc/callingConvention/expected
@@ -1,39 +1,39 @@
-Value *Main_dupargs
+Idris2_Value *Main_dupargs
 (
-    Value * var_0
+    Idris2_Value * var_0
 );
-Value *Main_dupargs
+Idris2_Value *Main_dupargs
 (
-    Value * var_0
+    Idris2_Value * var_0
 )
 {
-    Value *primVar_72 = idris2_add_Integer(var_0, idris2_newReference(var_0));
+    Idris2_Value *primVar_72 = idris2_add_Integer(var_0, idris2_newReference(var_0));
     idris2_removeReference(var_0);
     idris2_removeReference(var_0);
     return primVar_72;
 }
-Value *Main_last
+Idris2_Value *Main_last
 (
-    Value * var_0
-,   Value * var_1
+    Idris2_Value * var_0
+,   Idris2_Value * var_1
 );
-Value *Main_last
+Idris2_Value *Main_last
 (
-    Value * var_0
-,   Value * var_1
+    Idris2_Value * var_0
+,   Idris2_Value * var_1
 )
 {
-    Value * tmp_70 = NULL;                                   // Main:8:8--8:14
+    Idris2_Value * tmp_70 = NULL;                            // Main:8:8--8:14
     if (NULL == var_0 /* _builtin.NIL [nil] */) {
         tmp_70 = var_1;
     } else if (NULL != var_0 /* _builtin.CONS [cons] */) {
-        Value *var_2 = ((Idris2_Constructor*)var_0)->args[0];
-        Value *var_3 = ((Idris2_Constructor*)var_0)->args[1];
+        Idris2_Value *var_2 = ((Idris2_Constructor*)var_0)->args[0];
+        Idris2_Value *var_3 = ((Idris2_Constructor*)var_0)->args[1];
         idris2_newReference(var_2);
         idris2_newReference(var_3);
         idris2_removeReference(var_0);
         idris2_removeReference(var_1);
-        Value *closure_71 = (Value *)idris2_mkClosure((Value *(*)())Main_last, 2, 2);
+        Idris2_Value *closure_71 = (Idris2_Value *)idris2_mkClosure((Idris2_Value *(*)())Main_last, 2, 2);
                                                              // Main:10:20--10:24
         ((Idris2_Closure*)closure_71)->args[0] = var_3;
         ((Idris2_Closure*)closure_71)->args[1] = var_2;
@@ -41,205 +41,205 @@ Value *Main_last
     }
     return tmp_70;
 }
-Value *Main_main_0
+Idris2_Value *Main_main_0
 (
-    Value * var_4
-,   Value * var_3
-,   Value * var_2
-,   Value * var_1
-,   Value * var_0
+    Idris2_Value * var_4
+,   Idris2_Value * var_3
+,   Idris2_Value * var_2
+,   Idris2_Value * var_1
+,   Idris2_Value * var_0
 );
-Value *Main_main_1
+Idris2_Value *Main_main_1
 (
-    Value * var_2
-,   Value * var_1
-,   Value * var_0
+    Idris2_Value * var_2
+,   Idris2_Value * var_1
+,   Idris2_Value * var_0
 );
-Value *Main_main_2
+Idris2_Value *Main_main_2
 (
-    Value * var_4
-,   Value * var_3
-,   Value * var_2
-,   Value * var_1
-,   Value * var_0
+    Idris2_Value * var_4
+,   Idris2_Value * var_3
+,   Idris2_Value * var_2
+,   Idris2_Value * var_1
+,   Idris2_Value * var_0
 );
-Value *Main_main_3
+Idris2_Value *Main_main_3
 (
-    Value * var_4
-,   Value * var_3
-,   Value * var_2
-,   Value * var_1
-,   Value * var_0
+    Idris2_Value * var_4
+,   Idris2_Value * var_3
+,   Idris2_Value * var_2
+,   Idris2_Value * var_1
+,   Idris2_Value * var_0
 );
-Value *Main_main_4
+Idris2_Value *Main_main_4
 (
-    Value * var_4
-,   Value * var_3
-,   Value * var_2
-,   Value * var_1
-,   Value * var_0
+    Idris2_Value * var_4
+,   Idris2_Value * var_3
+,   Idris2_Value * var_2
+,   Idris2_Value * var_1
+,   Idris2_Value * var_0
 );
-Value *Main_main_5
+Idris2_Value *Main_main_5
 (
-    Value * var_1
-,   Value * var_0
+    Idris2_Value * var_1
+,   Idris2_Value * var_0
 );
-Value *Main_main_6
+Idris2_Value *Main_main_6
 (
-    Value * var_6
-,   Value * var_5
-,   Value * var_4
-,   Value * var_3
-,   Value * var_2
-,   Value * var_1
-,   Value * var_0
+    Idris2_Value * var_6
+,   Idris2_Value * var_5
+,   Idris2_Value * var_4
+,   Idris2_Value * var_3
+,   Idris2_Value * var_2
+,   Idris2_Value * var_1
+,   Idris2_Value * var_0
 );
-Value *Main_main_7
+Idris2_Value *Main_main_7
 (
-    Value * var_1
-,   Value * var_0
+    Idris2_Value * var_1
+,   Idris2_Value * var_0
 );
-Value *Main_main_8
+Idris2_Value *Main_main_8
 (
-    Value * var_4
-,   Value * var_3
-,   Value * var_2
-,   Value * var_1
-,   Value * var_0
+    Idris2_Value * var_4
+,   Idris2_Value * var_3
+,   Idris2_Value * var_2
+,   Idris2_Value * var_1
+,   Idris2_Value * var_0
 );
-Value *Main_main_9
+Idris2_Value *Main_main_9
 (
-    Value * var_1
-,   Value * var_0
+    Idris2_Value * var_1
+,   Idris2_Value * var_0
 );
-Value *Main_main_10
+Idris2_Value *Main_main_10
 (
-    Value * var_1
-,   Value * var_0
+    Idris2_Value * var_1
+,   Idris2_Value * var_0
 );
-Value *Main_main_11
+Idris2_Value *Main_main_11
 (
-    Value * var_0
+    Idris2_Value * var_0
 );
-Value *Main_main
+Idris2_Value *Main_main
 (
-    Value * var_0
+    Idris2_Value * var_0
 );
-Value *Main_main
+Idris2_Value *Main_main
 (
-    Value * var_0
+    Idris2_Value * var_0
 )
 {
-    Value *closure_42 = (Value *)idris2_mkClosure((Value *(*)())Main_main_9, 2, 0);
+    Idris2_Value *closure_42 = (Idris2_Value *)idris2_mkClosure((Idris2_Value *(*)())Main_main_9, 2, 0);
                                                              // Main:14:8--14:12
-    Value * var_10 = closure_42;                             // Main:14:3--14:7
-    Value *closure_43 = (Value *)idris2_mkClosure((Value *(*)())Main_main_10, 2, 0);
+    Idris2_Value * var_10 = closure_42;                      // Main:14:3--14:7
+    Idris2_Value *closure_43 = (Idris2_Value *)idris2_mkClosure((Idris2_Value *(*)())Main_main_10, 2, 0);
                                                              // Main:14:22--14:23
-    Value * var_11 = closure_43;                             // Main:14:3--14:7
-    Value * var_8 = (NULL /* _builtin.NIL */);               // Main:15:11--15:13
-    Value * var_5 = (NULL /* _builtin.NIL */);               // Prelude.Types:605:11--605:20
-    Value *closure_44 = (Value *)idris2_mkClosure((Value *(*)())Main_main_11, 1, 0);
+    Idris2_Value * var_11 = closure_43;                      // Main:14:3--14:7
+    Idris2_Value * var_8 = (NULL /* _builtin.NIL */);        // Main:15:11--15:13
+    Idris2_Value * var_5 = (NULL /* _builtin.NIL */);        // Prelude.Types:605:11--605:20
+    Idris2_Value *closure_44 = (Idris2_Value *)idris2_mkClosure((Idris2_Value *(*)())Main_main_11, 1, 0);
                                                              // Main:15:21--15:22
-    Value * var_6 = closure_44;                              // Prelude.Types:605:11--605:20
-    Value * var_2 = idris2_trampoline(csegen_44());          // Prelude.Types:1121:1--1138:48
-    Value * var_3 = idris2_getPredefinedInteger(1);          // Prelude.Types:1121:1--1138:48
-    Value * var_4 = idris2_getPredefinedInteger(5);          // Prelude.Types:1121:1--1138:48
-    Value * var_7 = idris2_trampoline(Prelude_Types_rangeFromTo_Range__dollara(var_2, var_3, var_4));
+    Idris2_Value * var_6 = closure_44;                       // Prelude.Types:605:11--605:20
+    Idris2_Value * var_2 = idris2_trampoline(csegen_44());   // Prelude.Types:1121:1--1138:48
+    Idris2_Value * var_3 = idris2_getPredefinedInteger(1);   // Prelude.Types:1121:1--1138:48
+    Idris2_Value * var_4 = idris2_getPredefinedInteger(5);   // Prelude.Types:1121:1--1138:48
+    Idris2_Value * var_7 = idris2_trampoline(Prelude_Types_rangeFromTo_Range__dollara(var_2, var_3, var_4));
                                                              // Prelude.Types:605:11--605:20
-    Value * var_9 = idris2_trampoline(Prelude_Types_List_mapAppend(var_5, var_6, var_7));
+    Idris2_Value * var_9 = idris2_trampoline(Prelude_Types_List_mapAppend(var_5, var_6, var_7));
                                                              // Main:15:11--15:13
      // constructor _builtin.CONS                            // Main:15:11--15:13
     Idris2_Constructor* constructor_45 = idris2_newConstructor(2, 1);
                                                              // Main:15:11--15:13
     constructor_45->args[0] = var_8;
     constructor_45->args[1] = var_9;
-    Value * var_12 = (Value*)constructor_45;                 // Main:14:3--14:7
-    Value * var_13 = idris2_trampoline(Prelude_Basics_flip(var_10, var_11, var_12));
+    Idris2_Value * var_12 = (Idris2_Value*)constructor_45;   // Main:14:3--14:7
+    Idris2_Value * var_13 = idris2_trampoline(Prelude_Basics_flip(var_10, var_11, var_12));
                                                              // Main:14:3--14:7
-    Value * var_1 = idris2_apply_closure(var_13, idris2_newReference(var_0));
+    Idris2_Value * var_1 = idris2_apply_closure(var_13, idris2_newReference(var_0));
                                                              // Prelude.IO:31:13--31:20
     idris2_removeReference(var_1);                           // Prelude.IO:31:13--31:20
-    Value * var_14 = idris2_mkIntegerLiteral("9999");        // Main:16:13--16:20
-    Value * var_15 = idris2_trampoline(Main_dupargs(var_14));
+    Idris2_Value * var_14 = idris2_mkIntegerLiteral("9999"); // Main:16:13--16:20
+    Idris2_Value * var_15 = idris2_trampoline(Main_dupargs(var_14));
                                                              // Prelude.Show:110:1--112:50
-    Value * var_16 = idris2_trampoline(Prelude_Show_show_Show_Integer(var_15));
-    Value * var_17 = ((Value*)&idris2_constant_String_46);
-    Value *primVar_47 = strAppend(var_16, var_17);
+    Idris2_Value * var_16 = idris2_trampoline(Prelude_Show_show_Show_Integer(var_15));
+    Idris2_Value * var_17 = ((Idris2_Value*)&idris2_constant_String_46);
+    Idris2_Value *primVar_47 = strAppend(var_16, var_17);
     idris2_removeReference(var_16);
     idris2_removeReference(var_17);
-    Value * var_18 = primVar_47;                             // Prelude.IO:98:22--98:34
-    Value *closure_48 = (Value *)idris2_mkClosure((Value *(*)())Prelude_IO_prim__putStr, 2, 2);
+    Idris2_Value * var_18 = primVar_47;                      // Prelude.IO:98:22--98:34
+    Idris2_Value *closure_48 = (Idris2_Value *)idris2_mkClosure((Idris2_Value *(*)())Prelude_IO_prim__putStr, 2, 2);
                                                              // Prelude.IO:98:22--98:34
     ((Idris2_Closure*)closure_48)->args[0] = var_18;
     ((Idris2_Closure*)closure_48)->args[1] = var_0;
     return closure_48;
 }
-Value *Main_main_11
+Idris2_Value *Main_main_11
 (
-    Value * var_0
+    Idris2_Value * var_0
 )
 {
-    Value * var_1 = idris2_trampoline(csegen_44());          // Prelude.Types:1121:1--1138:48
-    Value * var_2 = idris2_getPredefinedInteger(1);          // Prelude.Types:1121:1--1138:48
-    Value *closure_49 = (Value *)idris2_mkClosure((Value *(*)())Prelude_Types_rangeFromTo_Range__dollara, 3, 3);
+    Idris2_Value * var_1 = idris2_trampoline(csegen_44());   // Prelude.Types:1121:1--1138:48
+    Idris2_Value * var_2 = idris2_getPredefinedInteger(1);   // Prelude.Types:1121:1--1138:48
+    Idris2_Value *closure_49 = (Idris2_Value *)idris2_mkClosure((Idris2_Value *(*)())Prelude_Types_rangeFromTo_Range__dollara, 3, 3);
                                                              // Prelude.Types:1121:1--1138:48
     ((Idris2_Closure*)closure_49)->args[0] = var_1;
     ((Idris2_Closure*)closure_49)->args[1] = var_2;
     ((Idris2_Closure*)closure_49)->args[2] = var_0;
     return closure_49;
 }
-Value *Main_main_10
+Idris2_Value *Main_main_10
 (
-    Value * var_1
-,   Value * var_0
+    Idris2_Value * var_1
+,   Idris2_Value * var_0
 )
 {
-    Value * var_2 = idris2_getPredefinedInteger(0);          // Main:14:25--14:31
-    Value * var_3 = idris2_trampoline(Main_last(var_1, var_2));
+    Idris2_Value * var_2 = idris2_getPredefinedInteger(0);   // Main:14:25--14:31
+    Idris2_Value * var_3 = idris2_trampoline(Main_last(var_1, var_2));
                                                              // Prelude.Show:110:1--112:50
-    Value * var_4 = idris2_trampoline(Prelude_Show_show_Show_Integer(var_3));
-    Value * var_5 = ((Value*)&idris2_constant_String_46);
-    Value *primVar_50 = strAppend(var_4, var_5);
+    Idris2_Value * var_4 = idris2_trampoline(Prelude_Show_show_Show_Integer(var_3));
+    Idris2_Value * var_5 = ((Idris2_Value*)&idris2_constant_String_46);
+    Idris2_Value *primVar_50 = strAppend(var_4, var_5);
     idris2_removeReference(var_4);
     idris2_removeReference(var_5);
-    Value * var_6 = primVar_50;                              // Prelude.IO:98:22--98:34
-    Value *closure_51 = (Value *)idris2_mkClosure((Value *(*)())Prelude_IO_prim__putStr, 2, 2);
+    Idris2_Value * var_6 = primVar_50;                       // Prelude.IO:98:22--98:34
+    Idris2_Value *closure_51 = (Idris2_Value *)idris2_mkClosure((Idris2_Value *(*)())Prelude_IO_prim__putStr, 2, 2);
                                                              // Prelude.IO:98:22--98:34
     ((Idris2_Closure*)closure_51)->args[0] = var_6;
     ((Idris2_Closure*)closure_51)->args[1] = var_0;
     return closure_51;
 }
-Value *Main_main_9
+Idris2_Value *Main_main_9
 (
-    Value * var_1
-,   Value * var_0
+    Idris2_Value * var_1
+,   Idris2_Value * var_0
 )
 {
-    Value *closure_52 = (Value *)idris2_mkClosure((Value *(*)())Main_main_0, 5, 0);
-    Value * var_2 = closure_52;                              // Prelude.IO:19:1--26:30
-    Value *closure_53 = (Value *)idris2_mkClosure((Value *(*)())Main_main_1, 3, 0);
-    Value * var_3 = closure_53;                              // Prelude.IO:19:1--26:30
-    Value *closure_54 = (Value *)idris2_mkClosure((Value *(*)())Main_main_2, 5, 0);
-    Value * var_4 = closure_54;                              // Prelude.IO:19:1--26:30
+    Idris2_Value *closure_52 = (Idris2_Value *)idris2_mkClosure((Idris2_Value *(*)())Main_main_0, 5, 0);
+    Idris2_Value * var_2 = closure_52;                       // Prelude.IO:19:1--26:30
+    Idris2_Value *closure_53 = (Idris2_Value *)idris2_mkClosure((Idris2_Value *(*)())Main_main_1, 3, 0);
+    Idris2_Value * var_3 = closure_53;                       // Prelude.IO:19:1--26:30
+    Idris2_Value *closure_54 = (Idris2_Value *)idris2_mkClosure((Idris2_Value *(*)())Main_main_2, 5, 0);
+    Idris2_Value * var_4 = closure_54;                       // Prelude.IO:19:1--26:30
      // constructor Prelude.Interfaces.MkApplicative         // Prelude.IO:19:1--26:30
     Idris2_Constructor* constructor_55 = idris2_newConstructor(3, 0);
                                                              // Prelude.IO:19:1--26:30
     constructor_55->args[0] = var_2;
     constructor_55->args[1] = var_3;
     constructor_55->args[2] = var_4;
-    Value * var_11 = (Value*)constructor_55;                 // Main:14:8--14:12
-    Value *closure_56 = (Value *)idris2_mkClosure((Value *(*)())Main_main_3, 5, 0);
-    Value * var_5 = closure_56;                              // Prelude.Types:656:1--669:59
-    Value *closure_57 = (Value *)idris2_mkClosure((Value *(*)())Main_main_4, 5, 0);
-    Value * var_6 = closure_57;                              // Prelude.Types:656:1--669:59
-    Value *closure_58 = (Value *)idris2_mkClosure((Value *(*)())Main_main_5, 2, 0);
-    Value * var_7 = closure_58;                              // Prelude.Types:656:1--669:59
-    Value *closure_59 = (Value *)idris2_mkClosure((Value *(*)())Main_main_6, 7, 0);
-    Value * var_8 = closure_59;                              // Prelude.Types:656:1--669:59
-    Value *closure_60 = (Value *)idris2_mkClosure((Value *(*)())Main_main_7, 2, 0);
-    Value * var_9 = closure_60;                              // Prelude.Types:656:1--669:59
-    Value *closure_61 = (Value *)idris2_mkClosure((Value *(*)())Main_main_8, 5, 0);
-    Value * var_10 = closure_61;                             // Prelude.Types:656:1--669:59
+    Idris2_Value * var_11 = (Idris2_Value*)constructor_55;   // Main:14:8--14:12
+    Idris2_Value *closure_56 = (Idris2_Value *)idris2_mkClosure((Idris2_Value *(*)())Main_main_3, 5, 0);
+    Idris2_Value * var_5 = closure_56;                       // Prelude.Types:656:1--669:59
+    Idris2_Value *closure_57 = (Idris2_Value *)idris2_mkClosure((Idris2_Value *(*)())Main_main_4, 5, 0);
+    Idris2_Value * var_6 = closure_57;                       // Prelude.Types:656:1--669:59
+    Idris2_Value *closure_58 = (Idris2_Value *)idris2_mkClosure((Idris2_Value *(*)())Main_main_5, 2, 0);
+    Idris2_Value * var_7 = closure_58;                       // Prelude.Types:656:1--669:59
+    Idris2_Value *closure_59 = (Idris2_Value *)idris2_mkClosure((Idris2_Value *(*)())Main_main_6, 7, 0);
+    Idris2_Value * var_8 = closure_59;                       // Prelude.Types:656:1--669:59
+    Idris2_Value *closure_60 = (Idris2_Value *)idris2_mkClosure((Idris2_Value *(*)())Main_main_7, 2, 0);
+    Idris2_Value * var_9 = closure_60;                       // Prelude.Types:656:1--669:59
+    Idris2_Value *closure_61 = (Idris2_Value *)idris2_mkClosure((Idris2_Value *(*)())Main_main_8, 5, 0);
+    Idris2_Value * var_10 = closure_61;                      // Prelude.Types:656:1--669:59
      // constructor Prelude.Interfaces.MkFoldable            // Prelude.Types:656:1--669:59
     Idris2_Constructor* constructor_62 = idris2_newConstructor(6, 0);
                                                              // Prelude.Types:656:1--669:59
@@ -249,8 +249,8 @@ Value *Main_main_9
     constructor_62->args[3] = var_8;
     constructor_62->args[4] = var_9;
     constructor_62->args[5] = var_10;
-    Value * var_12 = (Value*)constructor_62;                 // Main:14:8--14:12
-    Value *closure_63 = (Value *)idris2_mkClosure((Value *(*)())Prelude_Interfaces_for_, 4, 4);
+    Idris2_Value * var_12 = (Idris2_Value*)constructor_62;   // Main:14:8--14:12
+    Idris2_Value *closure_63 = (Idris2_Value *)idris2_mkClosure((Idris2_Value *(*)())Prelude_Interfaces_for_, 4, 4);
                                                              // Main:14:8--14:12
     ((Idris2_Closure*)closure_63)->args[0] = var_11;
     ((Idris2_Closure*)closure_63)->args[1] = var_12;
@@ -258,48 +258,48 @@ Value *Main_main_9
     ((Idris2_Closure*)closure_63)->args[3] = var_0;
     return closure_63;
 }
-Value *Main_main_8
+Idris2_Value *Main_main_8
 (
-    Value * var_4
-,   Value * var_3
-,   Value * var_2
-,   Value * var_1
-,   Value * var_0
+    Idris2_Value * var_4
+,   Idris2_Value * var_3
+,   Idris2_Value * var_2
+,   Idris2_Value * var_1
+,   Idris2_Value * var_0
 )
 {
     idris2_removeReference(var_3);
     idris2_removeReference(var_4);
-    Value *closure_64 = (Value *)idris2_mkClosure((Value *(*)())Prelude_Types_foldMap_Foldable_List, 3, 3);
+    Idris2_Value *closure_64 = (Idris2_Value *)idris2_mkClosure((Idris2_Value *(*)())Prelude_Types_foldMap_Foldable_List, 3, 3);
                                                              // Prelude.Types:656:1--669:59
     ((Idris2_Closure*)closure_64)->args[0] = var_2;
     ((Idris2_Closure*)closure_64)->args[1] = var_1;
     ((Idris2_Closure*)closure_64)->args[2] = var_0;
     return closure_64;
 }
-Value *Main_main_7
+Idris2_Value *Main_main_7
 (
-    Value * var_1
-,   Value * var_0
+    Idris2_Value * var_1
+,   Idris2_Value * var_0
 )
 {
     idris2_removeReference(var_1);
     return var_0;
 }
-Value *Main_main_6
+Idris2_Value *Main_main_6
 (
-    Value * var_6
-,   Value * var_5
-,   Value * var_4
-,   Value * var_3
-,   Value * var_2
-,   Value * var_1
-,   Value * var_0
+    Idris2_Value * var_6
+,   Idris2_Value * var_5
+,   Idris2_Value * var_4
+,   Idris2_Value * var_3
+,   Idris2_Value * var_2
+,   Idris2_Value * var_1
+,   Idris2_Value * var_0
 )
 {
     idris2_removeReference(var_4);
     idris2_removeReference(var_5);
     idris2_removeReference(var_6);
-    Value *closure_65 = (Value *)idris2_mkClosure((Value *(*)())Prelude_Types_foldlM_Foldable_List, 4, 4);
+    Idris2_Value *closure_65 = (Idris2_Value *)idris2_mkClosure((Idris2_Value *(*)())Prelude_Types_foldlM_Foldable_List, 4, 4);
                                                              // Prelude.Types:656:1--669:59
     ((Idris2_Closure*)closure_65)->args[0] = var_3;
     ((Idris2_Closure*)closure_65)->args[1] = var_2;
@@ -307,93 +307,94 @@ Value *Main_main_6
     ((Idris2_Closure*)closure_65)->args[3] = var_0;
     return closure_65;
 }
-Value *Main_main_5
+Idris2_Value *Main_main_5
 (
-    Value * var_1
-,   Value * var_0
+    Idris2_Value * var_1
+,   Idris2_Value * var_0
 )
 {
     idris2_removeReference(var_1);
-    Value *closure_66 = (Value *)idris2_mkClosure((Value *(*)())Prelude_Types_null_Foldable_List, 1, 1);
+    Idris2_Value *closure_66 = (Idris2_Value *)idris2_mkClosure((Idris2_Value *(*)())Prelude_Types_null_Foldable_List, 1, 1);
                                                              // Prelude.Types:656:1--669:59
     ((Idris2_Closure*)closure_66)->args[0] = var_0;
     return closure_66;
 }
-Value *Main_main_4
+Idris2_Value *Main_main_4
 (
-    Value * var_4
-,   Value * var_3
-,   Value * var_2
-,   Value * var_1
-,   Value * var_0
+    Idris2_Value * var_4
+,   Idris2_Value * var_3
+,   Idris2_Value * var_2
+,   Idris2_Value * var_1
+,   Idris2_Value * var_0
 )
 {
     idris2_removeReference(var_3);
     idris2_removeReference(var_4);
-    Value *closure_67 = (Value *)idris2_mkClosure((Value *(*)())Prelude_Types_foldl_Foldable_List, 3, 3);
+    Idris2_Value *closure_67 = (Idris2_Value *)idris2_mkClosure((Idris2_Value *(*)())Prelude_Types_foldl_Foldable_List, 3, 3);
                                                              // Prelude.Types:656:1--669:59
     ((Idris2_Closure*)closure_67)->args[0] = var_2;
     ((Idris2_Closure*)closure_67)->args[1] = var_1;
     ((Idris2_Closure*)closure_67)->args[2] = var_0;
     return closure_67;
 }
-Value *Main_main_3
+Idris2_Value *Main_main_3
 (
-    Value * var_4
-,   Value * var_3
-,   Value * var_2
-,   Value * var_1
-,   Value * var_0
+    Idris2_Value * var_4
+,   Idris2_Value * var_3
+,   Idris2_Value * var_2
+,   Idris2_Value * var_1
+,   Idris2_Value * var_0
 )
 {
     idris2_removeReference(var_3);
     idris2_removeReference(var_4);
-    Value *closure_68 = (Value *)idris2_mkClosure((Value *(*)())Prelude_Types_foldr_Foldable_List, 3, 3);
+    Idris2_Value *closure_68 = (Idris2_Value *)idris2_mkClosure((Idris2_Value *(*)())Prelude_Types_foldr_Foldable_List, 3, 3);
                                                              // Prelude.Types:656:1--669:59
     ((Idris2_Closure*)closure_68)->args[0] = var_2;
     ((Idris2_Closure*)closure_68)->args[1] = var_1;
     ((Idris2_Closure*)closure_68)->args[2] = var_0;
     return closure_68;
 }
-Value *Main_main_2
+Idris2_Value *Main_main_2
 (
-    Value * var_4
-,   Value * var_3
-,   Value * var_2
-,   Value * var_1
-,   Value * var_0
+    Idris2_Value * var_4
+,   Idris2_Value * var_3
+,   Idris2_Value * var_2
+,   Idris2_Value * var_1
+,   Idris2_Value * var_0
 )
 {
     idris2_removeReference(var_3);
     idris2_removeReference(var_4);
-    Value * var_5 = idris2_apply_closure(var_2, idris2_newReference(var_0));
+    Idris2_Value * var_5 = idris2_apply_closure(var_2, idris2_newReference(var_0));
                                                              // Prelude.IO:24:9--24:16
-    Value * var_6 = idris2_apply_closure(var_1, var_0);      // Prelude.IO:25:11--25:18
+    Idris2_Value * var_6 = idris2_apply_closure(var_1, var_0);
+                                                             // Prelude.IO:25:11--25:18
     return idris2_tailcall_apply_closure(var_5, var_6);
 }
-Value *Main_main_1
+Idris2_Value *Main_main_1
 (
-    Value * var_2
-,   Value * var_1
-,   Value * var_0
+    Idris2_Value * var_2
+,   Idris2_Value * var_1
+,   Idris2_Value * var_0
 )
 {
     idris2_removeReference(var_0);
     idris2_removeReference(var_2);
     return var_1;
 }
-Value *Main_main_0
+Idris2_Value *Main_main_0
 (
-    Value * var_4
-,   Value * var_3
-,   Value * var_2
-,   Value * var_1
-,   Value * var_0
+    Idris2_Value * var_4
+,   Idris2_Value * var_3
+,   Idris2_Value * var_2
+,   Idris2_Value * var_1
+,   Idris2_Value * var_0
 )
 {
     idris2_removeReference(var_3);
     idris2_removeReference(var_4);
-    Value *closure_69 = (Value *)idris2_mkClosure((Value *(*)())Prelude_IO_map_Functor_IO, 3, 3);
+    Idris2_Value *closure_69 = (Idris2_Value *)idris2_mkClosure((Idris2_Value *(*)())Prelude_IO_map_Functor_IO, 3, 3);
                                                              // Prelude.IO:15:1--17:38
     ((Idris2_Closure*)closure_69)->args[0] = var_2;
     ((Idris2_Closure*)closure_69)->args[1] = var_1;

--- a/tests/refc/reuse/expected
+++ b/tests/refc/reuse/expected
@@ -18,10 +18,10 @@ Value *Main_insert
 )
 {
     Value * tmp_35 = NULL;                                   // Main:6:24--6:31
-    if (((Value_Constructor *)var_2)->tag == 0 /* Main.Leaf */) {
-        Value_Constructor* constructor_36 = NULL;
+    if (((Idris2_Constructor *)var_2)->tag == 0 /* Main.Leaf */) {
+        Idris2_Constructor* constructor_36 = NULL;
         if (idris2_isUnique(var_2)) {
-            constructor_36 = (Value_Constructor*)var_2;
+            constructor_36 = (Idris2_Constructor*)var_2;
         }
         else {
             idris2_removeReference(var_2);
@@ -33,23 +33,23 @@ Value *Main_insert
         }                                                    // Main:7:22--7:26
         Value * var_3 = (Value*)constructor_36;              // Main:7:17--7:21
          // constructor Main.Leaf                            // Main:7:29--7:33
-        Value_Constructor* constructor_37 = idris2_newConstructor(0, 0);
+        Idris2_Constructor* constructor_37 = idris2_newConstructor(0, 0);
                                                              // Main:7:29--7:33
         Value * var_4 = (Value*)constructor_37;              // Main:7:17--7:21
          // constructor Main.Node                            // Main:7:17--7:21
-        Value_Constructor* constructor_38 = idris2_newConstructor(3, 1);
+        Idris2_Constructor* constructor_38 = idris2_newConstructor(3, 1);
                                                              // Main:7:17--7:21
         constructor_38->args[0] = var_3;
         constructor_38->args[1] = var_1;
         constructor_38->args[2] = var_4;
         tmp_35 = (Value*)constructor_38;
-    } else if (((Value_Constructor *)var_2)->tag == 1 /* Main.Node */) {
-        Value *var_5 = ((Value_Constructor*)var_2)->args[0];
-        Value *var_6 = ((Value_Constructor*)var_2)->args[1];
-        Value *var_7 = ((Value_Constructor*)var_2)->args[2];
-        Value_Constructor* constructor_39 = NULL;
+    } else if (((Idris2_Constructor *)var_2)->tag == 1 /* Main.Node */) {
+        Value *var_5 = ((Idris2_Constructor*)var_2)->args[0];
+        Value *var_6 = ((Idris2_Constructor*)var_2)->args[1];
+        Value *var_7 = ((Idris2_Constructor*)var_2)->args[2];
+        Idris2_Constructor* constructor_39 = NULL;
         if (idris2_isUnique(var_2)) {
-            constructor_39 = (Value_Constructor*)var_2;
+            constructor_39 = (Idris2_Constructor*)var_2;
         }
         else {
             idris2_newReference(var_5);
@@ -58,15 +58,15 @@ Value *Main_insert
             idris2_removeReference(var_2);
         }
         Value * tmp_40 = NULL;                               // Prelude.EqOrd:121:3--121:6
-        if (((Value_Constructor *)var_0)->tag == 0 /* Prelude.EqOrd.MkOrd */) {
-            Value *var_8 = ((Value_Constructor*)var_0)->args[0];
-            Value *var_9 = ((Value_Constructor*)var_0)->args[1];
-            Value *var_10 = ((Value_Constructor*)var_0)->args[2];
-            Value *var_11 = ((Value_Constructor*)var_0)->args[3];
-            Value *var_12 = ((Value_Constructor*)var_0)->args[4];
-            Value *var_13 = ((Value_Constructor*)var_0)->args[5];
-            Value *var_14 = ((Value_Constructor*)var_0)->args[6];
-            Value *var_15 = ((Value_Constructor*)var_0)->args[7];
+        if (((Idris2_Constructor *)var_0)->tag == 0 /* Prelude.EqOrd.MkOrd */) {
+            Value *var_8 = ((Idris2_Constructor*)var_0)->args[0];
+            Value *var_9 = ((Idris2_Constructor*)var_0)->args[1];
+            Value *var_10 = ((Idris2_Constructor*)var_0)->args[2];
+            Value *var_11 = ((Idris2_Constructor*)var_0)->args[3];
+            Value *var_12 = ((Idris2_Constructor*)var_0)->args[4];
+            Value *var_13 = ((Idris2_Constructor*)var_0)->args[5];
+            Value *var_14 = ((Idris2_Constructor*)var_0)->args[6];
+            Value *var_15 = ((Idris2_Constructor*)var_0)->args[7];
             idris2_newReference(var_10);
             Value * var_16 = idris2_apply_closure(var_10, idris2_newReference(var_1));
                                                              // Prelude.EqOrd:121:3--121:6

--- a/tests/refc/reuse/expected
+++ b/tests/refc/reuse/expected
@@ -31,11 +31,13 @@ Idris2_Value *Main_insert
         if (! constructor_36) {                              // Main:7:22--7:26
             constructor_36 = idris2_newConstructor(0, 0);    // Main:7:22--7:26
         }                                                    // Main:7:22--7:26
-        Idris2_Value * var_3 = (Idris2_Value*)constructor_36;// Main:7:17--7:21
+        Idris2_Value * var_3 = (Idris2_Value*)constructor_36;
+                                                             // Main:7:17--7:21
          // constructor Main.Leaf                            // Main:7:29--7:33
         Idris2_Constructor* constructor_37 = idris2_newConstructor(0, 0);
                                                              // Main:7:29--7:33
-        Idris2_Value * var_4 = (Idris2_Value*)constructor_37;// Main:7:17--7:21
+        Idris2_Value * var_4 = (Idris2_Value*)constructor_37;
+                                                             // Main:7:17--7:21
          // constructor Main.Node                            // Main:7:17--7:21
         Idris2_Constructor* constructor_38 = idris2_newConstructor(3, 1);
                                                              // Main:7:17--7:21

--- a/tests/refc/reuse/expected
+++ b/tests/refc/reuse/expected
@@ -4,20 +4,20 @@
 5
 2
 4
-Value *Main_insert
+Idris2_Value *Main_insert
 (
-    Value * var_0
-,   Value * var_1
-,   Value * var_2
+    Idris2_Value * var_0
+,   Idris2_Value * var_1
+,   Idris2_Value * var_2
 );
-Value *Main_insert
+Idris2_Value *Main_insert
 (
-    Value * var_0
-,   Value * var_1
-,   Value * var_2
+    Idris2_Value * var_0
+,   Idris2_Value * var_1
+,   Idris2_Value * var_2
 )
 {
-    Value * tmp_35 = NULL;                                   // Main:6:24--6:31
+    Idris2_Value * tmp_35 = NULL;                            // Main:6:24--6:31
     if (((Idris2_Constructor *)var_2)->tag == 0 /* Main.Leaf */) {
         Idris2_Constructor* constructor_36 = NULL;
         if (idris2_isUnique(var_2)) {
@@ -31,22 +31,22 @@ Value *Main_insert
         if (! constructor_36) {                              // Main:7:22--7:26
             constructor_36 = idris2_newConstructor(0, 0);    // Main:7:22--7:26
         }                                                    // Main:7:22--7:26
-        Value * var_3 = (Value*)constructor_36;              // Main:7:17--7:21
+        Idris2_Value * var_3 = (Idris2_Value*)constructor_36;// Main:7:17--7:21
          // constructor Main.Leaf                            // Main:7:29--7:33
         Idris2_Constructor* constructor_37 = idris2_newConstructor(0, 0);
                                                              // Main:7:29--7:33
-        Value * var_4 = (Value*)constructor_37;              // Main:7:17--7:21
+        Idris2_Value * var_4 = (Idris2_Value*)constructor_37;// Main:7:17--7:21
          // constructor Main.Node                            // Main:7:17--7:21
         Idris2_Constructor* constructor_38 = idris2_newConstructor(3, 1);
                                                              // Main:7:17--7:21
         constructor_38->args[0] = var_3;
         constructor_38->args[1] = var_1;
         constructor_38->args[2] = var_4;
-        tmp_35 = (Value*)constructor_38;
+        tmp_35 = (Idris2_Value*)constructor_38;
     } else if (((Idris2_Constructor *)var_2)->tag == 1 /* Main.Node */) {
-        Value *var_5 = ((Idris2_Constructor*)var_2)->args[0];
-        Value *var_6 = ((Idris2_Constructor*)var_2)->args[1];
-        Value *var_7 = ((Idris2_Constructor*)var_2)->args[2];
+        Idris2_Value *var_5 = ((Idris2_Constructor*)var_2)->args[0];
+        Idris2_Value *var_6 = ((Idris2_Constructor*)var_2)->args[1];
+        Idris2_Value *var_7 = ((Idris2_Constructor*)var_2)->args[2];
         Idris2_Constructor* constructor_39 = NULL;
         if (idris2_isUnique(var_2)) {
             constructor_39 = (Idris2_Constructor*)var_2;
@@ -57,27 +57,27 @@ Value *Main_insert
             idris2_newReference(var_7);
             idris2_removeReference(var_2);
         }
-        Value * tmp_40 = NULL;                               // Prelude.EqOrd:121:3--121:6
+        Idris2_Value * tmp_40 = NULL;                        // Prelude.EqOrd:121:3--121:6
         if (((Idris2_Constructor *)var_0)->tag == 0 /* Prelude.EqOrd.MkOrd */) {
-            Value *var_8 = ((Idris2_Constructor*)var_0)->args[0];
-            Value *var_9 = ((Idris2_Constructor*)var_0)->args[1];
-            Value *var_10 = ((Idris2_Constructor*)var_0)->args[2];
-            Value *var_11 = ((Idris2_Constructor*)var_0)->args[3];
-            Value *var_12 = ((Idris2_Constructor*)var_0)->args[4];
-            Value *var_13 = ((Idris2_Constructor*)var_0)->args[5];
-            Value *var_14 = ((Idris2_Constructor*)var_0)->args[6];
-            Value *var_15 = ((Idris2_Constructor*)var_0)->args[7];
+            Idris2_Value *var_8 = ((Idris2_Constructor*)var_0)->args[0];
+            Idris2_Value *var_9 = ((Idris2_Constructor*)var_0)->args[1];
+            Idris2_Value *var_10 = ((Idris2_Constructor*)var_0)->args[2];
+            Idris2_Value *var_11 = ((Idris2_Constructor*)var_0)->args[3];
+            Idris2_Value *var_12 = ((Idris2_Constructor*)var_0)->args[4];
+            Idris2_Value *var_13 = ((Idris2_Constructor*)var_0)->args[5];
+            Idris2_Value *var_14 = ((Idris2_Constructor*)var_0)->args[6];
+            Idris2_Value *var_15 = ((Idris2_Constructor*)var_0)->args[7];
             idris2_newReference(var_10);
-            Value * var_16 = idris2_apply_closure(var_10, idris2_newReference(var_1));
+            Idris2_Value * var_16 = idris2_apply_closure(var_10, idris2_newReference(var_1));
                                                              // Prelude.EqOrd:121:3--121:6
             tmp_40 = idris2_apply_closure(var_16, idris2_newReference(var_6));
         }
-        Value * var_19 = tmp_40;
-        Value *tmp_41 = NULL;
+        Idris2_Value * var_19 = tmp_40;
+        Idris2_Value *tmp_41 = NULL;
         int64_t tmp_42 = idris2_extractInt(var_19);
         if (tmp_42 == UINT8_C(1)) {
             idris2_removeReference(var_19);
-            Value * var_17 = idris2_trampoline(Main_insert(var_0, var_1, var_5));
+            Idris2_Value * var_17 = idris2_trampoline(Main_insert(var_0, var_1, var_5));
                                                              // Main:8:42--8:46
              // constructor Main.Node                        // Main:8:42--8:46
             if (! constructor_39) {                          // Main:8:42--8:46
@@ -87,10 +87,10 @@ Value *Main_insert
             constructor_39->args[0] = var_17;
             constructor_39->args[1] = var_6;
             constructor_39->args[2] = var_7;
-            tmp_41 = (Value*)constructor_39;
+            tmp_41 = (Idris2_Value*)constructor_39;
         } else if (tmp_42 == UINT8_C(0)) {
             idris2_removeReference(var_19);
-            Value * var_18 = idris2_trampoline(Main_insert(var_0, var_1, var_7));
+            Idris2_Value * var_18 = idris2_trampoline(Main_insert(var_0, var_1, var_7));
                                                              // Main:9:42--9:46
              // constructor Main.Node                        // Main:9:42--9:46
             if (! constructor_39) {                          // Main:9:42--9:46
@@ -100,7 +100,7 @@ Value *Main_insert
             constructor_39->args[0] = var_5;
             constructor_39->args[1] = var_6;
             constructor_39->args[2] = var_18;
-            tmp_41 = (Value*)constructor_39;
+            tmp_41 = (Idris2_Value*)constructor_39;
         }
         tmp_35 = tmp_41;
     }


### PR DESCRIPTION
# Description

`Value` is sufficiently vague that it can collide with names from other support libs, such as `Value` in my MLIR lib. I've prefixed everything with `Idris2_`.

c.f. zulip discussion [#help > Rename &#96;Value&#96; in RefC?](https://idris-lang.zulipchat.com/#narrow/channel/556789-help/topic/Rename.20.60Value.60.20in.20RefC.3F/with/583615015)

## Self-check

<!-- /!\ Please delete sections that do not apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)
- [x] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.
