### PR TITLE
[ new ] add support for setting a datadir for a particular package in its ipkg file

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -86,6 +86,8 @@ should target this file (`CHANGELOG_NEXT`).
 * Change `flake.nix` to point at `idris-community/idris2-mode` as the URL for
   `inputs.idris-emacs-src` (from the user fork `redfish64/idris2-mode`).
 * Fix UTF-8 character handling in package description fields.
+* A project's data directory can now be specified with the `datadir` entry in
+  an `ipkg` file.
 
 ### Backend changes
 

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -65,6 +65,7 @@ data DescField  : Type where
   PExec         : String -> DescField
   POpts         : FC -> String -> DescField
   PSourceDir    : FC -> String -> DescField
+  PDataDir      : FC -> String -> DescField
   PBuildDir     : FC -> String -> DescField
   POutputDir    : FC -> String -> DescField
   PPrebuild     : FC -> String -> DescField
@@ -87,6 +88,7 @@ field fname
     <|> strField POpts "options"
     <|> strField POpts "opts"
     <|> strField PSourceDir "sourcedir"
+    <|> strField PDataDir "datadir"
     <|> strField PBuildDir "builddir"
     <|> strField POutputDir "outputdir"
     <|> strField PPrebuild "prebuild"
@@ -242,6 +244,7 @@ addField (PMainMod loc n)    pkg = do put MainMod (Just (loc, n))
 addField (PExec e)           pkg = pure $ { executable := Just e } pkg
 addField (POpts fc e)        pkg = pure $ { options := Just (fc, e) } pkg
 addField (PSourceDir fc a)   pkg = pure $ { sourcedir := Just a } pkg
+addField (PDataDir fc a)     pkg = pure $ { datadir := Just a } pkg
 addField (PBuildDir fc a)    pkg = pure $ { builddir := Just a } pkg
 addField (POutputDir fc a)   pkg = pure $ { outputdir := Just a } pkg
 addField (PPrebuild fc e)    pkg = pure $ { prebuild := Just (fc, e) } pkg
@@ -963,6 +966,7 @@ processPackage opts (cmd, mfile)
              setWorkingDir dir
              pkg <- parsePkgFile True filename
              whenJust (builddir pkg) setBuildDir
+             whenJust (datadir pkg) addDataDir
              setOutputDir (outputdir pkg)
              case cmd of
                   Build => do [] <- build pkg opts

--- a/src/Idris/Package/ToJson.idr
+++ b/src/Idris/Package/ToJson.idr
@@ -73,6 +73,7 @@ namespace Package
             executable
             options
             sourcedir
+            datadir
             builddir
             outputdir
             prebuild
@@ -96,6 +97,7 @@ namespace Package
           , "executable"  ~~= executable
           , "opts"        ~~= snd <$> options
           , "sourcedir"   ~~= sourcedir
+          , "datadir"     ~~= datadir
           , "builddir"    ~~= builddir
           , "outputdir"   ~~= outputdir
           , "prebuild"    ~~= snd <$> prebuild

--- a/src/Idris/Package/Types.idr
+++ b/src/Idris/Package/Types.idr
@@ -180,6 +180,7 @@ record PkgDesc where
   executable : Maybe String -- name of executable
   options : Maybe (FC, String)
   sourcedir : Maybe String
+  datadir : Maybe String
   builddir : Maybe String
   outputdir : Maybe String
   prebuild : Maybe (FC, String) -- Script to run before building
@@ -196,7 +197,7 @@ initPkgDesc pname
                 Nothing Nothing Nothing Nothing Nothing
                 [] []
                 Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
-                Nothing Nothing Nothing Nothing
+                Nothing Nothing Nothing Nothing Nothing
 
 export
 Show PkgDesc where
@@ -217,6 +218,7 @@ Show PkgDesc where
              maybe "" (\m => "Exec: " ++ m ++ "\n") (executable pkg) ++
              maybe "" (\m => "Opts: " ++ snd m ++ "\n") (options pkg) ++
              maybe "" (\m => "SourceDir: " ++ m ++ "\n") (sourcedir pkg) ++
+             maybe "" (\m => "DataDir: " ++ m ++ "\n") (datadir pkg) ++
              maybe "" (\m => "BuildDir: " ++ m ++ "\n") (builddir pkg) ++
              maybe "" (\m => "OutputDir: " ++ m ++ "\n") (outputdir pkg) ++
              maybe "" (\m => "Prebuild: " ++ snd m ++ "\n") (prebuild pkg) ++
@@ -256,6 +258,7 @@ Pretty Void PkgDesc where
     , strField "executable"  desc.executable
     , strField "opts"        (snd <$> desc.options)
     , strField "sourcedir"   desc.sourcedir
+    , strField "datadir"     desc.datadir
     , strField "builddir"    desc.builddir
     , strField "outputdir"   desc.outputdir
 

--- a/tests/idris2/api/api002/expected
+++ b/tests/idris2/api/api002/expected
@@ -25,6 +25,7 @@ authors = "Tomáš"
 -- executable =
 -- opts =
 -- sourcedir =
+-- datadir =
 -- builddir =
 -- outputdir =
 

--- a/tests/idris2/literate/literate017/project-expected.ipkg
+++ b/tests/idris2/literate/literate017/project-expected.ipkg
@@ -25,6 +25,7 @@ modules = A.A, A.AB, B.B, B.BA, Main
 -- executable =
 -- opts =
 sourcedir = "src/"
+-- datadir =
 -- builddir =
 -- outputdir =
 


### PR DESCRIPTION


# Description

This PR adds support for specifying one (additional) data directory for a package in its `ipkg` file if desired.

Idris2 supports the concept of "data directories" which can be used in different ways by different backends to augment Idris2 code during compilation or installation. Data directories can be set via ENV var currently but this mode of adding data directories is not well suited to projects that introduce a package meant to be consumed by other projects and need to set a new data directory up as well -- such packages should not need to rely on custom Makefile invocations to set an ENV var prior to compilation; after all, the package itself _always_ needs that data directory defined, not just sometimes, and that data directory is likely part of the project and so its relative path is always known and static.

To put a concrete example out there, a number of my projects provide `support/js` directories that get used via NodeJS FFI calls (much like the compiler project does) so I would benefit from being able to specify `datadir = "support"` for those projects.

It becomes particularly important to be able to set the data directory for a package when that package is consumed via a package manager like `pack` -- Such a package manager may manage ENV vars itself and regardless it may not use a Makefile provided by the package to build the package so there is no reliable way to set a data directory up as of today.

## Self-check

<!-- /!\ Please delete sections that do not apply -->
- [ ] This is my first time contributing, I've carefully read [`CONTRIBUTING.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTING.md)
      and I've updated [`CONTRIBUTORS`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTORS) with my name.
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)
- [x] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.
