### PR TITLE
[ fix ] pretty printer is sometimes exponential

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -85,6 +85,7 @@ should target this file (`CHANGELOG_NEXT`).
   than be accepted but do nothing.
 * HTML files generated using `--mkdoc` now contain attributes, that allow
   external tools to insert links from documentation to source code.
+* Fix exponential time issue in pretty printer.
 * Fixed `parseDouble` dropping "-" sign when whole part is "0"
   [#3804](https://github.com/idris-lang/Idris2/issues/3804),
 

--- a/libs/contrib/Text/PrettyPrint/Prettyprinter/Doc.idr
+++ b/libs/contrib/Text/PrettyPrint/Prettyprinter/Doc.idr
@@ -604,7 +604,7 @@ removeTrailingWhitespace = fromMaybe internalError . go (RecordedWithespace [] 0
 
 public export
 FittingPredicate : Type -> Type
-FittingPredicate ann = Int -> Int -> Maybe Int -> SimpleDocStream ann -> Bool
+FittingPredicate ann = Int -> Int -> Lazy (Maybe Int) -> SimpleDocStream ann -> Bool
 
 data LayoutPipeline ann = Nil | Cons Int (Doc ann) (LayoutPipeline ann) | UndoAnn (LayoutPipeline ann)
 
@@ -665,7 +665,7 @@ layoutWadlerLeijen fits pageWidth_ doc = best 0 0 (Cons 0 doc Nil)
     best nl cc (Cons i (Cat x y) ds) = assert_total $ best nl cc (Cons i x (Cons i y ds))
     best nl cc c@(Cons i (Nest j x) ds) = best nl cc $ assert_smaller c (Cons (i + j) x ds)
     best nl cc c@(Cons i (Union x y) ds) = let x' = best nl cc $ assert_smaller c (Cons i x ds)
-                                               y' = delay $ best nl cc $ assert_smaller c (Cons i y ds) in
+                                               y' : Lazy (SimpleDocStream ann) = delay $ best nl cc $ assert_smaller c (Cons i y ds) in
                                                selectNicer nl cc x' y'
     best nl cc c@(Cons i (Column f) ds) = best nl cc $ assert_smaller c (Cons i (f cc) ds)
     best nl cc c@(Cons i (WithPageWidth f) ds) = best nl cc $ assert_smaller c (Cons i (f pageWidth_) ds)
@@ -701,7 +701,7 @@ layoutSmart : LayoutOptions -> Doc ann -> SimpleDocStream ann
 layoutSmart (MkLayoutOptions pageWidth_@(AvailablePerLine lineLength ribbonFraction)) =
     layoutWadlerLeijen fits pageWidth_
   where
-    fits : Int -> Int -> Maybe Int -> SimpleDocStream ann -> Bool
+    fits : Int -> Int -> Lazy (Maybe Int) -> SimpleDocStream ann -> Bool
     fits lineIndent currentColumn initialIndentY sdoc = go availableWidth sdoc
       where
         availableWidth : Int

--- a/src/Libraries/Text/PrettyPrint/Prettyprinter/Doc.idr
+++ b/src/Libraries/Text/PrettyPrint/Prettyprinter/Doc.idr
@@ -631,7 +631,7 @@ removeTrailingWhitespace = fromMaybe internalError . go (RecordedWithespace [] 0
 
 public export
 FittingPredicate : Type -> Type
-FittingPredicate ann = Int -> Int -> Maybe Int -> SimpleDocStream ann -> Bool
+FittingPredicate ann = Int -> Int -> Lazy (Maybe Int) -> SimpleDocStream ann -> Bool
 
 data LayoutPipeline ann = Nil | Cons Int (Doc ann) (LayoutPipeline ann) | UndoAnn (LayoutPipeline ann)
 
@@ -692,7 +692,7 @@ layoutWadlerLeijen fits pageWidth_ doc = best 0 0 (Cons 0 doc Nil)
     best nl cc (Cons i (Cat x y) ds) = assert_total $ best nl cc (Cons i x (Cons i y ds))
     best nl cc c@(Cons i (Nest j x) ds) = best nl cc $ assert_smaller c (Cons (i + j) x ds)
     best nl cc c@(Cons i (Union x y) ds) = let x' = best nl cc $ assert_smaller c (Cons i x ds)
-                                               y' = delay $ best nl cc $ assert_smaller c (Cons i y ds) in
+                                               y' : Lazy (SimpleDocStream ann) = delay $ best nl cc $ assert_smaller c (Cons i y ds) in
                                                selectNicer nl cc x' y'
     best nl cc c@(Cons i (Column f) ds) = best nl cc $ assert_smaller c (Cons i (f cc) ds)
     best nl cc c@(Cons i (WithPageWidth f) ds) = best nl cc $ assert_smaller c (Cons i (f pageWidth_) ds)
@@ -728,7 +728,7 @@ layoutSmart : LayoutOptions -> Doc ann -> SimpleDocStream ann
 layoutSmart (MkLayoutOptions pageWidth_@(AvailablePerLine lineLength ribbonFraction)) =
     layoutWadlerLeijen fits pageWidth_
   where
-    fits : Int -> Int -> Maybe Int -> SimpleDocStream ann -> Bool
+    fits : Int -> Int -> Lazy (Maybe Int) -> SimpleDocStream ann -> Bool
     fits lineIndent currentColumn initialIndentY sdoc = go availableWidth sdoc
       where
         availableWidth : Int


### PR DESCRIPTION
# Description

In #3836 a file takes a long time to check because of an exponential time issue while printing the error message.

On line 668, the second branch of a `Union` is delayed before being passed to `selectNicer`, but it is immediately passed to `fits`, which takes a non-lazy argument. The argument is forced, but not used by the `fits` function passed in by `layoutPretty`. I made that argument lazy.

That change did not completely fix the issue, because the delayed value is `let` assigned to a variable, and Idris appears to infer the type as non-lazy, dropping the `delay`. So I added a type annotation to the `let`.

Prior to this change, it took about a minute to check the file in #3836. After the change, it takes a third of a second.

I made the same changes to the copy of the code in contrib.

## Self-check

- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)
- [x] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.
