### PR TITLE
[ fix ] update chez version in windows ci

### DIFF
--- a/.github/workflows/ci-idris2-and-libs.yml
+++ b/.github/workflows/ci-idris2-and-libs.yml
@@ -216,7 +216,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Get Chez Scheme
         run: |
-          git clone --depth 1 --branch v9.5.8a https://github.com/cisco/ChezScheme
+          git clone --depth 1 --branch v10.4.1 https://github.com/cisco/ChezScheme
           c:\msys64\usr\bin\bash -l -c "pacman -S --noconfirm tar make mingw-w64-x86_64-gcc"
           echo "PWD=$(c:\msys64\usr\bin\cygpath -u $(pwd))" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Configure and Build Chez Scheme
@@ -440,7 +440,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Get Chez Scheme
         run: |
-          git clone --depth 1 --branch v9.5.8a https://github.com/cisco/ChezScheme
+          git clone --depth 1 --branch v10.4.1 https://github.com/cisco/ChezScheme
           c:\msys64\usr\bin\bash -l -c "pacman -S --noconfirm tar make mingw-w64-x86_64-gcc"
           echo "PWD=$(c:\msys64\usr\bin\cygpath -u $(pwd))" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Configure and Build Chez Scheme

--- a/tests/chez/channels009/Main.idr
+++ b/tests/chez/channels009/Main.idr
@@ -27,7 +27,7 @@ main = do
       case n of
         1 => do
           tid <- fork (consumer c)
-          usleep 3500000
+          usleep 2500000
           pure tid
         _ =>
           fork (consumer c)

--- a/tests/chez/channels009/Main.idr
+++ b/tests/chez/channels009/Main.idr
@@ -27,7 +27,7 @@ main = do
       case n of
         1 => do
           tid <- fork (consumer c)
-          usleep 2500000
+          usleep 3500000
           pure tid
         _ =>
           fork (consumer c)


### PR DESCRIPTION
# Description

Windows CI is broken because it is using v9.5.8a which expects an older version of visual studio. It was pinned in #3040 because the dev branch occasionally failed to build.  I've updated it to the latest release, v10.4.1.

In a test build, this failed once in channels009 and then later worked, so we may need to revisit that test at some point in time. 

