### PR TITLE
[ pragma ] Remove Borrowing

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -76,6 +76,9 @@ should target this file (`CHANGELOG_NEXT`).
 * Optimised the passing of local variables during compile-time normalisation.
 * Added `getFC` to elaborator reflection, exposing the macro call-site source
   location.
+* Removed `Borrowing` as a language extension.  This was never implemented in
+  Idris2, so the only change is that `%language Borrowing` will now error rather
+  than be accepted but do nothing.
 
 ### Building/Packaging changes
 

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1433,8 +1433,7 @@ onoff
 extension : Rule LangExt
 extension
     = (exactIdent "ElabReflection" $> ElabReflection)
-  <|> (exactIdent "Borrowing" $> Borrowing)
-  <|> fail "expected either 'ElabReflection' or 'Borrowing'"
+  <|> fail "expected 'ElabReflection'"
 
 logLevel : OriginDesc -> Rule (Maybe LogLevel)
 logLevel fname

--- a/src/Idris/Syntax/Pragmas.idr
+++ b/src/Idris/Syntax/Pragmas.idr
@@ -32,21 +32,18 @@ data KwPragma
 public export
 data LangExt
   = ElabReflection
-  | Borrowing -- not yet implemented
 
 export
 allLangExts : List LangExt
-allLangExts = [ElabReflection, Borrowing]
+allLangExts = [ElabReflection]
 
 export
 Show LangExt where
   show ElabReflection = "ElabReflection"
-  show Borrowing = "Borrowing"
 
 export
 Eq LangExt where
   ElabReflection == ElabReflection = True
-  Borrowing == Borrowing = True
   _ == _ = False
 
 public export

--- a/src/Idris/Syntax/Pragmas.idr
+++ b/src/Idris/Syntax/Pragmas.idr
@@ -44,7 +44,6 @@ Show LangExt where
 export
 Eq LangExt where
   ElabReflection == ElabReflection = True
-  _ == _ = False
 
 public export
 data PragmaArg


### PR DESCRIPTION
# Description

This has existed in the codebase because it was in Idris 1, but to my knowledge it was never implemented nor used.  However, it was causing a tiny amount of confusion, since it was a valid `%language` argument (which didn't do anything).

I've rerun the build and tests, and everything seems fine.

## Self-check

- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)
- [x] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.
