### PR TITLE
[ new ] implement core interfaces for Data.Singleton

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -128,3 +128,4 @@ should target this file (`CHANGELOG_NEXT`).
 * Added `maybeEq` to `Decidable.Equality`.
 * Removed `writeIORef1`, which unsafely allowed a linear value to become unrestricted.
 * Made `xs` and `ys` explicit arguments of `SplitRecPair` in `Data.Vect.Views`.
+* Implemented core interfaces for `Data.Singleton`

--- a/libs/base/Data/Singleton.idr
+++ b/libs/base/Data/Singleton.idr
@@ -27,3 +27,23 @@ pure = Val
 public export
 (<*>) : Singleton f -> Singleton x -> Singleton (f x)
 Val f <*> Val x = Val (f x)
+
+public export %inline
+Eq (Singleton v) where
+  _ == _ = True
+
+public export %inline
+Ord (Singleton v) where
+  compare _ _ = EQ
+
+public export %inline
+Semigroup (Singleton v) where
+  x <+> _ = x
+
+public export %inline
+{v : a} -> Monoid (Singleton v) where
+  neutral = Val v
+
+export
+Show a => Show (Singleton {a} v) where
+  showPrec p (Val v) = showCon p "Val" (showArg v)

--- a/libs/base/Data/Singleton.idr
+++ b/libs/base/Data/Singleton.idr
@@ -1,5 +1,9 @@
 module Data.Singleton
 
+import Decidable.Equality
+
+%default total
+
 ||| The type containing only a particular value.
 ||| This is useful for calculating type-level information at runtime.
 public export
@@ -47,3 +51,7 @@ public export %inline
 export
 Show a => Show (Singleton {a} v) where
   showPrec p (Val v) = showCon p "Val" (showArg v)
+
+export
+DecEq (Singleton v) where
+  decEq (Val v) (Val v) = Yes Refl


### PR DESCRIPTION
# Description

This adds implementations of `Eq`, `Ord`, `Show`, `Semigroup`, `Monoid`, and `DecEq` for `Data.Singleton`. While most of these are trivial, I found them to still be useful occasionally.

## Self-check

<!-- /!\ Please delete sections that do not apply -->
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)
- [x] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.
