### PR TITLE
[ fix ] don't force terms with explicit delay

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -87,6 +87,7 @@ should target this file (`CHANGELOG_NEXT`).
   external tools to insert links from documentation to source code.
 * Fixed `parseDouble` dropping "-" sign when whole part is "0"
   [#3804](https://github.com/idris-lang/Idris2/issues/3804),
+* Do not insert `force` in front of an explicit `delay`.
 
 ### Building/Packaging changes
 

--- a/src/TTImp/Elab/Check.idr
+++ b/src/TTImp/Elab/Check.idr
@@ -784,7 +784,7 @@ checkExp : {vars : _} ->
            (got : Glued vars) -> (expected : Maybe (Glued vars)) ->
            Core (Term vars, Glued vars)
 checkExp rig elabinfo env fc tm got (Just exp)
-    = do vs <- convertWithLazy True fc elabinfo env got exp
+    = do vs <- convertWithLazy (withLazy tm) fc elabinfo env got exp
          case (constraints vs) of
               [] => case addLazy vs of
                          NoLazy => do logTerm "elab" 5 "Solved" tm
@@ -807,4 +807,9 @@ checkExp rig elabinfo env fc tm got (Just exp)
                             AddForce r => pure (TForce fc r tm, exp)
                             AddDelay r => do ty <- getTerm got
                                              pure (TDelay fc r ty tm, exp)
+    where
+      -- do not insert force in front of an explicit delay
+      withLazy : Term vars -> Bool
+      withLazy (TDelay fc1 lz ty arg) = False
+      withLazy _ = True
 checkExp rig elabinfo env fc tm got Nothing = pure (tm, got)

--- a/tests/idris2/misc/lazy006/Issue1900.idr
+++ b/tests/idris2/misc/lazy006/Issue1900.idr
@@ -1,0 +1,12 @@
+import Debug.Trace
+
+calc : Nat -> Nat
+calc n0 =
+  let n1  = delay $ (trace "foo" $ n0 + n0)
+      n2  = delay $ (trace "bar" $ 2 * n1)
+      n3  = delay $ (trace "baz" $ 2 * n2)
+   in if n0 > 10 then n2 else n3
+
+main : IO ()
+main = do printLn (calc 100)
+

--- a/tests/idris2/misc/lazy006/expected
+++ b/tests/idris2/misc/lazy006/expected
@@ -1,0 +1,4 @@
+foo
+bar
+baz
+400

--- a/tests/idris2/misc/lazy006/run
+++ b/tests/idris2/misc/lazy006/run
@@ -1,0 +1,3 @@
+. ../../../testutils.sh
+
+idris2 --exec main Issue1900.idr


### PR DESCRIPTION
# Description

This PR fixes issue #1900 by telling the elaborator not to insert `force` in front of an explicit `delay`.  This issue also came up in #3836 and was worked around there by adding an annotation to the `let`.

When a user types:
```idris
expensive : Nat -> Foo

test = let x = delay (expensive 10) in ?hole
```
The type of `x` is `Foo` rather than `Lazy Foo`, despite the user explicitly typing `delay`. Because the type is inferred and a `force` is being inserted during conversion checking. 

We sometimes want to force the value before assigning it, to avoid duplicate work, but I think we can safely assume that the user wants a `Lazy` value if they explicitly write `delay`. So the PR disables this mechanism only if the term being checked begins with a `TDelay`.

### Alternatives considered

A user could work around the issue by annotating the `let` with a type:
```idris
test = let x : Lazy Foo = delay (expensive 10) in ?hole
```

## Self-check

- [x] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)
- [x] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.
