### PR TITLE
[ ide-mode ] return formatted version string for `:interpret ":version"`  command

### DIFF
--- a/src/Idris/IDEMode/REPL.idr
+++ b/src/Idris/IDEMode/REPL.idr
@@ -127,6 +127,7 @@ data IDEResult
   | Term String   -- should be a PTerm + metadata, or SExp.
   | TTTerm String -- should be a TT Term + metadata, or perhaps SExp
   | NameLocList (List (Name, FC))
+  | VersionSExp Version
 
 replWrap : Core REPLResult -> Core IDEResult
 replWrap m = pure $ REPL !m
@@ -233,7 +234,7 @@ process (EnableSyntax b)
     = do setSynHighlightOn b
          pure $ REPL $ Printed (reflow "Syntax highlight option changed to" <++> byShow b)
 process Version
-    = replWrap $ Idris.REPL.process ShowVersion
+    = pure $ VersionSExp version
 process (Metavariables _)
     = FoundHoles <$> getUserHolesData
 process GetOptions
@@ -365,6 +366,8 @@ displayIDEResult outf i  (REPL $ LogLevelSet k)
 displayIDEResult outf i  (REPL $ OptionsSet opts)
   = printIDEResult outf i $ AnOptionList $ map cast opts
 displayIDEResult outf i  (REPL $ VersionIs x)
+  = printIDEResult outf i $ AString (showVersion True x)
+displayIDEResult outf i (VersionSExp x)
   = let (major, minor, patch) = semVer x
     in printIDEResult outf i $ AVersion $ MkIdrisVersion
       {major, minor, patch, tag = versionTag x}


### PR DESCRIPTION
Note:
**I acknowledge the AI contributing policy and made the changes primarily on own but I did consulted AI and been guided by it to make this change correctly.**

---

Previously, the IDE command `:version` (via `interpret`) reused `ShowVersion` and returned a structured S-expression containing semantic version components and commit hash.

As `idris-mode` expects for output of `:interpret` command to be always a string. This leads to bad user experience on commands that return S-expression. See: https://github.com/idris-hackers/idris-mode/issues/661 and https://github.com/idris-hackers/idris-mode/pull/662

This introduces a dedicated `VersionSExp` constructor in `IDEResult` and updates `process Version` to return the raw `version` value directly.
The IDE mode now distinguishes between:

 - `REPL (VersionIs x)` -> structured `AVersion` (unchanged)
 - `VersionSExp x`      -> formatted string via `showVersion`

As a result, `:version` in IDE interpret mode now produces a human-readable string (e.g. "0.8.0-<hash>") instead of a structured tuple.

 Before:

```
idris2 --ide-mode
000018(:protocol-version 2 1)
(:version 1)
00002a(:return (:ok ((0 8 0) ("19a3f4ec0"))) 1)
((:interpret ":version") 2)
00002a(:return (:ok ((0 8 0) ("19a3f4ec0"))) 2)
```

 After:

```
$ idris2 --ide-mode
000018(:protocol-version 2 1)
(:version 1)
00002a(:return (:ok ((0 8 0) ("ed55358b6"))) 1)
((:interpret ":version") 2)
000024(:return (:ok "0.8.0-ed55358b6") 2)
```

 Next steps:

Update `:opts` command in similar way.
```
((:interpret ":opts") 3)
00009b(:return (:ok ((:show-implicits :False) ...)) 3) ;; should be string
((:get-options) 3)
00009b(:return (:ok ((:show-implicits :False) .. (:editor "vim"))) 3) ;; stay same
```

# Description

<!-- Make your description as clear as possible for reviewers,
feel free to ask questions or bring attention to specific parts
of the code. Before submitting a large diff, ensure that this is
a change that we can accept by opening an issue first and discussing
the proposed change. -->

## Self-check

<!-- /!\ Please delete sections that do not apply -->
- [ ] This is my first time contributing, I've carefully read [`CONTRIBUTING.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTING.md)
      and I've updated [`CONTRIBUTORS`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTORS) with my name.
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)
- [ ] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.
