### PR TITLE
[ cleanup ] remove the redundant `assert_total` in `Data.Fin.restrict`

### DIFF
--- a/libs/base/Data/Fin.idr
+++ b/libs/base/Data/Fin.idr
@@ -255,7 +255,7 @@ fromInteger x = finFromInteger x {prf = lemma prf} where
 ||| This is essentially a composition of `mod` and `fromInteger`
 public export
 restrict : (n : Nat) -> Integer -> Fin (S n)
-restrict n val = let val' = assert_total (abs (mod val (cast (S n)))) in
+restrict n val = let val' = abs (mod val (cast (S n))) in
                      -- reasoning about primitives, so we need the
                      -- 'believe_me'. It's fine because val' must be
                      -- in the right range


### PR DESCRIPTION
# Description

<!-- Make your description as clear as possible for reviewers,
feel free to ask questions or bring attention to specific parts
of the code. Before submitting a large diff, ensure that this is
a change that we can accept by opening an issue first and discussing
the proposed change. -->

## Self-check

- [x] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.
