### PR TITLE
Functor and Applicative laws for core library types

### DIFF
--- a/libs/base/Data/Either.idr
+++ b/libs/base/Data/Either.idr
@@ -1,6 +1,7 @@
 module Data.Either
 
 import public Control.Function
+import Data.Laws
 import Data.List1
 
 %default total
@@ -175,3 +176,34 @@ Injective Left where
 export
 Injective Right where
   injective Refl = Refl
+
+export
+functorIdentity : Functor.Identity (Either e)
+functorIdentity (Left _) = Refl
+functorIdentity (Right _) = Refl
+
+export
+functorComposition : Functor.Composition (Either e)
+functorComposition (Left _) _ _ = Refl
+functorComposition (Right _) _ _ = Refl
+
+export
+applicativeIdentity : Applicative.Identity (Either e)
+applicativeIdentity (Left _) = Refl
+applicativeIdentity (Right _) = Refl
+
+export
+applicativeHomomorphism : Applicative.Homomorphism (Either e)
+applicativeHomomorphism _ _ = Refl
+
+export
+applicativeInterchange : Applicative.Interchange (Either e)
+applicativeInterchange (Left _) _ = Refl
+applicativeInterchange (Right _) _ = Refl
+
+export
+applicativeComposition : Applicative.Composition (Either e)
+applicativeComposition (Left _) _ _ = Refl
+applicativeComposition (Right _) (Left _) _ = Refl
+applicativeComposition (Right _) (Right _) (Left _) = Refl
+applicativeComposition (Right _) (Right _) (Right _) = Refl

--- a/libs/base/Data/Laws.idr
+++ b/libs/base/Data/Laws.idr
@@ -1,0 +1,33 @@
+module Data.Laws
+
+namespace Functor
+  public export 0
+  Identity : (f : Type -> Type) -> Functor f => Type
+  Identity f = forall a . (x : f a) -> map id x = x
+
+  public export 0
+  Composition : (f : Type -> Type) -> Functor f => Type
+  Composition f =
+    forall a, b, c . (x : f a) -> (g : a -> b) -> (h : b -> c) -> map h (map g x) = map (h . g) x
+
+namespace Applicative
+  public export 0
+  Identity : (f : Type -> Type) -> Applicative f => Type
+  Identity f = forall a . (x : f a) -> pure id <*> x = x
+
+  public export 0
+  Homomorphism : (f : Type -> Type) -> Applicative f => Type
+  Homomorphism f = forall a, b . (x : a) -> (g : a -> b) -> pure g <*> pure x = pure {f} (g x)
+
+  public export 0
+  Interchange : (f : Type -> Type) -> Applicative f => Type
+  Interchange f = forall a, b . (g : f (a -> b)) -> (x : a) -> g <*> pure x = pure ($ x) <*> g
+
+  public export 0
+  Composition : (f : Type -> Type) -> Applicative f => Type
+  Composition f =
+    forall a, b, c .
+    (h : f (b -> c)) ->
+    (g : f (a -> b)) ->
+    (x : f a) ->
+    pure (.) <*> h <*> g <*> x = h <*> (g <*> x)

--- a/libs/base/Data/List.idr
+++ b/libs/base/Data/List.idr
@@ -3,6 +3,7 @@ module Data.List
 import public Control.Function
 
 import Data.Nat
+import Data.Laws
 import Data.List1
 import Data.Fin
 import public Data.Zippable
@@ -1072,6 +1073,33 @@ dropFusion (S n) (S m) []     = Refl
 dropFusion (S n) (S m) (x::l) = rewrite plusAssociative n 1 m in
                                 rewrite plusCommutative n 1 in
                                 dropFusion (S n) m l
