### PR TITLE
[fixes #3846][ library ] Re-namespace quantifiers for easier disambiguation.

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -87,7 +87,7 @@ should target this file (`CHANGELOG_NEXT`).
   external tools to insert links from documentation to source code.
 * Fixed `parseDouble` dropping "-" sign when whole part is "0"
   [#3804](https://github.com/idris-lang/Idris2/issues/3804),
-
++ Changed module level namespace of `Libraries.Data.List01.Quantifiers` from `All` to `List01`
 ### Building/Packaging changes
 
 * Fix parsing of capitalised package names containing hyphens.
@@ -129,3 +129,5 @@ should target this file (`CHANGELOG_NEXT`).
 * Removed `writeIORef1`, which unsafely allowed a linear value to become unrestricted.
 * Made `xs` and `ys` explicit arguments of `SplitRecPair` in `Data.Vect.Views`.
 * Implemented core interfaces for `Data.Singleton`
++ Renamed-spaced quantifiers for `List`, `Vect`, `SnocList`, `List01` and other predicates,
+  so that their most recent parent is named for the datatype and not the quantifier.

--- a/libs/base/Data/List/AtIndex.idr
+++ b/libs/base/Data/List/AtIndex.idr
@@ -14,13 +14,14 @@ import Decidable.Equality
 
 %default total
 
-||| @AtIndex witnesses the fact that a natural number encodes a membership proof.
-||| It is meant to be used as a runtime-irrelevant gadget to guarantee that the
-||| natural number is indeed a valid index.
-public export
-data AtIndex : a -> List a -> Nat -> Type where
-  Z : AtIndex a (a :: as) Z
-  S : AtIndex a as n -> AtIndex a (b :: as) (S n)
+namespace List
+  ||| @AtIndex witnesses the fact that a natural number encodes a membership proof.
+  ||| It is meant to be used as a runtime-irrelevant gadget to guarantee that the
+  ||| natural number is indeed a valid index.
+  public export
+  data AtIndex : a -> List a -> Nat -> Type where
+    Z : AtIndex a (a :: as) Z
+    S : AtIndex a as n -> AtIndex a (b :: as) (S n)
 
 ||| Inversion principle for Z constructor
 export

--- a/libs/base/Data/List/Elem.idr
+++ b/libs/base/Data/List/Elem.idr
@@ -10,13 +10,14 @@ import Control.Function
 -- List membership proof
 --------------------------------------------------------------------------------
 
-||| A proof that some element is found in a list.
-public export
-data Elem : a -> List a -> Type where
-     ||| A proof that the element is at the head of the list
-     Here : Elem x (x :: xs)
-     ||| A proof that the element is in the tail of the list
-     There : Elem x xs -> Elem x (y :: xs)
+namespace List
+  ||| A proof that some element is found in a list.
+  public export
+  data Elem : a -> List a -> Type where
+       ||| A proof that the element is at the head of the list
+       Here : Elem x (x :: xs)
+       ||| A proof that the element is in the tail of the list
+       There : Elem x xs -> Elem x (y :: xs)
 
 export
 Uninhabited (Here {x} {xs} = There {x = x'} {y} {xs = xs'} e) where

--- a/libs/base/Data/List/HasLength.idr
+++ b/libs/base/Data/List/HasLength.idr
@@ -30,11 +30,12 @@ import Data.Nat
 ------------------------------------------------------------------------
 -- Type
 
-||| Ensure that the list's length is the provided natural number
-public export
-data HasLength : Nat -> List a -> Type where
-  Z : HasLength Z []
-  S : HasLength n xs -> HasLength (S n) (x :: xs)
+namespace List
+  ||| Ensure that the list's length is the provided natural number
+  public export
+  data HasLength : Nat -> List a -> Type where
+    Z : HasLength Z []
+    S : HasLength n xs -> HasLength (S n) (x :: xs)
 
 ||| This specification corresponds to the length function
 export
@@ -156,4 +157,3 @@ natTerminating : (n : Nat) -> (0 p : HasLength n xs ) -> P xs
 natTerminating n p = case view n p of
   Z => PNil
   S n p => PCon (natTerminating n (map id p))
-

--- a/libs/base/Data/List/Lazy/Quantifiers.idr
+++ b/libs/base/Data/List/Lazy/Quantifiers.idr
@@ -7,7 +7,7 @@ import Data.List.Lazy
 
 %default total
 
-namespace Any
+namespace List
 
   -- Note: it is crucial here that we mark `xs` as `Lazy`, otherwise Idris
   --  will happily use `Delay` in the return index and give us a badly-behaved

--- a/libs/base/Data/List/Quantifiers.idr
+++ b/libs/base/Data/List/Quantifiers.idr
@@ -10,7 +10,7 @@ import Data.List.Elem
 ------------------------------------------------------------------------
 -- Quantifier types
 
-namespace Any
+namespace List
 
   ||| A proof that some element of a list satisfies some property
   |||
@@ -21,8 +21,6 @@ namespace Any
     Here  : {0 xs : List a} -> p x -> Any p (x :: xs)
     ||| A proof that the satisfying element is in the tail of the `List`
     There : {0 xs : List a} -> Any p xs -> Any p (x :: xs)
-
-namespace All
 
   ||| A proof that all elements of a list satisfy a property. It is a list of
   ||| proofs, corresponding element-wise to the `List`.
@@ -319,31 +317,34 @@ altAll (a::as) = Here <$> a <|> There <$> altAll as
 ------------------------------------------------------------------------
 -- Partitioning lists according to All
 
-||| Two lists, `xs` and `ys`, whose elements are interleaved in the list `xys`.
-public export
-data Interleaving : (xs, ys, xys : List a) -> Type where
-  Nil   : Interleaving [] [] []
-  Left  : Interleaving xs ys xys -> Interleaving (x :: xs) ys (x :: xys)
-  Right : Interleaving xs ys xys -> Interleaving xs (y :: ys) (y :: xys)
+namespace Interleaving
+  namespace List
+    ||| Two lists, `xs` and `ys`, whose elements are interleaved in the list `xys`.
+    public export
+    data Interleaving : (xs, ys, xys : List a) -> Type where
+      Nil   : Interleaving [] [] []
+      Left  : Interleaving xs ys xys -> Interleaving (x :: xs) ys (x :: xys)
+      Right : Interleaving xs ys xys -> Interleaving xs (y :: ys) (y :: xys)
 
-||| A record for storing the result of splitting a list `xys` according to some
-||| property `p`.
-||| The `prfs` and `contras` are related to the original list (`xys`) via
-||| `Interleaving`.
-|||
-||| @ xys the list which has been split
-||| @ p   the property used for the split
-public export
-record Split {a : Type} (p : a -> Type) (xys : List a) where
-  constructor MkSplit
-  {ayes, naws : List a}
-  {auto interleaving : Interleaving ayes naws xys}
-  ||| A proof that all elements in `ayes` satisfies the property used for the
-  ||| split.
-  prfs    : All p ayes
-  ||| A proof that all elements in `naws` do not satisfy the property used for
-  ||| the split.
-  contras : All (Not . p) naws
+namespace List
+  ||| A record for storing the result of splitting a list `xys` according to some
+  ||| property `p`.
+  ||| The `prfs` and `contras` are related to the original list (`xys`) via
+  ||| `Interleaving`.
+  |||
+  ||| @ xys the list which has been split
+  ||| @ p   the property used for the split
+  public export
+  record Split {a : Type} (p : a -> Type) (xys : List a) where
+    constructor MkSplit
+    {ayes, naws : List a}
+    {auto interleaving : Interleaving ayes naws xys}
+    ||| A proof that all elements in `ayes` satisfies the property used for the
+    ||| split.
+    prfs    : All p ayes
+    ||| A proof that all elements in `naws` do not satisfy the property used for
+    ||| the split.
+    contras : All (Not . p) naws
 
 ||| Split the list according to the given decidable property, putting the
 ||| resulting proofs and contras in an accumulator.

--- a/libs/base/Data/List1/Elem.idr
+++ b/libs/base/Data/List1/Elem.idr
@@ -12,28 +12,29 @@ import Control.Function
 -- List1 membership proof
 --------------------------------------------------------------------------------
 
-||| A proof that some element is found in a list.
-public export
-data Elem : a -> List1 a -> Type where
-     ||| A proof that the element is at the head of the list
-     Here : Elem x (x ::: xs)
-     ||| A proof that the element is in the tail of the list
-     There : Elem x xs -> Elem x (y ::: xs)
+namespace List1
+  ||| A proof that some element is found in a list.
+  public export
+  data Elem : a -> List1 a -> Type where
+       ||| A proof that the element is at the head of the list
+       Here : Elem x (x ::: xs)
+       ||| A proof that the element is in the tail of the list
+       There : Elem x xs -> Elem x (y ::: xs)
 
 export
-Uninhabited (List1.Elem.Here {x} {xs} = List1.Elem.There {x = x'} {y} {xs = xs'} e) where
+Uninhabited (List1.Here {x} {xs} = List1.There {x = x'} {y} {xs = xs'} e) where
   uninhabited Refl impossible
 
 export
-Uninhabited (List1.Elem.There {x} {y} {xs} e = List1.Elem.Here {x = x'} {xs = xs'}) where
+Uninhabited (List1.There {x} {y} {xs} e = List1.Here {x = x'} {xs = xs'}) where
   uninhabited Refl impossible
 
 export
-Injective (List1.Elem.There {x} {y} {xs}) where
+Injective (List1.There {x} {y} {xs}) where
   injective Refl = Refl
 
 export
-DecEq (List1.Elem.Elem x xs) where
+DecEq (List1.Elem x xs) where
   decEq Here Here = Yes Refl
   decEq (There this) (There that) = decEqCong $ decEq this that
   decEq Here (There later) = No absurd
@@ -52,7 +53,7 @@ neitherHereNorThere _   xnxs  (There xxs) = xnxs xxs
 
 ||| Check whether the given element is a member of the given list.
 public export
-isElem : DecEq a => (x : a) -> (xs : List1 a) -> Dec (List1.Elem.Elem x xs)
+isElem : DecEq a => (x : a) -> (xs : List1 a) -> Dec (List1.Elem x xs)
 isElem x (y ::: xs) with (decEq x y)
   isElem x (x ::: xs) | Yes Refl = Yes Here
   isElem x (y ::: xs) | No xny with (isElem x xs)
@@ -69,7 +70,7 @@ dropElem (x ::: ys) (There p) = x :: dropElem ys p
 
 ||| Erase the indices, returning the numeric position of the element
 public export
-elemToNat : Data.List1.Elem.Elem x xs -> Nat
+elemToNat : List1.Elem x xs -> Nat
 elemToNat  Here     = Z
 elemToNat (There p) = S (elemToNat p)
 
@@ -81,6 +82,6 @@ indexElem (S n) (_ ::: ys) = map (\(x ** p) => (x ** There p)) (indexElem n ys)
 
 ||| Lift the membership proof to a mapped list
 export
-elemMap : (0 f : a -> b) -> List1.Elem.Elem x xs -> List1.Elem.Elem (f x) (map f xs)
+elemMap : (0 f : a -> b) -> List1.Elem x xs -> List1.Elem (f x) (map f xs)
 elemMap f  Here      = Here
 elemMap f (There el) = There $ elemMap f el

--- a/libs/base/Data/List1/Quantifiers.idr
+++ b/libs/base/Data/List1/Quantifiers.idr
@@ -11,7 +11,7 @@ import Data.List.Quantifiers
 ------------------------------------------------------------------------
 -- Quanfitier types
 
-namespace Any
+namespace List1
 
   ||| A proof that some element of a list satisfies some property
   |||
@@ -22,8 +22,6 @@ namespace Any
     Here  : {0 xs : List a} -> p x -> Any p (x ::: xs)
     ||| A proof that the satisfying element is in the tail of the `List1`
     There : {0 xs : List a} -> Any p xs -> Any p (x ::: xs)
-
-namespace All
 
   ||| A proof that all elements of a list satisfy a property. It is a list of
   ||| proofs, corresponding element-wise to the `List1`.
@@ -289,4 +287,3 @@ decide dec (x :: xs) = case dec x of
   Right px => Right (Here px)
 
 -}
-

--- a/libs/base/Data/SnocList/HasLength.idr
+++ b/libs/base/Data/SnocList/HasLength.idr
@@ -1,30 +1,23 @@
 module Data.SnocList.HasLength
 
 import Data.Nat
+import Data.List.HasLength
 import Data.SnocList
 
----------------------------------------
--- horrible hack
-import Data.List.HasLength as L
 
-public export
-LHasLength : Nat -> List a -> Type
-LHasLength = L.HasLength
-%hide L.HasLength
----------------------------------------
-
-public export
-data HasLength : Nat -> SnocList a -> Type where
-  Z : HasLength Z [<]
-  S : HasLength n sa -> HasLength (S n) (sa :< a)
+namespace SnocList
+  public export
+  data HasLength : Nat -> SnocList a -> Type where
+    Z : HasLength Z [<]
+    S : HasLength n sa -> HasLength (S n) (sa :< a)
 
 export
-hasLength : HasLength n sx -> length sx === n
+hasLength : SnocList.HasLength n sx -> length sx === n
 hasLength Z = Refl
 hasLength (S p) = cong S (hasLength p)
 
 export
-map : (f : a -> b) -> HasLength n xs -> HasLength n (map f xs)
+map : (f : a -> b) -> SnocList.HasLength n xs -> SnocList.HasLength n (map f xs)
 map f Z = Z
 map f (S hl) = S (map f hl)
 
@@ -38,12 +31,12 @@ sucR : HasLength n sx -> HasLength (S n) (sx ++ [<x])
 sucR = S
 
 export
-hlAppend : HasLength m sx -> HasLength n sy -> HasLength (n + m) (sx ++ sy)
+hlAppend : SnocList.HasLength m sx -> HasLength n sy -> HasLength (n + m) (sx ++ sy)
 hlAppend sx Z = sx
 hlAppend sx (S sy) = S (hlAppend sx sy)
 
 export
-hlFish : HasLength m sx -> LHasLength n ys -> HasLength (n + m) (sx <>< ys)
+hlFish : HasLength m sx -> List.HasLength n ys -> HasLength (n + m) (sx <>< ys)
 hlFish x Z = x
 hlFish {n = S n} x (S y) = rewrite plusSuccRightSucc n m in hlFish (S x) y
 
@@ -53,7 +46,7 @@ mkHasLength [<] = Z
 mkHasLength (sx :< _) = S (mkHasLength sx)
 
 export
-hlChips : HasLength m sx -> LHasLength n ys -> LHasLength (m + n) (sx <>> ys)
+hlChips : HasLength m sx -> List.HasLength n ys -> List.HasLength (m + n) (sx <>> ys)
 hlChips Z y = y
 hlChips {m = S m} {n} (S x) y
   = rewrite plusSuccRightSucc m n in
@@ -61,14 +54,14 @@ hlChips {m = S m} {n} (S x) y
 
 export
 cast : {sy : _} -> (0 _ : SnocList.length sx = SnocList.length sy) ->
-       HasLength m sx -> HasLength m sy
+       SnocList.HasLength m sx -> SnocList.HasLength m sy
 cast {sy = [<]} eq Z = Z
 cast {sy = sy :< _} eq (S p) = S (cast (injective eq) p)
 
-hlReverseOnto : HasLength m acc -> HasLength n sx -> HasLength (m + n) (reverseOnto acc sx)
+hlReverseOnto : SnocList.HasLength m acc -> HasLength n sx -> HasLength (m + n) (reverseOnto acc sx)
 hlReverseOnto p Z = rewrite plusZeroRightNeutral m in p
 hlReverseOnto {n = S n} p (S q) = rewrite sym (plusSuccRightSucc m n) in hlReverseOnto (S p) q
 
 export
-hlReverse : HasLength m acc -> HasLength m (reverse acc)
+hlReverse : SnocList.HasLength m acc -> HasLength m (reverse acc)
 hlReverse = hlReverseOnto Z

--- a/libs/base/Data/SnocList/Quantifiers.idr
+++ b/libs/base/Data/SnocList/Quantifiers.idr
@@ -10,7 +10,7 @@ import Data.SnocList.Elem
 ------------------------------------------------------------------------
 -- Types and basic properties
 
-namespace Any
+namespace SnocList
 
   ||| A proof that some element of a snoclist satisfies some property
   |||
@@ -21,8 +21,6 @@ namespace Any
     Here  : {0 xs : SnocList a} -> p x -> Any p (xs :< x)
     ||| A proof that there is an element the tail of the `SnocList` satisfying p
     There : {0 xs : SnocList a} -> Any p xs -> Any p (xs :< x)
-
-namespace All
 
   ||| A proof that all elements of a list satisfy a property. It is a list of
   ||| proofs, corresponding element-wise to the `List`.

--- a/libs/base/Data/Vect/AtIndex.idr
+++ b/libs/base/Data/Vect/AtIndex.idr
@@ -18,16 +18,17 @@ import Decidable.Equality
 
 %default total
 
-public export
-data AtIndex : (idx : Fin n)
-            -> (xs  : Vect n type)
-            -> (x   : type)
-                   -> Type
-  where
-    Here : AtIndex FZ (x::xs) x
+namespace Vect
+  public export
+  data AtIndex : (idx : Fin n)
+              -> (xs  : Vect n type)
+              -> (x   : type)
+                     -> Type
+    where
+      Here : AtIndex FZ (x::xs) x
 
-    There : (later : AtIndex     rest      xs  x)
-                  -> AtIndex (FS rest) (y::xs) x
+      There : (later : AtIndex     rest      xs  x)
+                    -> AtIndex (FS rest) (y::xs) x
 
 namespace Check
   public export

--- a/libs/base/Data/Vect/Quantifiers.idr
+++ b/libs/base/Data/Vect/Quantifiers.idr
@@ -11,7 +11,7 @@ import Decidable.Equality
 ------------------------------------------------------------------------
 -- Quantifier types
 
-namespace Any
+namespace Vect
 
   ||| A proof that some element of a vector satisfies some property
   |||
@@ -22,8 +22,6 @@ namespace Any
     Here  : {0 xs : Vect n a} -> p x -> Any p (x :: xs)
     ||| A proof that the satsifying element is in the tail of the `Vect`
     There : {0 xs : Vect n a} -> Any p xs -> Any p (x :: xs)
-
-namespace All
 
   ||| A proof that all elements of a vector satisfy a property. It is a list of
   ||| proofs, corresponding element-wise to the `Vect`.

--- a/src/Libraries/Data/List01/Quantifiers.idr
+++ b/src/Libraries/Data/List01/Quantifiers.idr
@@ -5,7 +5,7 @@ import Libraries.Data.List01
 
 %default total
 
-namespace All
+namespace List01
 
   ||| A proof that all elements of a list satisfy a property. It is a list of
   ||| proofs, corresponding element-wise to the `List`.

--- a/src/Libraries/Data/SnocList/HasLength.idr
+++ b/src/Libraries/Data/SnocList/HasLength.idr
@@ -1,23 +1,21 @@
 module Libraries.Data.SnocList.HasLength
 
 import Data.Nat
----------------------------------------
--- horrible hack
-import Data.List.HasLength as L
 
-public export
-LHasLength : Nat -> List a -> Type
-LHasLength = L.HasLength
-%hide L.HasLength
----------------------------------------
+import Data.List.HasLength
 
-public export
-data HasLength : Nat -> SnocList a -> Type where
-  Z : HasLength Z [<]
-  S : HasLength n sa -> HasLength (S n) (sa :< a)
+import Data.SnocList
+
+-- @TODO remove namespace disambiguation once prelude is updated.
+
+namespace SnocList
+  public export
+  data HasLength : Nat -> SnocList a -> Type where
+    Z : HasLength Z [<]
+    S : HasLength n sa -> HasLength (S n) (sa :< a)
 
 export
-hasLength : HasLength n sx -> length sx === n
+hasLength : SnocList.HasLength n sx -> length sx === n
 hasLength Z = Refl
 hasLength (S p) = cong S (hasLength p)
 
@@ -31,12 +29,12 @@ sucL Z     = S Z
 sucL (S n) = S (sucL n)
 
 export
-hlAppend : HasLength m sx -> HasLength n sy -> HasLength (n + m) (sx ++ sy)
+hlAppend : SnocList.HasLength m sx -> HasLength n sy -> HasLength (n + m) (sx ++ sy)
 hlAppend sx Z = sx
 hlAppend sx (S sy) = S (hlAppend sx sy)
 
 export
-hlFish : HasLength m sx -> LHasLength n ys -> HasLength (n + m) (sx <>< ys)
+hlFish : HasLength m sx -> List.HasLength.HasLength n ys -> HasLength (n + m) (sx <>< ys)
 hlFish x Z = x
 hlFish {n = S n} x (S y) = rewrite plusSuccRightSucc n m in hlFish (S x) y
 
@@ -46,7 +44,7 @@ mkHasLength [<] = Z
 mkHasLength (sx :< _) = S (mkHasLength sx)
 
 export
-hlChips : HasLength m sx -> LHasLength n ys -> LHasLength (m + n) (sx <>> ys)
+hlChips : HasLength m sx -> List.HasLength.HasLength n ys -> List.HasLength.HasLength (m + n) (sx <>> ys)
 hlChips Z y = y
 hlChips {m = S m} {n} (S x) y
   = rewrite plusSuccRightSucc m n in
@@ -61,14 +59,14 @@ take (S n) (x :: xs) = S (take n xs)
 
 export
 cast : {sy : _} -> (0 _ : SnocList.length sx = SnocList.length sy) ->
-       HasLength m sx -> HasLength m sy
+       SnocList.HasLength m sx -> SnocList.HasLength m sy
 cast {sy = [<]} eq Z = Z
 cast {sy = sy :< _} eq (S p) = S (cast (injective eq) p)
 
-hlReverseOnto : HasLength m acc -> HasLength n sx -> HasLength (m + n) (reverseOnto acc sx)
+hlReverseOnto : SnocList.HasLength m acc -> HasLength n sx -> HasLength (m + n) (reverseOnto acc sx)
 hlReverseOnto p Z = rewrite plusZeroRightNeutral m in p
 hlReverseOnto {n = S n} p (S q) = rewrite sym (plusSuccRightSucc m n) in hlReverseOnto (S p) q
 
 export
-hlReverse : HasLength m acc -> HasLength m (reverse acc)
+hlReverse : SnocList.HasLength m acc -> HasLength m (reverse acc)
 hlReverse = hlReverseOnto Z


### PR DESCRIPTION
When working with dependent types there will be times where you will have code that looks the same but is working with different values at the type-level. Leading to namespace ambiguities. Consider the following:

```
namespace List
  export
  extract : AtIndex x xs i -> All p xs -> p x

namespace Vect
  export
  extract : AtIndex x xs i -> All p xs -> p x
```

We need to disambiguate the names, a quick solution is to use namespace disambiguation. Depending on the namespace hierarchies involved, however, these names can become long and unwieldy. Consider the resolved names:

```
namespace List
  export
  extract : List.AtIndex.AtIndex x xs i -> All p xs -> p x

namespace Vect
  export
  extract : Vect.AtIndex.AtIndex x xs i -> All p xs -> p x
```

Here the subject of the quantifier is at the head of the namespace, with the verb, representing the quantifier itself, at the tail. The verb is even replicated.

When defining predicates acting on data, wrap them in a namespace named after their subject. Thus, shortening the hierarchy required for disambiguation.

```
namespace List
  export
  extract : List.AtIndex x xs i -> All p xs -> p x

namespace Vect
  export
  extract : Vect.AtIndex x xs i -> All p xs -> p x
```



## Self-check

- [ ] This is my first time contributing, I've carefully read [`CONTRIBUTING.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTING.md)
      and I've updated [`CONTRIBUTORS`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTORS) with my name.
- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)
- [x] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.
