### PR TITLE
[ proposal ] fixed size C arrays a-la Struct

### DIFF
--- a/src/Compiler/CompileExpr.idr
+++ b/src/Compiler/CompileExpr.idr
@@ -380,6 +380,7 @@ getVars (S rest) = first :: map weakenVar (getVars rest)
 data NArgs : Type where
      User : Name -> List ClosedClosure -> NArgs
      Struct : String -> List (String, ClosedClosure) -> NArgs
+     Array : Int -> ClosedClosure -> NArgs
      NUnit : NArgs
      NPtr : NArgs
      NGCPtr : NArgs
@@ -427,6 +428,11 @@ getNArgs defs (NS _ (UN $ Basic "Struct")) [n, args]
     = do NPrimVal _ (Str n') <- evalClosure defs n
              | nf => throw (GenericMsg (getLoc nf) "Unknown name for struct")
          pure (Struct n' !(getFieldArgs defs args))
+getNArgs defs (NS _ (UN $ Basic "CArray")) [n, ty]
+    = do NPrimVal _ (I n') <- evalClosure defs n
+             | nf => throw (GenericMsg (getLoc nf) "Invalid size for array")
+         pure (Array n' ty)
+
 getNArgs defs n args = pure $ User n args
 
 -- The order of the arguments have a big effect on case-tree size
@@ -471,6 +477,10 @@ nfToCFType _ (NTCon fc n_in _ args) s
                                        tycf <- nfToCFType fc tynf False
                                        pure (n, tycf)) fs
                    pure (CFStruct n fs')
+              Array n t =>
+                do narg <- evalClosure defs t
+                   carg <- nfToCFType fc narg s
+                   pure $ CFArray n carg
               NUnit => pure CFUnit
               NPtr => pure CFPtr
               NGCPtr => pure CFGCPtr

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -193,9 +193,16 @@ cftySpec fc CFGCPtr = pure "void*"
 cftySpec fc CFBuffer = pure "u8*"
 cftySpec fc (CFFun s t) = pure "void*"
 cftySpec fc (CFIORes t) = cftySpec fc t
-cftySpec fc (CFStruct n t) = pure $ "(* " ++ fromString n ++ ")"
+cftySpec fc (CFArray n t) = do
+  inner <- cftySpec fc t
+  pure $ "(array n " ++ inner ++ ")"
+cftySpec fc (CFStruct n t) = pure $ fromString n
 cftySpec fc t = throw (GenericMsg fc ("Can't pass argument of type " ++ show t ++
                          " to foreign function"))
+
+cftySpecArg : FC -> CFType -> Core Builder
+cftySpecArg fc t@(CFStruct _ _) = (\x => "(& " ++ x ++ ")") <$> cftySpec fc t
+cftySpecArg fc t = cftySpec fc t
 
 locateLib : {auto c : Ref Ctxt Defs} -> String -> String -> Core String
 locateLib appdir clib
@@ -252,7 +259,7 @@ cCall fc cfn clib args ret collectSafe
                    then pure Nothing
                    else do put Loaded (clib :: loaded)
                            pure (Just clib)
-         argTypes <- traverse (cftySpec fc . snd) args
+         argTypes <- traverse (cftySpecArg fc . snd) args
          retType <- cftySpec fc ret
          let callConv : Builder = if collectSafe then " __collect_safe" else ""
          let call = "((foreign-procedure" ++ callConv ++ " " ++ showB cfn ++ " ("
@@ -290,7 +297,7 @@ cCall fc cfn clib args ret collectSafe
     callback n args (CFFun s t) = callback n (s :: args) t
     callback n args_rev retty
         = do let args = reverse args_rev
-             argTypes <- traverse (cftySpec fc) (filter notWorld args)
+             argTypes <- traverse (cftySpecArg fc) (filter notWorld args)
              retType <- cftySpec fc retty
              pure $
                  "(let ([c-code (foreign-callable #f " ++

--- a/src/Core/CompileExpr.idr
+++ b/src/Core/CompileExpr.idr
@@ -197,6 +197,7 @@ data CFType : Type where
      CFFun : CFType -> CFType -> CFType
      CFIORes : CFType -> CFType
      CFStruct : String -> List (String, CFType) -> CFType
+     CFArray : Int -> CFType -> CFType
      CFUser : Name -> List CFType -> CFType
 
 public export
@@ -398,6 +399,7 @@ Show CFType where
   show (CFFun s t) = show s ++ " -> " ++ show t
   show (CFIORes t) = "IORes " ++ show t
   show (CFStruct n args) = "struct " ++ show n ++ " " ++ showSep " " (map show args)
+  show (CFArray n t) = "array " ++ show n ++ " " ++ show t
   show (CFUser n args) = show n ++ " " ++ showSep " " (map show args)
 
 export

--- a/src/Core/Hash.idr
+++ b/src/Core/Hash.idr
@@ -259,6 +259,8 @@ Hashable CFType where
       h `hashWithSalt` 14 `hashWithSalt` a
     CFStruct n fs =>
       h `hashWithSalt` 15 `hashWithSalt` n `hashWithSalt` fs
+    CFArray n t =>
+      h `hashWithSalt` 99 `hashWithSalt` n `hashWithSalt` t
     CFUser n xs =>
       h `hashWithSalt` 16 `hashWithSalt` n `hashWithSalt` xs
     CFInt8 =>

--- a/src/Core/TTC.idr
+++ b/src/Core/TTC.idr
@@ -838,6 +838,7 @@ TTC CFType where
   toBuf (CFFun s t) = do tag 11; toBuf s; toBuf t
   toBuf (CFIORes t) = do tag 12; toBuf t
   toBuf (CFStruct n a) = do tag 13; toBuf n; toBuf a
+  toBuf (CFArray n a) = do tag 99; toBuf n; toBuf a
   toBuf (CFUser n a) = do tag 14; toBuf n; toBuf a
   toBuf CFGCPtr = tag 15
   toBuf CFBuffer = tag 16


### PR DESCRIPTION
# Description

We have a blessed `Struct` type for passing around c structs using FFI, but I could not hack fixed size arrays. Idris seems to be okay with basic newtypes, but it complains for dependent types like:

```
data CArray : Nat -> Type -> Type where
```

I think what's happening is that the index types (the thing left of `:` right?) are being subject to the FFI restrictions of being basic types. I think a more radical fix here would be to drop the restrictions on types and only enforce them on constructors.

---

Some notes:
* the blessed type is called `CArray` in idris code to avoid clashing with the common `Array` type
* I'm using the 99 tag as placeholder

## Self-check

<!-- /!\ Please delete sections that do not apply -->
- [ ] This is my first time contributing, I've carefully read [`CONTRIBUTING.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTING.md)
      and I've updated [`CONTRIBUTORS`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTORS) with my name.
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)
- [x] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.