+
+export
+functorIdentity : Functor.Identity List
+functorIdentity [] = Refl
+functorIdentity (x :: xs) = cong2 (::) Refl (functorIdentity xs)
+
+export
+functorComposition : Functor.Composition List
+functorComposition [] _ _ = Refl
+functorComposition (x :: xs) f g = cong2 (::) Refl (functorComposition xs f g)
+
+export
+applicativeIdentity : Applicative.Identity List
+applicativeIdentity [] = Refl
+applicativeIdentity (x :: xs) = rewrite functorIdentity xs in reverseReverseOnto [x] xs
+
+export
+applicativeHomomorphism : Applicative.Homomorphism List
+applicativeHomomorphism _ _ = Refl
+
+export
+applicativeInterchange : Applicative.Interchange List
+applicativeInterchange [] _ = Refl
+applicativeInterchange (g :: gs) x = ?applicativeInterchange_rhs_1
+
+export
+applicativeComposition : Applicative.Composition List
 
 ||| Mapping a function over a list does not change the length of the list.
 export

--- a/libs/base/Data/Maybe.idr
+++ b/libs/base/Data/Maybe.idr
@@ -2,6 +2,7 @@ module Data.Maybe
 
 import Control.Function
 
+import Data.Laws
 import Data.Zippable
 
 %default total
@@ -116,3 +117,38 @@ maybeCong f = map (\eq => cong f eq)
 public export
 maybeCong2 : (f : a -> b -> c) -> Maybe (x = y) -> Maybe (v = w) -> Maybe (f x v = f y w)
 maybeCong2 f mxy mvw = (\xy, vw => cong2 f xy vw) <$> mxy <*> mvw
+
+--------------------------------------------------------------------------------
+-- Properties
+--------------------------------------------------------------------------------
+
+export
+functorIdentity : Functor.Identity Maybe
+functorIdentity Nothing = Refl
+functorIdentity (Just _) = Refl
+
+export
+functorComposition : Functor.Composition Maybe
+functorComposition Nothing _ _ = Refl
+functorComposition (Just _) _ _ = Refl
+
+export
+applicativeIdentity : Applicative.Identity Maybe
+applicativeIdentity Nothing = Refl
+applicativeIdentity (Just _) = Refl
+
+export
+applicativeHomomorphism : Applicative.Homomorphism Maybe
+applicativeHomomorphism _ _ = Refl
+
+export
+applicativeInterchange : Applicative.Interchange Maybe
+applicativeInterchange Nothing _ = Refl
+applicativeInterchange (Just _) _ = Refl
+
+export
+applicativeComposition : Applicative.Composition Maybe
+applicativeComposition Nothing _ _ = Refl
+applicativeComposition (Just _) Nothing _ = Refl
+applicativeComposition (Just _) (Just _) Nothing = Refl
+applicativeComposition (Just _) (Just _) (Just _) = Refl

--- a/libs/base/Data/SnocList.idr
+++ b/libs/base/Data/SnocList.idr
@@ -3,6 +3,7 @@ module Data.SnocList
 
 import Data.List
 import Data.Fin
+import Data.Laws
 
 %default total
 
@@ -344,6 +345,24 @@ filterCast f (x::xs) = do
       _ | True  = rewrite fishAsSnocAppend [<x] (filter f xs) in Refl
 
 --- Functor map ---
+
+export
+functorIdentity : FunctorIdentity SnocList
+functorIdentity [<] = Refl
+functorIdentity (xs :< x) = cong2 (:<) (functorIdentity xs) Refl
+
+export
+functorComposition : FunctorComposition SnocList
+functorComposition [<] _ _ = Refl
+functorComposition (xs :< x) f g = cong2 (:<) (functorComposition xs f g) Refl
+
+export
+applicativeIdentity : ApplicativeIdentity SnocList
+applicativeIdentity [<] = Refl
+applicativeIdentity (sx :< x) = cong (:< x) (applicativeIdentity sx)
+
+export
+applicativeComposition : ApplicativeComposition SnocList
 
 export
 mapFusion : (g : b -> c) -> (f : a -> b) -> (sx : SnocList a) -> map g (map f sx) = map (g . f) sx

