### PR TITLE
Remove code duplication in `Compiler.LambdaLift`

### DIFF
--- a/src/Compiler/LambdaLift.idr
+++ b/src/Compiler/LambdaLift.idr
@@ -16,6 +16,7 @@ import Core.Context
 import Data.Vect
 
 import Libraries.Data.SnocList.SizeOf
+import Libraries.Data.List.Extra
 
 %default covering
 
@@ -354,14 +355,6 @@ record Used (vars : Scope) where
 
 initUsed : {vars : _} -> Used vars
 initUsed {vars} = MkUsed (replicate (length vars) False)
-
--- TODO upstream
-lengthDistributesOverAppend
-  : (xs, ys : List a)
-  -> length (xs ++ ys) = length xs + length ys
-lengthDistributesOverAppend [] ys = Refl
-lengthDistributesOverAppend (x :: xs) ys =
-  cong S $ lengthDistributesOverAppend xs ys
 
 weakenUsed : {outer : _} -> Used vars -> Used (outer ++ vars)
 weakenUsed {outer} (MkUsed xs) =

--- a/src/Libraries/Data/List/Extra.idr
+++ b/src/Libraries/Data/List/Extra.idr
@@ -64,6 +64,7 @@ export
 sortedNub : Ord a => List a -> List a
 sortedNub = dedup . sort
 
+||| `List.length` is distributive over appending
 export
 lengthDistributesOverAppend
   : (xs, ys : List a)


### PR DESCRIPTION


# Description
Use `lengthDistributesOverAppend` from `Libraries.Data.List.Extra` in `Compiler.LambdaLift` instead of duplicating this code.
<!-- Make your description as clear as possible for reviewers,
feel free to ask questions or bring attention to specific parts
of the code. Before submitting a large diff, ensure that this is
a change that we can accept by opening an issue first and discussing
the proposed change. -->

## Self-check

- [x] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.
