### PR TITLE
update flake inputs and fix deprecation warnings

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755542980,
-        "narHash": "sha256-vVlLAZSI27Ge7Cb6Vwhcwccd+reTLwa/KtrjyamM30I=",
+        "lastModified": 1788139003,
+        "narHash": "sha256-BBDrWRW8dKAilvt9HfVRRMmwTkSsDoc5ckhhme6ddcA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "54260f5b36f6136fc2f71629fb8d2c8c7158f140",
+        "rev": "564e1729e9d32b4a634ac3b16b72a70e9d76f1ab",
         "type": "github"
       },
       "original": {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
   nativeBuildInputs = [ makeWrapper installShellFiles clang chez ]
-    ++ lib.optional stdenv.isDarwin [ zsh ]
+    ++ lib.optional stdenv.hostPlatform.isDarwin [ zsh ]
     ++ lib.optional (!bootstrap) [ idris2Bootstrap ];
   buildInputs = [ chez gmp support ];
 
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   '';
 
   makeFlags = [ "IDRIS2_SUPPORT_DIR=${supportLibrariesPath}" ]
-    ++ lib.optional stdenv.isDarwin "OS=";
+    ++ lib.optional stdenv.hostPlatform.isDarwin "OS=";
 
   # The name of the main executable of pkgs.chez is `scheme`
   buildFlags = [ "PREFIX=$(out)" ] ++

--- a/nix/support.nix
+++ b/nix/support.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "PREFIX=$(out)"
-  ] ++ lib.optional stdenv.isDarwin "OS=";
+  ] ++ lib.optional stdenv.hostPlatform.isDarwin "OS=";
 
   buildFlags = [ "support" ];
 


### PR DESCRIPTION
# Description

Just updating the Nix packageset this project is pinned to. This is of little consequence other than making sure the project's Nix configuration still works against newer nixpkgs versions and being able to spin up developer shells using newer external dependencies.

## Self-check

<!-- /!\ Please delete sections that do not apply -->
- [ ] This is my first time contributing, I've carefully read [`CONTRIBUTING.md`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTING.md)
      and I've updated [`CONTRIBUTORS`](https://github.com/idris-lang/Idris2/blob/main/CONTRIBUTORS) with my name.
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md)
- [x] I confirm that this contribution did not involve GenerativeAI nor Large Language Models.
