### PR TITLE
docs: add documentation for `Text.Quantity`

### DIFF
--- a/libs/contrib/Text/Quantity.idr
+++ b/libs/contrib/Text/Quantity.idr
@@ -2,10 +2,15 @@ module Text.Quantity
 
 %default total
 
+||| A quantity bounded by a minimum and, optionally, a maximum.
+||| It can be used in certain lexers or parsers to specify
+||| how many times an item is expected to appear.
 public export
 record Quantity where
   constructor Qty
+  ||| Minimum number of occurrences.
   min : Nat
+  ||| Optional maximum number of occurrences.
   max : Maybe Nat
 
 public export
@@ -22,22 +27,27 @@ Show Quantity where
                                      then ""
                                      else "," ++ show max'
 
+||| Create a `Quantity` with the given lower and upper bounds. {min,max}
 public export
 between : Nat -> Nat -> Quantity
 between min max = Qty min (Just max)
 
+||| Create a `Quantity` with only a lower bound. {min,}
 public export
 atLeast : Nat -> Quantity
 atLeast min = Qty min Nothing
 
+||| Create a `Quantity` from zero to the given upper bound. {0,max}
 public export
 atMost : Nat -> Quantity
 atMost max = Qty 0 (Just max)
 
+||| Create a `Quantity` requiring an exact number of occurrences. {n}
 public export
 exactly : Nat -> Quantity
 exactly n = Qty n (Just n)
 
+||| Check whether a `Quantity`'s bounds are well-formed, i.e. min <= max.
 public export
 inOrder : Quantity -> Bool
 inOrder (Qty min Nothing) = True

--- a/src/Libraries/Text/Quantity.idr
+++ b/src/Libraries/Text/Quantity.idr
@@ -2,10 +2,15 @@ module Libraries.Text.Quantity
 
 %default total
 
+||| A quantity bounded by a minimum and, optionally, a maximum.
+||| It can be used in certain lexers or parsers to specify
+||| how many times an item is expected to appear.
 public export
 record Quantity where
   constructor Qty
+  ||| Minimum number of occurrences.
   min : Nat
+  ||| Optional maximum number of occurrences.
   max : Maybe Nat
 
 public export
@@ -22,22 +27,27 @@ Show Quantity where
                                      then ""
                                      else "," ++ show max'
 
+||| Create a `Quantity` with the given lower and upper bounds. {min,max}
 public export
 between : Nat -> Nat -> Quantity
 between min max = Qty min (Just max)
 
+||| Create a `Quantity` with only a lower bound. {min,}
 public export
 atLeast : Nat -> Quantity
 atLeast min = Qty min Nothing
 
+||| Create a `Quantity` from zero to the given upper bound. {0,max}
 public export
 atMost : Nat -> Quantity
 atMost max = Qty 0 (Just max)
 
+||| Create a `Quantity` requiring an exact number of occurrences. {n}
 public export
 exactly : Nat -> Quantity
 exactly n = Qty n (Just n)
 
+||| Check whether a `Quantity`'s bounds are well-formed, i.e. min <= max.
 public export
 inOrder : Quantity -> Bool
 inOrder (Qty min Nothing) = True


### PR DESCRIPTION
Add documentation for contrib's `Text.Quantity` and copy it to src `Libraries.Text.Quantity.idr`.

# Description

<!-- Make your description as clear as possible for reviewers,
feel free to ask questions or bring attention to specific parts
of the code. Before submitting a large diff, ensure that this is
a change that we can accept by opening an issue first and discussing
the proposed change. -->

## Self-check

<!-- /!\ Please delete sections that do not apply -->
- [ ] This is my first time contributing, I've carefully read [`CONTRIBUTING.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTING.md)
      and I've updated [`CONTRIBUTORS`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTORS) with my name.
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)
- [x] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.
