### PR TITLE
[fix] nodejs terminal column and row code

### DIFF
--- a/libs/base/System/Term.idr
+++ b/libs/base/System/Term.idr
@@ -10,21 +10,29 @@ libterm s = "C:" ++ s ++ ", libidris2_support, idris_term.h"
 prim__setupTerm : PrimIO ()
 
 %foreign libterm "idris2_getTermCols"
-         "node:lambda:()=>process.stdout.columns"
+         "node:lambda:()=>(process.stdout.columns ? BigInt(process.stdout.columns) : 0)"
 prim__getTermCols : PrimIO Int
 
 %foreign libterm "idris2_getTermLines"
-         "node:lambda:()=>process.stdout.rows"
+         "node:lambda:()=>(process.stdout.rows ? BigInt(process.stdout.rows) : 0)"
 prim__getTermLines : PrimIO Int
 
 export
 setupTerm : IO ()
 setupTerm = primIO prim__setupTerm
 
+||| Get the number of columns in the terminal associated
+||| with stdout. If stdout is not a TTY terminal or for
+||| some other reason the width fails to be read you will
+||| get 0.
 export
 getTermCols : IO Int
 getTermCols = primIO prim__getTermCols
 
+||| Get the number of rows in the terminal associated
+||| with stdout. If stdout is not a TTY terminal or for
+||| some other reason the height fails to be read you
+||| will get 0.
 export
 getTermLines : IO Int
 getTermLines = primIO prim__getTermLines


### PR DESCRIPTION
# Description
The NodeJS FFI had bad edge case behavior for getting terminal width/height. Especially when run in a non-interactive shell where the result would be `undefined` even though the API's type is `Int`.

This fixes it by falling back to the same value the C FFI uses for rows/columns that cannot be read: 0.

## Self-check

<!-- /!\ Please delete sections that do not apply -->
- [ ] This is my first time contributing, I've carefully read [`CONTRIBUTING.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTING.md)
      and I've updated [`CONTRIBUTORS`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTORS) with my name.
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)
- [x] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.
