### PR TITLE
Fix typo

### DIFF
--- a/docs/source/tutorial/interfaces.rst
+++ b/docs/source/tutorial/interfaces.rst
@@ -317,7 +317,7 @@ the ``Nothing`` cases is achieved by the ``>>=`` operator, hidden by the
 ::
 
     Main> m_add (Just 82) (Just 22)
-    Just 94
+    Just 104
     Main> m_add (Just 82) Nothing
     Nothing
 


### PR DESCRIPTION
# Description

Fix a typo in one of the examples:

Main> m_add (Just 82) (Just 22)
Just 94

The result should be Just 104

## Self-check

- [X] This is my first time contributing, I've carefully read [`CONTRIBUTING.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTING.md)
      and I've updated [`CONTRIBUTORS`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTORS) with my name.
- [X] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.
