### PR TITLE
[ fix ] performance issue in totality checking

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -76,6 +76,7 @@ should target this file (`CHANGELOG_NEXT`).
 * Optimised the passing of local variables during compile-time normalisation.
 * Added `getFC` to elaborator reflection, exposing the macro call-site source
   location.
+* Fix exponential time issue in totality checking with large data on the left hand side (#3696).
 
 ### Building/Packaging changes
 

--- a/src/Core/Termination/CallGraph.idr
+++ b/src/Core/Termination/CallGraph.idr
@@ -194,7 +194,7 @@ mutual
      = if !(sizeCompareTyCon fuel s t) then pure Same
        else if !(sizeCompareCon fuel s t)
           then pure Smaller
-          else knownOr (sizeCompareApp fuel s t) (pure $ if sizeEq s t then Same else Unknown)
+          else sizeCompareApp fuel s t
 
   sizeCompareProdConArgs : {auto defs : Defs} -> Nat -> List (Term vars) -> List (Term vars) -> Core SizeChange
   sizeCompareProdConArgs _ [] [] = pure Same
@@ -238,8 +238,16 @@ mutual
           Unknown => sizeCompareConArgs fuel s ts
           _ => pure True
 
-  sizeCompareApp fuel (App _ f _) t = sizeCompare fuel f t
-  sizeCompareApp _ _ t = pure Unknown
+  sizeCompareApp fuel f t =
+    let (f,args) = getFnArgs f
+        (t,args') = getFnArgs t
+    in if sizeEq f t then checkArgs args args' else pure Unknown
+    where
+      checkArgs : List (Term vars) -> List (Term vars) -> Core SizeChange
+      checkArgs Nil Nil = pure Same
+      checkArgs (s :: ss) Nil = pure Same
+      checkArgs (s :: ss) (t :: ts) = if sizeEq s t then checkArgs ss ts else pure Unknown
+      checkArgs _ (t :: ts) = pure Unknown
 
   sizeCompareAsserted : {auto defs : Defs} -> Nat -> Maybe (Term vars) -> Term vars -> Core SizeChange
   sizeCompareAsserted fuel (Just s) t

--- a/tests/idris2/total/total031/Issue3696.idr
+++ b/tests/idris2/total/total031/Issue3696.idr
@@ -1,0 +1,8 @@
+bar : (a, b, c, d, e : Unit) -> Unit
+
+foo : (n : Nat) -> Unit
+foo 100 = id $ bar () () () () ()
+foo _ = ()
+
+bar _ _ _ _ _ = foo 0
+

--- a/tests/idris2/total/total031/expected
+++ b/tests/idris2/total/total031/expected
@@ -1,0 +1,1 @@
+1/1: Building Issue3696 (Issue3696.idr)

--- a/tests/idris2/total/total031/run
+++ b/tests/idris2/total/total031/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check Issue3696.idr


### PR DESCRIPTION
This PR addresses an exponential slowdown issue in totality checking and fixes #3696.

### Issue

The following code takes appears to freeze during totality checking of `foo`:
```idris
bar : (a, b, c, d, e : Unit) -> Unit

foo : (n : Nat) -> Unit
foo 100 = id $ bar () () () () () 
foo _ = ()

bar _ _ _ _ _ = foo 0
```

### Root cause

Here the term `bar () () () () ()` appears as an argument on the RHS. Idris tries to determine if it is smaller than an argument on the left. The LHS has a large `Nat`. Size compare falls through to the case where we check a constructor application in the pattern (`t`) against the application of `bar`.  This recurses to checking the function application against each of the arguments of that constructor:

https://github.com/idris-lang/Idris2/blob/6a54860ee748accc1a2be1da4a77727b5be4c1dc/src/Core/Termination/CallGraph.idr#L218-L223

And if `sizeCompareCon` fails, we hit fallback code that calls `sizeCompareApp`, which peels off an argument of the function and runs the entire process again, comparing `bar () () () ()` to `100`.

https://github.com/idris-lang/Idris2/blob/6a54860ee748accc1a2be1da4a77727b5be4c1dc/src/Core/Termination/CallGraph.idr#L241-L242

So we end up running:

- `sizeCompare (bar () () () () ())  (S (S (S ...))`
   - `sizeCompare (bar () () () () ()) (S (S ...))`  (peel off an `S` in `sizeCompareCon`)
      - `sizeCompare (bar () () () () ()) (S (S ...))`
        - ...
        - ...
      - `sizeCompare (bar () () () ()) (S (S ...))`
        - ...
        - ... 
   - `sizeCompare (bar () () () ()) (S (S (S ...)))` (peel off the `()` in `sizeCompareApp`)
     - `sizeCompare (bar () () () ()) (S (S ...))`   (remove `S` in `sizeCompareCon`)
        - ...
        - ...
     - `sizeCompare (bar () () ()) (S (S (S ...)))` (peel off the `()` in `sizeCompareApp`)
        - ...
        - ... 

Which is exponential and redundant. 

### Fix

The Foetus paper has a rule like "if y ρ x then (y a) ρ x" (for ρ in <,=). So we do need to check prefixes of the application, but we can do this at the leaves. Instead of rerunning everything in `sizeCompareApp`, check whether the LHS is equal or a prefix of the RHS as a function application. Deeper recursion is handled by the earlier branch, going under the constructor.

## Self-check

<!-- /!\ Please delete sections that do not apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)
- [x] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.
