### PR TITLE
[Zurihack] Small Driver refactor

### DIFF
--- a/.github/workflows/ci-sphinx.yml
+++ b/.github/workflows/ci-sphinx.yml
@@ -20,6 +20,7 @@ jobs:
       uses: actions/checkout@v4
     - name: Build docs
       run: |
+        sudo apt-get update
         sudo apt-get install -y python3-sphinx
         pip3 install -r docs/requirements.txt
         cd docs

--- a/src/Compiler/Common.idr
+++ b/src/Compiler/Common.idr
@@ -27,6 +27,10 @@ import System.Info
 
 %default covering
 
+||| Tag to indicate if the compiler needs to stop execution immediately
+public export
+data ProgramProgress = Continue | Abort
+
 ||| Generic interface to some code generator
 public export
 record Codegen where

--- a/src/Compiler/Common.idr
+++ b/src/Compiler/Common.idr
@@ -29,7 +29,7 @@ import System.Info
 
 ||| Tag to indicate if the compiler needs to stop execution immediately
 public export
-data ProgramProgress = Continue | Abort
+data ControlFlow = Continue | Abort
 
 ||| Generic interface to some code generator
 public export

--- a/src/Core/Options.idr
+++ b/src/Core/Options.idr
@@ -198,7 +198,6 @@ record Session where
      -- variables that set incremental compilation)
   caseTreeHeuristics : Bool -- apply heuristics to pick matches for case tree building
 
-
 public export
 record PPrinter where
   constructor MkPPOpts
@@ -266,7 +265,6 @@ defaultSession = MkSessionOpts False CoveringOnly False False Chez [] 1000 False
                                defaultLogLevel Nothing False Nothing Nothing
                                Nothing Nothing False 1 False False True
                                False [] False False
-
 
 export
 defaultElab : ElabDirectives

--- a/src/Core/Options.idr
+++ b/src/Core/Options.idr
@@ -139,7 +139,7 @@ record PostSession where
   constructor MkPostSession
   checkOnly : Bool
   outputFile : Maybe String
-  execExpr : Maybe String
+  execExpr : List String
   runRepl : Maybe String
 
 export
@@ -147,7 +147,7 @@ defaultPost : PostSession
 defaultPost = MkPostSession
   { checkOnly = False
   , outputFile = Nothing
-  , execExpr = Nothing
+  , execExpr = []
   , runRepl = Nothing
   }
 

--- a/src/Core/Options.idr
+++ b/src/Core/Options.idr
@@ -133,6 +133,28 @@ record ElabDirectives where
   -- default: yes
   prefixRecordProjections : Bool
 
+||| Options relevant after running a typechecking session
+public export
+record PostSession where
+  constructor MkPostSession
+  checkOnly : Bool
+  outputFile : Maybe String
+  execExpr : Maybe String
+  runRepl : Maybe String
+
+export
+defaultPost : PostSession
+defaultPost = MkPostSession
+  { checkOnly = False
+  , outputFile = Nothing
+  , execExpr = Nothing
+  , runRepl = Nothing
+  }
+
+-- tag for PostSession
+export
+data PostS : Type where
+
 public export
 record Session where
   constructor MkSessionOpts
@@ -175,6 +197,7 @@ record Session where
      -- incremental CGs are set (intended for overriding any environment
      -- variables that set incremental compilation)
   caseTreeHeuristics : Bool -- apply heuristics to pick matches for case tree building
+
 
 public export
 record PPrinter where
@@ -243,6 +266,7 @@ defaultSession = MkSessionOpts False CoveringOnly False False Chez [] 1000 False
                                defaultLogLevel Nothing False Nothing Nothing
                                Nothing Nothing False 1 False False True
                                False [] False False
+
 
 export
 defaultElab : ElabDirectives

--- a/src/Idris/Driver.idr
+++ b/src/Idris/Driver.idr
@@ -38,7 +38,6 @@ public export
 CustomBackends : Type
 CustomBackends = List (String, Codegen)
 
-
 findInputs : List CLOpt -> Maybe (List1 String)
 findInputs [] = Nothing
 findInputs (InputFile f :: fs) =
@@ -70,7 +69,7 @@ updateEnv
          cg <- coreLift $ idrisGetEnv "IDRIS2_CG"
          whenJust cg $ \ e => case getCG (options defs) e of
            Just cg => setCG cg
-           Nothing => throw (UserError ("Unknown code generator " ++ show e))
+           Nothing => throw (InternalError ("Unknown code generator " ++ show e))
          inccgs <- coreLift $ idrisGetEnv "IDRIS2_INC_CGS"
          whenJust inccgs $ \ cgs =>
            traverseList1_ (setIncrementalCG False) $

--- a/src/Idris/Driver.idr
+++ b/src/Idris/Driver.idr
@@ -34,6 +34,11 @@ import Yaffle.Main
 
 %default covering
 
+public export
+CustomBackends : Type
+CustomBackends = List (String, Codegen)
+
+
 findInputs : List CLOpt -> Maybe (List1 String)
 findInputs [] = Nothing
 findInputs (InputFile f :: fs) =
@@ -98,20 +103,26 @@ updateREPLOpts
 -- There are three ways to run the compiler
 -- Either run normall, or run in yaffle mode, or dump TTM
 data CLIMode
-  = Normal
+  = Normal CustomBackends (List CLOpt)
   | Yaffle String
   | TTM String
 
