### PR TITLE
[ new ] Support implicit arguments on lambdas

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -80,6 +80,7 @@ should target this file (`CHANGELOG_NEXT`).
   `%foreign_impl` strings [#3790](https://github.com/idris-lang/Idris2/issues/3790)
   * Improve related error messages
 * Fix exponential time issue in totality checking with large data on the left hand side (#3696).
+* Allow implicit lambdas using the syntax `\ {x} => ...`.
 * Removed `Borrowing` as a language extension.  This was never implemented in
   Idris2, so the only change is that `%language Borrowing` will now error rather
   than be accepted but do nothing.

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -653,15 +653,27 @@ mutual
           _ => fail "Invalid multiplicity (must be 0 or 1)"
 
   bindList : OriginDesc -> IndentInfo ->
-             Rule (List (RigCount, WithBounds PTerm, PTerm))
+             Rule (List (RigCount, WithBounds PTerm, PTerm, PiInfo PTerm))
   bindList fname indents
-      = forget <$> sepBy1 (decoratedSymbol fname ",")
-                          (do rig <- multiplicity fname
-                              pat <- bounds (simpleExpr fname indents)
-                              ty <- option
-                                       (PInfer (boundToFC fname pat))
-                                       (decoratedSymbol fname ":" *> opExpr pdef fname indents)
-                              pure (rig, pat, ty))
+      = forget <$> sepBy1 (decoratedSymbol fname ",") (explicitBind <|> implicitBind)
+    where
+      explicitBind : Rule (RigCount, WithBounds PTerm, PTerm, PiInfo PTerm)
+      explicitBind = do
+        rig <- multiplicity fname
+        pat <- bounds (simpleExpr fname indents)
+        ty <- option
+           (PInfer (boundToFC fname pat))
+           (decoratedSymbol fname ":" *> opExpr pdef fname indents)
+        pure (rig, pat, ty, Explicit)
+
+      implicitBind : Rule (RigCount, WithBounds PTerm, PTerm, PiInfo PTerm)
+      implicitBind = curly fname $ do
+        rig <- multiplicity fname
+        pat <- bounds (simpleExpr fname indents)
+        ty <- option
+           (PInfer (boundToFC fname pat))
+           (decoratedSymbol fname ":" *> opExpr pdef fname indents)
+        pure (rig, pat, ty, Implicit)
 
   ||| A list of names bound to the same type
   ||| BNF:
@@ -790,10 +802,10 @@ mutual
              (PLam fcCase top Explicit (PRef fcCase n) (PInfer fcCase) $
                  PCase (virtualiseFC fc) [] (PRef fcCase n) [alt]))
 
-       bindAll : List (RigCount, WithBounds PTerm, PTerm) -> PTerm -> PTerm
+       bindAll : List (RigCount, WithBounds PTerm, PTerm, PiInfo PTerm) -> PTerm -> PTerm
        bindAll [] scope = scope
-       bindAll ((rig, pat, ty) :: rest) scope
-           = PLam (boundToFC fname pat) rig Explicit pat.val ty
+       bindAll ((rig, pat, ty, icit) :: rest) scope
+           = PLam (boundToFC fname pat) rig icit pat.val ty
                   (bindAll rest scope)
 
        continueLam : Rule PTerm

--- a/tests/idris2/basic/basic077/ImplicitLam.idr
+++ b/tests/idris2/basic/basic077/ImplicitLam.idr
@@ -1,0 +1,26 @@
+import Data.Fin
+
+record DefaultCode (code : a -> Type) where
+  constructor MkDefault
+  choose : {0 ty : a} -> code ty
+
+Ex1,Ex2 : DefaultCode (Fin . S)
+
+Ex1 = MkDefault (\{n} => FZ)
+Ex2 = MkDefault {choose = \{n} => FZ}
+
+Code : Nat -> Type
+Code 0 = Fin 1
+Code n = Fin n
+
+aux : Nat -> Nat
+aux 0 = 0
+aux n@(S k) = k
+
+Ex0' : DefaultCode Code
+Ex0' = MkDefault $ \{n} =>
+  replace {p = id} (case n of
+    0 => Refl
+    (S k) => Refl
+  ) (Fin.FZ {k = aux n})
+

--- a/tests/idris2/basic/basic077/MultiArg.idr
+++ b/tests/idris2/basic/basic077/MultiArg.idr
@@ -1,0 +1,18 @@
+
+foo : ({a : Nat} -> {b : Unit} -> Nat) -> Nat
+foo f = f {a=42} {b = ()}
+
+callFoo : Nat
+callFoo = foo $ \ {x}, {y} => x
+
+failing "Mismatch between: () and Nat"
+  callFoo2 : Nat
+  callFoo2 = foo $ \ {x}, {x} => x
+
+failing "Mismatch between: () and Nat"
+  callFoo2 : Nat
+  callFoo2 = foo $ \ {x}, {y} => y
+
+main : IO ()
+main = printLn $ callFoo
+

--- a/tests/idris2/basic/basic077/expected
+++ b/tests/idris2/basic/basic077/expected
@@ -1,1 +1,2 @@
 1/1: Building ImplicitLam (ImplicitLam.idr)
+42

--- a/tests/idris2/basic/basic077/expected
+++ b/tests/idris2/basic/basic077/expected
@@ -1,0 +1,1 @@
+1/1: Building ImplicitLam (ImplicitLam.idr)

--- a/tests/idris2/basic/basic077/run
+++ b/tests/idris2/basic/basic077/run
@@ -1,3 +1,4 @@
 . ../../../testutils.sh
 
 check ImplicitLam.idr
+run MultiArg.idr

--- a/tests/idris2/basic/basic077/run
+++ b/tests/idris2/basic/basic077/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+check ImplicitLam.idr


### PR DESCRIPTION
# Description

This PR adds implicit lambda arguments to the surface syntax, following the [purely positional arguments](https://github.com/idris-lang/Idris2/issues/14#issuecomment-1206788173) proposed in issue #14.

The current syntax for _explicit_ arguments is `\ x, y : Nat, z => ...`. The change here is to allow wrapping each of those in braces to get an implicit argument in that position. So making the first two arguments implicit would look like `\ {x}, {y : Nat}, z => ...`. No commas inside the braces and no named arguments.  I think the syntax is a natural extension of the current lambda syntax. It varies a little from function definitions, but so do the commas in the current syntax.

I'll leave this as a draft while we sort out if there is a consensus and if this is useful. At that point we can update the documentation and add tests.

## Possible issues using implicit lambdas

An issue that may interfere with using this is automatic insertion of implicits.  I think there are two flavors that may come up:

**Idris2 will insert arguments on the left hand side for implicits referenced in the _normalized_ function type.** This insertion includes implicits after the last explicit argument given by the user. An implicit lambda expression at the beginning of the RHS will sometimes not work. (It may be a bug that Idris picks up implicits after the last argument or that it picks up implicits that aren't mentioned in the surface syntax.)

An example of this problem is:
```idris
WeirdType : Type
WeirdType = {0 a : Type} -> Nat -> Nat

oops : WeirdType -> WeirdType
oops f = \{0 a : Type} => f {a}
```
Here, `{0 a : Type}` is in the type _after normalization_, so Idris inserts `{a = a@{_}}` at the beginning of the LHS, even though that argument comes after the `f`.

**Idris2 will insert lambdas in front of most terms when the expected type begins with an implicit pi.** This does not happen if the term is lambda-shaped. If an implicit lambda is assigned to a name and then later used as an argument where an implicit Pi is expected, it won't typecheck. This issue is captured as #3223. I think it may be difficult to address because the insertion is sometimes desirable. This issue does not happen if a lambda is used directly as an argument.

So assuming these two issues are not yet addressed, I'd like to now if this feature is still useful for common use cases. And a test case would be nice.

A contrived example is:
```idris
data F : Nat -> Nat -> Type where

takesImpl : ({i : Nat} -> {j : Nat} -> F i j) -> ()
f : (i : Nat) -> F i j
g : (j : Nat) -> F i j

callImpl0 : ()
callImpl0 = takesImpl $ \ {i} => f i

callImpl3 : ()
callImpl3 = takesImpl $ \ {x} => f x
```


## Self-check

- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)
- [x] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.
