### PR TITLE
buildIdris cleanup

### DIFF
--- a/nix/buildIdris.nix
+++ b/nix/buildIdris.nix
@@ -41,7 +41,7 @@ let
   idrName = "idris2-${idris2Version}";
   libSuffix = "lib/${idrName}";
   libDirs = libs: lib.strings.makeSearchPath libSuffix libs;
-  drvAttrs = builtins.removeAttrs attrs [
+  drvAttrs = removeAttrs attrs [
     "ipkgName"
     "idrisLibraries"
   ];
@@ -95,9 +95,6 @@ let
         scheme_app="$(find ./build/exec -name '*_app')"
         if [ "$scheme_app" = ''' ]; then
           mv -- build/exec/* $out/bin/
-          chmod +x $out/bin/*
-          # ^ remove after Idris2 0.8.0 is released. will be superfluous:
-          # https://github.com/idris-lang/Idris2/pull/3189
         else
           bin_name="$(idris2 --dump-ipkg-json ${ipkgFileName} | jq -r '.executable')"
 


### PR DESCRIPTION
# Description

Address a trivial nix warning and (more impactfully) remove a line that used to support NodeJS executables but is not needed now that Idris2 0.8.0 has been released.

## Self-check

<!-- /!\ Please delete sections that do not apply -->
- [ ] This is my first time contributing, I've carefully read [`CONTRIBUTING.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTING.md)
      and I've updated [`CONTRIBUTORS`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTORS) with my name.
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)
- [x] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.
