### PR TITLE
[ ci ] adding last step requiring overall success

### DIFF
--- a/.github/workflows/ci-idris2-and-libs.yml
+++ b/.github/workflows/ci-idris2-and-libs.yml
@@ -809,7 +809,7 @@ jobs:
       , ubuntu-build-api
       , ubuntu-self-host-chez
       , ubuntu-bootstrap-racket # ubuntu-self-host-racket
-      , windows-self-host-racket
+      # windows build currently broken , windows-self-host-racket
       ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-idris2-and-libs.yml
+++ b/.github/workflows/ci-idris2-and-libs.yml
@@ -798,7 +798,7 @@ jobs:
 
   overall-success:
     needs:
-      [ ubuntu-self-host-racket
+      [ ubuntu-bootstrap-racket # ubuntu-self-host-racket
       , macos-self-host-chez
       , ub-pack-test-lsp
       , ub-pack-test-pack
@@ -808,7 +808,6 @@ jobs:
       , ub-test-katla-and-html
       , ubuntu-build-api
       , ubuntu-self-host-chez
-      , ubuntu-bootstrap-racket # ubuntu-self-host-racket
       # windows build currently broken , windows-self-host-racket
       ]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-idris2-and-libs.yml
+++ b/.github/workflows/ci-idris2-and-libs.yml
@@ -810,3 +810,6 @@ jobs:
       , windows-self-host-racket
       ]
     runs-on: ubuntu-latest
+    steps:
+      - name: Success!
+      - run: true

--- a/.github/workflows/ci-idris2-and-libs.yml
+++ b/.github/workflows/ci-idris2-and-libs.yml
@@ -795,3 +795,18 @@ jobs:
           branch: gh-pages
           folder: .github/scripts/html/
           git-config-name: Github Actions
+
+  overall-success:
+    needs:
+      [ ub-pack-test-lsp
+      , ub-pack-test-pack
+      , ub-test-collie
+      , ub-test-elab-util
+      , ub-test-frex
+      , ub-test-katla-and-html
+      , ubuntu-build-api
+      , ubuntu-self-host-chez
+      , ubuntu-bootstrap-racket # ubuntu-self-host-racket
+      , windows-self-host-racket
+      ]
+    runs-on: ubuntu-latest

--- a/.github/workflows/ci-idris2-and-libs.yml
+++ b/.github/workflows/ci-idris2-and-libs.yml
@@ -798,7 +798,7 @@ jobs:
 
   overall-success:
     needs:
-      [ ubuntu-self-host-racker
+      [ ubuntu-self-host-racket
       , macos-self-host-chez
       , ub-pack-test-lsp
       , ub-pack-test-pack

--- a/.github/workflows/ci-idris2-and-libs.yml
+++ b/.github/workflows/ci-idris2-and-libs.yml
@@ -798,7 +798,9 @@ jobs:
 
   overall-success:
     needs:
-      [ ub-pack-test-lsp
+      [ ubuntu-self-host-racker
+      , macos-self-host-chez
+      , ub-pack-test-lsp
       , ub-pack-test-pack
       , ub-test-collie
       , ub-test-elab-util

--- a/.github/workflows/ci-idris2-and-libs.yml
+++ b/.github/workflows/ci-idris2-and-libs.yml
@@ -812,4 +812,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Success!
-      - run: true
+        run: true

--- a/.github/workflows/ci-idris2-and-libs.yml
+++ b/.github/workflows/ci-idris2-and-libs.yml
@@ -1,6 +1,7 @@
 name: Idris2 and External Libs
 
 on:
+  merge_group:
   push:
     branches:
       - '*'


### PR DESCRIPTION
This will make using the merge queue protection easier than adding 10 separate
success rules in the admin panel.