--- Yaffle and TTM are mutually incompatible so we parse the flags here and
--- report the error if it occurs. If neither flag is present we run in normal mode
-parseCompilerMode : List CLOpt -> Maybe CLIMode -> Either String CLIMode
-parseCompilerMode [] Nothing = pure Normal
-parseCompilerMode [] (Just m) = pure m
-parseCompilerMode (Yaffle f :: xs) Nothing = parseCompilerMode xs (Just $ Yaffle f)
-parseCompilerMode (Metadata f :: xs) Nothing = parseCompilerMode xs (Just $ TTM f)
-parseCompilerMode (Yaffle _ :: xs) (Just (TTM _)) = Left "Incompatible modes --ttm and --yaffle"
-parseCompilerMode (Metadata _ :: xs) (Just (Yaffle _)) = Left "Incompatible modes --ttm and --yaffle"
-parseCompilerMode (_ :: xs) m = parseCompilerMode xs m
+parameters (backends : CustomBackends) (allOpts : List CLOpt)
+
+  -- Yaffle and TTM are mutually incompatible so we parse the flags here and
+  -- report the error if it occurs. If neither flag is present we run in normal mode
+
+  parseCompilerMode' : List CLOpt -> Maybe CLIMode -> Either String CLIMode
+  parseCompilerMode' [] Nothing = pure $ Normal backends allOpts
+  parseCompilerMode' [] (Just m) = pure m
+  parseCompilerMode' (Yaffle f :: xs) Nothing = parseCompilerMode' xs (Just $ Yaffle f)
+  parseCompilerMode' (Metadata f :: xs) Nothing = parseCompilerMode' xs (Just $ TTM f)
+  parseCompilerMode' (Yaffle _ :: xs) (Just (TTM _)) = Left "Incompatible modes --ttm and --yaffle"
+  parseCompilerMode' (Metadata _ :: xs) (Just (Yaffle _)) = Left "Incompatible modes --ttm and --yaffle"
+  parseCompilerMode' (_ :: xs) m = parseCompilerMode' xs m
+
+  parseCompilerMode : Either String CLIMode
+  parseCompilerMode = parseCompilerMode' allOpts Nothing
 
 ignoreMissingIpkg : List CLOpt -> Bool
 ignoreMissingIpkg [] = False
@@ -247,10 +258,10 @@ stMain cgs opts
     msg <- render doc
     coreLift (die msg)
 
-allMain : List (String, Codegen) -> List CLOpt -> CLIMode -> Core ()
-allMain cgs opts Normal = stMain cgs opts
-allMain cgs opts (Yaffle f) = yaffleMain f []
-allMain cgs opts (TTM f) = dumpTTM f
+allMain : CLIMode -> Core ()
+allMain (Normal cgs opts) = stMain cgs opts
+allMain (Yaffle f) = yaffleMain f []
+allMain (TTM f) = dumpTTM f
 
 -- Run any options (such as --version or --help) which imply printing a
 -- message then exiting. Returns wheter the program should continue
@@ -283,10 +294,10 @@ mainWithCodegens cgs = do
   Continue <- quitOpts opts
     | Abort => pure ()
   setupTerm
-  let Right cliMode = parseCompilerMode opts Nothing
+  let Right cliMode = parseCompilerMode cgs opts
     | Left err => do ignore $ fPutStrLn stderr $ "Error: " ++ err
                      exitWith (ExitFailure 1)
-  coreRun (allMain cgs opts cliMode)
+  coreRun (allMain cliMode)
     (\err : Error => do ignore $ fPutStrLn stderr $ "Uncaught error: " ++ show err
                         exitWith (ExitFailure 1))
     (\res => pure ())

--- a/src/Idris/Driver.idr
+++ b/src/Idris/Driver.idr
@@ -95,10 +95,10 @@ updateREPLOpts
     = do ed <- coreLift $ idrisGetEnv "EDITOR"
          whenJust ed $ \ e => update ROpts { editor := e }
 
-tryYaffle : List CLOpt -> Core Bool
-tryYaffle [] = pure False
+tryYaffle : List CLOpt -> Core ProgramProgress
+tryYaffle [] = pure Continue
 tryYaffle (Yaffle f :: _) = do yaffleMain f []
-                               pure True
+                               pure Abort
 tryYaffle (c :: cs) = tryYaffle cs
 
 ignoreMissingIpkg : List CLOpt -> Bool
@@ -106,10 +106,10 @@ ignoreMissingIpkg [] = False
 ignoreMissingIpkg (IgnoreMissingIPKG :: _) = True
 ignoreMissingIpkg (c :: cs) = ignoreMissingIpkg cs
 
-tryTTM : List CLOpt -> Core Bool
-tryTTM [] = pure False
+tryTTM : List CLOpt -> Core ProgramProgress
+tryTTM [] = pure Continue
 tryTTM (Metadata f :: _) = do dumpTTM f
-                              pure True
+                              pure Abort
 tryTTM (c :: cs) = tryTTM cs
 
 
@@ -131,10 +131,10 @@ checkVerbose (_ :: xs) = checkVerbose xs
 
 stMain : List (String, Codegen) -> List CLOpt -> Core ()
 stMain cgs opts
-    = do False <- tryYaffle opts
-            | True => pure ()
-         False <- tryTTM opts
-            | True => pure ()
+    = do Continue <- tryYaffle opts
+            | Abort => pure ()
+         Continue <- tryTTM opts
+            | Abort => pure ()
 
          defs <- initDefs
          -- Add the manually added codegens to the option set

--- a/src/Idris/Driver.idr
+++ b/src/Idris/Driver.idr
@@ -135,10 +135,14 @@ stMain cgs opts
             | True => pure ()
          False <- tryTTM opts
             | True => pure ()
+
          defs <- initDefs
+         -- Add the manually added codegens to the option set
          let updated = foldl (\o, (s, _) => addCG (s, Other s) o) (options defs) cgs
          c <- newRef Ctxt ({ options := updated } defs)
          s <- newRef Syn initSyntax
