### PR TITLE
docs: add documentation for `curry` and `uncurry` in `Prelude.Basics`

### DIFF
--- a/libs/prelude/Prelude/Basics.idr
+++ b/libs/prelude/Prelude/Basics.idr
@@ -82,12 +82,25 @@ public export %tcinline
 apply : (a -> b) -> a -> b
 apply f = \a => f a
 
+||| Converts a function on pairs to a curried function that takes arguments separately.
+||| The curried form allows partial application.
+||| @ f the function to curry
+|||
+||| ```idris example
+||| (curry swap) x y = (y, x)
+||| ```
 public export
-curry : ((a, b) -> c) -> a -> b -> c
+curry : (f : (a, b) -> c) -> a -> b -> c
 curry f a b = f (a, b)
 
+||| Converts a curried function that takes arguments separately to a function on pairs.
+||| @ f the function to uncurry
+|||
+||| ```idris example
+||| (uncurry min) (x, y) = min x y
+||| ```
 public export
-uncurry : (a -> b -> c) -> (a, b) -> c
+uncurry : (f : a -> b -> c) -> (a, b) -> c
 uncurry f (a, b) = f a b
 
 ||| ($) is compiled specially to shortcut any tricky unification issues, but if

--- a/libs/prelude/Prelude/Basics.idr
+++ b/libs/prelude/Prelude/Basics.idr
@@ -82,7 +82,7 @@ public export %tcinline
 apply : (a -> b) -> a -> b
 apply f = \a => f a
 
-||| Converts a function on pairs to a curried function that takes arguments separately.
+||| Convert a function on pairs to a curried function that takes arguments separately.
 ||| The curried form allows partial application.
 ||| @ f the function to curry
 |||
@@ -93,7 +93,7 @@ public export
 curry : (f : (a, b) -> c) -> a -> b -> c
 curry f a b = f (a, b)
 
-||| Converts a curried function that takes arguments separately to a function on pairs.
+||| Convert a curried function that takes arguments separately to a function on pairs.
 ||| @ f the function to uncurry
 |||
 ||| ```idris example

--- a/libs/prelude/Prelude/Basics.idr
+++ b/libs/prelude/Prelude/Basics.idr
@@ -87,7 +87,7 @@ apply f = \a => f a
 ||| @ f the function to curry
 |||
 ||| ```idris example
-||| (curry swap) x y = (y, x)
+||| (curry swap) 1 0 = swap (1, 0)
 ||| ```
 public export
 curry : (f : (a, b) -> c) -> a -> b -> c
@@ -97,7 +97,7 @@ curry f a b = f (a, b)
 ||| @ f the function to uncurry
 |||
 ||| ```idris example
-||| (uncurry min) (x, y) = min x y
+||| (uncurry min) (1, 0) = min 1 0
 ||| ```
 public export
 uncurry : (f : a -> b -> c) -> (a, b) -> c


### PR DESCRIPTION
# Description
Added documentation with examples for `curry` and `uncurry` in `Prelude.Basics`.
<!-- Make your description as clear as possible for reviewers,
feel free to ask questions or bring attention to specific parts
of the code. Before submitting a large diff, ensure that this is
a change that we can accept by opening an issue first and discussing
the proposed change. -->

## Self-check

<!-- /!\ Please delete sections that do not apply -->

- [x] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.
