### PR TITLE
[ide-mode] Make `(:interpret ":version" and ":ops")` return output as string instead of S-expression.

### DIFF
--- a/src/Idris/IDEMode/REPL.idr
+++ b/src/Idris/IDEMode/REPL.idr
@@ -127,6 +127,7 @@ data IDEResult
   | Term String   -- should be a PTerm + metadata, or SExp.
   | TTTerm String -- should be a TT Term + metadata, or perhaps SExp
   | NameLocList (List (Name, FC))
+  | VersionSExp Version
 
 replWrap : Core REPLResult -> Core IDEResult
 replWrap m = pure $ REPL !m
@@ -233,7 +234,7 @@ process (EnableSyntax b)
     = do setSynHighlightOn b
          pure $ REPL $ Printed (reflow "Syntax highlight option changed to" <++> byShow b)
 process Version
-    = replWrap $ Idris.REPL.process ShowVersion
+    = pure $ VersionSExp version
 process (Metavariables _)
     = FoundHoles <$> getUserHolesData
 process GetOptions
@@ -365,6 +366,8 @@ displayIDEResult outf i  (REPL $ LogLevelSet k)
 displayIDEResult outf i  (REPL $ OptionsSet opts)
   = printIDEResult outf i $ AnOptionList $ map cast opts
 displayIDEResult outf i  (REPL $ VersionIs x)
+  = printIDEResult outf i $ AString (showVersion True x)
+displayIDEResult outf i (VersionSExp x)
   = let (major, minor, patch) = semVer x
     in printIDEResult outf i $ AVersion $ MkIdrisVersion
       {major, minor, patch, tag = versionTag x}

--- a/src/Idris/IDEMode/REPL.idr
+++ b/src/Idris/IDEMode/REPL.idr
@@ -128,6 +128,7 @@ data IDEResult
   | TTTerm String -- should be a TT Term + metadata, or perhaps SExp
   | NameLocList (List (Name, FC))
   | VersionSExp Version
+  | OptionsSExp (List REPLOpt)
 
 replWrap : Core REPLResult -> Core IDEResult
 replWrap m = pure $ REPL !m
@@ -238,7 +239,8 @@ process Version
 process (Metavariables _)
     = FoundHoles <$> getUserHolesData
 process GetOptions
-    = replWrap $ Idris.REPL.process GetOpts
+    = do opts <- getOptions
+         pure $ OptionsSExp opts
 
 processCatch : {auto c : Ref Ctxt Defs} ->
                {auto u : Ref UST UState} ->
@@ -364,6 +366,9 @@ displayIDEResult outf i  (REPL $ LogLevelSet k)
   = printIDEResult outf i
   $ AString $ "Set loglevel to " ++ show k
 displayIDEResult outf i  (REPL $ OptionsSet opts)
+  = printIDEResult outf i
+  $ AString $ showSep "\n" $ map show opts
+displayIDEResult outf i  (OptionsSExp opts)
   = printIDEResult outf i $ AnOptionList $ map cast opts
 displayIDEResult outf i  (REPL $ VersionIs x)
   = printIDEResult outf i $ AString (showVersion True x)

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -194,9 +194,11 @@ getOptions : {auto c : Ref Ctxt Defs} ->
 getOptions = do
   pp <- getPPrint
   opts <- get ROpts
-  pure $ [ ShowImplicits (showImplicits pp), ShowMachineNames (showMachineNames pp)
+  pure $ [ ShowImplicits (showImplicits pp)
+         , ShowMachineNames (showMachineNames pp)
          , ShowNamespace (fullNamespace pp)
-         , ShowTypes (showTypes opts), EvalMode (evalMode opts)
+         , ShowTypes (showTypes opts)
+         , EvalMode (evalMode opts)
          , Editor (editor opts)
          ]
 

--- a/src/Idris/REPL.idr
+++ b/src/Idris/REPL.idr
@@ -188,6 +188,7 @@ setOpt (Profile t)
 setOpt (EvalTiming t)
     = setEvalTiming t
 
+export
 getOptions : {auto c : Ref Ctxt Defs} ->
          {auto o : Ref ROpts REPLOpts} ->
          Core (List REPLOpt)


### PR DESCRIPTION
# Description

Previously, the IDE commands  returned a structured S-expression 
which wasn't handled well by `idris-mode` as it expects for `interpret` always return a string.

See: https://github.com/idris-hackers/idris-mode/issues/661 
Although we have "hotfix" in `ide-mode` https://github.com/idris-hackers/idris-mode/pull/662
 I think better to make the change in Idris itself.

This PR supersede https://github.com/idris-lang/Idris2/pull/3768
Relates also to https://idris-lang.zulipchat.com/#narrow/channel/556701-general/topic/LLMs.20and.20Idris.202.20programming/near/590513106



### Before:

```
idris2 --ide-mode
((:interpret ":opts") 3)
00009b(:return (:ok ((:show-implicits :False) (:show-machinenames :False) (:show-namespace :False) (:show-types :False) (:eval "normalise") (:editor "vim"))) 3)
((:get-options) 3)
00009b(:return (:ok ((:show-implicits :False) (:show-machinenames :False) (:show-namespace :False) (:show-types :False) (:eval "normalise") (:editor "vim"))) 3)
```

In Emacs

<img width="788" height="389" alt="before-fix-version-opts" src="https://github.com/user-attachments/assets/bdd28967-e813-499e-94ca-4ddeea12c49f" />


### After:

```
$ idris2 --ide-mode
((:interpret ":opts") 3)
00008d(:return (:ok "showimplicits = False
showmachinenames = False
shownamespace = False
showtypes = False
eval = normalise
editor = \"vim\"") 3)
((:get-options) 3)
00009b(:return (:ok ((:show-implicits :False) (:show-machinenames :False) (:show-namespace :False) (:show-types :False) (:eval "normalise") (:editor "vim"))) 3)
```

Emacs:

<img width="524" height="336" alt="opts-idris-repl-emacs-after" src="https://github.com/user-attachments/assets/77ab3444-e2e5-4d72-82cc-37a449c9afe1" />

## Self-check

- [X]  I've carefully read [`CONTRIBUTING.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTING.md).
- [X] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.

(used LLM to review and correct solution in commit https://github.com/idris-lang/Idris2/pull/3769/changes/1163504b169e) Otherwise human, written contribution. 