### PR TITLE
[ ci ] add more dependencies to overall-success

### DIFF
--- a/.github/workflows/ci-idris2-and-libs.yml
+++ b/.github/workflows/ci-idris2-and-libs.yml
@@ -363,6 +363,7 @@ jobs:
   ubuntu-self-host-racket:
     needs: ubuntu-bootstrap-racket
     runs-on: ubuntu-latest
+    if: false
     timeout-minutes: 60
     env:
       IDRIS2_CG: racket
@@ -799,7 +800,7 @@ jobs:
 
   overall-success:
     needs:
-      [ ubuntu-self-host-racket
+      [ ubuntu-bootstrap-racket # ubuntu-self-host-racket
       , macos-self-host-chez
       , ub-pack-test-lsp
       , ub-pack-test-pack

--- a/.github/workflows/ci-idris2-and-libs.yml
+++ b/.github/workflows/ci-idris2-and-libs.yml
@@ -799,7 +799,7 @@ jobs:
 
   overall-success:
     needs:
-      [ ubuntu-bootstrap-racket # ubuntu-self-host-racket
+      [ ubuntu-self-host-racket
       , macos-self-host-chez
       , ub-pack-test-lsp
       , ub-pack-test-pack
@@ -807,8 +807,9 @@ jobs:
       , ub-test-elab-util
       , ub-test-frex
       , ub-test-katla-and-html
-      , ubuntu-build-api
+      , nix-bootstrap-chez
       , ubuntu-self-host-chez
+      , ubuntu-build-api
       , windows-self-host-racket
       ]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Now that we have reactivated another racket build, let's make the overall success
conditional on it too. Also grabbed the nix one that I had missed earlier.