--- a/libs/base/Data/Vect.idr
+++ b/libs/base/Data/Vect.idr
@@ -1,6 +1,7 @@
 module Data.Vect
 
 import Data.DPair
+import Data.Laws
 import Data.List
 import Data.Nat
 import public Data.Fin
@@ -1023,3 +1024,37 @@ overLength n xs with (cmp m n)
   overLength {m}                m xs | CmpEQ     = Just (0 ** xs)
   overLength {m = plus n (S x)} n xs | (CmpGT x)
          = Just (S x ** rewrite plusCommutative (S x) n in xs)
+
+--------------------------------------------------------------------------------
+-- Properties
+--------------------------------------------------------------------------------
+
+export
+functorIdentity : Functor.Identity (Vect n)
+functorIdentity [] = Refl
+functorIdentity (x :: xs) = cong2 (::) Refl (functorIdentity xs)
+
+export
+functorComposition : Functor.Composition (Vect n)
+functorComposition [] _ _ = Refl
+functorComposition (x :: xs) f g = cong2 (::) Refl (functorComposition xs f g)
+
+export
+applicativeIdentity : Applicative.Identity (Vect n)
+applicativeIdentity [] = Refl
+applicativeIdentity (x :: xs) = cong2 (::) Refl (applicativeIdentity xs)
+
+export
+applicativeHomomorphism : Applicative.Homomorphism (Vect n)
+applicativeHomomorphism _ _ = Refl
+
+export
+applicativeInterchange : Applicative.Interchange (Vect n)
+applicativeInterchange [] x = Refl
+applicativeInterchange (g :: gs) x = cong (g x) (applicativeInterchange gs x)
+
+export
+applicativeComposition : Applicative.Composition (Vect n)
+applicativeComposition [] [] [] = Refl
+applicativeComposition (h :: hs) (g :: gs) (x :: xs) =
+  cong2 (::) Refl (applicativeComposition hs gs xs)

--- a/libs/base/base.ipkg
+++ b/libs/base/base.ipkg
@@ -1,7 +1,9 @@
 package base
 version = 0.8.0
 
-opts = "--ignore-missing-ipkg -Wno-shadowing"
+--opts = "--ignore-missing-ipkg -Wno-shadowing"
+
+depends = prelude
 
 modules = Control.App,
           Control.App.Console,
@@ -58,6 +60,7 @@ modules = Control.App,
           Data.IOArray.Prims,
           Data.IORef,
           Data.Integral,
+          Data.Laws,
           Data.List,
           Data.List.AtIndex,
           Data.List.Elem,

--- a/libs/base/base.ipkg
+++ b/libs/base/base.ipkg
@@ -1,9 +1,7 @@
 package base
 version = 0.8.0
 
---opts = "--ignore-missing-ipkg -Wno-shadowing"
-
-depends = prelude
+opts = "--ignore-missing-ipkg -Wno-shadowing"
 
 modules = Control.App,
           Control.App.Console,


### PR DESCRIPTION
# Description

The functor and applicative laws for common library types. I am missing some applicative laws for list/snoclist, cos they're non-trivial. I could also add monad laws. I don't know if I'll get round to them (let's assume not). Laws from here https://en.wikibooks.org/wiki/Haskell/Applicative_functors. PLEASE CORRECT ME IF I'VE INTERPRETED THEM WRONG.

This is a draft to get opinions before I invest effort needlessly.

It's quite unclear what types make sense to implement these for. I originally asked about Prelude types, which doesn't include `Vect`. Unfussed if we include that or not. It's quite hard to know where the line is (what about List1, State etc.).

Could do just the functor laws for now - they're always easy.

## Self-check

<!-- /!\ Please delete sections that do not apply -->
- [ ] This is my first time contributing, I've carefully read [`CONTRIBUTING.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTING.md)
      and I've updated [`CONTRIBUTORS`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTORS) with my name.
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)
- [x] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.
