### PR TITLE
[ fix #3783 ] Improve error message for invalid C FFI declarations

### DIFF
--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -248,6 +248,7 @@ cCall fc cfn clib args CFBuffer _
     = throw (GenericMsg fc "Can't return Buffer from a foreign function")
 cCall fc cfn clib args ret collectSafe
     = do loaded <- get Loaded
+         when (clib == "") $ throw (GenericMsg fc "Invalid C foreign function declaration: a library name is required")
          lib <- if clib `elem` loaded
                    then pure Nothing
                    else do put Loaded (clib :: loaded)


### PR DESCRIPTION
# Description

As reported in #3783, the error message you receive when omitting the library name from a C FFI declaration is confusing and obscures the root cause.
Since the current implementation of Chez Scheme FFI into C depends on the use of a dynamic library, the error message should be explicit about it.

# TODO

- [ ] decide on exact wording of the error message
- [ ] check behaviour on Racket and RefC backends
- [ ] add tests

## Self-check

- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)
- [x] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.
