### PR TITLE
[ doc ] Update paragraph to be related to `ArithCmdDo.idr`

### DIFF
--- a/docs/source/typedd/typedd.rst
+++ b/docs/source/typedd/typedd.rst
@@ -367,13 +367,11 @@ now uses a safer type for the number of shifts:
 In ``ArithCmd.idr``, update ``DivBy``, ``randoms``, and ``import Data.Bits``
 as above. Also add ``import Data.String`` for ``String.toLower``.
 
-In ``ArithCmd.idr``, update ``DivBy``, ``randoms``, ``import Data.Bits`` and
+In ``ArithCmdDo.idr``, update ``DivBy``, ``randoms``, ``import Data.Bits`` and
 ``import Data.String`` as above.  Also, since export rules are per-namespace
 now, rather than per-file, you need to export ``(>>=)`` from the namespaces
-``CommandDo`` and ``ConsoleDo``.
-
-In ``ArithCmdDo.idr``, since ``(>>=)`` is ``export``, ``Command`` and ``ConsoleIO``
-also have to be ``export``. Also, update ``randoms`` and ``import Data.Bits`` as above.
+``CommandDo`` and ``ConsoleDo``. ``Command`` and ``ConsoleIO``
+also have to be ``export``.
 
 In ``StreamFail.idr``, add a ``partial`` annotation to ``labelWith``.
 


### PR DESCRIPTION
# Description

Previously, there were two update paragraphs for `ArithCmd.idr`.
I believe this was typo as it is `ArithCmdDo.idr` that implements `CommandDo` etc. 
See: https://github.com/idris-lang/Idris2/blob/main/tests/typedd-book/chapter11/ArithCmdDo.idr

## Self-check

- [X] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.