### PR TITLE
[ base ] Make the ST Monad inline to pick up IO optimisations

### DIFF
--- a/libs/base/Control/Monad/ST.idr
+++ b/libs/base/Control/Monad/ST.idr
@@ -39,6 +39,7 @@ Applicative (ST s) where
   pure = MkST . pure
   MkST f <*> MkST a = MkST $ f <*> a
 
+%inline
 export
 Monad (ST s) where
   MkST p >>= k


### PR DESCRIPTION
# Description

This PR adds `%inline` to the `ST` Monad. `ST` is a newtype around IO and will pick up the IO optimisations if inlined.

Given this test case:
```idris
testSt : ST s Int
testSt = do
  ref <- newSTRef 42
  val <- readSTRef ref
  writeSTRef ref $ val * 2
  readSTRef ref
```
The current compiler generates this javascript:
```js
function STTest_testSt($0) {
 return Control_Monad_ST_x3ex3ex3d_Monad_x28STx20x24sx29($3 => Control_Monad_ST_newSTRef(Number(_truncBigInt32(42n)), $3), ref => $9 => Control_Monad_ST_x3ex3ex3d_Monad_x28STx20x24sx29($c => (ref.value), val => $11 => Control_Monad_ST_x3ex3ex3d_Monad_x28STx20x24sx29($14 => (ref.value=_mul32s(val, Number(_truncBigInt32(2n)))), $1d => $1e => (ref.value), $11), $9), $0);
}
```
and with this change, we get:
```js
function STTest_testSt($0) {
 const $1 = Control_Monad_ST_newSTRef(Number(_truncBigInt32(42n)), $0);
 const $6 = ($1.value);
 const $a = ($1.value=_mul32s($6, Number(_truncBigInt32(2n))));
 return ($1.value);
}
```