+         -- If we give a custom codegen, set that as the default,
+         -- otherwise, use Chez
          setCG {c} $ maybe Chez (Other . fst) (head' cgs)
          addPrimitives
 
@@ -244,23 +248,25 @@ stMain cgs opts
 -- Run any options (such as --version or --help) which imply printing a
 -- message then exiting. Returns wheter the program should continue
 
-quitOpts : List CLOpt -> IO Bool
-quitOpts [] = pure True
+data ProgramProgress = Continue | Abort
+
+quitOpts : List CLOpt -> IO ProgramProgress
+quitOpts [] = pure Continue
 quitOpts (Version :: _)
     = do putStrLn versionMsg
-         pure False
+         pure Abort
 quitOpts (TTCVersion :: _)
     = do printLn ttcVersion
-         pure False
+         pure Abort
 quitOpts (Help Nothing :: _)
     = do putStrLn usage
-         pure False
+         pure Abort
 quitOpts (Help (Just HelpLogging) :: _)
     = do putStrLn helpTopics
-         pure False
+         pure Abort
 quitOpts (Help (Just HelpPragma) :: _)
     = do putStrLn pragmaTopics
-         pure False
+         pure Abort
 quitOpts (_ :: opts) = quitOpts opts
 
 export

--- a/src/Idris/Driver.idr
+++ b/src/Idris/Driver.idr
@@ -70,7 +70,7 @@ updateEnv
          cg <- coreLift $ idrisGetEnv "IDRIS2_CG"
          whenJust cg $ \ e => case getCG (options defs) e of
            Just cg => setCG cg
-           Nothing => throw (InternalError ("Unknown code generator " ++ show e))
+           Nothing => throw (UserError ("Unknown code generator " ++ show e))
          inccgs <- coreLift $ idrisGetEnv "IDRIS2_INC_CGS"
          whenJust inccgs $ \ cgs =>
            traverseList1_ (setIncrementalCG False) $
@@ -101,8 +101,8 @@ updateREPLOpts
          whenJust ed $ \ e => update ROpts { editor := e }
 
 -- There are three ways to run the compiler
--- Either run normall, or run in yaffle mode, or dump TTM
-data CLIMode
+-- Either run normally, or run in yaffle mode, or dump TTM
+data Entrypoint
   = Normal CustomBackends (List CLOpt)
   | Yaffle String
   | TTM String
@@ -112,7 +112,7 @@ parameters (backends : CustomBackends) (allOpts : List CLOpt)
   -- Yaffle and TTM are mutually incompatible so we parse the flags here and
   -- report the error if it occurs. If neither flag is present we run in normal mode
 
-  parseCompilerMode' : List CLOpt -> Maybe CLIMode -> Either String CLIMode
+  parseCompilerMode' : List CLOpt -> Maybe Entrypoint -> Either String Entrypoint
   parseCompilerMode' [] Nothing = pure $ Normal backends allOpts
   parseCompilerMode' [] (Just m) = pure m
   parseCompilerMode' (Yaffle f :: xs) Nothing = parseCompilerMode' xs (Just $ Yaffle f)
@@ -121,7 +121,7 @@ parameters (backends : CustomBackends) (allOpts : List CLOpt)
   parseCompilerMode' (Metadata _ :: xs) (Just (Yaffle _)) = Left "Incompatible modes --ttm and --yaffle"
   parseCompilerMode' (_ :: xs) m = parseCompilerMode' xs m
 
-  parseCompilerMode : Either String CLIMode
+  parseCompilerMode : Either String Entrypoint
   parseCompilerMode = parseCompilerMode' allOpts Nothing
 
 ignoreMissingIpkg : List CLOpt -> Bool
@@ -258,7 +258,7 @@ stMain cgs opts
     msg <- render doc
     coreLift (die msg)
 
-allMain : CLIMode -> Core ()
+allMain : Entrypoint -> Core ()
 allMain (Normal cgs opts) = stMain cgs opts
 allMain (Yaffle f) = yaffleMain f []
 allMain (TTM f) = dumpTTM f
@@ -266,7 +266,7 @@ allMain (TTM f) = dumpTTM f
 -- Run any options (such as --version or --help) which imply printing a
 -- message then exiting. Returns wheter the program should continue
 
-quitOpts : List CLOpt -> IO ProgramProgress
+quitOpts : List CLOpt -> IO ControlFlow
 quitOpts [] = pure Continue
 quitOpts (Version :: _)
     = do putStrLn versionMsg

--- a/src/Idris/Driver.idr
+++ b/src/Idris/Driver.idr
@@ -168,6 +168,7 @@ stMain cgs opts
                                      """
          update ROpts { mainfile := fname }
 
+         s <- newRef PostS defaultPost
          -- start by going over the pre-options, and stop if we do not need to
          -- continue
          Continue <- preOptions opts
@@ -205,7 +206,9 @@ stMain cgs opts
                                 res <- loadMainFile f
                                 displayStartupErrors res
                                 pure res
-               Continue <- catch (postOptions result opts)
+
+               post <- get PostS
+               Continue <- catch (postOptions result post)
                                (\err => emitError err *> pure Abort)
                 | Abort => do
                     -- exit with an error code if there was an error, otherwise

--- a/src/Idris/Driver.idr
+++ b/src/Idris/Driver.idr
@@ -205,11 +205,16 @@ stMain cgs opts
                                 res <- loadMainFile f
                                 displayStartupErrors res
                                 pure res
-
-               doRepl <- catch (postOptions result opts)
-                               (\err => emitError err *> pure False)
-               if doRepl then
-                 if ide || ideSocket then
+               Continue <- catch (postOptions result opts)
+                               (\err => emitError err *> pure Abort)
+                | Abort => do
+                    -- exit with an error code if there was an error, otherwise
+                    -- just exit
+                     ropts <- get ROpts
+                     showTimeRecord
+                     whenJust (errorLine ropts) $ \ _ =>
+                       coreLift $ exitWith (ExitFailure 1)
+               if ide || ideSocket then
                    if not ideSocket
                     then do
                      setOutput (IDEMode 0 stdin stdout)
@@ -227,13 +232,6 @@ stMain cgs opts
                  else do
                      repl {c} {u} {m}
                      showTimeRecord
-                else
-                    -- exit with an error code if there was an error, otherwise
-                    -- just exit
-                  do ropts <- get ROpts
-                     showTimeRecord
-                     whenJust (errorLine ropts) $ \ _ =>
-                       coreLift $ exitWith (ExitFailure 1)
 
   where
 

--- a/src/Idris/Driver.idr
+++ b/src/Idris/Driver.idr
@@ -95,23 +95,28 @@ updateREPLOpts
     = do ed <- coreLift $ idrisGetEnv "EDITOR"
          whenJust ed $ \ e => update ROpts { editor := e }
 
-tryYaffle : List CLOpt -> Core ProgramProgress
-tryYaffle [] = pure Continue
-tryYaffle (Yaffle f :: _) = do yaffleMain f []
-                               pure Abort
-tryYaffle (c :: cs) = tryYaffle cs
+-- There are three ways to run the compiler
+-- Either run normall, or run in yaffle mode, or dump TTM
+data CLIMode
+  = Normal
+  | Yaffle String
+  | TTM String
+
+-- Yaffle and TTM are mutually incompatible so we parse the flags here and
+-- report the error if it occurs. If neither flag is present we run in normal mode
+parseCompilerMode : List CLOpt -> Maybe CLIMode -> Either String CLIMode
+parseCompilerMode [] Nothing = pure Normal
+parseCompilerMode [] (Just m) = pure m
+parseCompilerMode (Yaffle f :: xs) Nothing = parseCompilerMode xs (Just $ Yaffle f)
+parseCompilerMode (Metadata f :: xs) Nothing = parseCompilerMode xs (Just $ TTM f)
+parseCompilerMode (Yaffle _ :: xs) (Just (TTM _)) = Left "Incompatible modes --ttm and --yaffle"
+parseCompilerMode (Metadata _ :: xs) (Just (Yaffle _)) = Left "Incompatible modes --ttm and --yaffle"
+parseCompilerMode (_ :: xs) m = parseCompilerMode xs m
 
 ignoreMissingIpkg : List CLOpt -> Bool
 ignoreMissingIpkg [] = False
 ignoreMissingIpkg (IgnoreMissingIPKG :: _) = True
 ignoreMissingIpkg (c :: cs) = ignoreMissingIpkg cs
-
-tryTTM : List CLOpt -> Core ProgramProgress
-tryTTM [] = pure Continue
-tryTTM (Metadata f :: _) = do dumpTTM f
-                              pure Abort
-tryTTM (c :: cs) = tryTTM cs
-
 
 banner : String
 banner = #"""
@@ -131,12 +136,7 @@ checkVerbose (_ :: xs) = checkVerbose xs
 
 stMain : List (String, Codegen) -> List CLOpt -> Core ()
 stMain cgs opts
-    = do Continue <- tryYaffle opts
-            | Abort => pure ()
-         Continue <- tryTTM opts
-            | Abort => pure ()
-
-         defs <- initDefs
+    = do defs <- initDefs
          -- Add the manually added codegens to the option set
          let updated = foldl (\o, (s, _) => addCG (s, Other s) o) (options defs) cgs
          c <- newRef Ctxt ({ options := updated } defs)
@@ -247,6 +247,11 @@ stMain cgs opts
     msg <- render doc
     coreLift (die msg)
 
+allMain : List (String, Codegen) -> List CLOpt -> CLIMode -> Core ()
+allMain cgs opts Normal = stMain cgs opts
+allMain cgs opts (Yaffle f) = yaffleMain f []
+allMain cgs opts (TTM f) = dumpTTM f
+
 -- Run any options (such as --version or --help) which imply printing a
 -- message then exiting. Returns wheter the program should continue
 
@@ -278,7 +283,10 @@ mainWithCodegens cgs = do
   Continue <- quitOpts opts
     | Abort => pure ()
   setupTerm
-  coreRun (stMain cgs opts)
+  let Right cliMode = parseCompilerMode opts Nothing
+    | Left err => do ignore $ fPutStrLn stderr $ "Error: " ++ err
+                     exitWith (ExitFailure 1)
+  coreRun (allMain cgs opts cliMode)
     (\err : Error => do ignore $ fPutStrLn stderr $ "Uncaught error: " ++ show err
                         exitWith (ExitFailure 1))
     (\res => pure ())

--- a/src/Idris/Driver.idr
+++ b/src/Idris/Driver.idr
@@ -170,8 +170,8 @@ stMain cgs opts
 
          -- start by going over the pre-options, and stop if we do not need to
          -- continue
-         True <- preOptions opts
-            | False => pure ()
+         Continue <- preOptions opts
+            | Abort => pure ()
 
          -- If there's a --build or --install, just do that then quit
          Continue <- flip catch quitWithError $ processPackageOpts opts

--- a/src/Idris/Driver.idr
+++ b/src/Idris/Driver.idr
@@ -174,9 +174,10 @@ stMain cgs opts
             | False => pure ()
 
          -- If there's a --build or --install, just do that then quit
-         done <- flip catch quitWithError $ processPackageOpts opts
+         Continue <- flip catch quitWithError $ processPackageOpts opts
+            | Abort => pure ()
 
-         when (not done) $ flip catch quitWithError $
+         flip catch quitWithError $
             do when (checkVerbose opts) $ -- override Quiet if implicitly set
                    setOutput (REPL InfoLvl)
                u <- newRef UST initUState
@@ -248,8 +249,6 @@ stMain cgs opts
 -- Run any options (such as --version or --help) which imply printing a
 -- message then exiting. Returns wheter the program should continue
 
-data ProgramProgress = Continue | Abort
-
 quitOpts : List CLOpt -> IO ProgramProgress
 quitOpts [] = pure Continue
 quitOpts (Version :: _)
@@ -275,10 +274,10 @@ mainWithCodegens cgs = do
   Right opts <- getCmdOpts
     | Left err => do ignore $ fPutStrLn stderr $ "Error: " ++ err
                      exitWith (ExitFailure 1)
-  continue <- quitOpts opts
-  when continue $ do
-    setupTerm
-    coreRun (stMain cgs opts)
-      (\err : Error => do ignore $ fPutStrLn stderr $ "Uncaught error: " ++ show err
-                          exitWith (ExitFailure 1))
-      (\res => pure ())
+  Continue <- quitOpts opts
+    | Abort => pure ()
+  setupTerm
+  coreRun (stMain cgs opts)
+    (\err : Error => do ignore $ fPutStrLn stderr $ "Uncaught error: " ++ show err
+                        exitWith (ExitFailure 1))
+    (\res => pure ())

--- a/src/Idris/IDEMode/REPL.idr
+++ b/src/Idris/IDEMode/REPL.idr
@@ -136,6 +136,7 @@ process : {auto c : Ref Ctxt Defs} ->
           {auto s : Ref Syn SyntaxInfo} ->
           {auto m : Ref MD Metadata} ->
           {auto o : Ref ROpts REPLOpts} ->
+          {auto _ : Ref PostS PostSession} ->
           IDECommand -> Core IDEResult
 process (Interpret cmd)
     = replWrap $ interpret cmd
@@ -244,6 +245,7 @@ processCatch : {auto c : Ref Ctxt Defs} ->
                {auto s : Ref Syn SyntaxInfo} ->
                {auto m : Ref MD Metadata} ->
                {auto o : Ref ROpts REPLOpts} ->
+               {auto p : Ref PostS PostSession} ->
                IDECommand -> Core IDEResult
 processCatch cmd
     = do c' <- branch
@@ -461,6 +463,7 @@ loop : {auto c : Ref Ctxt Defs} ->
        {auto s : Ref Syn SyntaxInfo} ->
        {auto m : Ref MD Metadata} ->
        {auto o : Ref ROpts REPLOpts} ->
+       {auto p : Ref PostS PostSession} ->
        Core ()
 loop
     = do res <- getOutput
@@ -498,6 +501,7 @@ replIDE : {auto c : Ref Ctxt Defs} ->
           {auto s : Ref Syn SyntaxInfo} ->
           {auto m : Ref MD Metadata} ->
           {auto o : Ref ROpts REPLOpts} ->
+          {auto p : Ref PostS PostSession} ->
           Core ()
 replIDE
     = do res <- getOutput

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -1072,7 +1072,7 @@ parameters
   {auto p : Ref PostS PostSession}
 
   export
-  processPackageOpts : List CLOpt -> Core ProgramProgress
+  processPackageOpts : List CLOpt -> Core ControlFlow
   processPackageOpts opts
       = do (MkPFR cmds@(_::_) opts' err) <- pure $ partitionOpts opts
                | (MkPFR Nil opts' _) => pure Continue

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -1062,6 +1062,10 @@ errorMsg = unlines
 export
 processPackageOpts : {auto c : Ref Ctxt Defs} ->
                      {auto s : Ref Syn SyntaxInfo} ->
+                     -- we need repl opts because
+                     -- we can emit warnings and emitting a warning
+                     -- requires knowing if we're in IDE more or in the repl
+                     -- which is in REPLOpts as the `idemode : OutputMode` field
                      {auto o : Ref ROpts REPLOpts} ->
                      List CLOpt -> Core ProgramProgress
 processPackageOpts opts

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -1063,14 +1063,14 @@ export
 processPackageOpts : {auto c : Ref Ctxt Defs} ->
                      {auto s : Ref Syn SyntaxInfo} ->
                      {auto o : Ref ROpts REPLOpts} ->
-                     List CLOpt -> Core Bool
+                     List CLOpt -> Core ProgramProgress
 processPackageOpts opts
     = do (MkPFR cmds@(_::_) opts' err) <- pure $ partitionOpts opts
-             | (MkPFR Nil opts' _) => pure False
+             | (MkPFR Nil opts' _) => pure Continue
          if err
            then coreLift $ putStrLn errorMsg
            else traverse_ (processPackage opts') cmds
-         pure True
+         pure Abort
 
 
 -- find an ipkg file in one of the parent directories

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -1065,53 +1065,47 @@ errorMsg = unlines
   , "    --output-dir <dir>"
   ]
 
-export
-processPackageOpts : {auto c : Ref Ctxt Defs} ->
-                     {auto s : Ref Syn SyntaxInfo} ->
-                     -- we need repl opts because
-                     -- we can emit warnings and emitting a warning
-                     -- requires knowing if we're in IDE more or in the repl
-                     -- which is in REPLOpts as the `idemode : OutputMode` field
-                     {auto o : Ref ROpts REPLOpts} ->
-                     {auto _ : Ref PostS PostSession} ->
-                     List CLOpt -> Core ProgramProgress
-processPackageOpts opts
-    = do (MkPFR cmds@(_::_) opts' err) <- pure $ partitionOpts opts
-             | (MkPFR Nil opts' _) => pure Continue
-         if err
-           then coreLift $ putStrLn errorMsg
-           else traverse_ (processPackage opts') cmds
-         pure Abort
+parameters
+  {auto c : Ref Ctxt Defs}
+  {auto s : Ref Syn SyntaxInfo}
+  {auto o : Ref ROpts REPLOpts}
+  {auto p : Ref PostS PostSession}
+
+  export
+  processPackageOpts : List CLOpt -> Core ProgramProgress
+  processPackageOpts opts
+      = do (MkPFR cmds@(_::_) opts' err) <- pure $ partitionOpts opts
+               | (MkPFR Nil opts' _) => pure Continue
+           if err
+             then coreLift $ putStrLn errorMsg
+             else traverse_ (processPackage opts') cmds
+           pure Abort
 
 
--- find an ipkg file in one of the parent directories
--- If it exists, read it, set the current directory to the root of the source
--- tree, and set the relevant command line options before proceeding
-export
-findIpkg : {auto c : Ref Ctxt Defs} ->
-           {auto r : Ref ROpts REPLOpts} ->
-           {auto s : Ref Syn SyntaxInfo} ->
-           {auto _ : Ref PostS PostSession} ->
-           Maybe String -> Core (Maybe String)
-findIpkg fname
-   = do Just (dir, ipkgn, up) <- coreLift findIpkgFile
-             | Nothing => pure fname
-        coreLift_ $ changeDir dir
-        setWorkingDir dir
-        pkg <- parsePkgFile True ipkgn
-        maybe (pure ()) setBuildDir (builddir pkg)
-        setOutputDir (outputdir pkg)
-        processOptions (options pkg)
-        addDeps pkg
-        case fname of
-             Nothing => pure Nothing
-             Just srcpath  =>
-                do let src' = up </> srcpath
-                   setSource src'
-                   update ROpts { mainfile := Just src' }
-                   pure (Just src')
-  where
-    dropHead : String -> List String -> List String
-    dropHead str [] = []
-    dropHead str (x :: xs)
-        = if x == str then xs else x :: xs
+  -- find an ipkg file in one of the parent directories
+  -- If it exists, read it, set the current directory to the root of the source
+  -- tree, and set the relevant command line options before proceeding
+  export
+  findIpkg : Maybe String -> Core (Maybe String)
+  findIpkg fname
+     = do Just (dir, ipkgn, up) <- coreLift findIpkgFile
+               | Nothing => pure fname
+          coreLift_ $ changeDir dir
+          setWorkingDir dir
+          pkg <- parsePkgFile True ipkgn
+          maybe (pure ()) setBuildDir (builddir pkg)
+          setOutputDir (outputdir pkg)
+          processOptions (options pkg)
+          addDeps pkg
+          case fname of
+               Nothing => pure Nothing
+               Just srcpath  =>
+                  do let src' = up </> srcpath
+                     setSource src'
+                     update ROpts { mainfile := Just src' }
+                     pure (Just src')
+    where
+      dropHead : String -> List String -> List String
+      dropHead str [] = []
+      dropHead str (x :: xs)
+          = if x == str then xs else x :: xs

--- a/src/Idris/Package.idr
+++ b/src/Idris/Package.idr
@@ -450,6 +450,7 @@ addDeps pkg = do
 
 processOptions : {auto c : Ref Ctxt Defs} ->
                  {auto o : Ref ROpts REPLOpts} ->
+                 {auto _ : Ref PostS PostSession} ->
                  Maybe (FC, String) -> Core ()
 processOptions Nothing = pure ()
 processOptions (Just (fc, opts))
@@ -489,6 +490,7 @@ withWarnings op = do o <- catch op $ \err =>
 prepareCompilation : {auto c : Ref Ctxt Defs} ->
                      {auto s : Ref Syn SyntaxInfo} ->
                      {auto o : Ref ROpts REPLOpts} ->
+                     {auto _ : Ref PostS PostSession} ->
                      PkgDesc ->
                      List CLOpt ->
                      Core (List Error)
@@ -517,6 +519,7 @@ export
 build : {auto c : Ref Ctxt Defs} ->
         {auto s : Ref Syn SyntaxInfo} ->
         {auto o : Ref ROpts REPLOpts} ->
+        {auto _ : Ref PostS PostSession} ->
         PkgDesc ->
         List CLOpt ->
         Core (List Error)
@@ -692,6 +695,7 @@ export
 check : {auto c : Ref Ctxt Defs} ->
         {auto s : Ref Syn SyntaxInfo} ->
         {auto o : Ref ROpts REPLOpts} ->
+        {auto _ : Ref PostS PostSession} ->
         PkgDesc ->
         List CLOpt ->
         Core (List Error)
@@ -706,6 +710,7 @@ check pkg opts =
 makeDoc : {auto c : Ref Ctxt Defs} ->
           {auto s : Ref Syn SyntaxInfo} ->
           {auto o : Ref ROpts REPLOpts} ->
+          {auto _ : Ref PostS PostSession} ->
           PkgDesc ->
           List CLOpt ->
           Core (List Error)
@@ -939,6 +944,7 @@ localPackageFile Nothing
 processPackage : {auto c : Ref Ctxt Defs} ->
                  {auto s : Ref Syn SyntaxInfo} ->
                  {auto o : Ref ROpts REPLOpts} ->
+                 {auto _ : Ref PostS PostSession} ->
                  List CLOpt ->
                  (PkgCommand, Maybe String) ->
                  Core ()
@@ -1067,6 +1073,7 @@ processPackageOpts : {auto c : Ref Ctxt Defs} ->
                      -- requires knowing if we're in IDE more or in the repl
                      -- which is in REPLOpts as the `idemode : OutputMode` field
                      {auto o : Ref ROpts REPLOpts} ->
+                     {auto _ : Ref PostS PostSession} ->
                      List CLOpt -> Core ProgramProgress
 processPackageOpts opts
     = do (MkPFR cmds@(_::_) opts' err) <- pure $ partitionOpts opts
@@ -1084,6 +1091,7 @@ export
 findIpkg : {auto c : Ref Ctxt Defs} ->
            {auto r : Ref ROpts REPLOpts} ->
            {auto s : Ref Syn SyntaxInfo} ->
+           {auto _ : Ref PostS PostSession} ->
            Maybe String -> Core (Maybe String)
 findIpkg fname
    = do Just (dir, ipkgn, up) <- coreLift findIpkgFile

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -596,8 +596,6 @@ postOptions _ (MkPostSession check out ex runRepl)
          whenJust runRepl $ \cmd => do
              replCmd cmd
              put ControlFlow Abort
-         -- if we compiled the file earlier, we stop now
-         -- otherwise, none of the options were set so we continue
          get ControlFlow
 
 export

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -406,7 +406,7 @@ export
 preOptions : {auto c : Ref Ctxt Defs} ->
              {auto o : Ref ROpts REPLOpts} ->
              {auto s : Ref PostS PostSession} ->
-             List CLOpt -> Core ProgramProgress
+             List CLOpt -> Core ControlFlow
 preOptions [] = pure Continue
 preOptions (NoBanner :: opts)
     = do setSession ({ nobanner := True } !getSession)
@@ -569,7 +569,8 @@ postOptions : {auto c : Ref Ctxt Defs} ->
               {auto s : Ref Syn SyntaxInfo} ->
               {auto o : Ref ROpts REPLOpts} ->
               {auto m : Ref MD Metadata} ->
-              REPLResult -> PostSession -> Core ProgramProgress
+              REPLResult -> PostSession -> Core ControlFlow
+-- In case of error loading the output file, we abort immediately without doing anything
 postOptions res@(ErrorLoadingFile {}) (MkPostSession _ (Just _) _ _)
     = pure Abort
 -- otherwise, we compile the file and
@@ -579,25 +580,25 @@ postOptions res@(ErrorLoadingFile {}) (MkPostSession _ (Just _) _ _)
 -- - run the REPL
 -- in this order, if either of those happened, we abort execution
 -- if none happened we continue
-postOptions res (MkPostSession check out ex runRepl)
-    = do controlFlow <- newRef ProgramProgress Continue
+postOptions _ (MkPostSession check out ex runRepl)
+    = do controlFlow <- newRef ControlFlow Continue
          whenJust out $ \ outfile => do
              ignore $ compileExp (PRef EmptyFC (UN $ Basic "main")) outfile
-             put ProgramProgress Abort
+             put ControlFlow Abort
          flip traverse_ (reverse ex) $ \ expr => do
              setCurrentElabSource expr
              let Right (_, _, e) = runParser (Virtual Interactive) Nothing expr $ aPTerm <* eoi
                    | Left err => throw err
              ignore $ execExp e
-             put ProgramProgress Abort
+             put ControlFlow Abort
          when check $
-             put ProgramProgress Abort
+             put ControlFlow Abort
          whenJust runRepl $ \cmd => do
              replCmd cmd
-             put ProgramProgress Abort
+             put ControlFlow Abort
          -- if we compiled the file earlier, we stop now
          -- otherwise, none of the options were set so we continue
-         get ProgramProgress
+         get ControlFlow
 
 export
 ideMode : List CLOpt -> Bool

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -445,7 +445,7 @@ preOptions (SetCG e :: opts)
             Just cg => do setCG cg
                           preOptions opts
             Nothing =>
-              do throw $ InternalError $ """
+              do throw $ UserError $ """
                    No such code generator
                    Code generators available: \{showSep ", " (map fst (availableCGs (options defs)))}
                    """

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -405,17 +405,20 @@ setIncrementalCG failOnError cgn
 export
 preOptions : {auto c : Ref Ctxt Defs} ->
              {auto o : Ref ROpts REPLOpts} ->
+             {auto s : Ref PostS PostSession} ->
              List CLOpt -> Core ProgramProgress
 preOptions [] = pure Continue
 preOptions (NoBanner :: opts)
     = do setSession ({ nobanner := True } !getSession)
          preOptions opts
 -- These things are processed later, but imply nobanner too
-preOptions (OutputFile _ :: opts)
-    = do setSession ({ nobanner := True } !getSession)
+preOptions (OutputFile file :: opts)
+    = do setSession ({ nobanner := True} !getSession)
+         update PostS {outputFile := Just file}
          preOptions opts
-preOptions (ExecFn _ :: opts)
-    = do setSession ({ nobanner := True } !getSession)
+preOptions (ExecFn expr :: opts)
+    = do setSession ({ nobanner := True} !getSession)
+         update PostS {execExpr := Just expr}
          preOptions opts
 preOptions (IdeMode :: opts)
     = do setSession ({ nobanner := True } !getSession)
@@ -424,7 +427,8 @@ preOptions (IdeModeSocket _ :: opts)
     = do setSession ({ nobanner := True } !getSession)
          preOptions opts
 preOptions (CheckOnly :: opts)
-    = do setSession ({ nobanner := True } !getSession)
+    = do setSession ({ nobanner := True} !getSession)
+         update PostS {checkOnly := True}
          preOptions opts
 preOptions (Profile :: opts)
     = do setSession ({ profile := True } !getSession)
@@ -477,9 +481,10 @@ preOptions (DebugElabCheck :: opts)
 preOptions (AltErrorCount c :: opts)
     = do setSession ({ logErrorCount := c } !getSession)
          preOptions opts
-preOptions (RunREPL _ :: opts)
+preOptions (RunREPL expr :: opts)
     = do setOutput (REPL VerbosityLvl.ErrorLvl)
-         setSession ({ nobanner := True } !getSession)
+         setSession ({ nobanner := True} !getSession)
+         update PostS {runRepl := Just expr}
          preOptions opts
 preOptions (FindIPKG :: opts)
     = do setSession ({ findipkg := True } !getSession)
@@ -562,31 +567,37 @@ export
 postOptions : {auto c : Ref Ctxt Defs} ->
               {auto u : Ref UST UState} ->
               {auto s : Ref Syn SyntaxInfo} ->
-              {auto m : Ref MD Metadata} ->
               {auto o : Ref ROpts REPLOpts} ->
-              REPLResult -> List CLOpt -> Core ProgramProgress
-postOptions _ [] = pure Continue
-postOptions res@(ErrorLoadingFile {}) (OutputFile _ :: rest)
-    = do ignore $ postOptions res rest
-         pure Abort
-postOptions res (OutputFile outfile :: rest)
-    = do ignore $ compileExp (PRef EmptyFC (UN $ Basic "main")) outfile
-         ignore $ postOptions res rest
-         pure Abort
-postOptions res (ExecFn expr :: rest)
-    = do setCurrentElabSource expr
-         let Right (_, _, e) = runParser (Virtual Interactive) Nothing expr $ aPTerm <* eoi
-           | Left err => throw err
-         ignore $ execExp e
-         ignore $ postOptions res rest
-         pure Abort
-postOptions res (CheckOnly :: rest)
-    = do ignore $ postOptions res rest
-         pure Abort
-postOptions res (RunREPL str :: rest)
-    = do replCmd str
-         pure Abort
-postOptions res (_ :: rest) = postOptions res rest
+              {auto m : Ref MD Metadata} ->
+              REPLResult -> PostSession -> Core ProgramProgress
+-- if we are expecting to load a file and there was an error loading the
+-- file we abort
+postOptions res@(ErrorLoadingFile {}) (MkPostSession _ (Just _) _ _)
+    = pure Abort
+-- otherwise, we compile the file and
+-- either :
+-- - execute the given expression
+-- - quit because the --check flag was given
+-- - run the REPL
+-- in this order, if either of those happened, we abort execution
+-- if none happened we continue
+postOptions res (MkPostSession check out ex runRepl)
+    = do whenJust out $ \outfile =>
+             ignore $ compileExp (PRef EmptyFC (UN $ Basic "main")) outfile
+         let Nothing = ex
+           | Just expr =>  do let Right (_, _, e) = runParser (Virtual Interactive) Nothing expr $ aPTerm <* eoi
+                                | Left err => throw err
+                              ignore $ execExp e
+                              pure Abort
+         let False = check
+           | True => pure Abort
+         let Nothing = runRepl
+           | Just cmd => replCmd cmd *> pure Abort
+         -- if we compiled the file earlier, we stop now
+         -- otherwise, none of the options were set so we continue
+         if isJust out
+            then pure Abort
+            else pure Continue
 
 export
 ideMode : List CLOpt -> Bool

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -405,8 +405,8 @@ setIncrementalCG failOnError cgn
 export
 preOptions : {auto c : Ref Ctxt Defs} ->
              {auto o : Ref ROpts REPLOpts} ->
-             List CLOpt -> Core Bool
-preOptions [] = pure True
+             List CLOpt -> Core ProgramProgress
+preOptions [] = pure Continue
 preOptions (NoBanner :: opts)
     = do setSession ({ nobanner := True } !getSession)
          preOptions opts
@@ -441,10 +441,11 @@ preOptions (SetCG e :: opts)
             Just cg => do setCG cg
                           preOptions opts
             Nothing =>
-              do coreLift $ putStrLn "No such code generator"
-                 coreLift $ putStrLn $ "Code generators available: " ++
-                                 showSep ", " (map fst (availableCGs (options defs)))
-                 coreLift $ exitWith (ExitFailure 1)
+              do throw $ InternalError $ """
+                   No such code generator
+                   Code generators available: \{showSep ", " (map fst (availableCGs (options defs)))}
+                   """
+                 pure Abort
 preOptions (Directive d :: opts)
     = do setSession ({ directives $= (d::) } !getSession)
          preOptions opts
@@ -463,10 +464,10 @@ preOptions (OutputDir d :: opts)
 preOptions (Directory d :: opts)
     = do defs <- get Ctxt
          dirOption (dirs (options defs)) d
-         pure False
+         pure Abort
 preOptions (ListPackages :: opts)
     = do listPackages
-         pure False
+         pure Abort
 preOptions (Timing tm :: opts)
     = do setLogTimings (fromMaybe 10 tm)
          preOptions opts
@@ -540,13 +541,13 @@ preOptions (WholeProgram :: opts)
 preOptions (BashCompletion a b :: _)
     = do os <- opts a b
          coreLift $ putStr $ unlines os
-         pure False
+         pure Abort
 preOptions (BashCompletionScript fun :: _)
     = do coreLift $ putStrLn $ bashCompletionScript fun
-         pure False
+         pure Abort
 preOptions (ZshCompletionScript fun :: _)
     = do coreLift $ putStrLn $ zshCompletionScript fun
-         pure False
+         pure Abort
 preOptions (Total :: opts)
     = do updateSession ({ totalReq := Total })
          preOptions opts

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -418,7 +418,7 @@ preOptions (OutputFile file :: opts)
          preOptions opts
 preOptions (ExecFn expr :: opts)
     = do setSession ({ nobanner := True} !getSession)
-         update PostS {execExpr := Just expr}
+         update PostS {execExpr $= (expr ::)}
          preOptions opts
 preOptions (IdeMode :: opts)
     = do setSession ({ nobanner := True } !getSession)
@@ -570,8 +570,6 @@ postOptions : {auto c : Ref Ctxt Defs} ->
               {auto o : Ref ROpts REPLOpts} ->
               {auto m : Ref MD Metadata} ->
               REPLResult -> PostSession -> Core ProgramProgress
--- if we are expecting to load a file and there was an error loading the
--- file we abort
 postOptions res@(ErrorLoadingFile {}) (MkPostSession _ (Just _) _ _)
     = pure Abort
 -- otherwise, we compile the file and
@@ -582,22 +580,24 @@ postOptions res@(ErrorLoadingFile {}) (MkPostSession _ (Just _) _ _)
 -- in this order, if either of those happened, we abort execution
 -- if none happened we continue
 postOptions res (MkPostSession check out ex runRepl)
-    = do whenJust out $ \outfile =>
+    = do controlFlow <- newRef ProgramProgress Continue
+         whenJust out $ \ outfile => do
              ignore $ compileExp (PRef EmptyFC (UN $ Basic "main")) outfile
-         let Nothing = ex
-           | Just expr =>  do let Right (_, _, e) = runParser (Virtual Interactive) Nothing expr $ aPTerm <* eoi
-                                | Left err => throw err
-                              ignore $ execExp e
-                              pure Abort
-         let False = check
-           | True => pure Abort
-         let Nothing = runRepl
-           | Just cmd => replCmd cmd *> pure Abort
+             put ProgramProgress Abort
+         flip traverse_ (reverse ex) $ \ expr => do
+             setCurrentElabSource expr
+             let Right (_, _, e) = runParser (Virtual Interactive) Nothing expr $ aPTerm <* eoi
+                   | Left err => throw err
+             ignore $ execExp e
+             put ProgramProgress Abort
+         when check $
+             put ProgramProgress Abort
+         whenJust runRepl $ \cmd => do
+             replCmd cmd
+             put ProgramProgress Abort
          -- if we compiled the file earlier, we stop now
          -- otherwise, none of the options were set so we continue
-         if isJust out
-            then pure Abort
-            else pure Continue
+         get ProgramProgress
 
 export
 ideMode : List CLOpt -> Bool

--- a/src/Idris/SetOptions.idr
+++ b/src/Idris/SetOptions.idr
@@ -564,28 +564,28 @@ postOptions : {auto c : Ref Ctxt Defs} ->
               {auto s : Ref Syn SyntaxInfo} ->
               {auto m : Ref MD Metadata} ->
               {auto o : Ref ROpts REPLOpts} ->
-              REPLResult -> List CLOpt -> Core Bool
-postOptions _ [] = pure True
+              REPLResult -> List CLOpt -> Core ProgramProgress
+postOptions _ [] = pure Continue
 postOptions res@(ErrorLoadingFile {}) (OutputFile _ :: rest)
     = do ignore $ postOptions res rest
-         pure False
+         pure Abort
 postOptions res (OutputFile outfile :: rest)
     = do ignore $ compileExp (PRef EmptyFC (UN $ Basic "main")) outfile
          ignore $ postOptions res rest
-         pure False
+         pure Abort
 postOptions res (ExecFn expr :: rest)
     = do setCurrentElabSource expr
          let Right (_, _, e) = runParser (Virtual Interactive) Nothing expr $ aPTerm <* eoi
            | Left err => throw err
          ignore $ execExp e
          ignore $ postOptions res rest
-         pure False
+         pure Abort
 postOptions res (CheckOnly :: rest)
     = do ignore $ postOptions res rest
-         pure False
+         pure Abort
 postOptions res (RunREPL str :: rest)
     = do replCmd str
-         pure False
+         pure Abort
 postOptions res (_ :: rest) = postOptions res rest
 
 export


### PR DESCRIPTION
# Description

This change is addressing technical debt related to the architecture of the driver. Those improvements
are driven by [Containers as APIs](https://arxiv.org/abs/2407.16713) as an experiment carried during Zurihack. While this PR itself does not introduce any containers or dependent lenses, the nature of changes were made evident by porting the driver to an API-first paradigm and refactoring the interaction model over there, and then backporting the changes to the main version.

## Changes
- `postOptions` was reading command line opts long after it became irrelevant. Instead we introduce a `PostSession` record that stores all the options that are relevant after a compiler session. To avoid polluting the global state (REPLOpts) it is stored in its own variable. It is also now written sequentially instead of recusively to better see the control flow of the application. There is more to do in that area in the future, but this is a good first step.
- The compiler has three different entry points depending on the flags `--ttm` and `--yaffle` (and nothing). The previous version handled this via a side effect, here we declaratively generate a value of `Entrypoint` carrying all the necessary data to run the matching entry point
- The imperative implementation of entrypoints would allow both `--ttm` and `--yaffle` flags and silently ignore the first one if the second was present. Because choosing the entry point is an exclusive choice, we now detect those two flags as being incompatible if they are present at the same time.
- Some boolean flags were used for control flow, sometimes `True` would stand for "continue" and sometimes for "abort", instead we now have `ControlFlow` type with two inhabitants `Continue` and `Abort` which clearly state intent.

There is a lot more opportunities to improve but there is a balance to strike between a small reviewable PR and one with too many unjustified changes. I think those changes are beneficial to the overall architecture without making large sweeping changes that are hard to review.

## Self-check

<!-- /!\ Please delete sections that do not apply -->
- [ ] This is my first time contributing, I've carefully read [`CONTRIBUTING.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTING.md)
      and I've updated [`CONTRIBUTORS`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTORS) with my name.
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)
- [x] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.
